### PR TITLE
fix: add icon-search for s1 and s2

### DIFF
--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -25,7 +25,7 @@ import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
 import { Textfield } from '@spectrum-web-components/textfield';
 import '@spectrum-web-components/button/sp-clear-button.js';
-import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-search.js';
 
 import searchStyles from './search.css.js';
 
@@ -114,9 +114,9 @@ export class Search extends Textfield {
                 @reset=${this.reset}
                 @keydown=${this.handleKeydown}
             >
-                <sp-icon-magnify
+                <sp-icon-search
                     class="icon magnifier icon-workflow icon-search"
-                ></sp-icon-magnify>
+                ></sp-icon-search>
                 ${super.renderField()}
                 ${this.value
                     ? html`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated `sp-icon-magnify` from SearchBar to `sp-icon-search` to maintain compatibility between three themes

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- N/A

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?
`sp-icon-magnify` is defaulting to DefaultIcon in S2 which is a bad UX for documentation site.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_

    1. Go here
    2. Do this

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
