### PR TITLE
chore: remove deprecated 'static' references

### DIFF
--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -90,18 +90,6 @@ export class ActionButton extends SizedMixin(ButtonBase, {
     @property({ reflect: true, attribute: 'static-color' })
     public staticColor?: 'white' | 'black';
 
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ reflect: true })
-    public static?: 'white' | 'black';
-
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ reflect: true })
-    public variant?: 'white' | 'black';
-
     @property({ type: String })
     public get value(): string {
         return this._value || this.itemText;
@@ -266,34 +254,6 @@ export class ActionButton extends SizedMixin(ButtonBase, {
                         this.selected ? 'true' : 'false'
                     );
                 }
-            }
-        }
-        if (
-            changes.has('variant') &&
-            (this.variant !== undefined || changes.get('variant') !== undefined)
-        ) {
-            this.staticColor = this.variant;
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "variant" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "variant" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/',
-                    { level: 'deprecation' }
-                );
-            }
-        }
-        if (
-            changes.has('static') &&
-            (this.static !== undefined || changes.get('static') !== undefined)
-        ) {
-            this.staticColor = this.static;
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "static" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/',
-                    { level: 'deprecation' }
-                );
             }
         }
         if (changes.has('holdAffordance')) {

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -24,7 +24,7 @@ import {
     waitUntil,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { spy, stub } from 'sinon';
+import { spy } from 'sinon';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 import { m as BlackActionButton } from '../stories/action-button-black.stories.js';
 
@@ -281,77 +281,5 @@ describe('ActionButton', () => {
         expect(button).not.to.have.attribute('aria-pressed');
         expect(button).to.have.attribute('aria-haspopup', 'true');
         expect(button).to.have.attribute('aria-expanded', 'true');
-    });
-    describe('dev mode', () => {
-        let consoleWarnStub!: ReturnType<typeof stub>;
-        before(() => {
-            window.__swc.verbose = true;
-            consoleWarnStub = stub(console, 'warn');
-        });
-        afterEach(() => {
-            consoleWarnStub.resetHistory();
-        });
-        after(() => {
-            window.__swc.verbose = false;
-            consoleWarnStub.restore();
-        });
-
-        it('warns that `variant` is deprecated', async () => {
-            const el = await fixture<ActionButton>(html`
-                <sp-action-button variant="white">Button</sp-action-button>
-            `);
-
-            await elementUpdated(el);
-
-            expect(consoleWarnStub.called).to.be.true;
-            const spyCall = consoleWarnStub.getCall(0);
-            expect(
-                (spyCall.args.at(0) as string).includes('"variant"'),
-                'confirm variant-centric message'
-            ).to.be.true;
-            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-                data: {
-                    localName: 'sp-action-button',
-                    type: 'api',
-                    level: 'deprecation',
-                },
-            });
-        });
-
-        it('warns that `variant` is deprecated', async () => {
-            const el = await fixture<ActionButton>(html`
-                <sp-action-button static="white">Button</sp-action-button>
-            `);
-
-            await elementUpdated(el);
-
-            expect(consoleWarnStub.called).to.be.true;
-            const spyCall = consoleWarnStub.getCall(0);
-            expect(
-                (spyCall.args.at(0) as string).includes('"static"'),
-                'confirm static-centric message'
-            ).to.be.true;
-            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-                data: {
-                    localName: 'sp-action-button',
-                    type: 'api',
-                    level: 'deprecation',
-                },
-            });
-        });
-
-        it('prefers `staticColor` over `static`', async () => {
-            const el = await fixture<ActionButton>(html`
-                <sp-action-button static="white">Button</sp-action-button>
-            `);
-
-            await elementUpdated(el);
-            expect(el.staticColor).to.equal('white');
-            el.setAttribute('static', 'white');
-            await elementUpdated(el);
-            expect(el.staticColor).to.equal('white');
-            expect(el.static).to.equal('white');
-            expect(el.getAttribute('static-color')).to.equal('white');
-        });
     });
 });

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -112,12 +112,6 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
     @property({ type: String })
     public selects: undefined | 'single' | 'multiple';
 
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ reflect: true })
-    public static?: 'white' | 'black';
-
     @property({ reflect: true, attribute: 'static-color' })
     public staticColor?: 'white' | 'black';
 
@@ -365,7 +359,6 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
             changes.has('quiet') ||
             changes.has('emphasized') ||
             changes.has('size') ||
-            changes.has('static') ||
             changes.has('staticColor')
         ) {
             this.manageChildren(changes);
@@ -390,18 +383,6 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
             }
             if (this.emphasized || changes?.get('emphasized')) {
                 button.emphasized = this.emphasized;
-            }
-            if (this.static || changes?.get('static')) {
-                if (window.__swc.DEBUG) {
-                    window.__swc.warn(
-                        this,
-                        `The "static" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/action-group/api/',
-                        { level: 'deprecation' }
-                    );
-                }
-                this.staticColor = this.static;
-                button.staticColor = this.staticColor;
             }
             if (this.staticColor || changes?.get('staticColor')) {
                 button.staticColor = this.staticColor;

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -1522,25 +1522,6 @@ describe('ActionGroup', () => {
         expect(actionButtons[1].selected).to.be.true;
         expect(actionButtons[2].selected).to.be.false;
     });
-    it('prefers `staticColor` over `static`', async () => {
-        const el = await fixture<ActionGroup>(html`
-            <sp-action-group
-                label="Selects Single Group"
-                selects="single"
-                static="white"
-                dir="ltr"
-            >
-                <sp-action-button>First</sp-action-button>
-            </sp-action-group>
-        `);
-        await elementUpdated(el);
-        expect(el.staticColor).to.equal('white');
-        el.setAttribute('static', 'white');
-        await elementUpdated(el);
-        expect(el.staticColor).to.equal('white');
-        expect(el.static).to.equal('white');
-        expect(el.getAttribute('static-color')).to.equal('white');
-    });
 });
 
 describe('dev mode', () => {

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -50,12 +50,6 @@ export class ActionMenu extends ObserveSlotPresence(
     @property({ type: String })
     public override selects: undefined | 'single' = undefined;
 
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ type: String, reflect: true })
-    public static: 'white' | 'black' | undefined = undefined;
-
     @property({ reflect: true, attribute: 'static-color' })
     public staticColor?: 'white' | 'black';
 

--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -239,20 +239,20 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
 
             expect(el.quiet).to.be.true;
         });
-        it('can be `static`', async () => {
+        it('can be `staticColor`', async () => {
             const el = await actionMenuFixture();
 
-            expect(el.static == undefined).to.be.true;
+            expect(el.staticColor == undefined).to.be.true;
 
-            el.static = 'black';
+            el.staticColor = 'black';
             await elementUpdated(el);
 
-            expect(el.static == 'black').to.be.true;
+            expect(el.staticColor == 'black').to.be.true;
 
-            el.static = 'white';
+            el.staticColor = 'white';
             await elementUpdated(el);
 
-            expect(el.static == 'white').to.be.true;
+            expect(el.staticColor == 'white').to.be.true;
         });
         it('stay `valid`', async () => {
             const el = await actionMenuFixture();

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -153,12 +153,6 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
     private _variant: ButtonVariants = 'accent';
 
     /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ type: String, reflect: true })
-    public static?: 'black' | 'white';
-
-    /**
      * The static color variant to use for this button.
      */
     @property({ reflect: true, attribute: 'static-color' })
@@ -201,24 +195,6 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
         }
         if (this.pending) {
             this.pendingStateController.hostUpdated();
-        }
-    }
-
-    protected override updated(changed: PropertyValues): void {
-        super.updated(changed);
-
-        if (changed.has('static')) {
-            if (this.static) {
-                this.staticColor = this.static;
-                if (window.__swc.DEBUG) {
-                    window.__swc.warn(
-                        this,
-                        `The "static" attribute/property on <${this.localName}> has been deprecated. Use "static-color" instead. "static" will be removed in a future release.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button/api',
-                        { level: 'deprecation' }
-                    );
-                }
-            }
         }
     }
 

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -74,748 +74,726 @@ describe('Button', () => {
                 },
             });
         });
-        it('warns in devMode when white/black static is provided', async () => {
+
+        it('loads default', async () => {
             const el = await fixture<Button>(html`
-                <sp-button tabindex="0" static="black">Button</sp-button>
+                <sp-button tabindex="0">Button</sp-button>
             `);
 
             await elementUpdated(el);
-            expect(consoleWarnStub.called).to.be.true;
-
-            const spyCall = consoleWarnStub.getCall(0);
-            expect(
-                (spyCall.args.at(0) as string).includes('deprecated'),
-                'confirm deprecated static warning'
-            ).to.be.true;
-            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-                data: {
-                    localName: 'sp-button',
-                    type: 'api',
-                    level: 'deprecation',
-                },
-            });
-        });
-        it('warns in devMode when white/black static is provided', async () => {
-            const el = await fixture<Button>(html`
-                <sp-button tabindex="0" static="white">Button</sp-button>
-            `);
-
-            await elementUpdated(el);
-            expect(consoleWarnStub.called).to.be.true;
-
-            const spyCall = consoleWarnStub.getCall(0);
-            expect(
-                (spyCall.args.at(0) as string).includes('deprecated'),
-                'confirm deprecated static warning'
-            ).to.be.true;
-            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-                data: {
-                    localName: 'sp-button',
-                    type: 'api',
-                    level: 'deprecation',
-                },
-            });
-        });
-    });
-
-    it('loads default', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button tabindex="0">Button</sp-button>
-        `);
-
-        await elementUpdated(el);
-        expect(el).to.not.be.undefined;
-        expect(el.textContent).to.include('Button');
-        await expect(el).to.be.accessible();
-
-        // Applies a default variant as an stylable attribute
-        expect(el.variant).to.equal('accent');
-        expect(el.getAttribute('variant')).to.equal('accent');
-    });
-    it('loads default w/ element content', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button label="Button"><svg></svg></sp-button>
-        `);
-
-        await elementUpdated(el);
-        expect(el).to.not.be.undefined;
-        await expect(el).to.be.accessible();
-    });
-    it('loads default w/ an icon', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button label="">
-                Button
-                <svg slot="icon"></svg>
-            </sp-button>
-        `);
-
-        await elementUpdated(el);
-        expect(el).to.not.be.undefined;
-        expect(el.textContent).to.include('Button');
-        expect(!(el as unknown as { hasIcon: boolean }).hasIcon);
-        await expect(el).to.be.accessible();
-    });
-    it('loads default only icon', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button label="Button" icon-only>
-                <svg slot="icon"></svg>
-            </sp-button>
-        `);
-
-        await elementUpdated(el);
-        expect(el).to.not.be.undefined;
-        await expect(el).to.be.accessible();
-    });
-    it('has a stable/predictable `updateComplete`', async () => {
-        const test = await fixture<HTMLDivElement>(html`
-            <div></div>
-        `);
-
-        let keydownTime = -1;
-        let updateComplete1 = -1;
-        let updateComplete2 = -1;
-
-        const el = document.createElement('sp-button');
-        el.autofocus = true;
-        el.addEventListener('keydown', () => {
-            keydownTime = performance.now();
-        });
-        el.updateComplete.then(() => {
-            updateComplete1 = performance.now();
-        });
-        el.updateComplete.then(() => {
-            updateComplete2 = performance.now();
-        });
-        test.append(el);
-        // don't use elementUpdated(), as it is under test...
-        await nextFrame();
-        await nextFrame();
-        await nextFrame();
-        await nextFrame();
-
-        expect(keydownTime, 'keydown happened').to.not.eq(-1);
-        expect(updateComplete1, 'first update complete happened').to.not.eq(-1);
-        expect(updateComplete2, 'first update complete happened').to.not.eq(-1);
-        expect(updateComplete1).lte(updateComplete2);
-        expect(updateComplete2).lte(keydownTime);
-    });
-    it('manages "role"', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button>Button</sp-button>
-        `);
-
-        await elementUpdated(el);
-        expect(el.getAttribute('role')).to.equal('button');
-
-        el.setAttribute('href', '#');
-
-        await elementUpdated(el);
-        expect(el.getAttribute('role')).to.equal('link');
-
-        el.removeAttribute('href');
-
-        await elementUpdated(el);
-        expect(el.getAttribute('role')).to.equal('button');
-    });
-    it('allows label to be toggled', async () => {
-        const testNode = document.createTextNode('Button');
-        const el = await fixture<Button>(html`
-            <sp-button>
-                ${testNode}
-                <svg slot="icon"></svg>
-            </sp-button>
-        `);
-
-        await elementUpdated(el);
-
-        const labelTestableEl = el as unknown as TestableButtonType;
-
-        expect(labelTestableEl.hasLabel, 'starts with label').to.be.true;
-
-        testNode.textContent = '';
-
-        await elementUpdated(el);
-
-        await waitUntil(() => !labelTestableEl.hasLabel, 'label is removed');
-
-        testNode.textContent = 'Button';
-
-        await elementUpdated(el);
-
-        expect(labelTestableEl.hasLabel, 'label is returned').to.be.true;
-    });
-    it('loads with href', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button href="test_url">With Href</sp-button>
-        `);
-
-        await elementUpdated(el);
-        expect(el).to.not.be.undefined;
-        expect(el.textContent).to.include('With Href');
-    });
-    it('loads with href and target', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button href="test_url" target="_blank">With Target</sp-button>
-        `);
-
-        await elementUpdated(el);
-        expect(el).to.not.be.undefined;
-        expect(el.textContent).to.include('With Target');
-    });
-    it('accepts shit+tab interactions', async () => {
-        let focusedCount = 0;
-        const el = await fixture<Button>(html`
-            <sp-button href="test_url" target="_blank">With Target</sp-button>
-        `);
-
-        await elementUpdated(el);
-        const input = document.createElement('input');
-        el.insertAdjacentElement('beforebegin', input);
-        input.focus();
-        expect(document.activeElement === input).to.be.true;
-
-        el.addEventListener('focus', () => {
-            focusedCount += 1;
-        });
-        expect(focusedCount).to.equal(0);
-
-        await sendKeys({
-            press: 'Tab',
-        });
-        await elementUpdated(el);
-
-        expect(document.activeElement === el).to.be.true;
-        expect(focusedCount).to.equal(1);
-
-        await sendKeys({
-            press: 'Shift+Tab',
-        });
-        await elementUpdated(el);
-
-        expect(focusedCount).to.equal(1);
-        expect(document.activeElement === input).to.be.true;
-    });
-    it('manages `disabled`', async () => {
-        const clickSpy = spy();
-        const el = await fixture<Button>(html`
-            <sp-button @click=${() => clickSpy()}>Button</sp-button>
-        `);
-
-        await elementUpdated(el);
-        el.click();
-        await elementUpdated(el);
-        expect(clickSpy.calledOnce).to.be.true;
-
-        clickSpy.resetHistory();
-        el.disabled = true;
-        await elementUpdated(el);
-        el.click();
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(0);
-
-        clickSpy.resetHistory();
-        await elementUpdated(el);
-        el.dispatchEvent(new Event('click', {}));
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(0);
-
-        clickSpy.resetHistory();
-        el.disabled = false;
-        el.click();
-        await elementUpdated(el);
-        expect(clickSpy.calledOnce).to.be.true;
-    });
-    it('`disabled` manages `tabindex`', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button disabled>Button</sp-button>
-        `);
-
-        await elementUpdated(el);
-        expect(el.tabIndex).to.equal(-1);
-        expect(el.getAttribute('tabindex')).to.equal('-1');
-
-        el.disabled = false;
-        await elementUpdated(el);
-
-        expect(el.tabIndex).to.equal(0);
-        expect(el.getAttribute('tabindex')).to.equal('0');
-
-        el.disabled = true;
-        await elementUpdated(el);
-
-        expect(el.tabIndex).to.equal(-1);
-        expect(el.getAttribute('tabindex')).to.equal('-1');
-    });
-    it('manages `aria-disabled`', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button href="test_url" target="_blank">With Target</sp-button>
-        `);
-
-        await elementUpdated(el);
-
-        expect(el.hasAttribute('aria-disabled'), 'initially not').to.be.false;
-
-        el.disabled = true;
-        await elementUpdated(el);
-
-        expect(el.getAttribute('aria-disabled')).to.equal('true');
-
-        el.disabled = false;
-        await elementUpdated(el);
-
-        expect(el.hasAttribute('aria-disabled'), 'finally not').to.be.false;
-    });
-    it('manages aria-label from disabled state', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button
-                href="test_url"
-                target="_blank"
-                label="clickable"
-                disabled
-                pending-label="Pending Button"
-            >
-                Click me
-            </sp-button>
-        `);
-
-        await elementUpdated(el);
-
-        expect(el.getAttribute('aria-label')).to.equal('clickable');
-
-        // button set to pending while disabled and the aria-label should stay the same
-        el.pending = true;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('clickable');
-
-        // button set to enabled while pending is true and the aria-label should update
-        el.disabled = false;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('Pending Button');
-
-        // pending is removed and the aria-label should be back to the original
-        el.pending = false;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('clickable');
-    });
-
-    it('manages aria-label from pending state', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button
-                href="test_url"
-                target="_blank"
-                label="clickable"
-                pending
-            >
-                Click me
-            </sp-button>
-        `);
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('Pending');
-
-        // button set to disabled while pending is true and the aria-label should be original
-        el.disabled = true;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('clickable');
-
-        // pending is removed and the aria-label should not change as the button is disabled
-        el.pending = false;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('clickable');
-
-        // button is enabled and the aria-label should not change
-        el.disabled = false;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('clickable');
-    });
-
-    it('manages aria-label set from outside', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button
-                href="test_url"
-                target="_blank"
-                aria-label="test"
-                pending-label="Pending Button"
-            >
-                Click me
-            </sp-button>
-        `);
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('test');
-
-        // button set to pending and aria-label should update
-        el.pending = true;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('Pending Button');
-
-        // button set to disabled while pending and aria-label should update
-        el.disabled = true;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('test');
-
-        // button set to enabled while pending and aria-label should update
-        el.disabled = false;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('Pending Button');
-
-        // pending removed and aria-label should update
-        el.pending = false;
-        await elementUpdated(el);
-        expect(el.getAttribute('aria-label')).to.equal('test');
-    });
-
-    it('updates pending label accessibly', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button href="test_url" target="_blank">Button</sp-button>
-        `);
-
-        await elementUpdated(el);
-        el.pending = true;
-        await elementUpdated(el);
-
-        await nextFrame();
-
-        type NamedNode = { name: string };
-        let snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
-            children: NamedNode[];
-        };
-        expect(
-            findAccessibilityNode<NamedNode>(
-                snapshot,
-                (node) => node.name === 'Pending'
-            ),
-            '`Pending` is the label text'
-        ).to.not.be.null;
-
-        expect(el.pending).to.be.true;
-
-        // remove pending state
-        el.pending = false;
-        await elementUpdated(el);
-
-        await nextFrame();
-
-        snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
-            children: NamedNode[];
-        };
-
-        // check label returns to previous value
-        expect(
-            findAccessibilityNode<NamedNode>(
-                snapshot,
-                (node) => node.name === 'Button'
-            ),
-            '`Button` is the label text'
-        ).to.not.be.null;
-
-        expect(el.pending).to.be.false;
-    });
-
-    it('manages tabIndex while disabled', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button href="test_url" target="_blank">With Target</sp-button>
-        `);
-
-        await elementUpdated(el);
-
-        expect(el.tabIndex).to.equal(0);
-
-        el.disabled = true;
-        await elementUpdated(el);
-
-        expect(el.tabIndex).to.equal(-1);
-
-        el.tabIndex = 2;
-        await elementUpdated(el);
-
-        expect(el.tabIndex).to.equal(-1);
-
-        el.disabled = false;
-        await elementUpdated(el);
-
-        expect(el.tabIndex).to.equal(2);
-    });
-    it('swallows `click` interaction when `[disabled]`', async () => {
-        const clickSpy = spy();
-        const el = await fixture<Button>(html`
-            <sp-button disabled @click=${() => clickSpy()}>Button</sp-button>
-        `);
-
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(0);
-
-        el.click();
-
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(0);
-    });
-    it('translates keyboard interactions to click', async () => {
-        const clickSpy = spy();
-        const el = await fixture<Button>(html`
-            <sp-button @click=${() => clickSpy()}>Button</sp-button>
-        `);
-
-        await elementUpdated(el);
-
-        el.dispatchEvent(
-            new KeyboardEvent('keypress', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'Enter',
-                key: 'Enter',
-            })
-        );
-
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(1);
-        clickSpy.resetHistory();
-
-        el.dispatchEvent(
-            new KeyboardEvent('keypress', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'NumpadEnter',
-                key: 'NumpadEnter',
-            })
-        );
-
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(1);
-        clickSpy.resetHistory();
-
-        el.dispatchEvent(
-            new KeyboardEvent('keypress', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'Space',
-                key: 'Space',
-            })
-        );
-
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(0);
-        clickSpy.resetHistory();
-
-        el.dispatchEvent(
-            new KeyboardEvent('keydown', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'Space',
-                key: 'Space',
-            })
-        );
-        el.dispatchEvent(
-            new KeyboardEvent('keyup', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'Space',
-                key: 'Space',
-            })
-        );
-
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(1);
-        clickSpy.resetHistory();
-
-        el.dispatchEvent(
-            new KeyboardEvent('keydown', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'Space',
-                key: 'Space',
-            })
-        );
-        el.dispatchEvent(
-            new KeyboardEvent('keyup', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'KeyG',
-                key: 'g',
-            })
-        );
-
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(0);
-
-        el.dispatchEvent(
-            new KeyboardEvent('keyup', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'Space',
-                key: 'Space',
-            })
-        );
-        clickSpy.resetHistory();
-
-        el.dispatchEvent(
-            new KeyboardEvent('keydown', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'KeyG',
-                key: 'g',
-            })
-        );
-        el.dispatchEvent(
-            new KeyboardEvent('keyup', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-                code: 'Space',
-                key: 'Space',
-            })
-        );
-
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(0);
-    });
-    it('proxies clicks by "type"', async () => {
-        const submitSpy = spy();
-        const resetSpy = spy();
-        const test = await fixture<HTMLFormElement>(html`
-            <form
-                @submit=${(event: Event): void => {
-                    event.preventDefault();
-                    submitSpy();
-                }}
-                @reset=${(event: Event): void => {
-                    event.preventDefault();
-                    resetSpy();
-                }}
-            >
-                <sp-button>Button</sp-button>
-            </form>
-        `);
-        const el = test.querySelector('sp-button') as Button;
-
-        await elementUpdated(el);
-        el.type = 'submit';
-
-        await elementUpdated(el);
-        el.click();
-
-        expect(submitSpy.callCount).to.equal(1);
-        expect(resetSpy.callCount).to.equal(0);
-
-        el.type = 'reset';
-
-        await elementUpdated(el);
-        el.click();
-
-        expect(submitSpy.callCount).to.equal(1);
-        expect(resetSpy.callCount).to.equal(1);
-
-        el.type = 'button';
-
-        await elementUpdated(el);
-        el.click();
-
-        expect(submitSpy.callCount).to.equal(1);
-        expect(resetSpy.callCount).to.equal(1);
-    });
-    it('proxies click by [href]', async () => {
-        const clickSpy = spy();
-        const el = await fixture<Button>(html`
-            <sp-button href="test_url">With Href</sp-button>
-        `);
-
-        await elementUpdated(el);
-        (
-            el as unknown as {
-                anchorElement: HTMLAnchorElement;
-            }
-        ).anchorElement.addEventListener('click', (event: Event): void => {
-            event.preventDefault();
-            event.stopPropagation();
-            clickSpy();
-        });
-        expect(clickSpy.callCount).to.equal(0);
-
-        el.click();
-        await elementUpdated(el);
-        expect(clickSpy.callCount).to.equal(1);
-    });
-    it('manages "active" while focused', async () => {
-        const el = await fixture<Button>(html`
-            <sp-button label="Button">
-                <svg slot="icon"></svg>
-            </sp-button>
-        `);
-
-        await elementUpdated(el);
-        el.focus();
-        await elementUpdated(el);
-        await sendKeys({
-            down: 'Space',
-        });
-        await elementUpdated(el);
-        expect(el.active).to.be.true;
-        await sendKeys({
-            up: 'Space',
-        });
-        await elementUpdated(el);
-        expect(el.active).to.be.false;
-    });
-    describe('deprecated variants and attributes', () => {
-        it('manages [quiet]', async () => {
-            const el = await fixture<Button>(html`
-                <sp-button quiet>Button</sp-button>
-            `);
-
-            await elementUpdated(el);
-            expect(el.treatment).to.equal('outline');
-
-            el.quiet = false;
-
-            await elementUpdated(el);
-            expect(el.treatment).to.equal('fill');
-        });
-        it('upgrades [variant="cta"] to [variant="accent"]', async () => {
-            const el = await fixture<Button>(html`
-                <sp-button variant="cta">Button</sp-button>
-            `);
-
-            await elementUpdated(el);
+            expect(el).to.not.be.undefined;
+            expect(el.textContent).to.include('Button');
+            await expect(el).to.be.accessible();
+
+            // Applies a default variant as an stylable attribute
             expect(el.variant).to.equal('accent');
+            expect(el.getAttribute('variant')).to.equal('accent');
         });
-        it('manages [variant="overBackground"]', async () => {
+        it('loads default w/ element content', async () => {
             const el = await fixture<Button>(html`
-                <sp-button variant="overBackground">Button</sp-button>
+                <sp-button label="Button"><svg></svg></sp-button>
             `);
 
             await elementUpdated(el);
-            expect(el.getAttribute('variant')).to.not.equal('overBackground');
-            expect(el.treatment).to.equal('outline');
-            expect(el.staticColor).to.equal('white');
+            expect(el).to.not.be.undefined;
+            await expect(el).to.be.accessible();
         });
-        ['white', 'black'].forEach((variant) => {
-            it(`manages [variant="${variant}"]`, async () => {
+        it('loads default w/ an icon', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button label="">
+                    Button
+                    <svg slot="icon"></svg>
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(el).to.not.be.undefined;
+            expect(el.textContent).to.include('Button');
+            expect(!(el as unknown as { hasIcon: boolean }).hasIcon);
+            await expect(el).to.be.accessible();
+        });
+        it('loads default only icon', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button label="Button" icon-only>
+                    <svg slot="icon"></svg>
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(el).to.not.be.undefined;
+            await expect(el).to.be.accessible();
+        });
+        it('has a stable/predictable `updateComplete`', async () => {
+            const test = await fixture<HTMLDivElement>(html`
+                <div></div>
+            `);
+
+            let keydownTime = -1;
+            let updateComplete1 = -1;
+            let updateComplete2 = -1;
+
+            const el = document.createElement('sp-button');
+            el.autofocus = true;
+            el.addEventListener('keydown', () => {
+                keydownTime = performance.now();
+            });
+            el.updateComplete.then(() => {
+                updateComplete1 = performance.now();
+            });
+            el.updateComplete.then(() => {
+                updateComplete2 = performance.now();
+            });
+            test.append(el);
+            // don't use elementUpdated(), as it is under test...
+            await nextFrame();
+            await nextFrame();
+            await nextFrame();
+            await nextFrame();
+
+            expect(keydownTime, 'keydown happened').to.not.eq(-1);
+            expect(updateComplete1, 'first update complete happened').to.not.eq(
+                -1
+            );
+            expect(updateComplete2, 'first update complete happened').to.not.eq(
+                -1
+            );
+            expect(updateComplete1).lte(updateComplete2);
+            expect(updateComplete2).lte(keydownTime);
+        });
+        it('manages "role"', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button>Button</sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(el.getAttribute('role')).to.equal('button');
+
+            el.setAttribute('href', '#');
+
+            await elementUpdated(el);
+            expect(el.getAttribute('role')).to.equal('link');
+
+            el.removeAttribute('href');
+
+            await elementUpdated(el);
+            expect(el.getAttribute('role')).to.equal('button');
+        });
+        it('allows label to be toggled', async () => {
+            const testNode = document.createTextNode('Button');
+            const el = await fixture<Button>(html`
+                <sp-button>
+                    ${testNode}
+                    <svg slot="icon"></svg>
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+
+            const labelTestableEl = el as unknown as TestableButtonType;
+
+            expect(labelTestableEl.hasLabel, 'starts with label').to.be.true;
+
+            testNode.textContent = '';
+
+            await elementUpdated(el);
+
+            await waitUntil(
+                () => !labelTestableEl.hasLabel,
+                'label is removed'
+            );
+
+            testNode.textContent = 'Button';
+
+            await elementUpdated(el);
+
+            expect(labelTestableEl.hasLabel, 'label is returned').to.be.true;
+        });
+        it('loads with href', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button href="test_url">With Href</sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(el).to.not.be.undefined;
+            expect(el.textContent).to.include('With Href');
+        });
+        it('loads with href and target', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button href="test_url" target="_blank">
+                    With Target
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(el).to.not.be.undefined;
+            expect(el.textContent).to.include('With Target');
+        });
+        it('accepts shit+tab interactions', async () => {
+            let focusedCount = 0;
+            const el = await fixture<Button>(html`
+                <sp-button href="test_url" target="_blank">
+                    With Target
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+            const input = document.createElement('input');
+            el.insertAdjacentElement('beforebegin', input);
+            input.focus();
+            expect(document.activeElement === input).to.be.true;
+
+            el.addEventListener('focus', () => {
+                focusedCount += 1;
+            });
+            expect(focusedCount).to.equal(0);
+
+            await sendKeys({
+                press: 'Tab',
+            });
+            await elementUpdated(el);
+
+            expect(document.activeElement === el).to.be.true;
+            expect(focusedCount).to.equal(1);
+
+            await sendKeys({
+                press: 'Shift+Tab',
+            });
+            await elementUpdated(el);
+
+            expect(focusedCount).to.equal(1);
+            expect(document.activeElement === input).to.be.true;
+        });
+        it('manages `disabled`', async () => {
+            const clickSpy = spy();
+            const el = await fixture<Button>(html`
+                <sp-button @click=${() => clickSpy()}>Button</sp-button>
+            `);
+
+            await elementUpdated(el);
+            el.click();
+            await elementUpdated(el);
+            expect(clickSpy.calledOnce).to.be.true;
+
+            clickSpy.resetHistory();
+            el.disabled = true;
+            await elementUpdated(el);
+            el.click();
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(0);
+
+            clickSpy.resetHistory();
+            await elementUpdated(el);
+            el.dispatchEvent(new Event('click', {}));
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(0);
+
+            clickSpy.resetHistory();
+            el.disabled = false;
+            el.click();
+            await elementUpdated(el);
+            expect(clickSpy.calledOnce).to.be.true;
+        });
+        it('`disabled` manages `tabindex`', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button disabled>Button</sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(el.tabIndex).to.equal(-1);
+            expect(el.getAttribute('tabindex')).to.equal('-1');
+
+            el.disabled = false;
+            await elementUpdated(el);
+
+            expect(el.tabIndex).to.equal(0);
+            expect(el.getAttribute('tabindex')).to.equal('0');
+
+            el.disabled = true;
+            await elementUpdated(el);
+
+            expect(el.tabIndex).to.equal(-1);
+            expect(el.getAttribute('tabindex')).to.equal('-1');
+        });
+        it('manages `aria-disabled`', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button href="test_url" target="_blank">
+                    With Target
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+
+            expect(el.hasAttribute('aria-disabled'), 'initially not').to.be
+                .false;
+
+            el.disabled = true;
+            await elementUpdated(el);
+
+            expect(el.getAttribute('aria-disabled')).to.equal('true');
+
+            el.disabled = false;
+            await elementUpdated(el);
+
+            expect(el.hasAttribute('aria-disabled'), 'finally not').to.be.false;
+        });
+        it('manages aria-label from disabled state', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button
+                    href="test_url"
+                    target="_blank"
+                    label="clickable"
+                    disabled
+                    pending-label="Pending Button"
+                >
+                    Click me
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+
+            expect(el.getAttribute('aria-label')).to.equal('clickable');
+
+            // button set to pending while disabled and the aria-label should stay the same
+            el.pending = true;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('clickable');
+
+            // button set to enabled while pending is true and the aria-label should update
+            el.disabled = false;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('Pending Button');
+
+            // pending is removed and the aria-label should be back to the original
+            el.pending = false;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('clickable');
+        });
+
+        it('manages aria-label from pending state', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button
+                    href="test_url"
+                    target="_blank"
+                    label="clickable"
+                    pending
+                >
+                    Click me
+                </sp-button>
+            `);
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('Pending');
+
+            // button set to disabled while pending is true and the aria-label should be original
+            el.disabled = true;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('clickable');
+
+            // pending is removed and the aria-label should not change as the button is disabled
+            el.pending = false;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('clickable');
+
+            // button is enabled and the aria-label should not change
+            el.disabled = false;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('clickable');
+        });
+
+        it('manages aria-label set from outside', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button
+                    href="test_url"
+                    target="_blank"
+                    aria-label="test"
+                    pending-label="Pending Button"
+                >
+                    Click me
+                </sp-button>
+            `);
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('test');
+
+            // button set to pending and aria-label should update
+            el.pending = true;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('Pending Button');
+
+            // button set to disabled while pending and aria-label should update
+            el.disabled = true;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('test');
+
+            // button set to enabled while pending and aria-label should update
+            el.disabled = false;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('Pending Button');
+
+            // pending removed and aria-label should update
+            el.pending = false;
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('test');
+        });
+
+        it('updates pending label accessibly', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button href="test_url" target="_blank">Button</sp-button>
+            `);
+
+            await elementUpdated(el);
+            el.pending = true;
+            await elementUpdated(el);
+
+            await nextFrame();
+
+            type NamedNode = { name: string };
+            let snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
+                children: NamedNode[];
+            };
+            expect(
+                findAccessibilityNode<NamedNode>(
+                    snapshot,
+                    (node) => node.name === 'Pending'
+                ),
+                '`Pending` is the label text'
+            ).to.not.be.null;
+
+            expect(el.pending).to.be.true;
+
+            // remove pending state
+            el.pending = false;
+            await elementUpdated(el);
+
+            await nextFrame();
+
+            snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
+                children: NamedNode[];
+            };
+
+            // check label returns to previous value
+            expect(
+                findAccessibilityNode<NamedNode>(
+                    snapshot,
+                    (node) => node.name === 'Button'
+                ),
+                '`Button` is the label text'
+            ).to.not.be.null;
+
+            expect(el.pending).to.be.false;
+        });
+
+        it('manages tabIndex while disabled', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button href="test_url" target="_blank">
+                    With Target
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+
+            expect(el.tabIndex).to.equal(0);
+
+            el.disabled = true;
+            await elementUpdated(el);
+
+            expect(el.tabIndex).to.equal(-1);
+
+            el.tabIndex = 2;
+            await elementUpdated(el);
+
+            expect(el.tabIndex).to.equal(-1);
+
+            el.disabled = false;
+            await elementUpdated(el);
+
+            expect(el.tabIndex).to.equal(2);
+        });
+        it('swallows `click` interaction when `[disabled]`', async () => {
+            const clickSpy = spy();
+            const el = await fixture<Button>(html`
+                <sp-button disabled @click=${() => clickSpy()}>
+                    Button
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(0);
+
+            el.click();
+
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(0);
+        });
+        it('translates keyboard interactions to click', async () => {
+            const clickSpy = spy();
+            const el = await fixture<Button>(html`
+                <sp-button @click=${() => clickSpy()}>Button</sp-button>
+            `);
+
+            await elementUpdated(el);
+
+            el.dispatchEvent(
+                new KeyboardEvent('keypress', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'Enter',
+                    key: 'Enter',
+                })
+            );
+
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(1);
+            clickSpy.resetHistory();
+
+            el.dispatchEvent(
+                new KeyboardEvent('keypress', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'NumpadEnter',
+                    key: 'NumpadEnter',
+                })
+            );
+
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(1);
+            clickSpy.resetHistory();
+
+            el.dispatchEvent(
+                new KeyboardEvent('keypress', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'Space',
+                    key: 'Space',
+                })
+            );
+
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(0);
+            clickSpy.resetHistory();
+
+            el.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'Space',
+                    key: 'Space',
+                })
+            );
+            el.dispatchEvent(
+                new KeyboardEvent('keyup', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'Space',
+                    key: 'Space',
+                })
+            );
+
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(1);
+            clickSpy.resetHistory();
+
+            el.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'Space',
+                    key: 'Space',
+                })
+            );
+            el.dispatchEvent(
+                new KeyboardEvent('keyup', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'KeyG',
+                    key: 'g',
+                })
+            );
+
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(0);
+
+            el.dispatchEvent(
+                new KeyboardEvent('keyup', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'Space',
+                    key: 'Space',
+                })
+            );
+            clickSpy.resetHistory();
+
+            el.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'KeyG',
+                    key: 'g',
+                })
+            );
+            el.dispatchEvent(
+                new KeyboardEvent('keyup', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    code: 'Space',
+                    key: 'Space',
+                })
+            );
+
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(0);
+        });
+        it('proxies clicks by "type"', async () => {
+            const submitSpy = spy();
+            const resetSpy = spy();
+            const test = await fixture<HTMLFormElement>(html`
+                <form
+                    @submit=${(event: Event): void => {
+                        event.preventDefault();
+                        submitSpy();
+                    }}
+                    @reset=${(event: Event): void => {
+                        event.preventDefault();
+                        resetSpy();
+                    }}
+                >
+                    <sp-button>Button</sp-button>
+                </form>
+            `);
+            const el = test.querySelector('sp-button') as Button;
+
+            await elementUpdated(el);
+            el.type = 'submit';
+
+            await elementUpdated(el);
+            el.click();
+
+            expect(submitSpy.callCount).to.equal(1);
+            expect(resetSpy.callCount).to.equal(0);
+
+            el.type = 'reset';
+
+            await elementUpdated(el);
+            el.click();
+
+            expect(submitSpy.callCount).to.equal(1);
+            expect(resetSpy.callCount).to.equal(1);
+
+            el.type = 'button';
+
+            await elementUpdated(el);
+            el.click();
+
+            expect(submitSpy.callCount).to.equal(1);
+            expect(resetSpy.callCount).to.equal(1);
+        });
+        it('proxies click by [href]', async () => {
+            const clickSpy = spy();
+            const el = await fixture<Button>(html`
+                <sp-button href="test_url">With Href</sp-button>
+            `);
+
+            await elementUpdated(el);
+            (
+                el as unknown as {
+                    anchorElement: HTMLAnchorElement;
+                }
+            ).anchorElement.addEventListener('click', (event: Event): void => {
+                event.preventDefault();
+                event.stopPropagation();
+                clickSpy();
+            });
+            expect(clickSpy.callCount).to.equal(0);
+
+            el.click();
+            await elementUpdated(el);
+            expect(clickSpy.callCount).to.equal(1);
+        });
+        it('manages "active" while focused', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button label="Button">
+                    <svg slot="icon"></svg>
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+            el.focus();
+            await elementUpdated(el);
+            await sendKeys({
+                down: 'Space',
+            });
+            await elementUpdated(el);
+            expect(el.active).to.be.true;
+            await sendKeys({
+                up: 'Space',
+            });
+            await elementUpdated(el);
+            expect(el.active).to.be.false;
+        });
+        describe('deprecated variants and attributes', () => {
+            it('manages [quiet]', async () => {
                 const el = await fixture<Button>(html`
-                    <sp-button variant="${variant as 'white' | 'black'}">
-                        Button
-                    </sp-button>
+                    <sp-button quiet>Button</sp-button>
                 `);
 
                 await elementUpdated(el);
-                expect(el.hasAttribute('variant')).to.not.equal(variant);
-                expect(el.staticColor).to.equal(variant);
-                expect(el.getAttribute('static-color')).to.equal(variant);
-            });
-        });
-        it('forces [variant="accent"]', async () => {
-            const el = await fixture<Button>(html`
-                <sp-button variant="not-supported">Button</sp-button>
-            `);
+                expect(el.treatment).to.equal('outline');
 
-            await elementUpdated(el);
-            expect(el.variant).to.equal('accent');
+                el.quiet = false;
+
+                await elementUpdated(el);
+                expect(el.treatment).to.equal('fill');
+            });
+            it('upgrades [variant="cta"] to [variant="accent"]', async () => {
+                const el = await fixture<Button>(html`
+                    <sp-button variant="cta">Button</sp-button>
+                `);
+
+                await elementUpdated(el);
+                expect(el.variant).to.equal('accent');
+            });
+            it('manages [variant="overBackground"]', async () => {
+                const el = await fixture<Button>(html`
+                    <sp-button variant="overBackground">Button</sp-button>
+                `);
+
+                await elementUpdated(el);
+                expect(el.getAttribute('variant')).to.not.equal(
+                    'overBackground'
+                );
+                expect(el.treatment).to.equal('outline');
+                expect(el.staticColor).to.equal('white');
+            });
+            ['white', 'black'].forEach((variant) => {
+                it(`manages [variant="${variant}"]`, async () => {
+                    const el = await fixture<Button>(html`
+                        <sp-button variant="${variant as 'white' | 'black'}">
+                            Button
+                        </sp-button>
+                    `);
+
+                    await elementUpdated(el);
+                    expect(el.hasAttribute('variant')).to.not.equal(variant);
+                    expect(el.staticColor).to.equal(variant);
+                    expect(el.getAttribute('static-color')).to.equal(variant);
+                });
+            });
+            it('forces [variant="accent"]', async () => {
+                const el = await fixture<Button>(html`
+                    <sp-button variant="not-supported">Button</sp-button>
+                `);
+
+                await elementUpdated(el);
+                expect(el.variant).to.equal('accent');
+            });
         });
     });
 });

--- a/packages/coachmark/src/CoachIndicator.ts
+++ b/packages/coachmark/src/CoachIndicator.ts
@@ -30,12 +30,6 @@ export class CoachIndicator extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public quiet = false;
 
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ reflect: true })
-    public static?: 'white' | 'black';
-
     @property({ reflect: true, attribute: 'static-color' })
     public staticColor?: 'white' | 'black';
 
@@ -60,22 +54,8 @@ export class CoachIndicator extends SpectrumElement {
             if (window.__swc.DEBUG) {
                 window.__swc.warn(
                     this,
-                    `The "variant" attribute/property of <${this.localName}> have been deprecated. Use "static" with any of the same values instead. "variant" will be removed in a future release.`,
+                    `The "variant" attribute/property of <${this.localName}> have been deprecated. Use "static-color" with any of the same values instead. "variant" will be removed in a future release.`,
                     'https://opensource.adobe.com/spectrum-web-components/components/badge/#fixed',
-                    { level: 'deprecation' }
-                );
-            }
-        }
-        if (
-            changes.has('static') &&
-            (this.static || typeof changes.get('static'))
-        ) {
-            this.staticColor = this.static;
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "static" attribute/property of <${this.localName}> have been deprecated. Use "static-color" with any of the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/coach-indicator',
                     { level: 'deprecation' }
                 );
             }

--- a/packages/coachmark/test/coach-indicator.test.ts
+++ b/packages/coachmark/test/coach-indicator.test.ts
@@ -30,14 +30,6 @@ describe('CoachIndicator', () => {
         await elementUpdated(el);
         await expect(el).to.be.accessible();
     });
-    it('loads coach-indicator white static-color when static is set', async () => {
-        const el = await fixture<CoachIndicator>(html`
-            <sp-coach-indicator static="white"></sp-coach-indicator>
-        `);
-        await elementUpdated(el);
-        expect(el.staticColor == 'white').to.be.true;
-        expect(el.getAttribute('static-color')).to.equal('white');
-    });
     it('loads coach-indicator white static-color variant', async () => {
         const el = await fixture<CoachIndicator>(html`
             <sp-coach-indicator variant="white"></sp-coach-indicator>
@@ -59,27 +51,6 @@ describe('dev mode', () => {
     after(() => {
         window.__swc.verbose = false;
         consoleWarnStub.restore();
-    });
-
-    it('warns in Dev Mode when deprecated `static` attribute is used', async () => {
-        const el = await fixture<CoachIndicator>(html`
-            <sp-coach-indicator static="white"></sp-coach-indicator>
-        `);
-        await elementUpdated(el);
-        expect(consoleWarnStub.called).to.be.true;
-
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            (spyCall.args.at(0) as string).includes('deprecated'),
-            'confirm deprecated static warning'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-coach-indicator',
-                type: 'api',
-                level: 'deprecation',
-            },
-        });
     });
 
     it('warns in Dev Mode when deprecated `variant` attribute is used', async () => {

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -62,7 +62,7 @@ This is a <sp-link href="#" variant="secondary">secondary link</sp-link>.
 
 ### Static colored links
 
-When a link needs to be placed on top of a colored background or a visual it may be appropriate to ship it with a static color, regardless of the theme settings with which it is delivered. Leverage the `static` attribute with its `white` or `black` values to ensure the delivery is the same in all contexts.
+When a link needs to be placed on top of a colored background or a visual it may be appropriate to ship it with a static color, regardless of the theme settings with which it is delivered. Leverage the `static-color` attribute with its `white` or `black` values to ensure the delivery is the same in all contexts.
 
 <sp-tabs selected="white" auto label="Static Attribute Options">
 <sp-tab value="white">White</sp-tab>

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -10,11 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import {
-    CSSResultArray,
-    PropertyValues,
-    TemplateResult,
-} from '@spectrum-web-components/base';
+import { CSSResultArray, TemplateResult } from '@spectrum-web-components/base';
 import {
     property,
     query,
@@ -38,12 +34,6 @@ export class Link extends LikeAnchor(Focusable) {
     @property({ type: String, reflect: true })
     public variant: 'secondary' | undefined;
 
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ type: String, reflect: true })
-    public static: 'black' | 'white' | undefined;
-
     @property({ reflect: true, attribute: 'static-color' })
     public staticColor?: 'black' | 'white';
 
@@ -59,23 +49,5 @@ export class Link extends LikeAnchor(Focusable) {
 
     protected override render(): TemplateResult {
         return this.renderAnchor({ id: 'anchor' });
-    }
-
-    protected override updated(changes: PropertyValues): void {
-        super.updated(changes);
-        if (
-            changes.has('static') &&
-            (this.static !== undefined || changes.get('static') !== undefined)
-        ) {
-            this.staticColor = this.static;
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "static" attribute of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/link/api/',
-                    { level: 'deprecation' }
-                );
-            }
-        }
     }
 }

--- a/packages/link/test/link.test.ts
+++ b/packages/link/test/link.test.ts
@@ -14,7 +14,7 @@ import '@spectrum-web-components/link/sp-link.js';
 import { Link } from '@spectrum-web-components/link';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
-import { spy, stub } from 'sinon';
+import { spy } from 'sinon';
 
 describe('Link', () => {
     testForLitDevWarnings(
@@ -75,54 +75,5 @@ describe('Link', () => {
         await expect(el).to.be.accessible();
         el.click();
         expect(clickSpy.callCount).to.equal(0);
-    });
-
-    it('prefers `staticColor` over `static`', async () => {
-        const el = await fixture<Link>(html`
-            <sp-link static="white" href="test_url">Default Link</sp-link>
-        `);
-        await elementUpdated(el);
-        expect(el.staticColor).to.equal('white');
-        el.setAttribute('static', 'white');
-        await elementUpdated(el);
-        expect(el.staticColor).to.equal('white');
-        expect(el.static).to.equal('white');
-        expect(el.getAttribute('static-color')).to.equal('white');
-    });
-});
-
-describe('dev mode', () => {
-    let consoleWarnStub!: ReturnType<typeof stub>;
-    before(() => {
-        window.__swc.verbose = true;
-        consoleWarnStub = stub(console, 'warn');
-    });
-    afterEach(() => {
-        consoleWarnStub.resetHistory();
-    });
-    after(() => {
-        window.__swc.verbose = false;
-        consoleWarnStub.restore();
-    });
-
-    it('warns in Dev Mode when deprecated `static` attribute is used', async () => {
-        const el = await fixture<Link>(html`
-            <sp-link static="white" href="test_url">Default Link</sp-link>
-        `);
-        await elementUpdated(el);
-        expect(consoleWarnStub.called).to.be.true;
-
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            (spyCall.args.at(0) as string).includes('deprecated'),
-            'confirm deprecated static warning'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-link',
-                type: 'api',
-                level: 'deprecation',
-            },
-        });
     });
 });

--- a/packages/meter/src/Meter.ts
+++ b/packages/meter/src/Meter.ts
@@ -89,12 +89,6 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, ''), {
     // called sideLabel
     public sideLabel = false;
 
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ type: String, reflect: true })
-    public static: 'white' | undefined;
-
     @property({ reflect: true, attribute: 'static-color' })
     public staticColor?: 'white';
 
@@ -141,20 +135,6 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, ''), {
                 this.setAttribute('aria-label', this.label);
             } else {
                 this.removeAttribute('aria-label');
-            }
-        }
-        if (
-            changes.has('static') &&
-            (this.static !== undefined || changes.get('static') !== undefined)
-        ) {
-            this.staticColor = this.static;
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "static" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/meter/api/',
-                    { level: 'deprecation' }
-                );
             }
         }
     }

--- a/packages/meter/test/meter.test.ts
+++ b/packages/meter/test/meter.test.ts
@@ -16,7 +16,6 @@ import '@spectrum-web-components/meter/sp-meter.js';
 import { Meter, meterVariants } from '@spectrum-web-components/meter';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 import { createLanguageContext } from '../../../tools/reactive-controllers/test/helpers.js';
-import { stub } from 'sinon';
 
 describe('Meter', () => {
     testForLitDevWarnings(
@@ -154,54 +153,5 @@ describe('Meter', () => {
 
         await elementUpdated(el);
         expect(el.variant).to.equal(meterVariants[0]);
-    });
-
-    it('prefers `staticColor` over `static`', async () => {
-        const el = await fixture<Meter>(html`
-            <sp-meter static="white" label="Loading"></sp-meter>
-        `);
-        await elementUpdated(el);
-        expect(el.staticColor).to.equal('white');
-        el.setAttribute('static', 'white');
-        await elementUpdated(el);
-        expect(el.staticColor).to.equal('white');
-        expect(el.static).to.equal('white');
-        expect(el.getAttribute('static-color')).to.equal('white');
-    });
-});
-
-describe('dev mode', () => {
-    let consoleWarnStub!: ReturnType<typeof stub>;
-    before(() => {
-        window.__swc.verbose = true;
-        consoleWarnStub = stub(console, 'warn');
-    });
-    afterEach(() => {
-        consoleWarnStub.resetHistory();
-    });
-    after(() => {
-        window.__swc.verbose = false;
-        consoleWarnStub.restore();
-    });
-
-    it('warns in Dev Mode when deprecated `static` attribute is used', async () => {
-        const el = await fixture<Meter>(html`
-            <sp-meter static="white" label="Loading"></sp-meter>
-        `);
-        await elementUpdated(el);
-        expect(consoleWarnStub.called).to.be.true;
-
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            (spyCall.args.at(0) as string).includes('deprecated'),
-            'confirm deprecated static warning'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-meter',
-                type: 'api',
-                level: 'deprecation',
-            },
-        });
     });
 });

--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -60,12 +60,6 @@ export class ProgressBar extends SizedMixin(
     @property({ type: Number })
     public progress = 0;
 
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ type: String, reflect: true })
-    public static: 'white' | undefined;
-
     @property({ reflect: true, attribute: 'static-color' })
     public staticColor?: 'white';
 
@@ -128,20 +122,6 @@ export class ProgressBar extends SizedMixin(
 
     protected override updated(changes: PropertyValues): void {
         super.updated(changes);
-        if (
-            changes.has('static') &&
-            (this.static !== undefined || changes.get('static') !== undefined)
-        ) {
-            this.staticColor = this.static;
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "static" attribute of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/progress-bar/api/',
-                    { level: 'deprecation' }
-                );
-            }
-        }
         if (changes.has('indeterminate')) {
             if (this.indeterminate) {
                 this.removeAttribute('aria-valuemin');

--- a/packages/progress-circle/README.md
+++ b/packages/progress-circle/README.md
@@ -51,9 +51,9 @@ An `<sp-progress-circle>` is used to visually show the progression of a system o
 </div>
 ```
 
-### Static
+### Static color
 
-If you display your `<sp-progress-cicle>` element over the top of other content, e.g. an image or an alternate background color, it may become appropariate to update the colors with which the circle and loading progress indicator are delivered. To do this, leverage the `static` attribute with the value of `white` to ensure the content of your page is being delivered accessibly.
+If you display your `<sp-progress-cicle>` element over the top of other content, e.g. an image or an alternate background color, it may become appropariate to update the colors with which the circle and loading progress indicator are delivered. To do this, leverage the `static-color` attribute with the value of `white` to ensure the content of your page is being delivered accessibly.
 
 ```html
 <div

--- a/packages/progress-circle/src/ProgressCircle.ts
+++ b/packages/progress-circle/src/ProgressCircle.ts
@@ -49,12 +49,6 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
     @property({ type: Boolean, reflect: true, attribute: 'over-background' })
     public overBackground = false;
 
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ reflect: true })
-    public static?: 'white';
-
     @property({ reflect: true, attribute: 'static-color' })
     public staticColor?: 'white';
 
@@ -82,21 +76,6 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
                     window.__swc.warn(
                         this,
                         `<${this.localName}> element will stop accepting the "over-background" attribute, and its related "overBackground" property in a future release. Use the "static-color" attribute with a value of "white" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/progress-circle/#static',
-                        { level: 'deprecation' }
-                    );
-                }
-            }
-        }
-        if (changes.has('static')) {
-            // Apply "staticColor" from "static", preferring "staticColor",
-            // until the deprecation period is over.
-            this.staticColor = this.static;
-            if (window.__swc.DEBUG) {
-                if (this.static) {
-                    window.__swc.warn(
-                        this,
-                        `<${this.localName}> element will stop accepting the "static" attribute. Use the "static-color" attribute with a value of "white" instead.`,
                         'https://opensource.adobe.com/spectrum-web-components/components/progress-circle/#static',
                         { level: 'deprecation' }
                     );

--- a/packages/progress-circle/test/progress-circle.test.ts
+++ b/packages/progress-circle/test/progress-circle.test.ts
@@ -59,32 +59,6 @@ describe('ProgressCircle', () => {
                 },
             });
         });
-        it('warns in Dev Mode when static attribute is supplied', async () => {
-            const el = await fixture<ProgressCircle>(html`
-                <sp-progress-circle
-                    progress="50"
-                    static="white"
-                ></sp-progress-circle>
-            `);
-
-            await elementUpdated(el);
-
-            expect(consoleWarnStub.called).to.be.true;
-            const spyCall = consoleWarnStub.getCall(0);
-            expect(
-                (spyCall.args.at(0) as string).includes(
-                    'element will stop accepting the "static" attribute'
-                ),
-                'confirm attribute deprecation message'
-            ).to.be.true;
-            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-                data: {
-                    localName: 'sp-progress-circle',
-                    type: 'api',
-                    level: 'deprecation',
-                },
-            });
-        });
         it('warns in Dev Mode when overBackground attribute is supplied', async () => {
             const el = await fixture<ProgressCircle>(html`
                 <sp-progress-circle
@@ -209,24 +183,5 @@ describe('ProgressCircle', () => {
 
         expect(el.hasAttribute('aria-label')).to.be.true;
         expect(el.getAttribute('aria-label')).to.equal('Loading');
-    });
-    it('prefers `staticColor` over `static`', async () => {
-        const el = await fixture<ProgressCircle>(html`
-            <sp-progress-circle
-                progress="50"
-                static="white"
-            ></sp-progress-circle>
-        `);
-
-        await elementUpdated(el);
-
-        expect(el.staticColor).to.equal('white');
-
-        el.setAttribute('static', 'white');
-        await elementUpdated(el);
-
-        expect(el.staticColor).to.equal('white');
-        expect(el.static).to.equal('white');
-        expect(el.getAttribute('static-color')).to.equal('white');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We added `staticColor` to replace the `static` property, while at the same time, deprecating it (https://github.com/adobe/spectrum-web-components/pull/4808). So now we need to remove this new deprecation for 1.0.0 along with all its references.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- Task: [SWC-302](https://jira.corp.adobe.com/browse/SWC-302)
- Subtask: [SWC-542](https://jira.corp.adobe.com/browse/SWC-542)

## Motivation and context

For the upcoming 1.0.0 release of Spectrum Web Components, we will remove the deprecated components and features.

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
