### PR TITLE
feat(date-time-picker): events and invalid triggering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: ef7c7c0e0b5827a2f5e95bf6aba539959453f5dc
+        default: f4162e996c90be272af90b6ffdc1b5b9d350f56e
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -63,10 +63,10 @@
     "dependencies": {
         "@internationalized/date": "^3.5.1",
         "@internationalized/number": "^3.1.0",
-        "@spectrum-web-components/action-button": "^0.47.2",
-        "@spectrum-web-components/base": "^0.47.2",
-        "@spectrum-web-components/icons-workflow": "^0.47.2",
-        "@spectrum-web-components/reactive-controllers": "^0.47.2"
+        "@spectrum-web-components/action-button": "0.49.0",
+        "@spectrum-web-components/base": "0.49.0",
+        "@spectrum-web-components/icons-workflow": "0.49.0",
+        "@spectrum-web-components/reactive-controllers": "0.49.0"
     },
     "devDependencies": {
         "@spectrum-css/calendar": "^4.2.4"

--- a/packages/calendar/test/calendar.test.ts
+++ b/packages/calendar/test/calendar.test.ts
@@ -624,20 +624,20 @@ describe('Calendar', () => {
 
     describe('Dispatched change', () => {
         let changeSpy: sinon.SinonSpy;
-        let availableDateToSelect: CalendarDate;
         let availableDayElement: HTMLElement;
+        const availableDateToSelect = new CalendarDate(
+            fixedYear,
+            fixedMonth,
+            fixedDay + 1
+        );
 
         beforeEach(() => {
+            changeSpy = spy();
             element.addEventListener('change', changeSpy);
-            availableDateToSelect = new CalendarDate(
-                fixedYear,
-                fixedMonth,
-                fixedDay + 1
-            );
+
             availableDayElement = element.shadowRoot.querySelector(
                 `[data-value='${availableDateToSelect.toString()}']`
             ) as HTMLElement;
-            changeSpy = spy();
         });
 
         it("should dispatch 'change' when an available day is selected by clicking", async () => {

--- a/packages/calendar/test/calendar.test.ts
+++ b/packages/calendar/test/calendar.test.ts
@@ -627,10 +627,6 @@ describe('Calendar', () => {
         let availableDateToSelect: CalendarDate;
         let availableDayElement: HTMLElement;
 
-        before(() => {
-            changeSpy = spy();
-        });
-
         beforeEach(() => {
             element.addEventListener('change', changeSpy);
             availableDateToSelect = new CalendarDate(
@@ -641,10 +637,7 @@ describe('Calendar', () => {
             availableDayElement = element.shadowRoot.querySelector(
                 `[data-value='${availableDateToSelect.toString()}']`
             ) as HTMLElement;
-        });
-
-        afterEach(() => {
-            changeSpy.resetHistory();
+            changeSpy = spy();
         });
 
         it("should dispatch 'change' when an available day is selected by clicking", async () => {

--- a/packages/calendar/test/helpers.ts
+++ b/packages/calendar/test/helpers.ts
@@ -25,7 +25,12 @@ export async function fixtureElement({
     props?: { [prop: string]: unknown };
 } = {}): Promise<Calendar> {
     const wrapped = await fixture<HTMLElement>(html`
-        <sp-theme lang=${locale} color="light" scale="medium">
+        <sp-theme
+            system=${'spectrum'}
+            lang=${locale}
+            color="light"
+            scale="medium"
+        >
             <sp-calendar ...=${spreadProps(props)}></sp-calendar>
         </sp-theme>
     `);

--- a/packages/date-time-picker/package.json
+++ b/packages/date-time-picker/package.json
@@ -66,11 +66,11 @@
     ],
     "dependencies": {
         "@spectrum-web-components/calendar": "^0.0.1",
-        "@spectrum-web-components/field-label": "^0.47.2",
-        "@spectrum-web-components/icons-workflow": "^0.47.2",
-        "@spectrum-web-components/overlay": "^0.47.2",
-        "@spectrum-web-components/picker-button": "^0.47.2",
-        "@spectrum-web-components/popover": "^0.47.2"
+        "@spectrum-web-components/field-label": "^0.49.0",
+        "@spectrum-web-components/icons-workflow": "^0.49.0",
+        "@spectrum-web-components/overlay": "^0.49.0",
+        "@spectrum-web-components/picker-button": "^0.49.0",
+        "@spectrum-web-components/popover": "^0.49.0"
     },
     "devDependencies": {
         "@spectrum-css/datepicker": "^3.2.1"

--- a/packages/date-time-picker/src/DateTimePicker.ts
+++ b/packages/date-time-picker/src/DateTimePicker.ts
@@ -671,7 +671,12 @@ export class DateTimePicker extends ManageHelpText(
             this.value === undefined &&
             this.previousCommitedValue === undefined
         ) {
-            this.invalid = true;
+            const allSegmentsEmpty = this.segments.editableValues.every(
+                (value) => value === undefined
+            );
+            if (allSegmentsEmpty) this.invalid = false;
+            else this.invalid = true;
+
             return;
         }
 

--- a/packages/date-time-picker/src/DateTimePicker.ts
+++ b/packages/date-time-picker/src/DateTimePicker.ts
@@ -286,23 +286,26 @@ export class DateTimePicker extends ManageHelpText(
             }
         }
 
-        if (this.value) {
-            const isNonCompliantValue =
-                (this.min && this.value.compare(this.min) < 0) ||
-                (this.max && this.value.compare(this.max) > 0);
-
-            if (isNonCompliantValue) {
-                window.__swc.warn(
-                    this,
-                    `<${this.localName}> expects the preselected value to comply with the min and max constraints. Please ensure that 'value' property's date is in between the dates for the 'min' and 'max' properties.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/date-time-picker' // TODO: update link
-                );
-                this.value = undefined;
-            }
+        if (this.isNonCompliantValue()) {
+            window.__swc.warn(
+                this,
+                `<${this.localName}> expects the preselected value to comply with the min and max constraints. Please ensure that 'value' property's date is in between the dates for the 'min' and 'max' properties.`,
+                'https://opensource.adobe.com/spectrum-web-components/components/date-time-picker' // TODO: update link
+            );
+            this.value = undefined;
         }
 
         if (!this.min && !this.max && !this.value)
             this.timeZone = getLocalTimeZone();
+    }
+
+    private isNonCompliantValue(): boolean {
+        if (this.value === undefined) return false;
+
+        return Boolean(
+            (this.min && this.value.compare(this.min) < 0) ||
+                (this.max && this.value.compare(this.max) > 0)
+        );
     }
 
     protected override willUpdate(changedProperties: PropertyValues): void {
@@ -667,8 +670,14 @@ export class DateTimePicker extends ManageHelpText(
         if (
             this.value === undefined &&
             this.previousCommitedValue === undefined
-        )
+        ) {
+            this.invalid = true;
             return;
+        }
+
+        if (this.value === undefined || this.isNonCompliantValue())
+            this.invalid = true;
+        else this.invalid = false;
 
         this.previousCommitedValue = this.value;
         this.dispatchChange();

--- a/packages/date-time-picker/src/helpers.ts
+++ b/packages/date-time-picker/src/helpers.ts
@@ -44,3 +44,12 @@ export function convertHourTo24hFormat(
 export function getDayPeriodModifier(hour: number): typeof AM | typeof PM {
     return hour >= PM ? PM : AM;
 }
+
+export function equalSegmentValues(
+    a: (number | undefined)[],
+    b: (number | undefined)[]
+): boolean {
+    return (
+        a.length === b.length && a.every((value, index) => value === b[index])
+    );
+}

--- a/packages/date-time-picker/src/segments/DateTimeSegments.ts
+++ b/packages/date-time-picker/src/segments/DateTimeSegments.ts
@@ -40,6 +40,14 @@ export class DateTimeSegments {
         return this.segments;
     }
 
+    public get editableValues(): (number | undefined)[] {
+        return (
+            this.all.filter(
+                (segment) => segment instanceof EditableSegment
+            ) as EditableSegment[]
+        ).map((segment) => segment.value);
+    }
+
     public get year(): YearSegment | undefined {
         const yearSegment = this.getByType(SegmentTypes.Year);
         if (yearSegment) return yearSegment as YearSegment;

--- a/packages/date-time-picker/src/segments/SegmentsFactory.ts
+++ b/packages/date-time-picker/src/segments/SegmentsFactory.ts
@@ -29,9 +29,14 @@ export class SegmentsFactory {
         this.dateFormatter = dateFormatter;
     }
 
+    /**
+     * Creates the `DateTimeSegments` needed for the DateTimePicker
+     * @param currentDate - The date to create the segments from. This is used to set the limits and values of the segments.
+     * @param setValues - If true, the segments will have their values set from the currentDate. If false, the segments will have no values.
+     */
     createSegments(
         currentDate: ZonedDateTime,
-        shouldSetSegmentsValues: boolean = false
+        setValues: boolean = false
     ): DateTimeSegments {
         const date = new Date(
             currentDate.year,
@@ -59,13 +64,13 @@ export class SegmentsFactory {
 
         year.setLimits(currentDate);
         month.setLimits(currentDate);
-        if (shouldSetSegmentsValues) {
+        if (setValues) {
             year.setValueFromDate(currentDate);
             month.setValueFromDate(currentDate);
         }
 
         day.setLimits(currentDate, month.value, year.value);
-        if (shouldSetSegmentsValues) day.setValueFromDate(currentDate);
+        if (setValues) day.setValueFromDate(currentDate);
 
         const hour = segments.hour;
         const minute = segments.minute;
@@ -78,7 +83,7 @@ export class SegmentsFactory {
 
         const is12HourFormat = Boolean(dayPeriod);
         hour.setLimits(is12HourFormat);
-        if (shouldSetSegmentsValues) {
+        if (setValues) {
             hour.setValueFromDate(currentDate, is12HourFormat);
 
             if (is12HourFormat) {

--- a/packages/date-time-picker/src/segments/SegmentsFormatter.ts
+++ b/packages/date-time-picker/src/segments/SegmentsFormatter.ts
@@ -38,6 +38,11 @@ export class SegmentsFormatter {
         this.currentDate = currentDate;
     }
 
+    /**
+     * Formats all the `DateTimeSegments` to have the formatted property based on the value property, according to the date formatter.
+     * @param segments - `DateTimeSegments` to format
+     * @returns Formatted DateTimeSegments
+     */
     public format(segments: DateTimeSegments): DateTimeSegments {
         if (!segments.year || !segments.month || !segments.day) return segments;
 

--- a/packages/date-time-picker/stories/date-time-picker.stories.ts
+++ b/packages/date-time-picker/stories/date-time-picker.stories.ts
@@ -46,7 +46,8 @@ type ComponentArgs = {
 };
 
 type StoryArgs = ComponentArgs & {
-    onChange?: (dateTime: Date) => void;
+    onChange?: () => void;
+    onInput?: () => void;
 };
 
 const storyMeta = {
@@ -109,7 +110,7 @@ const storyMeta = {
     },
     parameters: {
         actions: {
-            handles: ['onChange'],
+            handles: ['onChange', 'onInput'],
         },
     },
 };
@@ -142,6 +143,7 @@ const Template = (args: StoryArgs = {}): TemplateResult => {
         <sp-date-time-picker
             ...=${spreadProps(args)}
             @change=${args.onChange}
+            @input=${args.onInput}
         ></sp-date-time-picker>
     `;
 };
@@ -262,12 +264,11 @@ export const negativeHelpText = (args: StoryArgs): TemplateResult => {
     return html`
         <sp-date-time-picker
             ...=${spreadProps(args)}
-            .value=${new CalendarDate(2020, 2, 14)}
             .min=${new CalendarDate(2020, 0, 1)}
             .max=${new CalendarDate(2025, 0, 1)}
         >
             <sp-help-text slot="help-text">
-                Select a date for your event
+                Change state to invalid to see the negative help text
             </sp-help-text>
             <sp-help-text slot="negative-help-text">
                 Please select a date between 2020 and 2025
@@ -275,7 +276,7 @@ export const negativeHelpText = (args: StoryArgs): TemplateResult => {
         </sp-date-time-picker>
     `;
 };
-minAndMaxDates.argTypes = dateControlsDisabledArgTypes;
+negativeHelpText.argTypes = dateControlsDisabledArgTypes;
 
 export const customIcon = (): TemplateResult => {
     return html`

--- a/packages/date-time-picker/test/date-time-picker.test.ts
+++ b/packages/date-time-picker/test/date-time-picker.test.ts
@@ -3158,17 +3158,17 @@ describe('DateTimePicker', () => {
                 props: { min, max, value: min },
             });
             editableSegments = getEditableSegments(element);
-            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
-            yearSegment.focus();
-            await sendKeys({ type: (min.year - 1).toString() });
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            daySegment.focus();
+            await sendKeys({ type: (min.day - 1).toString() });
             await elementUpdated(element);
+
             expect(element.invalid).to.be.false;
 
             await sendKeys({ press: 'Enter' });
             await elementUpdated(element);
 
             expect(element.invalid).to.be.true;
-            expectPlaceholders(editableSegments, [yearSegment]);
         });
 
         it("should stop the 'invalid' state when a value that does comply is commited using Enter", async () => {
@@ -3176,15 +3176,14 @@ describe('DateTimePicker', () => {
                 props: { min, max, value: min },
             });
             editableSegments = getEditableSegments(element);
-            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
-            yearSegment.focus();
-            await sendKeys({ type: (min.year - 1).toString() });
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            daySegment.focus();
+            await sendKeys({ type: (min.day - 1).toString() });
             await elementUpdated(element);
             await sendKeys({ press: 'Enter' });
             await elementUpdated(element);
 
-            await sendKeys({ press: 'ArrowUp' });
-            await sendKeys({ press: 'ArrowUp' });
+            await sendKeys({ type: (min.day + 1).toString() });
             await elementUpdated(element);
             await sendKeys({ press: 'Enter' });
             await elementUpdated(element);
@@ -3197,9 +3196,9 @@ describe('DateTimePicker', () => {
                 props: { min, max, value: min },
             });
             editableSegments = getEditableSegments(element);
-            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
-            yearSegment.focus();
-            await sendKeys({ type: (min.year - 1).toString() });
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            daySegment.focus();
+            await sendKeys({ type: (min.day - 1).toString() });
             await elementUpdated(element);
             expect(element.invalid).to.be.false;
 
@@ -3207,7 +3206,6 @@ describe('DateTimePicker', () => {
             await elementUpdated(element);
 
             expect(element.invalid).to.be.true;
-            expectPlaceholders(editableSegments, [yearSegment]);
         });
 
         it("should stop the 'invalid' state when a value that does comply is commited using Space", async () => {
@@ -3215,15 +3213,14 @@ describe('DateTimePicker', () => {
                 props: { min, max, value: min },
             });
             editableSegments = getEditableSegments(element);
-            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
-            yearSegment.focus();
-            await sendKeys({ type: (min.year - 1).toString() });
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            daySegment.focus();
+            await sendKeys({ type: (min.day - 1).toString() });
             await elementUpdated(element);
             await sendKeys({ press: 'Space' });
             await elementUpdated(element);
 
-            await sendKeys({ press: 'ArrowUp' });
-            await sendKeys({ press: 'ArrowUp' });
+            await sendKeys({ type: (min.day + 1).toString() });
             await elementUpdated(element);
             await sendKeys({ press: 'Space' });
             await elementUpdated(element);
@@ -3236,9 +3233,9 @@ describe('DateTimePicker', () => {
                 props: { min, max, value: min },
             });
             editableSegments = getEditableSegments(element);
-            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
-            yearSegment.focus();
-            await sendKeys({ type: (min.year - 1).toString() });
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            daySegment.focus();
+            await sendKeys({ type: (min.day - 1).toString() });
             await elementUpdated(element);
             expect(element.invalid).to.be.false;
 
@@ -3248,7 +3245,6 @@ describe('DateTimePicker', () => {
             });
 
             expect(element.invalid).to.be.true;
-            expectPlaceholders(editableSegments, [yearSegment]);
         });
 
         it("should stop the 'invalid' state when a value that does comply is commited on blur", async () => {
@@ -3256,19 +3252,18 @@ describe('DateTimePicker', () => {
                 props: { min, max, value: min },
             });
             editableSegments = getEditableSegments(element);
-            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
-            yearSegment.focus();
-            await sendKeys({ type: (min.year - 1).toString() });
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            daySegment.focus();
+            await sendKeys({ type: (min.day - 1).toString() });
             await elementUpdated(element);
-
             await sendMouse({
                 type: 'click',
                 position: [0, 0],
             });
             await elementUpdated(element);
 
-            await sendKeys({ press: 'ArrowUp' });
-            await sendKeys({ press: 'ArrowUp' });
+            daySegment.focus();
+            await sendKeys({ type: (min.day + 1).toString() });
             await elementUpdated(element);
             await sendMouse({
                 type: 'click',

--- a/packages/date-time-picker/test/date-time-picker.test.ts
+++ b/packages/date-time-picker/test/date-time-picker.test.ts
@@ -3273,6 +3273,29 @@ describe('DateTimePicker', () => {
 
             expect(element.invalid).to.be.false;
         });
+
+        it('should not be invalid when all segments are placeholders', async () => {
+            expect(element.invalid).to.be.false;
+
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            monthSegment.focus();
+            await sendKeys({ press: 'ArrowUp' });
+            await elementUpdated(element);
+            await sendKeys({ press: 'Enter' });
+            await elementUpdated(element);
+
+            expect(element.invalid).to.be.true;
+
+            await sendKeys({ press: 'Delete' });
+            await elementUpdated(element);
+            await sendMouse({
+                type: 'click',
+                position: [0, 0],
+            });
+            await elementUpdated(element);
+
+            expect(element.invalid).to.be.false;
+        });
     });
 
     describe('Multiple types for min, max and value properties', () => {

--- a/packages/date-time-picker/test/helpers.ts
+++ b/packages/date-time-picker/test/helpers.ts
@@ -40,7 +40,12 @@ export async function fixtureElement({
     props?: { [prop: string]: unknown };
 } = {}): Promise<DateTimePicker> {
     const wrapped = await fixture<HTMLElement>(html`
-        <sp-theme lang=${locale} color="light" scale="medium">
+        <sp-theme
+            system=${'spectrum'}
+            lang=${locale}
+            color="light"
+            scale="medium"
+        >
             <sp-date-time-picker
                 ...=${spreadProps(props)}
             ></sp-date-time-picker>


### PR DESCRIPTION
This PR adds the `input` event to the DateTimePicker and updates the `change` event dispatching. This also takes care of the `invalid` state triggering in different scenarios. 

## Description
- Input event dispatches
    - when the segment's value change through user inputs (type-in, increment/decrement, deletion)
- Change event dispatches
    - when all the segments have a value for the first time (the value gets defined)
    - when the value changes are committed on a fully defined date (Space/Enter or when the component loses focus)
    - the first time when a segment is being deleted from a fully defined date
    - the value is changed using the Calendar
- Invalid 
    - triggers when an incomplete date is committed
    - triggers when a non-compliant date is committed
    - untriggers when a fully defined date is committed
    - untriggers when a date that does comply is committed


----
The DateTimePicker's methods were slightly repositioned inside the source file to improve readability.
Fixes the new components dep. versions and tests failing due to feature branch main merge.


## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/2559
- https://github.com/adobe/spectrum-web-components/issues/2560

## Motivation and context

Implements the events part of the RFC for the DateTimePicker.

## How has this been tested?

Unit tested.

-   [x] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
