### PR TITLE
chore: make the spectrum-two theme fully functional

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
             "files": [
                 "packages/**/*.css",
                 "tools/**/*.css",
-                "tasks/build-css.js"
+                "tasks/build-css.js",
+                "tasks/css-tools.js"
             ],
             "output": [
                 "packages/**/*.css.ts",
@@ -244,6 +245,7 @@
                 "!tools/**/*.d.ts",
                 "tasks/esbuild-packages.js",
                 "tasks/ts-tools.js",
+                "tasks/hydrate-export-maps.js",
                 "packages/**/exports.json",
                 "tools/**/exports.json"
             ],

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -58,7 +58,7 @@
         "lit-html"
     ],
     "dependencies": {
-        "@lit-labs/observers": "^2.0.0",
+        "@lit-labs/observers": "^2.0.2",
         "@spectrum-web-components/action-button": "^0.49.0",
         "@spectrum-web-components/base": "^0.49.0",
         "@spectrum-web-components/icons-workflow": "^0.49.0",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -75,7 +75,7 @@
     ],
     "dependencies": {
         "@internationalized/number": "^3.1.0",
-        "@lit-labs/observers": "^2.0.0",
+        "@lit-labs/observers": "^2.0.2",
         "@spectrum-web-components/base": "^0.49.0",
         "@spectrum-web-components/field-label": "^0.49.0",
         "@spectrum-web-components/number-field": "^0.49.0",

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -25,7 +25,7 @@ import {
 import { DARK_MODE } from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
-import '@spectrum-web-components/theme/src/spectrum-two/themes-core-tokens.js';
+import '@spectrum-web-components/theme/src/spectrum-two/themes.js';
 import '@spectrum-web-components/theme/src/express/themes.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/picker/sp-picker.js';

--- a/scripts/spectrum-vars.js
+++ b/scripts/spectrum-vars.js
@@ -134,46 +134,7 @@ const processTypography = async (
     fs.writeFileSync(fontPath, result, 'utf8');
 };
 
-// where is spectrum-css?
-// TODO: use resolve package to find node_modules
-// TODO: we need to revisit whether we need these
-const spectrumPaths = [
-    // Spectrum 1
-    path.resolve(
-        path.join(
-            __dirname,
-            '..',
-            'node_modules',
-            '@spectrum-css',
-            'vars',
-            'dist'
-        )
-    ),
-    // Spectrum 2 (same source as Spectrum 1)
-    path.resolve(
-        path.join(
-            __dirname,
-            '..',
-            'node_modules',
-            '@spectrum-css',
-            'vars',
-            'dist'
-        )
-    ),
-    // Express
-    path.resolve(
-        path.join(
-            __dirname,
-            '..',
-            'node_modules',
-            '@spectrum-css',
-            'expressvars',
-            'dist'
-        )
-    ),
-];
-
-// sources to use from spectrum-css
+const systems = ['spectrum', 'spectrum-two', 'express'];
 const themes = ['lightest', 'light', 'dark', 'darkest'];
 const scales = ['medium', 'large'];
 const cores = ['global'];
@@ -181,22 +142,20 @@ const processes = [];
 
 const foundVars = await findUsedVars();
 
-spectrumPaths.forEach((spectrumPath, i) => {
+systems.forEach((system) => {
+    const varsPackage = system === 'express' ? 'expressvars' : 'vars';
+    const varsPath = path
+        .dirname(import.meta.resolve(`@spectrum-css/${varsPackage}`))
+        .replace(/^file:/, '');
     const packageDir = ['styles'];
-    const isSpectrum1 = i === 0;
-    const isSpectrum2 = i === 1;
-    const isExpress = i === 2;
-    if (isSpectrum2) {
-        packageDir.push('spectrum-two');
-    }
-    if (isExpress) {
-        packageDir.push('express');
+    if (system !== 'spectrum') {
+        packageDir.push(system);
     }
     themes.forEach((theme) => {
-        if (!isSpectrum1 && ['lightest', 'darkest'].includes(theme)) {
+        if (system !== 'spectrum' && ['lightest', 'darkest'].includes(theme)) {
             return;
         }
-        const srcPath = path.join(spectrumPath, `spectrum-${theme}.css`);
+        const srcPath = path.join(varsPath, `spectrum-${theme}.css`);
         const dstPath = path.resolve(
             path.join(
                 __dirname,
@@ -212,7 +171,7 @@ spectrumPaths.forEach((spectrumPath, i) => {
     });
 
     scales.forEach((scale) => {
-        const srcPath = path.join(spectrumPath, `spectrum-${scale}.css`);
+        const srcPath = path.join(varsPath, `spectrum-${scale}.css`);
         const dstPath = path.resolve(
             path.join(
                 __dirname,
@@ -229,7 +188,7 @@ spectrumPaths.forEach((spectrumPath, i) => {
     });
 
     cores.forEach((core) => {
-        const srcPath = path.join(spectrumPath, `spectrum-${core}.css`);
+        const srcPath = path.join(varsPath, `spectrum-${core}.css`);
         const dstPath = path.resolve(
             path.join(
                 __dirname,

--- a/scripts/spectrum-vars.js
+++ b/scripts/spectrum-vars.js
@@ -138,6 +138,7 @@ const processTypography = async (
 // TODO: use resolve package to find node_modules
 // TODO: we need to revisit whether we need these
 const spectrumPaths = [
+    // Spectrum 1
     path.resolve(
         path.join(
             __dirname,
@@ -148,6 +149,18 @@ const spectrumPaths = [
             'dist'
         )
     ),
+    // Spectrum 2 (same source as Spectrum 1)
+    path.resolve(
+        path.join(
+            __dirname,
+            '..',
+            'node_modules',
+            '@spectrum-css',
+            'vars',
+            'dist'
+        )
+    ),
+    // Express
     path.resolve(
         path.join(
             __dirname,
@@ -170,10 +183,19 @@ const foundVars = await findUsedVars();
 
 spectrumPaths.forEach((spectrumPath, i) => {
     const packageDir = ['styles'];
-    const isExpress = i === 1;
-    if (isExpress) packageDir.push('express');
+    const isSpectrum1 = i === 0;
+    const isSpectrum2 = i === 1;
+    const isExpress = i === 2;
+    if (isSpectrum2) {
+        packageDir.push('spectrum-two');
+    }
+    if (isExpress) {
+        packageDir.push('express');
+    }
     themes.forEach((theme) => {
-        if (isExpress && ['lightest', 'darkest'].includes(theme)) return;
+        if (!isSpectrum1 && ['lightest', 'darkest'].includes(theme)) {
+            return;
+        }
         const srcPath = path.join(spectrumPath, `spectrum-${theme}.css`);
         const dstPath = path.resolve(
             path.join(

--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -20,7 +20,11 @@ const buildCSS = async () => {
         './tools/*/src/*.css',
         './tools/*/src/**/*.css',
     ])) {
-        await processCSS(cssPath);
+        try {
+            await processCSS(cssPath);
+        } catch (error) {
+            console.error(`Error processing ${cssPath}: ${error}`);
+        }
     }
     process.exit(0);
 };

--- a/tasks/hydrate-export-maps.js
+++ b/tasks/hydrate-export-maps.js
@@ -19,7 +19,7 @@ const excludes = [
     './src/spectrum-config.js',
     './src/spectrum-config.v1.js',
     // partial only asset the is used to build other exports
-    /spectrum-(?![i][c][o][n][-]).+\.css/,
+    /spectrum-(?!(([i][c][o][n][-])|([t][w][o]))).+\.css/,
     /\.css$/,
     /\.ts$/,
     /\.map/,

--- a/tools/styles/spectrum-two/core-global.css
+++ b/tools/styles/spectrum-two/core-global.css
@@ -3,16 +3,15 @@ Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software distributed under
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+@import './spectrum-core-global.css';
+
+:host,
+:root {
+    -webkit-tap-highlight-color: rgb(0 0 0 / 0%);
+}

--- a/tools/styles/spectrum-two/scale-large.css
+++ b/tools/styles/spectrum-two/scale-large.css
@@ -10,9 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+@import './spectrum-scale-large.css';
+
+:host,
+:root {
+    --spectrum-global-alias-appframe-border-size: 1px;
+    --swc-scale-factor: 1.25;
+}

--- a/tools/styles/spectrum-two/scale-medium.css
+++ b/tools/styles/spectrum-two/scale-medium.css
@@ -10,9 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+@import './spectrum-scale-medium.css';
+
+:host,
+:root {
+    --spectrum-global-alias-appframe-border-size: 2px;
+    --swc-scale-factor: 1;
+}

--- a/tools/styles/spectrum-two/spectrum-core-global.css
+++ b/tools/styles/spectrum-two/spectrum-core-global.css
@@ -1,0 +1,3241 @@
+:root,
+:host {
+    --spectrum-global-animation-linear: cubic-bezier(0, 0, 1, 1);
+    --spectrum-global-animation-duration-0: 0s;
+    --spectrum-global-animation-duration-100: 0.13s;
+    --spectrum-global-animation-duration-200: 0.16s;
+    --spectrum-global-animation-duration-300: 0.19s;
+    --spectrum-global-animation-duration-400: 0.22s;
+    --spectrum-global-animation-duration-500: 0.25s;
+    --spectrum-global-animation-duration-600: 0.3s;
+    --spectrum-global-animation-duration-700: 0.35s;
+    --spectrum-global-animation-duration-800: 0.4s;
+    --spectrum-global-animation-duration-900: 0.45s;
+    --spectrum-global-animation-duration-1000: 0.5s;
+    --spectrum-global-animation-duration-2000: 1s;
+    --spectrum-global-animation-duration-4000: 2s;
+    --spectrum-global-animation-ease-in-out: cubic-bezier(0.45, 0, 0.4, 1);
+    --spectrum-global-animation-ease-in: cubic-bezier(0.5, 0, 1, 1);
+    --spectrum-global-animation-ease-out: cubic-bezier(0, 0, 0.4, 1);
+    --spectrum-global-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
+    --spectrum-global-color-status: Verified;
+    --spectrum-global-color-version: 5.1;
+    --spectrum-global-color-static-black-rgb: 0, 0, 0;
+    --spectrum-global-color-static-black: rgb(
+        var(--spectrum-global-color-static-black-rgb)
+    );
+    --spectrum-global-color-static-white-rgb: 255, 255, 255;
+    --spectrum-global-color-static-white: rgb(
+        var(--spectrum-global-color-static-white-rgb)
+    );
+    --spectrum-global-color-static-blue-rgb: 0, 87, 191;
+    --spectrum-global-color-static-blue: rgb(
+        var(--spectrum-global-color-static-blue-rgb)
+    );
+    --spectrum-global-color-static-gray-50-rgb: 255, 255, 255;
+    --spectrum-global-color-static-gray-50: rgb(
+        var(--spectrum-global-color-static-gray-50-rgb)
+    );
+    --spectrum-global-color-static-gray-75-rgb: 255, 255, 255;
+    --spectrum-global-color-static-gray-75: rgb(
+        var(--spectrum-global-color-static-gray-75-rgb)
+    );
+    --spectrum-global-color-static-gray-100-rgb: 255, 255, 255;
+    --spectrum-global-color-static-gray-100: rgb(
+        var(--spectrum-global-color-static-gray-100-rgb)
+    );
+    --spectrum-global-color-static-gray-200-rgb: 235, 235, 235;
+    --spectrum-global-color-static-gray-200: rgb(
+        var(--spectrum-global-color-static-gray-200-rgb)
+    );
+    --spectrum-global-color-static-gray-300-rgb: 217, 217, 217;
+    --spectrum-global-color-static-gray-300: rgb(
+        var(--spectrum-global-color-static-gray-300-rgb)
+    );
+    --spectrum-global-color-static-gray-400-rgb: 179, 179, 179;
+    --spectrum-global-color-static-gray-400: rgb(
+        var(--spectrum-global-color-static-gray-400-rgb)
+    );
+    --spectrum-global-color-static-gray-500-rgb: 146, 146, 146;
+    --spectrum-global-color-static-gray-500: rgb(
+        var(--spectrum-global-color-static-gray-500-rgb)
+    );
+    --spectrum-global-color-static-gray-600-rgb: 110, 110, 110;
+    --spectrum-global-color-static-gray-600: rgb(
+        var(--spectrum-global-color-static-gray-600-rgb)
+    );
+    --spectrum-global-color-static-gray-700-rgb: 71, 71, 71;
+    --spectrum-global-color-static-gray-700: rgb(
+        var(--spectrum-global-color-static-gray-700-rgb)
+    );
+    --spectrum-global-color-static-gray-800-rgb: 34, 34, 34;
+    --spectrum-global-color-static-gray-800: rgb(
+        var(--spectrum-global-color-static-gray-800-rgb)
+    );
+    --spectrum-global-color-static-gray-900-rgb: 0, 0, 0;
+    --spectrum-global-color-static-gray-900: rgb(
+        var(--spectrum-global-color-static-gray-900-rgb)
+    );
+    --spectrum-global-color-static-red-400-rgb: 237, 64, 48;
+    --spectrum-global-color-static-red-400: rgb(
+        var(--spectrum-global-color-static-red-400-rgb)
+    );
+    --spectrum-global-color-static-red-500-rgb: 217, 28, 21;
+    --spectrum-global-color-static-red-500: rgb(
+        var(--spectrum-global-color-static-red-500-rgb)
+    );
+    --spectrum-global-color-static-red-600-rgb: 187, 2, 2;
+    --spectrum-global-color-static-red-600: rgb(
+        var(--spectrum-global-color-static-red-600-rgb)
+    );
+    --spectrum-global-color-static-red-700-rgb: 154, 0, 0;
+    --spectrum-global-color-static-red-700: rgb(
+        var(--spectrum-global-color-static-red-700-rgb)
+    );
+    --spectrum-global-color-static-red-800-rgb: 124, 0, 0;
+    --spectrum-global-color-static-red-800: rgb(
+        var(--spectrum-global-color-static-red-800-rgb)
+    );
+    --spectrum-global-color-static-orange-400-rgb: 250, 139, 26;
+    --spectrum-global-color-static-orange-400: rgb(
+        var(--spectrum-global-color-static-orange-400-rgb)
+    );
+    --spectrum-global-color-static-orange-500-rgb: 233, 117, 0;
+    --spectrum-global-color-static-orange-500: rgb(
+        var(--spectrum-global-color-static-orange-500-rgb)
+    );
+    --spectrum-global-color-static-orange-600-rgb: 209, 97, 0;
+    --spectrum-global-color-static-orange-600: rgb(
+        var(--spectrum-global-color-static-orange-600-rgb)
+    );
+    --spectrum-global-color-static-orange-700-rgb: 182, 80, 0;
+    --spectrum-global-color-static-orange-700: rgb(
+        var(--spectrum-global-color-static-orange-700-rgb)
+    );
+    --spectrum-global-color-static-orange-800-rgb: 155, 64, 0;
+    --spectrum-global-color-static-orange-800: rgb(
+        var(--spectrum-global-color-static-orange-800-rgb)
+    );
+    --spectrum-global-color-static-yellow-200-rgb: 250, 237, 123;
+    --spectrum-global-color-static-yellow-200: rgb(
+        var(--spectrum-global-color-static-yellow-200-rgb)
+    );
+    --spectrum-global-color-static-yellow-300-rgb: 250, 224, 23;
+    --spectrum-global-color-static-yellow-300: rgb(
+        var(--spectrum-global-color-static-yellow-300-rgb)
+    );
+    --spectrum-global-color-static-yellow-400-rgb: 238, 205, 0;
+    --spectrum-global-color-static-yellow-400: rgb(
+        var(--spectrum-global-color-static-yellow-400-rgb)
+    );
+    --spectrum-global-color-static-yellow-500-rgb: 221, 185, 0;
+    --spectrum-global-color-static-yellow-500: rgb(
+        var(--spectrum-global-color-static-yellow-500-rgb)
+    );
+    --spectrum-global-color-static-yellow-600-rgb: 201, 164, 0;
+    --spectrum-global-color-static-yellow-600: rgb(
+        var(--spectrum-global-color-static-yellow-600-rgb)
+    );
+    --spectrum-global-color-static-yellow-700-rgb: 181, 144, 0;
+    --spectrum-global-color-static-yellow-700: rgb(
+        var(--spectrum-global-color-static-yellow-700-rgb)
+    );
+    --spectrum-global-color-static-yellow-800-rgb: 160, 125, 0;
+    --spectrum-global-color-static-yellow-800: rgb(
+        var(--spectrum-global-color-static-yellow-800-rgb)
+    );
+    --spectrum-global-color-static-chartreuse-300-rgb: 176, 222, 27;
+    --spectrum-global-color-static-chartreuse-300: rgb(
+        var(--spectrum-global-color-static-chartreuse-300-rgb)
+    );
+    --spectrum-global-color-static-chartreuse-400-rgb: 157, 203, 13;
+    --spectrum-global-color-static-chartreuse-400: rgb(
+        var(--spectrum-global-color-static-chartreuse-400-rgb)
+    );
+    --spectrum-global-color-static-chartreuse-500-rgb: 139, 182, 4;
+    --spectrum-global-color-static-chartreuse-500: rgb(
+        var(--spectrum-global-color-static-chartreuse-500-rgb)
+    );
+    --spectrum-global-color-static-chartreuse-600-rgb: 122, 162, 0;
+    --spectrum-global-color-static-chartreuse-600: rgb(
+        var(--spectrum-global-color-static-chartreuse-600-rgb)
+    );
+    --spectrum-global-color-static-chartreuse-700-rgb: 106, 141, 0;
+    --spectrum-global-color-static-chartreuse-700: rgb(
+        var(--spectrum-global-color-static-chartreuse-700-rgb)
+    );
+    --spectrum-global-color-static-chartreuse-800-rgb: 90, 120, 0;
+    --spectrum-global-color-static-chartreuse-800: rgb(
+        var(--spectrum-global-color-static-chartreuse-800-rgb)
+    );
+    --spectrum-global-color-static-celery-200-rgb: 126, 229, 114;
+    --spectrum-global-color-static-celery-200: rgb(
+        var(--spectrum-global-color-static-celery-200-rgb)
+    );
+    --spectrum-global-color-static-celery-300-rgb: 87, 212, 86;
+    --spectrum-global-color-static-celery-300: rgb(
+        var(--spectrum-global-color-static-celery-300-rgb)
+    );
+    --spectrum-global-color-static-celery-400-rgb: 48, 193, 61;
+    --spectrum-global-color-static-celery-400: rgb(
+        var(--spectrum-global-color-static-celery-400-rgb)
+    );
+    --spectrum-global-color-static-celery-500-rgb: 15, 172, 38;
+    --spectrum-global-color-static-celery-500: rgb(
+        var(--spectrum-global-color-static-celery-500-rgb)
+    );
+    --spectrum-global-color-static-celery-600-rgb: 0, 150, 20;
+    --spectrum-global-color-static-celery-600: rgb(
+        var(--spectrum-global-color-static-celery-600-rgb)
+    );
+    --spectrum-global-color-static-celery-700-rgb: 0, 128, 15;
+    --spectrum-global-color-static-celery-700: rgb(
+        var(--spectrum-global-color-static-celery-700-rgb)
+    );
+    --spectrum-global-color-static-celery-800-rgb: 0, 107, 15;
+    --spectrum-global-color-static-celery-800: rgb(
+        var(--spectrum-global-color-static-celery-800-rgb)
+    );
+    --spectrum-global-color-static-green-400-rgb: 29, 169, 115;
+    --spectrum-global-color-static-green-400: rgb(
+        var(--spectrum-global-color-static-green-400-rgb)
+    );
+    --spectrum-global-color-static-green-500-rgb: 0, 148, 97;
+    --spectrum-global-color-static-green-500: rgb(
+        var(--spectrum-global-color-static-green-500-rgb)
+    );
+    --spectrum-global-color-static-green-600-rgb: 0, 126, 80;
+    --spectrum-global-color-static-green-600: rgb(
+        var(--spectrum-global-color-static-green-600-rgb)
+    );
+    --spectrum-global-color-static-green-700-rgb: 0, 105, 65;
+    --spectrum-global-color-static-green-700: rgb(
+        var(--spectrum-global-color-static-green-700-rgb)
+    );
+    --spectrum-global-color-static-green-800-rgb: 0, 86, 53;
+    --spectrum-global-color-static-green-800: rgb(
+        var(--spectrum-global-color-static-green-800-rgb)
+    );
+    --spectrum-global-color-static-seafoam-200-rgb: 75, 206, 199;
+    --spectrum-global-color-static-seafoam-200: rgb(
+        var(--spectrum-global-color-static-seafoam-200-rgb)
+    );
+    --spectrum-global-color-static-seafoam-300-rgb: 32, 187, 180;
+    --spectrum-global-color-static-seafoam-300: rgb(
+        var(--spectrum-global-color-static-seafoam-300-rgb)
+    );
+    --spectrum-global-color-static-seafoam-400-rgb: 0, 166, 160;
+    --spectrum-global-color-static-seafoam-400: rgb(
+        var(--spectrum-global-color-static-seafoam-400-rgb)
+    );
+    --spectrum-global-color-static-seafoam-500-rgb: 0, 145, 139;
+    --spectrum-global-color-static-seafoam-500: rgb(
+        var(--spectrum-global-color-static-seafoam-500-rgb)
+    );
+    --spectrum-global-color-static-seafoam-600-rgb: 0, 124, 118;
+    --spectrum-global-color-static-seafoam-600: rgb(
+        var(--spectrum-global-color-static-seafoam-600-rgb)
+    );
+    --spectrum-global-color-static-seafoam-700-rgb: 0, 103, 99;
+    --spectrum-global-color-static-seafoam-700: rgb(
+        var(--spectrum-global-color-static-seafoam-700-rgb)
+    );
+    --spectrum-global-color-static-seafoam-800-rgb: 10, 83, 80;
+    --spectrum-global-color-static-seafoam-800: rgb(
+        var(--spectrum-global-color-static-seafoam-800-rgb)
+    );
+    --spectrum-global-color-static-blue-200-rgb: 130, 193, 251;
+    --spectrum-global-color-static-blue-200: rgb(
+        var(--spectrum-global-color-static-blue-200-rgb)
+    );
+    --spectrum-global-color-static-blue-300-rgb: 98, 173, 247;
+    --spectrum-global-color-static-blue-300: rgb(
+        var(--spectrum-global-color-static-blue-300-rgb)
+    );
+    --spectrum-global-color-static-blue-400-rgb: 66, 151, 244;
+    --spectrum-global-color-static-blue-400: rgb(
+        var(--spectrum-global-color-static-blue-400-rgb)
+    );
+    --spectrum-global-color-static-blue-500-rgb: 27, 127, 245;
+    --spectrum-global-color-static-blue-500: rgb(
+        var(--spectrum-global-color-static-blue-500-rgb)
+    );
+    --spectrum-global-color-static-blue-600-rgb: 4, 105, 227;
+    --spectrum-global-color-static-blue-600: rgb(
+        var(--spectrum-global-color-static-blue-600-rgb)
+    );
+    --spectrum-global-color-static-blue-700-rgb: 0, 87, 190;
+    --spectrum-global-color-static-blue-700: rgb(
+        var(--spectrum-global-color-static-blue-700-rgb)
+    );
+    --spectrum-global-color-static-blue-800-rgb: 0, 72, 153;
+    --spectrum-global-color-static-blue-800: rgb(
+        var(--spectrum-global-color-static-blue-800-rgb)
+    );
+    --spectrum-global-color-static-indigo-200-rgb: 178, 181, 255;
+    --spectrum-global-color-static-indigo-200: rgb(
+        var(--spectrum-global-color-static-indigo-200-rgb)
+    );
+    --spectrum-global-color-static-indigo-300-rgb: 155, 159, 255;
+    --spectrum-global-color-static-indigo-300: rgb(
+        var(--spectrum-global-color-static-indigo-300-rgb)
+    );
+    --spectrum-global-color-static-indigo-400-rgb: 132, 137, 253;
+    --spectrum-global-color-static-indigo-400: rgb(
+        var(--spectrum-global-color-static-indigo-400-rgb)
+    );
+    --spectrum-global-color-static-indigo-500-rgb: 109, 115, 246;
+    --spectrum-global-color-static-indigo-500: rgb(
+        var(--spectrum-global-color-static-indigo-500-rgb)
+    );
+    --spectrum-global-color-static-indigo-600-rgb: 87, 93, 232;
+    --spectrum-global-color-static-indigo-600: rgb(
+        var(--spectrum-global-color-static-indigo-600-rgb)
+    );
+    --spectrum-global-color-static-indigo-700-rgb: 68, 74, 208;
+    --spectrum-global-color-static-indigo-700: rgb(
+        var(--spectrum-global-color-static-indigo-700-rgb)
+    );
+    --spectrum-global-color-static-indigo-800-rgb: 68, 74, 208;
+    --spectrum-global-color-static-indigo-800: rgb(
+        var(--spectrum-global-color-static-indigo-800-rgb)
+    );
+    --spectrum-global-color-static-purple-400-rgb: 178, 121, 250;
+    --spectrum-global-color-static-purple-400: rgb(
+        var(--spectrum-global-color-static-purple-400-rgb)
+    );
+    --spectrum-global-color-static-purple-500-rgb: 161, 93, 246;
+    --spectrum-global-color-static-purple-500: rgb(
+        var(--spectrum-global-color-static-purple-500-rgb)
+    );
+    --spectrum-global-color-static-purple-600-rgb: 142, 67, 234;
+    --spectrum-global-color-static-purple-600: rgb(
+        var(--spectrum-global-color-static-purple-600-rgb)
+    );
+    --spectrum-global-color-static-purple-700-rgb: 120, 43, 216;
+    --spectrum-global-color-static-purple-700: rgb(
+        var(--spectrum-global-color-static-purple-700-rgb)
+    );
+    --spectrum-global-color-static-purple-800-rgb: 98, 23, 190;
+    --spectrum-global-color-static-purple-800: rgb(
+        var(--spectrum-global-color-static-purple-800-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-400-rgb: 228, 93, 230;
+    --spectrum-global-color-static-fuchsia-400: rgb(
+        var(--spectrum-global-color-static-fuchsia-400-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-500-rgb: 211, 63, 212;
+    --spectrum-global-color-static-fuchsia-500: rgb(
+        var(--spectrum-global-color-static-fuchsia-500-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-600-rgb: 188, 39, 187;
+    --spectrum-global-color-static-fuchsia-600: rgb(
+        var(--spectrum-global-color-static-fuchsia-600-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-700-rgb: 163, 10, 163;
+    --spectrum-global-color-static-fuchsia-700: rgb(
+        var(--spectrum-global-color-static-fuchsia-700-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-800-rgb: 135, 0, 136;
+    --spectrum-global-color-static-fuchsia-800: rgb(
+        var(--spectrum-global-color-static-fuchsia-800-rgb)
+    );
+    --spectrum-global-color-static-magenta-200-rgb: 253, 127, 175;
+    --spectrum-global-color-static-magenta-200: rgb(
+        var(--spectrum-global-color-static-magenta-200-rgb)
+    );
+    --spectrum-global-color-static-magenta-300-rgb: 242, 98, 157;
+    --spectrum-global-color-static-magenta-300: rgb(
+        var(--spectrum-global-color-static-magenta-300-rgb)
+    );
+    --spectrum-global-color-static-magenta-400-rgb: 226, 68, 135;
+    --spectrum-global-color-static-magenta-400: rgb(
+        var(--spectrum-global-color-static-magenta-400-rgb)
+    );
+    --spectrum-global-color-static-magenta-500-rgb: 205, 40, 111;
+    --spectrum-global-color-static-magenta-500: rgb(
+        var(--spectrum-global-color-static-magenta-500-rgb)
+    );
+    --spectrum-global-color-static-magenta-600-rgb: 179, 15, 89;
+    --spectrum-global-color-static-magenta-600: rgb(
+        var(--spectrum-global-color-static-magenta-600-rgb)
+    );
+    --spectrum-global-color-static-magenta-700-rgb: 149, 0, 72;
+    --spectrum-global-color-static-magenta-700: rgb(
+        var(--spectrum-global-color-static-magenta-700-rgb)
+    );
+    --spectrum-global-color-static-magenta-800-rgb: 119, 0, 58;
+    --spectrum-global-color-static-magenta-800: rgb(
+        var(--spectrum-global-color-static-magenta-800-rgb)
+    );
+    --spectrum-global-color-static-transparent-white-200: #ffffff1a;
+    --spectrum-global-color-static-transparent-white-300: #ffffff40;
+    --spectrum-global-color-static-transparent-white-400: #fff6;
+    --spectrum-global-color-static-transparent-white-500: #ffffff8c;
+    --spectrum-global-color-static-transparent-white-600: #ffffffb3;
+    --spectrum-global-color-static-transparent-white-700: #fffc;
+    --spectrum-global-color-static-transparent-white-800: #ffffffe6;
+    --spectrum-global-color-static-transparent-white-900-rgb: 255, 255, 255;
+    --spectrum-global-color-static-transparent-white-900: rgb(
+        var(--spectrum-global-color-static-transparent-white-900-rgb)
+    );
+    --spectrum-global-color-static-transparent-black-200: #0000001a;
+    --spectrum-global-color-static-transparent-black-300: #00000040;
+    --spectrum-global-color-static-transparent-black-400: #0006;
+    --spectrum-global-color-static-transparent-black-500: #0000008c;
+    --spectrum-global-color-static-transparent-black-600: #000000b3;
+    --spectrum-global-color-static-transparent-black-700: #000c;
+    --spectrum-global-color-static-transparent-black-800: #000000e6;
+    --spectrum-global-color-static-transparent-black-900-rgb: 0, 0, 0;
+    --spectrum-global-color-static-transparent-black-900: rgb(
+        var(--spectrum-global-color-static-transparent-black-900-rgb)
+    );
+    --spectrum-global-color-sequential-cerulean: #e9fff1, #c8f1e4, #a5e3d7,
+        #82d5ca, #68c5c1, #54b4ba, #3fa2b2, #2991ac, #2280a2, #1f6d98, #1d5c8d,
+        #1a4b83, #1a3979, #1a266f, #191264, #180057;
+    --spectrum-global-color-sequential-forest: #ffffdf, #e2f6ba, #c4eb95,
+        #a4e16d, #8dd366, #77c460, #5fb65a, #48a754, #36984f, #2c894d, #237a4a,
+        #196b47, #105c45, #094d41, #033f3e, #00313a;
+    --spectrum-global-color-sequential-rose: #fff4dd, #ffddd7, #ffc5d2, #feaecb,
+        #fa96c4, #f57ebd, #ef64b5, #e846ad, #d238a1, #bb2e96, #a3248c, #8a1b83,
+        #71167c, #560f74, #370b6e, #000968;
+    --spectrum-global-color-diverging-orange-yellow-seafoam: #580000, #79260b,
+        #9c4511, #bd651a, #dd8629, #f5ad52, #fed693, #ffffe0, #bbe4d1, #76c7be,
+        #3ea8a6, #208288, #076769, #00494b, #002c2d;
+    --spectrum-global-color-diverging-red-yellow-blue: #4a001e, #751232, #a52747,
+        #c65154, #e47961, #f0a882, #fad4ac, #ffffe0, #bce2cf, #89c0c4, #579eb9,
+        #397aa8, #1c5796, #163771, #10194d;
+    --spectrum-global-color-diverging-red-blue: #4a001e, #731331, #9f2945,
+        #cc415a, #e06e85, #ed9ab0, #f8c3d9, #faf0ff, #c6d0f2, #92b2de, #5d94cb,
+        #2f74b3, #265191, #163670, #0b194c;
+    --spectrum-semantic-negative-background-color: var(
+        --spectrum-global-color-static-red-600
+    );
+    --spectrum-semantic-negative-color-default: var(
+        --spectrum-global-color-red-500
+    );
+    --spectrum-semantic-negative-color-hover: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-color-dark: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-border-color: var(
+        --spectrum-global-color-red-400
+    );
+    --spectrum-semantic-negative-icon-color: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-status-color: var(
+        --spectrum-global-color-red-400
+    );
+    --spectrum-semantic-negative-text-color-large: var(
+        --spectrum-global-color-red-500
+    );
+    --spectrum-semantic-negative-text-color-small: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-text-color-small-hover: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-semantic-negative-text-color-small-down: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-semantic-negative-text-color-small-key-focus: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-color-down: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-semantic-negative-color-key-focus: var(
+        --spectrum-global-color-red-400
+    );
+    --spectrum-semantic-negative-background-color-default: var(
+        --spectrum-global-color-static-red-600
+    );
+    --spectrum-semantic-negative-background-color-hover: var(
+        --spectrum-global-color-static-red-700
+    );
+    --spectrum-semantic-negative-background-color-down: var(
+        --spectrum-global-color-static-red-800
+    );
+    --spectrum-semantic-negative-background-color-key-focus: var(
+        --spectrum-global-color-static-red-700
+    );
+    --spectrum-semantic-notice-background-color: var(
+        --spectrum-global-color-static-orange-600
+    );
+    --spectrum-semantic-notice-color-default: var(
+        --spectrum-global-color-orange-500
+    );
+    --spectrum-semantic-notice-color-dark: var(
+        --spectrum-global-color-orange-600
+    );
+    --spectrum-semantic-notice-border-color: var(
+        --spectrum-global-color-orange-400
+    );
+    --spectrum-semantic-notice-icon-color: var(
+        --spectrum-global-color-orange-600
+    );
+    --spectrum-semantic-notice-status-color: var(
+        --spectrum-global-color-orange-400
+    );
+    --spectrum-semantic-notice-text-color-large: var(
+        --spectrum-global-color-orange-500
+    );
+    --spectrum-semantic-notice-text-color-small: var(
+        --spectrum-global-color-orange-600
+    );
+    --spectrum-semantic-notice-color-down: var(
+        --spectrum-global-color-orange-700
+    );
+    --spectrum-semantic-notice-color-key-focus: var(
+        --spectrum-global-color-orange-400
+    );
+    --spectrum-semantic-notice-background-color-default: var(
+        --spectrum-global-color-static-orange-600
+    );
+    --spectrum-semantic-notice-background-color-hover: var(
+        --spectrum-global-color-static-orange-700
+    );
+    --spectrum-semantic-notice-background-color-down: var(
+        --spectrum-global-color-static-orange-800
+    );
+    --spectrum-semantic-notice-background-color-key-focus: var(
+        --spectrum-global-color-static-orange-700
+    );
+    --spectrum-semantic-positive-background-color: var(
+        --spectrum-global-color-static-green-600
+    );
+    --spectrum-semantic-positive-color-default: var(
+        --spectrum-global-color-green-500
+    );
+    --spectrum-semantic-positive-color-dark: var(
+        --spectrum-global-color-green-600
+    );
+    --spectrum-semantic-positive-border-color: var(
+        --spectrum-global-color-green-400
+    );
+    --spectrum-semantic-positive-icon-color: var(
+        --spectrum-global-color-green-600
+    );
+    --spectrum-semantic-positive-status-color: var(
+        --spectrum-global-color-green-400
+    );
+    --spectrum-semantic-positive-text-color-large: var(
+        --spectrum-global-color-green-500
+    );
+    --spectrum-semantic-positive-text-color-small: var(
+        --spectrum-global-color-green-600
+    );
+    --spectrum-semantic-positive-color-down: var(
+        --spectrum-global-color-green-700
+    );
+    --spectrum-semantic-positive-color-key-focus: var(
+        --spectrum-global-color-green-400
+    );
+    --spectrum-semantic-positive-background-color-default: var(
+        --spectrum-global-color-static-green-600
+    );
+    --spectrum-semantic-positive-background-color-hover: var(
+        --spectrum-global-color-static-green-700
+    );
+    --spectrum-semantic-positive-background-color-down: var(
+        --spectrum-global-color-static-green-800
+    );
+    --spectrum-semantic-positive-background-color-key-focus: var(
+        --spectrum-global-color-static-green-700
+    );
+    --spectrum-semantic-informative-background-color: var(
+        --spectrum-global-color-static-blue-600
+    );
+    --spectrum-semantic-informative-color-default: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-semantic-informative-color-dark: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-semantic-informative-border-color: var(
+        --spectrum-global-color-blue-400
+    );
+    --spectrum-semantic-informative-icon-color: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-semantic-informative-status-color: var(
+        --spectrum-global-color-blue-400
+    );
+    --spectrum-semantic-informative-text-color-large: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-semantic-informative-text-color-small: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-semantic-informative-color-down: var(
+        --spectrum-global-color-blue-700
+    );
+    --spectrum-semantic-informative-color-key-focus: var(
+        --spectrum-global-color-blue-400
+    );
+    --spectrum-semantic-informative-background-color-default: var(
+        --spectrum-global-color-static-blue-600
+    );
+    --spectrum-semantic-informative-background-color-hover: var(
+        --spectrum-global-color-static-blue-700
+    );
+    --spectrum-semantic-informative-background-color-down: var(
+        --spectrum-global-color-static-blue-800
+    );
+    --spectrum-semantic-informative-background-color-key-focus: var(
+        --spectrum-global-color-static-blue-700
+    );
+    --spectrum-semantic-cta-background-color-default: var(
+        --spectrum-global-color-static-blue-600
+    );
+    --spectrum-semantic-cta-background-color-hover: var(
+        --spectrum-global-color-static-blue-700
+    );
+    --spectrum-semantic-cta-background-color-down: var(
+        --spectrum-global-color-static-blue-800
+    );
+    --spectrum-semantic-cta-background-color-key-focus: var(
+        --spectrum-global-color-static-blue-700
+    );
+    --spectrum-semantic-emphasized-border-color-default: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-semantic-emphasized-border-color-hover: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-semantic-emphasized-border-color-down: var(
+        --spectrum-global-color-blue-700
+    );
+    --spectrum-semantic-emphasized-border-color-key-focus: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-semantic-neutral-background-color-default: var(
+        --spectrum-global-color-static-gray-700
+    );
+    --spectrum-semantic-neutral-background-color-hover: var(
+        --spectrum-global-color-static-gray-800
+    );
+    --spectrum-semantic-neutral-background-color-down: var(
+        --spectrum-global-color-static-gray-900
+    );
+    --spectrum-semantic-neutral-background-color-key-focus: var(
+        --spectrum-global-color-static-gray-800
+    );
+    --spectrum-semantic-presence-color-1: var(
+        --spectrum-global-color-static-red-500
+    );
+    --spectrum-semantic-presence-color-2: var(
+        --spectrum-global-color-static-orange-400
+    );
+    --spectrum-semantic-presence-color-3: var(
+        --spectrum-global-color-static-yellow-400
+    );
+    --spectrum-semantic-presence-color-4-rgb: 75, 204, 162;
+    --spectrum-semantic-presence-color-4: rgb(
+        var(--spectrum-semantic-presence-color-4-rgb)
+    );
+    --spectrum-semantic-presence-color-5-rgb: 0, 199, 255;
+    --spectrum-semantic-presence-color-5: rgb(
+        var(--spectrum-semantic-presence-color-5-rgb)
+    );
+    --spectrum-semantic-presence-color-6-rgb: 0, 140, 184;
+    --spectrum-semantic-presence-color-6: rgb(
+        var(--spectrum-semantic-presence-color-6-rgb)
+    );
+    --spectrum-semantic-presence-color-7-rgb: 126, 75, 243;
+    --spectrum-semantic-presence-color-7: rgb(
+        var(--spectrum-semantic-presence-color-7-rgb)
+    );
+    --spectrum-semantic-presence-color-8: var(
+        --spectrum-global-color-static-fuchsia-600
+    );
+    --spectrum-global-dimension-static-percent-50: 50%;
+    --spectrum-global-dimension-static-percent-70: 70%;
+    --spectrum-global-dimension-static-percent-100: 100%;
+    --spectrum-global-dimension-static-breakpoint-xsmall: 304px;
+    --spectrum-global-dimension-static-breakpoint-small: 768px;
+    --spectrum-global-dimension-static-breakpoint-medium: 1280px;
+    --spectrum-global-dimension-static-breakpoint-large: 1768px;
+    --spectrum-global-dimension-static-breakpoint-xlarge: 2160px;
+    --spectrum-global-dimension-static-grid-columns: 12;
+    --spectrum-global-dimension-static-grid-fluid-width: 100%;
+    --spectrum-global-dimension-static-grid-fixed-max-width: 1280px;
+    --spectrum-global-dimension-static-size-0: 0px;
+    --spectrum-global-dimension-static-size-10: 1px;
+    --spectrum-global-dimension-static-size-25: 2px;
+    --spectrum-global-dimension-static-size-40: 3px;
+    --spectrum-global-dimension-static-size-50: 4px;
+    --spectrum-global-dimension-static-size-65: 5px;
+    --spectrum-global-dimension-static-size-75: 6px;
+    --spectrum-global-dimension-static-size-85: 7px;
+    --spectrum-global-dimension-static-size-100: 8px;
+    --spectrum-global-dimension-static-size-115: 9px;
+    --spectrum-global-dimension-static-size-125: 10px;
+    --spectrum-global-dimension-static-size-130: 11px;
+    --spectrum-global-dimension-static-size-150: 12px;
+    --spectrum-global-dimension-static-size-160: 13px;
+    --spectrum-global-dimension-static-size-175: 14px;
+    --spectrum-global-dimension-static-size-185: 15px;
+    --spectrum-global-dimension-static-size-200: 16px;
+    --spectrum-global-dimension-static-size-225: 18px;
+    --spectrum-global-dimension-static-size-250: 20px;
+    --spectrum-global-dimension-static-size-275: 22px;
+    --spectrum-global-dimension-static-size-300: 24px;
+    --spectrum-global-dimension-static-size-325: 26px;
+    --spectrum-global-dimension-static-size-350: 28px;
+    --spectrum-global-dimension-static-size-400: 32px;
+    --spectrum-global-dimension-static-size-450: 36px;
+    --spectrum-global-dimension-static-size-500: 40px;
+    --spectrum-global-dimension-static-size-550: 44px;
+    --spectrum-global-dimension-static-size-600: 48px;
+    --spectrum-global-dimension-static-size-700: 56px;
+    --spectrum-global-dimension-static-size-800: 64px;
+    --spectrum-global-dimension-static-size-900: 72px;
+    --spectrum-global-dimension-static-size-1000: 80px;
+    --spectrum-global-dimension-static-size-1200: 96px;
+    --spectrum-global-dimension-static-size-1700: 136px;
+    --spectrum-global-dimension-static-size-2400: 192px;
+    --spectrum-global-dimension-static-size-2500: 200px;
+    --spectrum-global-dimension-static-size-2600: 208px;
+    --spectrum-global-dimension-static-size-2800: 224px;
+    --spectrum-global-dimension-static-size-3200: 256px;
+    --spectrum-global-dimension-static-size-3400: 272px;
+    --spectrum-global-dimension-static-size-3500: 280px;
+    --spectrum-global-dimension-static-size-3600: 288px;
+    --spectrum-global-dimension-static-size-3800: 304px;
+    --spectrum-global-dimension-static-size-4600: 368px;
+    --spectrum-global-dimension-static-size-5000: 400px;
+    --spectrum-global-dimension-static-size-6000: 480px;
+    --spectrum-global-dimension-static-size-16000: 1280px;
+    --spectrum-global-dimension-static-font-size-50: 11px;
+    --spectrum-global-dimension-static-font-size-75: 12px;
+    --spectrum-global-dimension-static-font-size-100: 14px;
+    --spectrum-global-dimension-static-font-size-150: 15px;
+    --spectrum-global-dimension-static-font-size-200: 16px;
+    --spectrum-global-dimension-static-font-size-300: 18px;
+    --spectrum-global-dimension-static-font-size-400: 20px;
+    --spectrum-global-dimension-static-font-size-500: 22px;
+    --spectrum-global-dimension-static-font-size-600: 25px;
+    --spectrum-global-dimension-static-font-size-700: 28px;
+    --spectrum-global-dimension-static-font-size-800: 32px;
+    --spectrum-global-dimension-static-font-size-900: 36px;
+    --spectrum-global-dimension-static-font-size-1000: 40px;
+    --spectrum-global-font-family-base: adobe-clean, 'Source Sans Pro',
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu,
+        'Trebuchet MS', 'Lucida Grande', sans-serif;
+    --spectrum-global-font-family-serif: adobe-clean-serif, 'Source Serif Pro',
+        Georgia, serif;
+    --spectrum-global-font-family-code: 'Source Code Pro', Monaco, monospace;
+    --spectrum-global-font-weight-thin: 100;
+    --spectrum-global-font-weight-ultra-light: 200;
+    --spectrum-global-font-weight-light: 300;
+    --spectrum-global-font-weight-regular: 400;
+    --spectrum-global-font-weight-medium: 500;
+    --spectrum-global-font-weight-semi-bold: 600;
+    --spectrum-global-font-weight-bold: 700;
+    --spectrum-global-font-weight-extra-bold: 800;
+    --spectrum-global-font-weight-black: 900;
+    --spectrum-global-font-style-regular: normal;
+    --spectrum-global-font-style-italic: italic;
+    --spectrum-global-font-letter-spacing-none: 0;
+    --spectrum-global-font-letter-spacing-small: 0.0125em;
+    --spectrum-global-font-letter-spacing-han: 0.05em;
+    --spectrum-global-font-letter-spacing-medium: 0.06em;
+    --spectrum-global-font-line-height-large: 1.7;
+    --spectrum-global-font-line-height-medium: 1.5;
+    --spectrum-global-font-line-height-small: 1.3;
+    --spectrum-global-font-multiplier-0: 0em;
+    --spectrum-global-font-multiplier-25: 0.25em;
+    --spectrum-global-font-multiplier-75: 0.75em;
+    --spectrum-global-font-font-family-ar: myriad-arabic, adobe-clean,
+        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
+    --spectrum-global-font-font-family-he: myriad-hebrew, adobe-clean,
+        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
+    --spectrum-global-font-font-family-zh: adobe-clean-han-traditional,
+        source-han-traditional, 'MingLiu', 'Heiti TC Light', 'sans-serif';
+    --spectrum-global-font-font-family-zhhans: adobe-clean-han-simplified-c,
+        source-han-simplified-c, 'SimSun', 'Heiti SC Light', 'sans-serif';
+    --spectrum-global-font-font-family-ko: adobe-clean-han-korean,
+        source-han-korean, 'Malgun Gothic', 'Apple Gothic', 'sans-serif';
+    --spectrum-global-font-font-family-ja: adobe-clean-han-japanese,
+        'Hiragino Kaku Gothic ProN', 'ヒラギノ角ゴ ProN W3', 'Osaka', YuGothic,
+        'Yu Gothic', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', 'MS PGothic',
+        'sans-serif';
+    --spectrum-global-font-font-family-condensed: adobe-clean-han-traditional,
+        source-han-traditional, 'MingLiu', 'Heiti TC Light', adobe-clean,
+        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
+    --spectrum-alias-border-size-thin: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-border-size-thick: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-border-size-thicker: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-border-size-thickest: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-border-offset-thin: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-border-offset-thick: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-border-offset-thicker: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-border-offset-thickest: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-baseline: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-grid-gutter-xsmall: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-gutter-small: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-grid-gutter-medium: var(
+        --spectrum-global-dimension-static-size-400
+    );
+    --spectrum-alias-grid-gutter-large: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-grid-gutter-xlarge: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-grid-margin-xsmall: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-margin-small: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-grid-margin-medium: var(
+        --spectrum-global-dimension-static-size-400
+    );
+    --spectrum-alias-grid-margin-large: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-grid-margin-xlarge: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-small: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(
+        --spectrum-global-dimension-static-size-400
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-large: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-radial-reaction-size-default: var(
+        --spectrum-global-dimension-static-size-550
+    );
+    --spectrum-alias-focus-ring-gap: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-focus-ring-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-loupe-entry-animation-duration: var(
+        --spectrum-global-animation-duration-300
+    );
+    --spectrum-alias-loupe-exit-animation-duration: var(
+        --spectrum-global-animation-duration-300
+    );
+    --spectrum-alias-heading-text-line-height: var(
+        --spectrum-global-font-line-height-small
+    );
+    --spectrum-alias-heading-text-font-weight-regular: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-heading-text-font-weight-regular-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-text-font-weight-light: var(
+        --spectrum-global-font-weight-light
+    );
+    --spectrum-alias-heading-text-font-weight-light-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-heading-text-font-weight-heavy: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-text-font-weight-heavy-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-text-font-weight-quiet: var(
+        --spectrum-global-font-weight-light
+    );
+    --spectrum-alias-heading-text-font-weight-quiet-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-heading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-text-font-weight-strong-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-margin-bottom: var(
+        --spectrum-global-font-multiplier-25
+    );
+    --spectrum-alias-subheading-text-font-weight: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-subheading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-body-text-font-family: var(
+        --spectrum-global-font-family-base
+    );
+    --spectrum-alias-body-text-line-height: var(
+        --spectrum-global-font-line-height-medium
+    );
+    --spectrum-alias-body-text-font-weight: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-body-text-font-weight-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-body-margin-bottom: var(
+        --spectrum-global-font-multiplier-75
+    );
+    --spectrum-alias-detail-text-font-weight: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-detail-text-font-weight-regular: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-detail-text-font-weight-light: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-detail-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-article-heading-text-font-weight: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-article-heading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-article-heading-text-font-weight-quiet: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-article-heading-text-font-weight-quiet-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-article-body-text-font-weight: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-article-body-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-article-subheading-text-font-weight: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-article-subheading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-article-detail-text-font-weight: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-article-detail-text-font-weight-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-code-text-font-family: var(
+        --spectrum-global-font-family-code
+    );
+    --spectrum-alias-code-text-font-weight-regular: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-code-text-font-weight-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-code-text-line-height: var(
+        --spectrum-global-font-line-height-medium
+    );
+    --spectrum-alias-code-margin-bottom: var(
+        --spectrum-global-font-multiplier-0
+    );
+    --spectrum-alias-font-family-ar: var(--spectrum-global-font-font-family-ar);
+    --spectrum-alias-font-family-he: var(--spectrum-global-font-font-family-he);
+    --spectrum-alias-font-family-zh: var(--spectrum-global-font-font-family-zh);
+    --spectrum-alias-font-family-zhhans: var(
+        --spectrum-global-font-font-family-zhhans
+    );
+    --spectrum-alias-font-family-ko: var(--spectrum-global-font-font-family-ko);
+    --spectrum-alias-font-family-ja: var(--spectrum-global-font-font-family-ja);
+    --spectrum-alias-font-family-condensed: var(
+        --spectrum-global-font-font-family-condensed
+    );
+    --spectrum-alias-button-text-line-height: var(
+        --spectrum-global-font-line-height-small
+    );
+    --spectrum-alias-component-text-line-height: var(
+        --spectrum-global-font-line-height-small
+    );
+    --spectrum-alias-han-component-text-line-height: var(
+        --spectrum-global-font-line-height-medium
+    );
+    --spectrum-alias-serif-text-font-family: var(
+        --spectrum-global-font-family-serif
+    );
+    --spectrum-alias-han-heading-text-line-height: var(
+        --spectrum-global-font-line-height-medium
+    );
+    --spectrum-alias-han-heading-text-font-weight-regular: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-heading-text-font-weight-regular-emphasis: var(
+        --spectrum-global-font-weight-extra-bold
+    );
+    --spectrum-alias-han-heading-text-font-weight-regular-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-heading-text-font-weight-quiet-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-heading-text-font-weight-light: var(
+        --spectrum-global-font-weight-light
+    );
+    --spectrum-alias-han-heading-text-font-weight-light-emphasis: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-han-heading-text-font-weight-light-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-heading-text-font-weight-heavy: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-heading-text-font-weight-heavy-emphasis: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-heading-text-font-weight-heavy-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-body-text-line-height: var(
+        --spectrum-global-font-line-height-large
+    );
+    --spectrum-alias-han-body-text-font-weight-regular: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-han-body-text-font-weight-emphasis: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-body-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-subheading-text-font-weight-regular: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-subheading-text-font-weight-emphasis: var(
+        --spectrum-global-font-weight-extra-bold
+    );
+    --spectrum-alias-han-subheading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-detail-text-font-weight: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-han-detail-text-font-weight-emphasis: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-detail-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+}
+
+:root,
+:host {
+    --spectrum-alias-item-height-s: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-item-height-m: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-item-height-l: var(--spectrum-global-dimension-size-500);
+    --spectrum-alias-item-height-xl: var(--spectrum-global-dimension-size-600);
+    --spectrum-alias-item-rounded-border-radius-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-rounded-border-radius-m: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-item-rounded-border-radius-l: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-item-rounded-border-radius-xl: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-item-text-size-s: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-alias-item-text-size-m: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-item-text-size-l: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-item-text-size-xl: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-alias-item-text-padding-top-s: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-item-text-padding-top-m: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-text-padding-top-xl: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-text-padding-bottom-m: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-text-padding-bottom-l: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-item-text-padding-bottom-xl: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-item-icon-padding-top-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-item-icon-padding-top-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-icon-padding-top-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-icon-padding-top-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-icon-padding-bottom-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-item-icon-padding-bottom-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-icon-padding-bottom-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-icon-padding-bottom-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-padding-s: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-padding-m: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-padding-l: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-padding-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-rounded-padding-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-rounded-padding-m: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-item-rounded-padding-l: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-item-rounded-padding-xl: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-item-icononly-padding-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-item-icononly-padding-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-icononly-padding-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-icononly-padding-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-control-gap-s: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-gap-m: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-gap-l: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-item-control-gap-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-workflow-icon-gap-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-workflow-icon-gap-m: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-workflow-icon-gap-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-workflow-icon-gap-xl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-mark-gap-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-mark-gap-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-mark-gap-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-mark-gap-xl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-ui-icon-gap-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-ui-icon-gap-m: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-ui-icon-gap-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-ui-icon-gap-xl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-clearbutton-gap-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-item-clearbutton-gap-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-clearbutton-gap-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-clearbutton-gap-xl: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-workflow-padding-left-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-workflow-padding-left-l: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-workflow-padding-left-xl: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-s: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-l: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-item-mark-padding-top-s: var(
+        --spectrum-global-dimension-size-40
+    );
+    --spectrum-alias-item-mark-padding-top-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-mark-padding-top-xl: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-item-mark-padding-bottom-s: var(
+        --spectrum-global-dimension-size-40
+    );
+    --spectrum-alias-item-mark-padding-bottom-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-mark-padding-bottom-xl: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-item-mark-padding-left-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-mark-padding-left-l: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-mark-padding-left-xl: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-item-control-1-size-s: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-item-control-1-size-m: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-control-2-size-m: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-item-control-2-size-l: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-item-control-2-size-xl: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-item-control-2-size-xxl: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-item-control-2-border-radius-s: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-control-2-border-radius-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-control-2-border-radius-l: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-control-2-border-radius-xl: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-2-border-radius-xxl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-2-padding-s: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-control-2-padding-m: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-2-padding-l: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-control-2-padding-xl: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-item-control-3-height-m: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-item-control-3-height-l: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-item-control-3-height-xl: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-item-control-3-border-radius-s: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-control-3-border-radius-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-control-3-border-radius-l: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-control-3-border-radius-xl: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-3-padding-s: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-control-3-padding-m: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-3-padding-l: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-control-3-padding-xl: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-item-mark-size-s: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-item-mark-size-l: var(
+        --spectrum-global-dimension-size-275
+    );
+    --spectrum-alias-item-mark-size-xl: var(
+        --spectrum-global-dimension-size-325
+    );
+    --spectrum-alias-heading-xxxl-text-size: var(
+        --spectrum-global-dimension-font-size-1300
+    );
+    --spectrum-alias-heading-xxl-text-size: var(
+        --spectrum-global-dimension-font-size-1100
+    );
+    --spectrum-alias-heading-xl-text-size: var(
+        --spectrum-global-dimension-font-size-900
+    );
+    --spectrum-alias-heading-l-text-size: var(
+        --spectrum-global-dimension-font-size-700
+    );
+    --spectrum-alias-heading-m-text-size: var(
+        --spectrum-global-dimension-font-size-500
+    );
+    --spectrum-alias-heading-s-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-alias-heading-xs-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-heading-xxs-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-heading-xxxl-margin-top: var(
+        --spectrum-global-dimension-font-size-1200
+    );
+    --spectrum-alias-heading-xxl-margin-top: var(
+        --spectrum-global-dimension-font-size-900
+    );
+    --spectrum-alias-heading-xl-margin-top: var(
+        --spectrum-global-dimension-font-size-800
+    );
+    --spectrum-alias-heading-l-margin-top: var(
+        --spectrum-global-dimension-font-size-600
+    );
+    --spectrum-alias-heading-m-margin-top: var(
+        --spectrum-global-dimension-font-size-400
+    );
+    --spectrum-alias-heading-s-margin-top: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-heading-xs-margin-top: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-heading-xxs-margin-top: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-alias-heading-han-xxxl-text-size: var(
+        --spectrum-global-dimension-font-size-1300
+    );
+    --spectrum-alias-heading-han-xxl-text-size: var(
+        --spectrum-global-dimension-font-size-900
+    );
+    --spectrum-alias-heading-han-xl-text-size: var(
+        --spectrum-global-dimension-font-size-800
+    );
+    --spectrum-alias-heading-han-l-text-size: var(
+        --spectrum-global-dimension-font-size-600
+    );
+    --spectrum-alias-heading-han-m-text-size: var(
+        --spectrum-global-dimension-font-size-400
+    );
+    --spectrum-alias-heading-han-s-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-alias-heading-han-xs-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-heading-han-xxs-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-heading-han-xxxl-margin-top: var(
+        --spectrum-global-dimension-font-size-1200
+    );
+    --spectrum-alias-heading-han-xxl-margin-top: var(
+        --spectrum-global-dimension-font-size-800
+    );
+    --spectrum-alias-heading-han-xl-margin-top: var(
+        --spectrum-global-dimension-font-size-700
+    );
+    --spectrum-alias-heading-han-l-margin-top: var(
+        --spectrum-global-dimension-font-size-500
+    );
+    --spectrum-alias-heading-han-m-margin-top: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-alias-heading-han-s-margin-top: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-heading-han-xs-margin-top: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-heading-han-xxs-margin-top: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-alias-component-border-radius: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-component-border-radius-quiet: var(
+        --spectrum-global-dimension-static-size-0
+    );
+    --spectrum-alias-component-focusring-gap: var(
+        --spectrum-global-dimension-static-size-0
+    );
+    --spectrum-alias-component-focusring-gap-emphasized: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-component-focusring-size: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-component-focusring-size-emphasized: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-input-border-size: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-input-focusring-gap: var(
+        --spectrum-global-dimension-static-size-0
+    );
+    --spectrum-alias-input-quiet-focusline-gap: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-control-two-size-m: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-control-two-size-l: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-control-two-size-xl: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-control-two-size-xxl: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-control-two-border-radius-s: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-control-two-border-radius-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-control-two-border-radius-l: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-control-two-border-radius-xl: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-control-two-border-radius-xxl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-control-two-focus-ring-border-radius-s: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-control-two-focus-ring-border-radius-m: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-control-two-focus-ring-border-radius-l: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-control-two-focus-ring-border-radius-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-control-two-focus-ring-border-radius-xxl: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-control-three-height-m: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-control-three-height-l: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-control-three-height-xl: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-infieldbutton-icon-margin-y-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-infieldbutton-icon-margin-y-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-infieldbutton-icon-margin-y-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-infieldbutton-icon-margin-y-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-infieldbutton-border-radius: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-infieldbutton-border-radius-sided: 0;
+    --spectrum-alias-infieldbutton-border-size: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-infieldbutton-fill-padding-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-infieldbutton-fill-padding-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-infieldbutton-fill-padding-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-infieldbutton-fill-padding-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-infieldbutton-padding-s: 0;
+    --spectrum-alias-infieldbutton-padding-m: 0;
+    --spectrum-alias-infieldbutton-padding-l: 0;
+    --spectrum-alias-infieldbutton-padding-xl: 0;
+    --spectrum-alias-infieldbutton-full-height-s: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-infieldbutton-full-height-m: var(
+        --spectrum-global-dimension-size-400
+    );
+    --spectrum-alias-infieldbutton-full-height-l: var(
+        --spectrum-global-dimension-size-500
+    );
+    --spectrum-alias-infieldbutton-full-height-xl: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-alias-infieldbutton-half-height-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-infieldbutton-half-height-m: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-infieldbutton-half-height-l: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-infieldbutton-half-height-xl: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-stepperbutton-gap: 0;
+    --spectrum-alias-stepperbutton-width-s: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-stepperbutton-width-m: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-stepperbutton-width-l: var(
+        --spectrum-global-dimension-size-400
+    );
+    --spectrum-alias-stepperbutton-width-xl: var(
+        --spectrum-global-dimension-size-450
+    );
+    --spectrum-alias-stepperbutton-icon-x-offset-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-stepperbutton-icon-x-offset-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-stepperbutton-icon-x-offset-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-stepperbutton-icon-x-offset-xl: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-stepperbutton-icon-y-offset-top-s: var(
+        --spectrum-global-dimension-size-25
+    );
+    --spectrum-alias-stepperbutton-icon-y-offset-top-m: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-stepperbutton-icon-y-offset-top-l: var(
+        --spectrum-global-dimension-size-65
+    );
+    --spectrum-alias-stepperbutton-icon-y-offset-top-xl: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-s: var(
+        --spectrum-global-dimension-size-10
+    );
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-m: var(
+        --spectrum-global-dimension-size-25
+    );
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-l: var(
+        --spectrum-global-dimension-size-40
+    );
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-xl: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-stepperbutton-radius-touching: 0;
+    --spectrum-alias-clearbutton-icon-margin-s: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-clearbutton-icon-margin-m: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-clearbutton-icon-margin-l: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-clearbutton-icon-margin-xl: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-clearbutton-border-radius: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-pickerbutton-icononly-padding-x-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-pickerbutton-icononly-padding-x-m: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-pickerbutton-icononly-padding-x-l: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-pickerbutton-icononly-padding-x-xl: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-pickerbutton-icon-margin-y-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-pickerbutton-icon-margin-y-m: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-pickerbutton-icon-margin-y-l: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-pickerbutton-icon-margin-y-xl: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-pickerbutton-label-padding-y-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-pickerbutton-label-padding-y-m: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-pickerbutton-label-padding-y-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-pickerbutton-label-padding-y-xl: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-pickerbutton-border-radius-rounded: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-pickerbutton-border-radius-rounded-sided: 0;
+    --spectrum-alias-search-border-radius: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-search-border-radius-quiet: 0;
+    --spectrum-alias-combobox-quiet-button-offset-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-thumbnail-border-radius-small: var(
+        --spectrum-global-dimension-size-25
+    );
+    --spectrum-alias-actiongroup-button-gap: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-actiongroup-button-gap-compact: var(
+        --spectrum-global-dimension-size-0
+    );
+    --spectrum-alias-actiongroup-button-gap-quiet: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-actiongroup-button-gap-quiet-compact: var(
+        --spectrum-global-dimension-size-25
+    );
+    --spectrum-alias-search-padding-left-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-search-padding-left-l: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-search-padding-left-xl: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-percent-50: 50%;
+    --spectrum-alias-percent-70: 70%;
+    --spectrum-alias-percent-100: 100%;
+    --spectrum-alias-breakpoint-xsmall: 304px;
+    --spectrum-alias-breakpoint-small: 768px;
+    --spectrum-alias-breakpoint-medium: 1280px;
+    --spectrum-alias-breakpoint-large: 1768px;
+    --spectrum-alias-breakpoint-xlarge: 2160px;
+    --spectrum-alias-grid-columns: 12;
+    --spectrum-alias-grid-fluid-width: 100%;
+    --spectrum-alias-grid-fixed-max-width: 1280px;
+    --spectrum-alias-border-size-thin: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-border-size-thick: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-border-size-thicker: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-border-size-thickest: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-border-offset-thin: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-border-offset-thick: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-border-offset-thicker: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-border-offset-thickest: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-baseline: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-grid-gutter-xsmall: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-gutter-small: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-grid-gutter-medium: var(
+        --spectrum-global-dimension-static-size-400
+    );
+    --spectrum-alias-grid-gutter-large: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-grid-gutter-xlarge: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-grid-margin-xsmall: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-margin-small: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-grid-margin-medium: var(
+        --spectrum-global-dimension-static-size-400
+    );
+    --spectrum-alias-grid-margin-large: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-grid-margin-xlarge: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-small: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(
+        --spectrum-global-dimension-static-size-400
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-large: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-radial-reaction-size-default: var(
+        --spectrum-global-dimension-static-size-550
+    );
+    --spectrum-alias-focus-ring-gap: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-focus-ring-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-focus-ring-gap-small: var(
+        --spectrum-global-dimension-static-size-0
+    );
+    --spectrum-alias-focus-ring-size-small: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-dropshadow-blur: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-dropshadow-offset-y: var(
+        --spectrum-global-dimension-size-10
+    );
+    --spectrum-alias-font-size-default: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-layout-label-gap-size: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-pill-button-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-pill-button-text-baseline: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-border-radius-xsmall: var(
+        --spectrum-global-dimension-size-10
+    );
+    --spectrum-alias-border-radius-small: var(
+        --spectrum-global-dimension-size-25
+    );
+    --spectrum-alias-border-radius-regular: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-border-radius-medium: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-border-radius-large: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-border-radius-xlarge: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-focus-ring-border-radius-xsmall: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-focus-ring-border-radius-small: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-alias-focus-ring-border-radius-medium: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-focus-ring-border-radius-large: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-focus-ring-border-radius-xlarge: var(
+        --spectrum-global-dimension-size-350
+    );
+    --spectrum-alias-single-line-height: var(
+        --spectrum-global-dimension-size-400
+    );
+    --spectrum-alias-single-line-width: var(
+        --spectrum-global-dimension-size-2400
+    );
+    --spectrum-alias-workflow-icon-size-s: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-workflow-icon-size-m: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-workflow-icon-size-xl: var(
+        --spectrum-global-dimension-size-275
+    );
+    --spectrum-alias-ui-icon-alert-size-75: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-ui-icon-alert-size-100: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-ui-icon-alert-size-200: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-ui-icon-alert-size-300: var(
+        --spectrum-global-dimension-size-275
+    );
+    --spectrum-alias-ui-icon-triplegripper-size-100-height: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-ui-icon-doublegripper-size-100-width: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-ui-icon-singlegripper-size-100-width: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-75: var(
+        --spectrum-global-dimension-size-65
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-200: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-ui-icon-asterisk-size-75: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-asterisk-size-100: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-avatar-size-50: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-avatar-size-75: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-avatar-size-200: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-avatar-size-300: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-avatar-size-500: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-avatar-size-700: var(--spectrum-global-dimension-size-500);
+    --spectrum-alias-avatar-border-size: var(
+        --spectrum-global-dimension-size-0
+    );
+    --spectrum-alias-tag-border-radius: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-tag-border-size-default: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-tag-border-size-key-focus: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-tag-border-size-disabled: var(
+        --spectrum-global-dimension-size-0
+    );
+    --spectrum-alias-tag-border-size: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-tag-padding-right-s: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-tag-padding-right-m: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-tag-padding-right-l: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-tag-height-s: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-tag-height-m: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-tag-height-l: var(--spectrum-global-dimension-size-500);
+    --spectrum-alias-tag-font-size-s: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-alias-tag-font-size-m: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-tag-font-size-l: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-tag-text-padding-top-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-tag-text-padding-top-m: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-tag-text-padding-top-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-tag-icon-size-s: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-tag-icon-size-m: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-tag-icon-margin-top-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-tag-icon-margin-top-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-tag-icon-margin-top-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-tag-icon-margin-right-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-tag-icon-margin-right-m: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-tag-icon-margin-right-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-tag-clearbutton-width-s: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-tag-clearbutton-width-m: var(
+        --spectrum-global-dimension-size-400
+    );
+    --spectrum-alias-tag-clearbutton-width-l: var(
+        --spectrum-global-dimension-size-500
+    );
+    --spectrum-alias-tag-clearbutton-icon-margin-s: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-tag-clearbutton-icon-margin-m: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-tag-clearbutton-icon-margin-l: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-tag-focusring-size: var(
+        --spectrum-global-dimension-size-25
+    );
+    --spectrum-alias-tag-focusring-gap: var(
+        --spectrum-global-dimension-static-size-0
+    );
+    --spectrum-alias-tag-focusring-gap-selected: var(
+        --spectrum-global-dimension-size-25
+    );
+    --spectrum-alias-colorloupe-width: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-colorloupe-height: var(
+        --spectrum-global-dimension-static-size-800
+    );
+}
+
+:root,
+:host {
+    --spectrum-alias-colorhandle-outer-border-color: #0000006b;
+    --spectrum-alias-transparent-blue-background-color-hover: #0057be26;
+    --spectrum-alias-transparent-blue-background-color-down: #0048994d;
+    --spectrum-alias-transparent-blue-background-color-key-focus: var(
+        --spectrum-alias-transparent-blue-background-color-hover
+    );
+    --spectrum-alias-transparent-blue-background-color-mouse-focus: var(
+        --spectrum-alias-transparent-blue-background-color-hover
+    );
+    --spectrum-alias-transparent-blue-background-color: var(
+        --spectrum-alias-component-text-color-default
+    );
+    --spectrum-alias-transparent-red-background-color-hover: #9a000026;
+    --spectrum-alias-transparent-red-background-color-down: #7c00004d;
+    --spectrum-alias-transparent-red-background-color-key-focus: var(
+        --spectrum-alias-transparent-red-background-color-hover
+    );
+    --spectrum-alias-transparent-red-background-color-mouse-focus: var(
+        --spectrum-alias-transparent-red-background-color-hover
+    );
+    --spectrum-alias-transparent-red-background-color: var(
+        --spectrum-alias-component-text-color-default
+    );
+    --spectrum-alias-component-text-color-disabled: var(
+        --spectrum-global-color-gray-500
+    );
+    --spectrum-alias-component-text-color-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-component-text-color-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-component-text-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-component-text-color-key-focus: var(
+        --spectrum-alias-component-text-color-hover
+    );
+    --spectrum-alias-component-text-color-mouse-focus: var(
+        --spectrum-alias-component-text-color-hover
+    );
+    --spectrum-alias-component-text-color: var(
+        --spectrum-alias-component-text-color-default
+    );
+    --spectrum-alias-component-text-color-selected-default: var(
+        --spectrum-alias-component-text-color-default
+    );
+    --spectrum-alias-component-text-color-selected-hover: var(
+        --spectrum-alias-component-text-color-hover
+    );
+    --spectrum-alias-component-text-color-selected-down: var(
+        --spectrum-alias-component-text-color-down
+    );
+    --spectrum-alias-component-text-color-selected-key-focus: var(
+        --spectrum-alias-component-text-color-key-focus
+    );
+    --spectrum-alias-component-text-color-selected-mouse-focus: var(
+        --spectrum-alias-component-text-color-mouse-focus
+    );
+    --spectrum-alias-component-text-color-selected: var(
+        --spectrum-alias-component-text-color-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-default: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-hover: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-down: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-key-focus: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-mouse-focus: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-error-default: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-component-text-color-error-hover: var(
+        --spectrum-semantic-negative-text-color-small-hover
+    );
+    --spectrum-alias-component-text-color-error-down: var(
+        --spectrum-semantic-negative-text-color-small-down
+    );
+    --spectrum-alias-component-text-color-error-key-focus: var(
+        --spectrum-semantic-negative-text-color-small-key-focus
+    );
+    --spectrum-alias-component-text-color-error-mouse-focus: var(
+        --spectrum-semantic-negative-text-color-small-key-focus
+    );
+    --spectrum-alias-component-text-color-error: var(
+        --spectrum-alias-component-text-color-error-default
+    );
+    --spectrum-alias-component-icon-color-disabled: var(
+        --spectrum-alias-icon-color-disabled
+    );
+    --spectrum-alias-component-icon-color-default: var(
+        --spectrum-alias-icon-color
+    );
+    --spectrum-alias-component-icon-color-hover: var(
+        --spectrum-alias-icon-color-hover
+    );
+    --spectrum-alias-component-icon-color-down: var(
+        --spectrum-alias-icon-color-down
+    );
+    --spectrum-alias-component-icon-color-key-focus: var(
+        --spectrum-alias-icon-color-hover
+    );
+    --spectrum-alias-component-icon-color-mouse-focus: var(
+        --spectrum-alias-icon-color-down
+    );
+    --spectrum-alias-component-icon-color: var(
+        --spectrum-alias-component-icon-color-default
+    );
+    --spectrum-alias-component-icon-color-selected: var(
+        --spectrum-alias-icon-color-selected-neutral-subdued
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected-default: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected-hover: var(
+        --spectrum-alias-component-icon-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected-down: var(
+        --spectrum-alias-component-icon-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected-key-focus: var(
+        --spectrum-alias-component-icon-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected: var(
+        --spectrum-alias-component-icon-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-background-color-disabled: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-background-color-quiet-disabled: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-component-background-color-quiet-selected-disabled: var(
+        --spectrum-alias-component-background-color-disabled
+    );
+    --spectrum-alias-component-background-color-default: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-alias-component-background-color-hover: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-component-background-color-down: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-background-color-key-focus: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-component-background-color: var(
+        --spectrum-alias-component-background-color-default
+    );
+    --spectrum-alias-component-background-color-selected-default: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-background-color-selected-hover: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-background-color-selected-down: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-background-color-selected-key-focus: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-background-color-selected: var(
+        --spectrum-alias-component-background-color-selected-default
+    );
+    --spectrum-alias-component-background-color-quiet-default: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-component-background-color-quiet-hover: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-component-background-color-quiet-down: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-component-background-color-quiet-key-focus: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-component-background-color-quiet: var(
+        --spectrum-alias-component-background-color-quiet-default
+    );
+    --spectrum-alias-component-background-color-quiet-selected-default: var(
+        --spectrum-alias-component-background-color-selected-default
+    );
+    --spectrum-alias-component-background-color-quiet-selected-hover: var(
+        --spectrum-alias-component-background-color-selected-hover
+    );
+    --spectrum-alias-component-background-color-quiet-selected-down: var(
+        --spectrum-alias-component-background-color-selected-down
+    );
+    --spectrum-alias-component-background-color-quiet-selected-key-focus: var(
+        --spectrum-alias-component-background-color-selected-key-focus
+    );
+    --spectrum-alias-component-background-color-quiet-selected: var(
+        --spectrum-alias-component-background-color-selected-default
+    );
+    --spectrum-alias-component-background-color-emphasized-selected-default: var(
+        --spectrum-semantic-cta-background-color-default
+    );
+    --spectrum-alias-component-background-color-emphasized-selected-hover: var(
+        --spectrum-semantic-cta-background-color-hover
+    );
+    --spectrum-alias-component-background-color-emphasized-selected-down: var(
+        --spectrum-semantic-cta-background-color-down
+    );
+    --spectrum-alias-component-background-color-emphasized-selected-key-focus: var(
+        --spectrum-semantic-cta-background-color-key-focus
+    );
+    --spectrum-alias-component-background-color-emphasized-selected: var(
+        --spectrum-alias-component-background-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-border-color-disabled: var(
+        --spectrum-alias-border-color-disabled
+    );
+    --spectrum-alias-component-border-color-quiet-disabled: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-component-border-color-default: var(
+        --spectrum-alias-border-color
+    );
+    --spectrum-alias-component-border-color-hover: var(
+        --spectrum-alias-border-color-hover
+    );
+    --spectrum-alias-component-border-color-down: var(
+        --spectrum-alias-border-color-down
+    );
+    --spectrum-alias-component-border-color-key-focus: var(
+        --spectrum-alias-border-color-key-focus
+    );
+    --spectrum-alias-component-border-color: var(
+        --spectrum-alias-component-border-color-default
+    );
+    --spectrum-alias-component-border-color-selected-default: var(
+        --spectrum-alias-border-color
+    );
+    --spectrum-alias-component-border-color-selected-hover: var(
+        --spectrum-alias-border-color-hover
+    );
+    --spectrum-alias-component-border-color-selected-down: var(
+        --spectrum-alias-border-color-down
+    );
+    --spectrum-alias-component-border-color-selected-key-focus: var(
+        --spectrum-alias-border-color-key-focus
+    );
+    --spectrum-alias-component-border-color-selected: var(
+        --spectrum-alias-component-border-color-selected-default
+    );
+    --spectrum-alias-component-border-color-quiet-default: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-component-border-color-quiet-hover: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-component-border-color-quiet-down: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-component-border-color-quiet-key-focus: var(
+        --spectrum-alias-border-color-key-focus
+    );
+    --spectrum-alias-component-border-color-quiet: var(
+        --spectrum-alias-component-border-color-quiet-default
+    );
+    --spectrum-alias-component-border-color-quiet-selected-default: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-border-color-quiet-selected-hover: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-border-color-quiet-selected-down: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-border-color-quiet-selected-key-focus: var(
+        --spectrum-alias-border-color-key-focus
+    );
+    --spectrum-alias-component-border-color-quiet-selected: var(
+        --spectrum-alias-component-border-color-quiet-selected-default
+    );
+    --spectrum-alias-component-border-color-emphasized-selected-default: var(
+        --spectrum-semantic-cta-background-color-default
+    );
+    --spectrum-alias-component-border-color-emphasized-selected-hover: var(
+        --spectrum-semantic-cta-background-color-hover
+    );
+    --spectrum-alias-component-border-color-emphasized-selected-down: var(
+        --spectrum-semantic-cta-background-color-down
+    );
+    --spectrum-alias-component-border-color-emphasized-selected-key-focus: var(
+        --spectrum-semantic-cta-background-color-key-focus
+    );
+    --spectrum-alias-component-border-color-emphasized-selected: var(
+        --spectrum-alias-component-border-color-emphasized-selected-default
+    );
+    --spectrum-alias-tag-border-color-default: var(
+        --spectrum-alias-border-color-darker-default
+    );
+    --spectrum-alias-tag-border-color-hover: var(
+        --spectrum-alias-border-color-darker-hover
+    );
+    --spectrum-alias-tag-border-color-down: var(
+        --spectrum-alias-border-color-darker-hover
+    );
+    --spectrum-alias-tag-border-color-key-focus: var(
+        --spectrum-alias-border-color-key-focus
+    );
+    --spectrum-alias-tag-border-color-error-default: var(
+        --spectrum-semantic-negative-color-default
+    );
+    --spectrum-alias-tag-border-color-error-hover: var(
+        --spectrum-semantic-negative-color-hover
+    );
+    --spectrum-alias-tag-border-color-error-down: var(
+        --spectrum-semantic-negative-color-hover
+    );
+    --spectrum-alias-tag-border-color-error-key-focus: var(
+        --spectrum-alias-border-color-key-focus
+    );
+    --spectrum-alias-tag-border-color-error-selected: var(
+        --spectrum-semantic-negative-color-default
+    );
+    --spectrum-alias-tag-border-color-selected: var(
+        --spectrum-alias-tag-background-color-selected-default
+    );
+    --spectrum-alias-tag-border-color: var(
+        --spectrum-alias-tag-border-color-default
+    );
+    --spectrum-alias-tag-border-color-disabled: var(
+        --spectrum-alias-border-color-disabled
+    );
+    --spectrum-alias-tag-border-color-error: var(
+        --spectrum-alias-tag-border-color-error-default
+    );
+    --spectrum-alias-tag-text-color-default: var(
+        --spectrum-alias-label-text-color
+    );
+    --spectrum-alias-tag-text-color-hover: var(
+        --spectrum-alias-text-color-hover
+    );
+    --spectrum-alias-tag-text-color-down: var(--spectrum-alias-text-color-down);
+    --spectrum-alias-tag-text-color-key-focus: var(
+        --spectrum-alias-text-color-hover
+    );
+    --spectrum-alias-tag-text-color-disabled: var(
+        --spectrum-global-color-gray-500
+    );
+    --spectrum-alias-tag-text-color: var(
+        --spectrum-alias-tag-text-color-default
+    );
+    --spectrum-alias-tag-text-color-error-default: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-alias-tag-text-color-error-hover: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-alias-tag-text-color-error-down: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-alias-tag-text-color-error-key-focus: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-alias-tag-text-color-error: var(
+        --spectrum-alias-tag-text-color-error-default
+    );
+    --spectrum-alias-tag-text-color-selected: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-tag-icon-color-default: var(--spectrum-alias-icon-color);
+    --spectrum-alias-tag-icon-color-hover: var(
+        --spectrum-alias-icon-color-hover
+    );
+    --spectrum-alias-tag-icon-color-down: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-tag-icon-color-key-focus: var(
+        --spectrum-alias-icon-color-hover
+    );
+    --spectrum-alias-tag-icon-color-disabled: var(
+        --spectrum-alias-icon-color-disabled
+    );
+    --spectrum-alias-tag-icon-color: var(
+        --spectrum-alias-tag-icon-color-default
+    );
+    --spectrum-alias-tag-icon-color-error: var(--spectrum-global-color-red-600);
+    --spectrum-alias-tag-icon-color-selected: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-tag-background-color-disabled: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-tag-background-color-default: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-tag-background-color-hover: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-tag-background-color-down: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-tag-background-color-key-focus: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-tag-background-color: var(
+        --spectrum-alias-tag-background-color-default
+    );
+    --spectrum-alias-tag-background-color-error-default: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-tag-background-color-error-hover: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-tag-background-color-error-down: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-tag-background-color-error-key-focus: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-tag-background-color-error: var(
+        --spectrum-alias-tag-background-color-error-default
+    );
+    --spectrum-alias-tag-background-color-error-selected-default: var(
+        --spectrum-semantic-negative-color-default
+    );
+    --spectrum-alias-tag-background-color-error-selected-hover: var(
+        --spectrum-semantic-negative-color-hover
+    );
+    --spectrum-alias-tag-background-color-error-selected-down: var(
+        --spectrum-semantic-negative-color-hover
+    );
+    --spectrum-alias-tag-background-color-error-selected-key-focus: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-alias-tag-background-color-error-selected: var(
+        --spectrum-alias-tag-background-color-error-selected-default
+    );
+    --spectrum-alias-tag-background-color-selected-default: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-tag-background-color-selected-hover: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-tag-background-color-selected-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-tag-background-color-selected-key-focus: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-tag-background-color-selected: var(
+        --spectrum-alias-tag-background-color-selected-default
+    );
+    --spectrum-alias-tag-focusring-border-color-default: transparent;
+    --spectrum-alias-tag-focusring-border-color-key-focus: transparent;
+    --spectrum-alias-tag-focusring-border-color-disabled: transparent;
+    --spectrum-alias-tag-focusring-border-color-selected-key-focus: var(
+        --spectrum-alias-focus-ring-color
+    );
+    --spectrum-alias-tag-focusring-border-color: var(
+        --spectrum-alias-tag-focusring-border-color-default
+    );
+    --spectrum-alias-avatar-border-color-default: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color-hover: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color-down: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color-key-focus: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color: var(
+        --spectrum-alias-avatar-border-color-default
+    );
+    --spectrum-alias-avatar-border-color-disabled: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color-selected-default: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color-selected-hover: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color-selected-down: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color-selected-key-focus: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color-selected: var(
+        --spectrum-alias-avatar-border-color-selected-default
+    );
+    --spectrum-alias-avatar-border-color-selected-disabled: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-toggle-background-color-default: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-toggle-background-color-hover: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-toggle-background-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-toggle-background-color-key-focus: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-toggle-background-color: var(
+        --spectrum-alias-toggle-background-color-default
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected-default: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected-hover: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected-down: var(
+        --spectrum-global-color-blue-700
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected-key-focus: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected: var(
+        --spectrum-alias-toggle-background-color-emphasized-selected-default
+    );
+    --spectrum-alias-toggle-border-color-default: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-toggle-border-color-hover: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-toggle-border-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-toggle-border-color-key-focus: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-toggle-border-color: var(
+        --spectrum-alias-toggle-border-color-default
+    );
+    --spectrum-alias-toggle-icon-color-selected: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-alias-toggle-icon-color-emphasized-selected: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-alias-button-primary-background-color-default: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-button-primary-background-color-hover: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-button-primary-background-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-button-primary-background-color-key-focus: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-button-primary-background-color: var(
+        --spectrum-alias-button-primary-background-color-default
+    );
+    --spectrum-alias-button-primary-border-color-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-button-primary-border-color-hover: var(
+        --spectrum-alias-button-primary-background-color-hover
+    );
+    --spectrum-alias-button-primary-border-color-down: var(
+        --spectrum-alias-button-primary-background-color-down
+    );
+    --spectrum-alias-button-primary-border-color-key-focus: var(
+        --spectrum-alias-button-primary-background-color-key-focus
+    );
+    --spectrum-alias-button-primary-border-color: var(
+        --spectrum-alias-button-primary-border-color-default
+    );
+    --spectrum-alias-button-primary-text-color-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-button-primary-text-color-hover: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-primary-text-color-down: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-primary-text-color-key-focus: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-primary-text-color: var(
+        --spectrum-alias-button-primary-text-color-default
+    );
+    --spectrum-alias-button-primary-icon-color-default: var(
+        --spectrum-alias-button-primary-text-color-default
+    );
+    --spectrum-alias-button-primary-icon-color-hover: var(
+        --spectrum-alias-button-primary-text-color-hover
+    );
+    --spectrum-alias-button-primary-icon-color-down: var(
+        --spectrum-alias-button-primary-text-color-down
+    );
+    --spectrum-alias-button-primary-icon-color-key-focus: var(
+        --spectrum-alias-button-primary-text-color-key-focus
+    );
+    --spectrum-alias-button-primary-icon-color: var(
+        --spectrum-alias-button-primary-icon-color-default
+    );
+    --spectrum-alias-button-secondary-background-color-default: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-button-secondary-background-color-hover: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-button-secondary-background-color-down: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-button-secondary-background-color-key-focus: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-button-secondary-background-color: var(
+        --spectrum-alias-button-secondary-background-color-default
+    );
+    --spectrum-alias-button-secondary-border-color-default: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-button-secondary-border-color-hover: var(
+        --spectrum-alias-button-secondary-background-color-hover
+    );
+    --spectrum-alias-button-secondary-border-color-down: var(
+        --spectrum-alias-button-secondary-background-color-down
+    );
+    --spectrum-alias-button-secondary-border-color-key-focus: var(
+        --spectrum-alias-button-secondary-background-color-key-focus
+    );
+    --spectrum-alias-button-secondary-border-color: var(
+        --spectrum-alias-button-secondary-border-color-default
+    );
+    --spectrum-alias-button-secondary-text-color-default: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-button-secondary-text-color-hover: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-secondary-text-color-down: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-secondary-text-color-key-focus: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-secondary-text-color: var(
+        --spectrum-alias-button-secondary-text-color-default
+    );
+    --spectrum-alias-button-secondary-icon-color-default: var(
+        --spectrum-alias-button-secondary-text-color-default
+    );
+    --spectrum-alias-button-secondary-icon-color-hover: var(
+        --spectrum-alias-button-secondary-text-color-hover
+    );
+    --spectrum-alias-button-secondary-icon-color-down: var(
+        --spectrum-alias-button-secondary-text-color-down
+    );
+    --spectrum-alias-button-secondary-icon-color-key-focus: var(
+        --spectrum-alias-button-secondary-text-color-key-focus
+    );
+    --spectrum-alias-button-secondary-icon-color: var(
+        --spectrum-alias-button-secondary-icon-color-default
+    );
+    --spectrum-alias-button-negative-background-color-default: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-button-negative-background-color-hover: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-background-color-down: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-alias-button-negative-background-color-key-focus: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-background-color: var(
+        --spectrum-alias-button-negative-background-color-default
+    );
+    --spectrum-alias-button-negative-border-color-default: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-border-color-hover: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-border-color-down: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-alias-button-negative-border-color-key-focus: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-border-color: var(
+        --spectrum-alias-button-negative-border-color-default
+    );
+    --spectrum-alias-button-negative-text-color-default: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-text-color-hover: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-negative-text-color-down: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-negative-text-color-key-focus: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-negative-text-color: var(
+        --spectrum-alias-button-negative-text-color-default
+    );
+    --spectrum-alias-button-negative-icon-color-default: var(
+        --spectrum-alias-button-negative-text-color-default
+    );
+    --spectrum-alias-button-negative-icon-color-hover: var(
+        --spectrum-alias-button-negative-text-color-hover
+    );
+    --spectrum-alias-button-negative-icon-color-down: var(
+        --spectrum-alias-button-negative-text-color-down
+    );
+    --spectrum-alias-button-negative-icon-color-key-focus: var(
+        --spectrum-alias-button-negative-text-color-key-focus
+    );
+    --spectrum-alias-button-negative-icon-color: var(
+        --spectrum-alias-button-negative-icon-color-default
+    );
+    --spectrum-alias-input-border-color-disabled: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-input-border-color-quiet-disabled: var(
+        --spectrum-alias-border-color-mid
+    );
+    --spectrum-alias-input-border-color-default: var(
+        --spectrum-alias-border-color
+    );
+    --spectrum-alias-input-border-color-hover: var(
+        --spectrum-alias-border-color-hover
+    );
+    --spectrum-alias-input-border-color-down: var(
+        --spectrum-alias-border-color-mouse-focus
+    );
+    --spectrum-alias-input-border-color-mouse-focus: var(
+        --spectrum-alias-border-color-mouse-focus
+    );
+    --spectrum-alias-input-border-color-key-focus: var(
+        --spectrum-alias-border-color-key-focus
+    );
+    --spectrum-alias-input-border-color: var(
+        --spectrum-alias-input-border-color-default
+    );
+    --spectrum-alias-input-border-color-invalid-default: var(
+        --spectrum-semantic-negative-color-default
+    );
+    --spectrum-alias-input-border-color-invalid-hover: var(
+        --spectrum-semantic-negative-color-hover
+    );
+    --spectrum-alias-input-border-color-invalid-down: var(
+        --spectrum-semantic-negative-color-down
+    );
+    --spectrum-alias-input-border-color-invalid-mouse-focus: var(
+        --spectrum-semantic-negative-color-hover
+    );
+    --spectrum-alias-input-border-color-invalid-key-focus: var(
+        --spectrum-alias-border-color-key-focus
+    );
+    --spectrum-alias-input-border-color-invalid: var(
+        --spectrum-alias-input-border-color-invalid-default
+    );
+    --spectrum-alias-background-color-yellow-default: var(
+        --spectrum-global-color-static-yellow-300
+    );
+    --spectrum-alias-background-color-yellow-hover: var(
+        --spectrum-global-color-static-yellow-400
+    );
+    --spectrum-alias-background-color-yellow-key-focus: var(
+        --spectrum-global-color-static-yellow-400
+    );
+    --spectrum-alias-background-color-yellow-down: var(
+        --spectrum-global-color-static-yellow-500
+    );
+    --spectrum-alias-background-color-yellow: var(
+        --spectrum-alias-background-color-yellow-default
+    );
+    --spectrum-alias-infieldbutton-background-color: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessLow-border-color-disabled: transparent;
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-border-color-disabled: transparent;
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-border-color-disabled: var(
+        --spectrum-alias-component-background-color-disabled
+    );
+    --spectrum-alias-infieldbutton-fill-border-color-default: var(
+        --spectrum-alias-input-border-color-default
+    );
+    --spectrum-alias-infieldbutton-fill-border-color-hover: var(
+        --spectrum-alias-input-border-color-hover
+    );
+    --spectrum-alias-infieldbutton-fill-border-color-down: var(
+        --spectrum-alias-input-border-color-down
+    );
+    --spectrum-alias-infieldbutton-fill-border-color-mouse-focus: var(
+        --spectrum-alias-input-border-color-mouse-focus
+    );
+    --spectrum-alias-infieldbutton-fill-border-color-key-focus: var(
+        --spectrum-alias-input-border-color-key-focus
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-default: transparent;
+    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover: transparent;
+    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down: transparent;
+    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus: transparent;
+    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-disabled: transparent;
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-default: var(
+        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-default
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-hover: var(
+        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-down: var(
+        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-key-focus: var(
+        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-disabled: transparent;
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-default: var(
+        --spectrum-alias-component-background-color-default
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover: var(
+        --spectrum-alias-component-background-color-hover
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down: var(
+        --spectrum-alias-component-background-color-down
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus: var(
+        --spectrum-alias-component-background-color-key-focus
+    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-disabled: var(
+        --spectrum-alias-component-background-color-disabled
+    );
+    --spectrum-alias-actionbutton-staticBlack-border-color-default: #0006;
+    --spectrum-alias-actionbutton-staticBlack-background-color-default: transparent;
+    --spectrum-alias-actionbutton-staticBlack-border-color-hover: #0000008c;
+    --spectrum-alias-actionbutton-staticBlack-background-color-hover: #00000040;
+    --spectrum-alias-actionbutton-staticBlack-border-color-down: #000000b3;
+    --spectrum-alias-actionbutton-staticBlack-background-color-down: #0006;
+    --spectrum-alias-actionbutton-staticBlack-border-color-key-focus: #0000008c;
+    --spectrum-alias-actionbutton-staticBlack-background-color-key-focus: #00000040;
+    --spectrum-alias-actionbutton-staticBlack-border-color-disabled: #00000040;
+    --spectrum-alias-actionbutton-staticBlack-background-color-disabled: transparent;
+    --spectrum-alias-actionbutton-staticBlack-border-color-disabled-selected: transparent;
+    --spectrum-alias-actionbutton-staticBlack-background-color-disabled-selected: #0000001a;
+    --spectrum-alias-actionbutton-staticWhite-border-color-default: #fff6;
+    --spectrum-alias-actionbutton-staticWhite-background-color-default: transparent;
+    --spectrum-alias-actionbutton-staticWhite-border-color-hover: #ffffff8c;
+    --spectrum-alias-actionbutton-staticWhite-background-color-hover: #ffffff40;
+    --spectrum-alias-actionbutton-staticWhite-border-color-down: #ffffffb3;
+    --spectrum-alias-actionbutton-staticWhite-background-color-down: #fff6;
+    --spectrum-alias-actionbutton-staticWhite-border-color-key-focus: #ffffff8c;
+    --spectrum-alias-actionbutton-staticWhite-background-color-key-focus: #ffffff40;
+    --spectrum-alias-actionbutton-staticWhite-border-color-disabled: #ffffff40;
+    --spectrum-alias-actionbutton-staticWhite-background-color-disabled: transparent;
+    --spectrum-alias-actionbutton-staticWhite-border-color-disabled-selected: transparent;
+    --spectrum-alias-actionbutton-staticWhite-background-color-disabled-selected: #ffffff1a;
+    --spectrum-alias-tabs-divider-background-color-default: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-tabs-divider-background-color-quiet: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-tabitem-text-color-default: var(
+        --spectrum-alias-label-text-color
+    );
+    --spectrum-alias-tabitem-text-color-hover: var(
+        --spectrum-alias-text-color-hover
+    );
+    --spectrum-alias-tabitem-text-color-down: var(
+        --spectrum-alias-text-color-down
+    );
+    --spectrum-alias-tabitem-text-color-key-focus: var(
+        --spectrum-alias-text-color-hover
+    );
+    --spectrum-alias-tabitem-text-color-mouse-focus: var(
+        --spectrum-alias-text-color-hover
+    );
+    --spectrum-alias-tabitem-text-color: var(
+        --spectrum-alias-tabitem-text-color-default
+    );
+    --spectrum-alias-tabitem-text-color-selected-default: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-tabitem-text-color-selected-hover: var(
+        --spectrum-alias-tabitem-text-color-selected-default
+    );
+    --spectrum-alias-tabitem-text-color-selected-down: var(
+        --spectrum-alias-tabitem-text-color-selected-default
+    );
+    --spectrum-alias-tabitem-text-color-selected-key-focus: var(
+        --spectrum-alias-tabitem-text-color-selected-default
+    );
+    --spectrum-alias-tabitem-text-color-selected-mouse-focus: var(
+        --spectrum-alias-tabitem-text-color-selected-default
+    );
+    --spectrum-alias-tabitem-text-color-selected: var(
+        --spectrum-alias-tabitem-text-color-selected-default
+    );
+    --spectrum-alias-tabitem-text-color-emphasized: var(
+        --spectrum-alias-tabitem-text-color-default
+    );
+    --spectrum-alias-tabitem-text-color-emphasized-selected-default: var(
+        --spectrum-global-color-static-blue-500
+    );
+    --spectrum-alias-tabitem-text-color-emphasized-selected-hover: var(
+        --spectrum-alias-tabitem-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-tabitem-text-color-emphasized-selected-down: var(
+        --spectrum-alias-tabitem-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-tabitem-text-color-emphasized-selected-key-focus: var(
+        --spectrum-alias-tabitem-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-tabitem-text-color-emphasized-selected-mouse-focus: var(
+        --spectrum-alias-tabitem-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-tabitem-text-color-emphasized-selected: var(
+        --spectrum-alias-tabitem-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-tabitem-selection-indicator-color-default: var(
+        --spectrum-alias-tabitem-text-color-selected-default
+    );
+    --spectrum-alias-tabitem-selection-indicator-color-emphasized: var(
+        --spectrum-alias-tabitem-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-tabitem-icon-color-disabled: var(
+        --spectrum-alias-text-color-disabled
+    );
+    --spectrum-alias-tabitem-icon-color-default: var(
+        --spectrum-alias-icon-color
+    );
+    --spectrum-alias-tabitem-icon-color-hover: var(
+        --spectrum-alias-icon-color-hover
+    );
+    --spectrum-alias-tabitem-icon-color-down: var(
+        --spectrum-alias-icon-color-down
+    );
+    --spectrum-alias-tabitem-icon-color-key-focus: var(
+        --spectrum-alias-icon-color-hover
+    );
+    --spectrum-alias-tabitem-icon-color-mouse-focus: var(
+        --spectrum-alias-icon-color-down
+    );
+    --spectrum-alias-tabitem-icon-color: var(
+        --spectrum-alias-tabitem-icon-color-default
+    );
+    --spectrum-alias-tabitem-icon-color-selected: var(
+        --spectrum-alias-icon-color-selected-neutral
+    );
+    --spectrum-alias-tabitem-icon-color-emphasized: var(
+        --spectrum-alias-tabitem-text-color-default
+    );
+    --spectrum-alias-tabitem-icon-color-emphasized-selected: var(
+        --spectrum-alias-tabitem-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-assetcard-selectionindicator-background-color-ordered: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-alias-assetcard-overlay-background-color: #1b7ff51a;
+    --spectrum-alias-assetcard-border-color-selected: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-alias-assetcard-border-color-selected-hover: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-alias-assetcard-border-color-selected-down: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-background-color-default: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-background-color-disabled: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-background-color-transparent: transparent;
+    --spectrum-alias-background-color-overbackground-down: #fff3;
+    --spectrum-alias-background-color-quiet-overbackground-hover: #ffffff1a;
+    --spectrum-alias-background-color-quiet-overbackground-down: #fff3;
+    --spectrum-alias-background-color-overbackground-disabled: #ffffff1a;
+    --spectrum-alias-background-color-quickactions-overlay: #0003;
+    --spectrum-alias-placeholder-text-color: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-placeholder-text-color-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-placeholder-text-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-placeholder-text-color-selected: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-label-text-color: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-text-color: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-text-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-text-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-text-color-key-focus: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-text-color-mouse-focus: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-text-color-disabled: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-text-color-invalid: var(--spectrum-global-color-red-500);
+    --spectrum-alias-text-color-selected: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-text-color-selected-neutral: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-text-color-overbackground: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-text-color-overbackground-disabled: #fff3;
+    --spectrum-alias-text-color-quiet-overbackground-disabled: #fff3;
+    --spectrum-alias-heading-text-color: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-link-primary-text-color-default: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-link-primary-text-color-hover: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-link-primary-text-color-down: var(
+        --spectrum-global-color-blue-700
+    );
+    --spectrum-alias-link-primary-text-color-key-focus: var(
+        --spectrum-alias-text-color-key-focus
+    );
+    --spectrum-alias-link-primary-text-color: var(
+        --spectrum-alias-link-primary-text-color-default
+    );
+    --spectrum-alias-link-secondary-text-color-default: var(
+        --spectrum-alias-link-primary-text-color-default
+    );
+    --spectrum-alias-link-secondary-text-color-hover: var(
+        --spectrum-alias-link-primary-text-color-hover
+    );
+    --spectrum-alias-link-secondary-text-color-down: var(
+        --spectrum-alias-link-primary-text-color-down
+    );
+    --spectrum-alias-link-secondary-text-color-key-focus: var(
+        --spectrum-alias-link-primary-text-color-key-focus
+    );
+    --spectrum-alias-link-secondary-text-color: var(
+        --spectrum-alias-link-secondary-text-color-default
+    );
+    --spectrum-alias-border-color: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-border-color-hover: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-border-color-down: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-border-color-key-focus: var(
+        --spectrum-global-color-blue-400
+    );
+    --spectrum-alias-border-color-mouse-focus: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-alias-border-color-disabled: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-border-color-extralight: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-border-color-light: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-border-color-mid: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-border-color-dark: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-border-color-darker-default: var(
+        --spectrum-global-color-gray-600
+    );
+    --spectrum-alias-border-color-darker-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-border-color-darker-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-border-color-transparent: transparent;
+    --spectrum-alias-border-color-translucent-dark: #0000000d;
+    --spectrum-alias-border-color-translucent-darker: #0000001a;
+    --spectrum-alias-focus-color: var(--spectrum-global-color-blue-400);
+    --spectrum-alias-focus-ring-color: var(--spectrum-alias-focus-color);
+    --spectrum-alias-track-color-default: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-track-fill-color-overbackground: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-track-color-disabled: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-thumbnail-darksquare-background-color: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-thumbnail-lightsquare-background-color: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-track-color-overbackground: #fff3;
+    --spectrum-alias-icon-color: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-icon-color-overbackground: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-icon-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-icon-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-icon-color-key-focus: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-icon-color-disabled: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-icon-color-overbackground-disabled: #fff3;
+    --spectrum-alias-icon-color-quiet-overbackground-disabled: #ffffff26;
+    --spectrum-alias-icon-color-selected-neutral: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-icon-color-selected-neutral-subdued: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-icon-color-selected: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-icon-color-selected-hover: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-icon-color-selected-down: var(
+        --spectrum-global-color-blue-700
+    );
+    --spectrum-alias-icon-color-selected-focus: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-image-opacity-disabled: var(
+        --spectrum-global-color-opacity-30
+    );
+    --spectrum-alias-toolbar-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-code-highlight-color-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-code-highlight-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-alias-code-highlight-color-keyword: var(
+        --spectrum-global-color-fuchsia-600
+    );
+    --spectrum-alias-code-highlight-color-section: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-alias-code-highlight-color-literal: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-code-highlight-color-attribute: var(
+        --spectrum-global-color-seafoam-600
+    );
+    --spectrum-alias-code-highlight-color-class: var(
+        --spectrum-global-color-magenta-600
+    );
+    --spectrum-alias-code-highlight-color-variable: var(
+        --spectrum-global-color-purple-600
+    );
+    --spectrum-alias-code-highlight-color-title: var(
+        --spectrum-global-color-indigo-600
+    );
+    --spectrum-alias-code-highlight-color-string: var(
+        --spectrum-global-color-fuchsia-600
+    );
+    --spectrum-alias-code-highlight-color-function: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-code-highlight-color-comment: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-categorical-color-1: var(
+        --spectrum-global-color-static-seafoam-200
+    );
+    --spectrum-alias-categorical-color-2: var(
+        --spectrum-global-color-static-indigo-700
+    );
+    --spectrum-alias-categorical-color-3: var(
+        --spectrum-global-color-static-orange-500
+    );
+    --spectrum-alias-categorical-color-4: var(
+        --spectrum-global-color-static-magenta-500
+    );
+    --spectrum-alias-categorical-color-5: var(
+        --spectrum-global-color-static-indigo-200
+    );
+    --spectrum-alias-categorical-color-6: var(
+        --spectrum-global-color-static-celery-200
+    );
+    --spectrum-alias-categorical-color-7: var(
+        --spectrum-global-color-static-blue-500
+    );
+    --spectrum-alias-categorical-color-8: var(
+        --spectrum-global-color-static-purple-800
+    );
+    --spectrum-alias-categorical-color-9: var(
+        --spectrum-global-color-static-yellow-500
+    );
+    --spectrum-alias-categorical-color-10: var(
+        --spectrum-global-color-static-orange-700
+    );
+    --spectrum-alias-categorical-color-11: var(
+        --spectrum-global-color-static-green-600
+    );
+    --spectrum-alias-categorical-color-12: var(
+        --spectrum-global-color-static-chartreuse-300
+    );
+    --spectrum-alias-categorical-color-13: var(
+        --spectrum-global-color-static-blue-200
+    );
+    --spectrum-alias-categorical-color-14: var(
+        --spectrum-global-color-static-fuchsia-500
+    );
+    --spectrum-alias-categorical-color-15: var(
+        --spectrum-global-color-static-magenta-200
+    );
+    --spectrum-alias-categorical-color-16: var(
+        --spectrum-global-color-static-yellow-200
+    );
+}

--- a/tools/styles/spectrum-two/spectrum-scale-large.css
+++ b/tools/styles/spectrum-two/spectrum-scale-large.css
@@ -1,0 +1,292 @@
+:root,
+:host {
+    --spectrum-global-dimension-scale-factor: 1.25;
+    --spectrum-global-dimension-size-0: 0px;
+    --spectrum-global-dimension-size-10: 1px;
+    --spectrum-global-dimension-size-25: 2px;
+    --spectrum-global-dimension-size-30: 3px;
+    --spectrum-global-dimension-size-40: 4px;
+    --spectrum-global-dimension-size-50: 5px;
+    --spectrum-global-dimension-size-65: 6px;
+    --spectrum-global-dimension-size-75: 8px;
+    --spectrum-global-dimension-size-85: 9px;
+    --spectrum-global-dimension-size-100: 10px;
+    --spectrum-global-dimension-size-115: 11px;
+    --spectrum-global-dimension-size-125: 13px;
+    --spectrum-global-dimension-size-130: 14px;
+    --spectrum-global-dimension-size-150: 15px;
+    --spectrum-global-dimension-size-160: 16px;
+    --spectrum-global-dimension-size-175: 18px;
+    --spectrum-global-dimension-size-185: 19px;
+    --spectrum-global-dimension-size-200: 20px;
+    --spectrum-global-dimension-size-225: 22px;
+    --spectrum-global-dimension-size-250: 25px;
+    --spectrum-global-dimension-size-275: 28px;
+    --spectrum-global-dimension-size-300: 30px;
+    --spectrum-global-dimension-size-325: 32px;
+    --spectrum-global-dimension-size-350: 35px;
+    --spectrum-global-dimension-size-400: 40px;
+    --spectrum-global-dimension-size-450: 45px;
+    --spectrum-global-dimension-size-500: 50px;
+    --spectrum-global-dimension-size-550: 56px;
+    --spectrum-global-dimension-size-600: 60px;
+    --spectrum-global-dimension-size-650: 65px;
+    --spectrum-global-dimension-size-675: 68px;
+    --spectrum-global-dimension-size-700: 70px;
+    --spectrum-global-dimension-size-750: 75px;
+    --spectrum-global-dimension-size-800: 80px;
+    --spectrum-global-dimension-size-900: 90px;
+    --spectrum-global-dimension-size-1000: 100px;
+    --spectrum-global-dimension-size-1125: 112px;
+    --spectrum-global-dimension-size-1200: 120px;
+    --spectrum-global-dimension-size-1250: 125px;
+    --spectrum-global-dimension-size-1600: 160px;
+    --spectrum-global-dimension-size-1700: 170px;
+    --spectrum-global-dimension-size-1800: 180px;
+    --spectrum-global-dimension-size-2000: 200px;
+    --spectrum-global-dimension-size-2400: 240px;
+    --spectrum-global-dimension-size-2500: 250px;
+    --spectrum-global-dimension-size-3000: 300px;
+    --spectrum-global-dimension-size-3400: 340px;
+    --spectrum-global-dimension-size-3600: 360px;
+    --spectrum-global-dimension-size-4600: 460px;
+    --spectrum-global-dimension-size-5000: 500px;
+    --spectrum-global-dimension-size-6000: 600px;
+    --spectrum-global-dimension-font-size-25: 12px;
+    --spectrum-global-dimension-font-size-50: 13px;
+    --spectrum-global-dimension-font-size-75: 15px;
+    --spectrum-global-dimension-font-size-100: 17px;
+    --spectrum-global-dimension-font-size-150: 18px;
+    --spectrum-global-dimension-font-size-200: 19px;
+    --spectrum-global-dimension-font-size-300: 22px;
+    --spectrum-global-dimension-font-size-400: 24px;
+    --spectrum-global-dimension-font-size-500: 27px;
+    --spectrum-global-dimension-font-size-600: 31px;
+    --spectrum-global-dimension-font-size-700: 34px;
+    --spectrum-global-dimension-font-size-800: 39px;
+    --spectrum-global-dimension-font-size-900: 44px;
+    --spectrum-global-dimension-font-size-1000: 49px;
+    --spectrum-global-dimension-font-size-1100: 55px;
+    --spectrum-global-dimension-font-size-1200: 62px;
+    --spectrum-global-dimension-font-size-1300: 70px;
+    --spectrum-alias-item-text-padding-top-l: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-text-padding-bottom-s: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-item-workflow-padding-left-m: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-m: 17px;
+    --spectrum-alias-item-rounded-workflow-padding-left-xl: 27px;
+    --spectrum-alias-item-mark-padding-top-m: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-item-mark-padding-bottom-m: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-item-mark-padding-left-m: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-control-1-size-l: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-control-1-size-xl: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-control-2-size-s: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-control-3-height-s: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-control-3-width-s: var(
+        --spectrum-global-dimension-size-325
+    );
+    --spectrum-alias-item-control-3-width-m: var(
+        --spectrum-global-dimension-static-size-450
+    );
+    --spectrum-alias-item-control-3-width-l: 41px;
+    --spectrum-alias-item-control-3-width-xl: 46px;
+    --spectrum-alias-item-mark-size-m: var(
+        --spectrum-global-dimension-static-size-325
+    );
+    --spectrum-alias-component-focusring-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-alias-control-two-size-s: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-control-three-height-s: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-control-three-width-s: var(
+        --spectrum-global-dimension-size-325
+    );
+    --spectrum-alias-control-three-width-m: var(
+        --spectrum-global-dimension-static-size-450
+    );
+    --spectrum-alias-control-three-width-l: 41px;
+    --spectrum-alias-control-three-width-xl: 46px;
+    --spectrum-alias-search-padding-left-m: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-focus-ring-border-radius-regular: var(
+        --spectrum-global-dimension-static-size-115
+    );
+    --spectrum-alias-focus-ring-radius-default: var(
+        --spectrum-global-dimension-static-size-115
+    );
+    --spectrum-alias-workflow-icon-size-l: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-ui-icon-chevron-size-75: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-chevron-size-100: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-chevron-size-200: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-chevron-size-300: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-chevron-size-400: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-chevron-size-500: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-checkmark-size-50: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-checkmark-size-75: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-checkmark-size-100: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-checkmark-size-200: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-300: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-400: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-checkmark-size-500: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-checkmark-size-600: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-ui-icon-dash-size-50: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-dash-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-dash-size-100: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-dash-size-200: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-dash-size-300: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-dash-size-400: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-dash-size-500: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-dash-size-600: var(
+        --spectrum-global-dimension-static-size-275
+    );
+    --spectrum-alias-ui-icon-cross-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-cross-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-cross-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-cross-size-300: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-cross-size-400: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-cross-size-500: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-cross-size-600: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-arrow-size-75: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-arrow-size-100: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-arrow-size-200: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-arrow-size-300: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-arrow-size-400: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-arrow-size-500: var(
+        --spectrum-global-dimension-static-size-275
+    );
+    --spectrum-alias-ui-icon-arrow-size-600: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-asterisk-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-asterisk-size-300: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-avatar-size-100: 26px;
+    --spectrum-alias-avatar-size-400: 36px;
+    --spectrum-alias-avatar-size-600: 46px;
+    --spectrum-alias-tag-icon-size-l: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-tag-focusring-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-button-m-primary-outline-texticon-padding-left: 17px;
+    --spectrum-colorwheel-min-width: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-dialog-confirm-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-confirm-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+}

--- a/tools/styles/spectrum-two/spectrum-scale-medium.css
+++ b/tools/styles/spectrum-two/spectrum-scale-medium.css
@@ -1,0 +1,290 @@
+:root,
+:host {
+    --spectrum-global-dimension-scale-factor: 1;
+    --spectrum-global-dimension-size-0: 0px;
+    --spectrum-global-dimension-size-10: 1px;
+    --spectrum-global-dimension-size-25: 2px;
+    --spectrum-global-dimension-size-30: 2px;
+    --spectrum-global-dimension-size-40: 3px;
+    --spectrum-global-dimension-size-50: 4px;
+    --spectrum-global-dimension-size-65: 5px;
+    --spectrum-global-dimension-size-75: 6px;
+    --spectrum-global-dimension-size-85: 7px;
+    --spectrum-global-dimension-size-100: 8px;
+    --spectrum-global-dimension-size-115: 9px;
+    --spectrum-global-dimension-size-125: 10px;
+    --spectrum-global-dimension-size-130: 11px;
+    --spectrum-global-dimension-size-150: 12px;
+    --spectrum-global-dimension-size-160: 13px;
+    --spectrum-global-dimension-size-175: 14px;
+    --spectrum-global-dimension-size-185: 15px;
+    --spectrum-global-dimension-size-200: 16px;
+    --spectrum-global-dimension-size-225: 18px;
+    --spectrum-global-dimension-size-250: 20px;
+    --spectrum-global-dimension-size-275: 22px;
+    --spectrum-global-dimension-size-300: 24px;
+    --spectrum-global-dimension-size-325: 26px;
+    --spectrum-global-dimension-size-350: 28px;
+    --spectrum-global-dimension-size-400: 32px;
+    --spectrum-global-dimension-size-450: 36px;
+    --spectrum-global-dimension-size-500: 40px;
+    --spectrum-global-dimension-size-550: 44px;
+    --spectrum-global-dimension-size-600: 48px;
+    --spectrum-global-dimension-size-650: 52px;
+    --spectrum-global-dimension-size-675: 54px;
+    --spectrum-global-dimension-size-700: 56px;
+    --spectrum-global-dimension-size-750: 60px;
+    --spectrum-global-dimension-size-800: 64px;
+    --spectrum-global-dimension-size-900: 72px;
+    --spectrum-global-dimension-size-1000: 80px;
+    --spectrum-global-dimension-size-1125: 90px;
+    --spectrum-global-dimension-size-1200: 96px;
+    --spectrum-global-dimension-size-1250: 100px;
+    --spectrum-global-dimension-size-1600: 128px;
+    --spectrum-global-dimension-size-1700: 136px;
+    --spectrum-global-dimension-size-1800: 144px;
+    --spectrum-global-dimension-size-2000: 160px;
+    --spectrum-global-dimension-size-2400: 192px;
+    --spectrum-global-dimension-size-2500: 200px;
+    --spectrum-global-dimension-size-3000: 240px;
+    --spectrum-global-dimension-size-3400: 272px;
+    --spectrum-global-dimension-size-3600: 288px;
+    --spectrum-global-dimension-size-4600: 368px;
+    --spectrum-global-dimension-size-5000: 400px;
+    --spectrum-global-dimension-size-6000: 480px;
+    --spectrum-global-dimension-font-size-25: 10px;
+    --spectrum-global-dimension-font-size-50: 11px;
+    --spectrum-global-dimension-font-size-75: 12px;
+    --spectrum-global-dimension-font-size-100: 14px;
+    --spectrum-global-dimension-font-size-150: 15px;
+    --spectrum-global-dimension-font-size-200: 16px;
+    --spectrum-global-dimension-font-size-300: 18px;
+    --spectrum-global-dimension-font-size-400: 20px;
+    --spectrum-global-dimension-font-size-500: 22px;
+    --spectrum-global-dimension-font-size-600: 25px;
+    --spectrum-global-dimension-font-size-700: 28px;
+    --spectrum-global-dimension-font-size-800: 32px;
+    --spectrum-global-dimension-font-size-900: 36px;
+    --spectrum-global-dimension-font-size-1000: 40px;
+    --spectrum-global-dimension-font-size-1100: 45px;
+    --spectrum-global-dimension-font-size-1200: 50px;
+    --spectrum-global-dimension-font-size-1300: 60px;
+    --spectrum-alias-item-text-padding-top-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-text-padding-bottom-s: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-alias-item-workflow-padding-left-m: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-m: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-xl: 21px;
+    --spectrum-alias-item-mark-padding-top-m: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-alias-item-mark-padding-bottom-m: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-alias-item-mark-padding-left-m: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-1-size-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-1-size-xl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-2-size-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-control-3-height-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-control-3-width-s: 23px;
+    --spectrum-alias-item-control-3-width-m: var(
+        --spectrum-global-dimension-static-size-325
+    );
+    --spectrum-alias-item-control-3-width-l: 29px;
+    --spectrum-alias-item-control-3-width-xl: 33px;
+    --spectrum-alias-item-mark-size-m: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-component-focusring-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-alias-control-two-size-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-control-three-height-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-control-three-width-s: 23px;
+    --spectrum-alias-control-three-width-m: var(
+        --spectrum-global-dimension-static-size-325
+    );
+    --spectrum-alias-control-three-width-l: 29px;
+    --spectrum-alias-control-three-width-xl: 33px;
+    --spectrum-alias-search-padding-left-m: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-focus-ring-border-radius-regular: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-focus-ring-radius-default: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-workflow-icon-size-l: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-chevron-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-chevron-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-chevron-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-chevron-size-300: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-chevron-size-400: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-chevron-size-500: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-50: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-checkmark-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-checkmark-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-checkmark-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-checkmark-size-300: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-checkmark-size-400: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-500: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-600: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-dash-size-50: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-dash-size-75: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-dash-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-dash-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-dash-size-300: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-dash-size-400: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-dash-size-500: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-dash-size-600: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-cross-size-75: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-cross-size-100: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-cross-size-200: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-cross-size-300: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-cross-size-400: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-cross-size-500: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-cross-size-600: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-arrow-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-arrow-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-arrow-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-arrow-size-300: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-arrow-size-400: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-arrow-size-500: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-arrow-size-600: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-ui-icon-asterisk-size-200: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-asterisk-size-300: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-avatar-size-100: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-avatar-size-400: var(--spectrum-global-dimension-size-350);
+    --spectrum-alias-avatar-size-600: var(--spectrum-global-dimension-size-450);
+    --spectrum-alias-tag-icon-size-l: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-tag-focusring-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-m-primary-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-colorwheel-min-width: var(--spectrum-global-dimension-size-2400);
+    --spectrum-dialog-confirm-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-confirm-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+}

--- a/tools/styles/spectrum-two/spectrum-theme-dark.css
+++ b/tools/styles/spectrum-two/spectrum-theme-dark.css
@@ -1,0 +1,293 @@
+:root,
+:host {
+    --spectrum-global-color-status: Verified;
+    --spectrum-global-color-version: 5.1;
+    --spectrum-global-color-opacity-100: 1;
+    --spectrum-global-color-opacity-90: 0.9;
+    --spectrum-global-color-opacity-80: 0.8;
+    --spectrum-global-color-opacity-70: 0.7;
+    --spectrum-global-color-opacity-60: 0.6;
+    --spectrum-global-color-opacity-55: 0.55;
+    --spectrum-global-color-opacity-50: 0.5;
+    --spectrum-global-color-opacity-42: 0.42;
+    --spectrum-global-color-opacity-40: 0.4;
+    --spectrum-global-color-opacity-30: 0.3;
+    --spectrum-global-color-opacity-25: 0.25;
+    --spectrum-global-color-opacity-20: 0.2;
+    --spectrum-global-color-opacity-15: 0.15;
+    --spectrum-global-color-opacity-10: 0.1;
+    --spectrum-global-color-opacity-8: 0.08;
+    --spectrum-global-color-opacity-7: 0.07;
+    --spectrum-global-color-opacity-6: 0.06;
+    --spectrum-global-color-opacity-5: 0.05;
+    --spectrum-global-color-opacity-4: 0.04;
+    --spectrum-global-color-opacity-0: 0;
+    --spectrum-global-color-celery-400-rgb: 34, 184, 51;
+    --spectrum-global-color-celery-400: rgb(
+        var(--spectrum-global-color-celery-400-rgb)
+    );
+    --spectrum-global-color-celery-500-rgb: 68, 202, 73;
+    --spectrum-global-color-celery-500: rgb(
+        var(--spectrum-global-color-celery-500-rgb)
+    );
+    --spectrum-global-color-celery-600-rgb: 105, 220, 99;
+    --spectrum-global-color-celery-600: rgb(
+        var(--spectrum-global-color-celery-600-rgb)
+    );
+    --spectrum-global-color-celery-700-rgb: 142, 235, 127;
+    --spectrum-global-color-celery-700: rgb(
+        var(--spectrum-global-color-celery-700-rgb)
+    );
+    --spectrum-global-color-chartreuse-400-rgb: 148, 192, 8;
+    --spectrum-global-color-chartreuse-400: rgb(
+        var(--spectrum-global-color-chartreuse-400-rgb)
+    );
+    --spectrum-global-color-chartreuse-500-rgb: 166, 211, 18;
+    --spectrum-global-color-chartreuse-500: rgb(
+        var(--spectrum-global-color-chartreuse-500-rgb)
+    );
+    --spectrum-global-color-chartreuse-600-rgb: 184, 229, 37;
+    --spectrum-global-color-chartreuse-600: rgb(
+        var(--spectrum-global-color-chartreuse-600-rgb)
+    );
+    --spectrum-global-color-chartreuse-700-rgb: 205, 245, 71;
+    --spectrum-global-color-chartreuse-700: rgb(
+        var(--spectrum-global-color-chartreuse-700-rgb)
+    );
+    --spectrum-global-color-yellow-400-rgb: 228, 194, 0;
+    --spectrum-global-color-yellow-400: rgb(
+        var(--spectrum-global-color-yellow-400-rgb)
+    );
+    --spectrum-global-color-yellow-500-rgb: 244, 213, 0;
+    --spectrum-global-color-yellow-500: rgb(
+        var(--spectrum-global-color-yellow-500-rgb)
+    );
+    --spectrum-global-color-yellow-600-rgb: 249, 232, 92;
+    --spectrum-global-color-yellow-600: rgb(
+        var(--spectrum-global-color-yellow-600-rgb)
+    );
+    --spectrum-global-color-yellow-700-rgb: 252, 246, 187;
+    --spectrum-global-color-yellow-700: rgb(
+        var(--spectrum-global-color-yellow-700-rgb)
+    );
+    --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
+    --spectrum-global-color-magenta-400: rgb(
+        var(--spectrum-global-color-magenta-400-rgb)
+    );
+    --spectrum-global-color-magenta-500-rgb: 237, 87, 149;
+    --spectrum-global-color-magenta-500: rgb(
+        var(--spectrum-global-color-magenta-500-rgb)
+    );
+    --spectrum-global-color-magenta-600-rgb: 249, 114, 167;
+    --spectrum-global-color-magenta-600: rgb(
+        var(--spectrum-global-color-magenta-600-rgb)
+    );
+    --spectrum-global-color-magenta-700-rgb: 255, 143, 185;
+    --spectrum-global-color-magenta-700: rgb(
+        var(--spectrum-global-color-magenta-700-rgb)
+    );
+    --spectrum-global-color-fuchsia-400-rgb: 205, 57, 206;
+    --spectrum-global-color-fuchsia-400: rgb(
+        var(--spectrum-global-color-fuchsia-400-rgb)
+    );
+    --spectrum-global-color-fuchsia-500-rgb: 223, 81, 224;
+    --spectrum-global-color-fuchsia-500: rgb(
+        var(--spectrum-global-color-fuchsia-500-rgb)
+    );
+    --spectrum-global-color-fuchsia-600-rgb: 235, 110, 236;
+    --spectrum-global-color-fuchsia-600: rgb(
+        var(--spectrum-global-color-fuchsia-600-rgb)
+    );
+    --spectrum-global-color-fuchsia-700-rgb: 244, 140, 242;
+    --spectrum-global-color-fuchsia-700: rgb(
+        var(--spectrum-global-color-fuchsia-700-rgb)
+    );
+    --spectrum-global-color-purple-400-rgb: 157, 87, 243;
+    --spectrum-global-color-purple-400: rgb(
+        var(--spectrum-global-color-purple-400-rgb)
+    );
+    --spectrum-global-color-purple-500-rgb: 172, 111, 249;
+    --spectrum-global-color-purple-500: rgb(
+        var(--spectrum-global-color-purple-500-rgb)
+    );
+    --spectrum-global-color-purple-600-rgb: 187, 135, 251;
+    --spectrum-global-color-purple-600: rgb(
+        var(--spectrum-global-color-purple-600-rgb)
+    );
+    --spectrum-global-color-purple-700-rgb: 202, 159, 252;
+    --spectrum-global-color-purple-700: rgb(
+        var(--spectrum-global-color-purple-700-rgb)
+    );
+    --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
+    --spectrum-global-color-indigo-400: rgb(
+        var(--spectrum-global-color-indigo-400-rgb)
+    );
+    --spectrum-global-color-indigo-500-rgb: 124, 129, 251;
+    --spectrum-global-color-indigo-500: rgb(
+        var(--spectrum-global-color-indigo-500-rgb)
+    );
+    --spectrum-global-color-indigo-600-rgb: 145, 149, 255;
+    --spectrum-global-color-indigo-600: rgb(
+        var(--spectrum-global-color-indigo-600-rgb)
+    );
+    --spectrum-global-color-indigo-700-rgb: 167, 170, 255;
+    --spectrum-global-color-indigo-700: rgb(
+        var(--spectrum-global-color-indigo-700-rgb)
+    );
+    --spectrum-global-color-seafoam-400-rgb: 0, 158, 152;
+    --spectrum-global-color-seafoam-400: rgb(
+        var(--spectrum-global-color-seafoam-400-rgb)
+    );
+    --spectrum-global-color-seafoam-500-rgb: 3, 178, 171;
+    --spectrum-global-color-seafoam-500: rgb(
+        var(--spectrum-global-color-seafoam-500-rgb)
+    );
+    --spectrum-global-color-seafoam-600-rgb: 54, 197, 189;
+    --spectrum-global-color-seafoam-600: rgb(
+        var(--spectrum-global-color-seafoam-600-rgb)
+    );
+    --spectrum-global-color-seafoam-700-rgb: 93, 214, 207;
+    --spectrum-global-color-seafoam-700: rgb(
+        var(--spectrum-global-color-seafoam-700-rgb)
+    );
+    --spectrum-global-color-red-400-rgb: 234, 56, 41;
+    --spectrum-global-color-red-400: rgb(
+        var(--spectrum-global-color-red-400-rgb)
+    );
+    --spectrum-global-color-red-500-rgb: 246, 88, 67;
+    --spectrum-global-color-red-500: rgb(
+        var(--spectrum-global-color-red-500-rgb)
+    );
+    --spectrum-global-color-red-600-rgb: 255, 117, 94;
+    --spectrum-global-color-red-600: rgb(
+        var(--spectrum-global-color-red-600-rgb)
+    );
+    --spectrum-global-color-red-700-rgb: 255, 149, 129;
+    --spectrum-global-color-red-700: rgb(
+        var(--spectrum-global-color-red-700-rgb)
+    );
+    --spectrum-global-color-orange-400-rgb: 244, 129, 12;
+    --spectrum-global-color-orange-400: rgb(
+        var(--spectrum-global-color-orange-400-rgb)
+    );
+    --spectrum-global-color-orange-500-rgb: 254, 154, 46;
+    --spectrum-global-color-orange-500: rgb(
+        var(--spectrum-global-color-orange-500-rgb)
+    );
+    --spectrum-global-color-orange-600-rgb: 255, 181, 88;
+    --spectrum-global-color-orange-600: rgb(
+        var(--spectrum-global-color-orange-600-rgb)
+    );
+    --spectrum-global-color-orange-700-rgb: 253, 206, 136;
+    --spectrum-global-color-orange-700: rgb(
+        var(--spectrum-global-color-orange-700-rgb)
+    );
+    --spectrum-global-color-green-400-rgb: 18, 162, 108;
+    --spectrum-global-color-green-400: rgb(
+        var(--spectrum-global-color-green-400-rgb)
+    );
+    --spectrum-global-color-green-500-rgb: 43, 180, 125;
+    --spectrum-global-color-green-500: rgb(
+        var(--spectrum-global-color-green-500-rgb)
+    );
+    --spectrum-global-color-green-600-rgb: 67, 199, 143;
+    --spectrum-global-color-green-600: rgb(
+        var(--spectrum-global-color-green-600-rgb)
+    );
+    --spectrum-global-color-green-700-rgb: 94, 217, 162;
+    --spectrum-global-color-green-700: rgb(
+        var(--spectrum-global-color-green-700-rgb)
+    );
+    --spectrum-global-color-blue-400-rgb: 52, 143, 244;
+    --spectrum-global-color-blue-400: rgb(
+        var(--spectrum-global-color-blue-400-rgb)
+    );
+    --spectrum-global-color-blue-500-rgb: 84, 163, 246;
+    --spectrum-global-color-blue-500: rgb(
+        var(--spectrum-global-color-blue-500-rgb)
+    );
+    --spectrum-global-color-blue-600-rgb: 114, 183, 249;
+    --spectrum-global-color-blue-600: rgb(
+        var(--spectrum-global-color-blue-600-rgb)
+    );
+    --spectrum-global-color-blue-700-rgb: 143, 202, 252;
+    --spectrum-global-color-blue-700: rgb(
+        var(--spectrum-global-color-blue-700-rgb)
+    );
+    --spectrum-global-color-gray-50-rgb: 29, 29, 29;
+    --spectrum-global-color-gray-50: rgb(
+        var(--spectrum-global-color-gray-50-rgb)
+    );
+    --spectrum-global-color-gray-75-rgb: 38, 38, 38;
+    --spectrum-global-color-gray-75: rgb(
+        var(--spectrum-global-color-gray-75-rgb)
+    );
+    --spectrum-global-color-gray-100-rgb: 50, 50, 50;
+    --spectrum-global-color-gray-100: rgb(
+        var(--spectrum-global-color-gray-100-rgb)
+    );
+    --spectrum-global-color-gray-200-rgb: 63, 63, 63;
+    --spectrum-global-color-gray-200: rgb(
+        var(--spectrum-global-color-gray-200-rgb)
+    );
+    --spectrum-global-color-gray-300-rgb: 84, 84, 84;
+    --spectrum-global-color-gray-300: rgb(
+        var(--spectrum-global-color-gray-300-rgb)
+    );
+    --spectrum-global-color-gray-400-rgb: 112, 112, 112;
+    --spectrum-global-color-gray-400: rgb(
+        var(--spectrum-global-color-gray-400-rgb)
+    );
+    --spectrum-global-color-gray-500-rgb: 144, 144, 144;
+    --spectrum-global-color-gray-500: rgb(
+        var(--spectrum-global-color-gray-500-rgb)
+    );
+    --spectrum-global-color-gray-600-rgb: 178, 178, 178;
+    --spectrum-global-color-gray-600: rgb(
+        var(--spectrum-global-color-gray-600-rgb)
+    );
+    --spectrum-global-color-gray-700-rgb: 209, 209, 209;
+    --spectrum-global-color-gray-700: rgb(
+        var(--spectrum-global-color-gray-700-rgb)
+    );
+    --spectrum-global-color-gray-800-rgb: 235, 235, 235;
+    --spectrum-global-color-gray-800: rgb(
+        var(--spectrum-global-color-gray-800-rgb)
+    );
+    --spectrum-global-color-gray-900-rgb: 255, 255, 255;
+    --spectrum-global-color-gray-900: rgb(
+        var(--spectrum-global-color-gray-900-rgb)
+    );
+    --spectrum-alias-background-color-primary: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-background-color-secondary: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-alias-background-color-tertiary: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-background-color-modal-overlay: #00000080;
+    --spectrum-alias-dropshadow-color: #00000080;
+    --spectrum-alias-background-color-hover-overlay: #ffffff0f;
+    --spectrum-alias-highlight-hover: #ffffff12;
+    --spectrum-alias-highlight-down: #ffffff1a;
+    --spectrum-alias-highlight-selected: #54a3f626;
+    --spectrum-alias-highlight-selected-hover: #54a3f640;
+    --spectrum-alias-text-highlight-color: #54a3f640;
+    --spectrum-alias-background-color-quickactions: #323232e6;
+    --spectrum-alias-border-color-selected: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-border-color-translucent: #ffffff1a;
+    --spectrum-alias-radial-reaction-color-default: #ebebeb99;
+    --spectrum-alias-pasteboard-background-color: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-appframe-border-color: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-appframe-separator-color: var(
+        --spectrum-global-color-gray-50
+    );
+}

--- a/tools/styles/spectrum-two/spectrum-theme-light.css
+++ b/tools/styles/spectrum-two/spectrum-theme-light.css
@@ -1,0 +1,293 @@
+:root,
+:host {
+    --spectrum-global-color-status: Verified;
+    --spectrum-global-color-version: 5.1;
+    --spectrum-global-color-opacity-100: 1;
+    --spectrum-global-color-opacity-90: 0.9;
+    --spectrum-global-color-opacity-80: 0.8;
+    --spectrum-global-color-opacity-70: 0.7;
+    --spectrum-global-color-opacity-60: 0.6;
+    --spectrum-global-color-opacity-55: 0.55;
+    --spectrum-global-color-opacity-50: 0.5;
+    --spectrum-global-color-opacity-42: 0.42;
+    --spectrum-global-color-opacity-40: 0.4;
+    --spectrum-global-color-opacity-30: 0.3;
+    --spectrum-global-color-opacity-25: 0.25;
+    --spectrum-global-color-opacity-20: 0.2;
+    --spectrum-global-color-opacity-15: 0.15;
+    --spectrum-global-color-opacity-10: 0.1;
+    --spectrum-global-color-opacity-8: 0.08;
+    --spectrum-global-color-opacity-7: 0.07;
+    --spectrum-global-color-opacity-6: 0.06;
+    --spectrum-global-color-opacity-5: 0.05;
+    --spectrum-global-color-opacity-4: 0.04;
+    --spectrum-global-color-opacity-0: 0;
+    --spectrum-global-color-celery-400-rgb: 39, 187, 54;
+    --spectrum-global-color-celery-400: rgb(
+        var(--spectrum-global-color-celery-400-rgb)
+    );
+    --spectrum-global-color-celery-500-rgb: 7, 167, 33;
+    --spectrum-global-color-celery-500: rgb(
+        var(--spectrum-global-color-celery-500-rgb)
+    );
+    --spectrum-global-color-celery-600-rgb: 0, 145, 18;
+    --spectrum-global-color-celery-600: rgb(
+        var(--spectrum-global-color-celery-600-rgb)
+    );
+    --spectrum-global-color-celery-700-rgb: 0, 124, 15;
+    --spectrum-global-color-celery-700: rgb(
+        var(--spectrum-global-color-celery-700-rgb)
+    );
+    --spectrum-global-color-chartreuse-400-rgb: 152, 197, 10;
+    --spectrum-global-color-chartreuse-400: rgb(
+        var(--spectrum-global-color-chartreuse-400-rgb)
+    );
+    --spectrum-global-color-chartreuse-500-rgb: 135, 177, 3;
+    --spectrum-global-color-chartreuse-500: rgb(
+        var(--spectrum-global-color-chartreuse-500-rgb)
+    );
+    --spectrum-global-color-chartreuse-600-rgb: 118, 156, 0;
+    --spectrum-global-color-chartreuse-600: rgb(
+        var(--spectrum-global-color-chartreuse-600-rgb)
+    );
+    --spectrum-global-color-chartreuse-700-rgb: 103, 136, 0;
+    --spectrum-global-color-chartreuse-700: rgb(
+        var(--spectrum-global-color-chartreuse-700-rgb)
+    );
+    --spectrum-global-color-yellow-400-rgb: 232, 198, 0;
+    --spectrum-global-color-yellow-400: rgb(
+        var(--spectrum-global-color-yellow-400-rgb)
+    );
+    --spectrum-global-color-yellow-500-rgb: 215, 179, 0;
+    --spectrum-global-color-yellow-500: rgb(
+        var(--spectrum-global-color-yellow-500-rgb)
+    );
+    --spectrum-global-color-yellow-600-rgb: 196, 159, 0;
+    --spectrum-global-color-yellow-600: rgb(
+        var(--spectrum-global-color-yellow-600-rgb)
+    );
+    --spectrum-global-color-yellow-700-rgb: 176, 140, 0;
+    --spectrum-global-color-yellow-700: rgb(
+        var(--spectrum-global-color-yellow-700-rgb)
+    );
+    --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
+    --spectrum-global-color-magenta-400: rgb(
+        var(--spectrum-global-color-magenta-400-rgb)
+    );
+    --spectrum-global-color-magenta-500-rgb: 200, 34, 105;
+    --spectrum-global-color-magenta-500: rgb(
+        var(--spectrum-global-color-magenta-500-rgb)
+    );
+    --spectrum-global-color-magenta-600-rgb: 173, 9, 85;
+    --spectrum-global-color-magenta-600: rgb(
+        var(--spectrum-global-color-magenta-600-rgb)
+    );
+    --spectrum-global-color-magenta-700-rgb: 142, 0, 69;
+    --spectrum-global-color-magenta-700: rgb(
+        var(--spectrum-global-color-magenta-700-rgb)
+    );
+    --spectrum-global-color-fuchsia-400-rgb: 205, 58, 206;
+    --spectrum-global-color-fuchsia-400: rgb(
+        var(--spectrum-global-color-fuchsia-400-rgb)
+    );
+    --spectrum-global-color-fuchsia-500-rgb: 182, 34, 183;
+    --spectrum-global-color-fuchsia-500: rgb(
+        var(--spectrum-global-color-fuchsia-500-rgb)
+    );
+    --spectrum-global-color-fuchsia-600-rgb: 157, 3, 158;
+    --spectrum-global-color-fuchsia-600: rgb(
+        var(--spectrum-global-color-fuchsia-600-rgb)
+    );
+    --spectrum-global-color-fuchsia-700-rgb: 128, 0, 129;
+    --spectrum-global-color-fuchsia-700: rgb(
+        var(--spectrum-global-color-fuchsia-700-rgb)
+    );
+    --spectrum-global-color-purple-400-rgb: 157, 87, 244;
+    --spectrum-global-color-purple-400: rgb(
+        var(--spectrum-global-color-purple-400-rgb)
+    );
+    --spectrum-global-color-purple-500-rgb: 137, 61, 231;
+    --spectrum-global-color-purple-500: rgb(
+        var(--spectrum-global-color-purple-500-rgb)
+    );
+    --spectrum-global-color-purple-600-rgb: 115, 38, 211;
+    --spectrum-global-color-purple-600: rgb(
+        var(--spectrum-global-color-purple-600-rgb)
+    );
+    --spectrum-global-color-purple-700-rgb: 93, 19, 183;
+    --spectrum-global-color-purple-700: rgb(
+        var(--spectrum-global-color-purple-700-rgb)
+    );
+    --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
+    --spectrum-global-color-indigo-400: rgb(
+        var(--spectrum-global-color-indigo-400-rgb)
+    );
+    --spectrum-global-color-indigo-500-rgb: 82, 88, 228;
+    --spectrum-global-color-indigo-500: rgb(
+        var(--spectrum-global-color-indigo-500-rgb)
+    );
+    --spectrum-global-color-indigo-600-rgb: 64, 70, 202;
+    --spectrum-global-color-indigo-600: rgb(
+        var(--spectrum-global-color-indigo-600-rgb)
+    );
+    --spectrum-global-color-indigo-700-rgb: 50, 54, 168;
+    --spectrum-global-color-indigo-700: rgb(
+        var(--spectrum-global-color-indigo-700-rgb)
+    );
+    --spectrum-global-color-seafoam-400-rgb: 0, 161, 154;
+    --spectrum-global-color-seafoam-400: rgb(
+        var(--spectrum-global-color-seafoam-400-rgb)
+    );
+    --spectrum-global-color-seafoam-500-rgb: 0, 140, 135;
+    --spectrum-global-color-seafoam-500: rgb(
+        var(--spectrum-global-color-seafoam-500-rgb)
+    );
+    --spectrum-global-color-seafoam-600-rgb: 0, 119, 114;
+    --spectrum-global-color-seafoam-600: rgb(
+        var(--spectrum-global-color-seafoam-600-rgb)
+    );
+    --spectrum-global-color-seafoam-700-rgb: 0, 99, 95;
+    --spectrum-global-color-seafoam-700: rgb(
+        var(--spectrum-global-color-seafoam-700-rgb)
+    );
+    --spectrum-global-color-red-400-rgb: 234, 56, 41;
+    --spectrum-global-color-red-400: rgb(
+        var(--spectrum-global-color-red-400-rgb)
+    );
+    --spectrum-global-color-red-500-rgb: 211, 21, 16;
+    --spectrum-global-color-red-500: rgb(
+        var(--spectrum-global-color-red-500-rgb)
+    );
+    --spectrum-global-color-red-600-rgb: 180, 0, 0;
+    --spectrum-global-color-red-600: rgb(
+        var(--spectrum-global-color-red-600-rgb)
+    );
+    --spectrum-global-color-red-700-rgb: 147, 0, 0;
+    --spectrum-global-color-red-700: rgb(
+        var(--spectrum-global-color-red-700-rgb)
+    );
+    --spectrum-global-color-orange-400-rgb: 246, 133, 17;
+    --spectrum-global-color-orange-400: rgb(
+        var(--spectrum-global-color-orange-400-rgb)
+    );
+    --spectrum-global-color-orange-500-rgb: 228, 111, 0;
+    --spectrum-global-color-orange-500: rgb(
+        var(--spectrum-global-color-orange-500-rgb)
+    );
+    --spectrum-global-color-orange-600-rgb: 203, 93, 0;
+    --spectrum-global-color-orange-600: rgb(
+        var(--spectrum-global-color-orange-600-rgb)
+    );
+    --spectrum-global-color-orange-700-rgb: 177, 76, 0;
+    --spectrum-global-color-orange-700: rgb(
+        var(--spectrum-global-color-orange-700-rgb)
+    );
+    --spectrum-global-color-green-400-rgb: 0, 143, 93;
+    --spectrum-global-color-green-400: rgb(
+        var(--spectrum-global-color-green-400-rgb)
+    );
+    --spectrum-global-color-green-500-rgb: 0, 122, 77;
+    --spectrum-global-color-green-500: rgb(
+        var(--spectrum-global-color-green-500-rgb)
+    );
+    --spectrum-global-color-green-600-rgb: 0, 101, 62;
+    --spectrum-global-color-green-600: rgb(
+        var(--spectrum-global-color-green-600-rgb)
+    );
+    --spectrum-global-color-green-700-rgb: 0, 81, 50;
+    --spectrum-global-color-green-700: rgb(
+        var(--spectrum-global-color-green-700-rgb)
+    );
+    --spectrum-global-color-blue-400-rgb: 20, 122, 243;
+    --spectrum-global-color-blue-400: rgb(
+        var(--spectrum-global-color-blue-400-rgb)
+    );
+    --spectrum-global-color-blue-500-rgb: 2, 101, 220;
+    --spectrum-global-color-blue-500: rgb(
+        var(--spectrum-global-color-blue-500-rgb)
+    );
+    --spectrum-global-color-blue-600-rgb: 0, 84, 182;
+    --spectrum-global-color-blue-600: rgb(
+        var(--spectrum-global-color-blue-600-rgb)
+    );
+    --spectrum-global-color-blue-700-rgb: 0, 68, 145;
+    --spectrum-global-color-blue-700: rgb(
+        var(--spectrum-global-color-blue-700-rgb)
+    );
+    --spectrum-global-color-gray-50-rgb: 255, 255, 255;
+    --spectrum-global-color-gray-50: rgb(
+        var(--spectrum-global-color-gray-50-rgb)
+    );
+    --spectrum-global-color-gray-75-rgb: 253, 253, 253;
+    --spectrum-global-color-gray-75: rgb(
+        var(--spectrum-global-color-gray-75-rgb)
+    );
+    --spectrum-global-color-gray-100-rgb: 248, 248, 248;
+    --spectrum-global-color-gray-100: rgb(
+        var(--spectrum-global-color-gray-100-rgb)
+    );
+    --spectrum-global-color-gray-200-rgb: 230, 230, 230;
+    --spectrum-global-color-gray-200: rgb(
+        var(--spectrum-global-color-gray-200-rgb)
+    );
+    --spectrum-global-color-gray-300-rgb: 213, 213, 213;
+    --spectrum-global-color-gray-300: rgb(
+        var(--spectrum-global-color-gray-300-rgb)
+    );
+    --spectrum-global-color-gray-400-rgb: 177, 177, 177;
+    --spectrum-global-color-gray-400: rgb(
+        var(--spectrum-global-color-gray-400-rgb)
+    );
+    --spectrum-global-color-gray-500-rgb: 144, 144, 144;
+    --spectrum-global-color-gray-500: rgb(
+        var(--spectrum-global-color-gray-500-rgb)
+    );
+    --spectrum-global-color-gray-600-rgb: 109, 109, 109;
+    --spectrum-global-color-gray-600: rgb(
+        var(--spectrum-global-color-gray-600-rgb)
+    );
+    --spectrum-global-color-gray-700-rgb: 70, 70, 70;
+    --spectrum-global-color-gray-700: rgb(
+        var(--spectrum-global-color-gray-700-rgb)
+    );
+    --spectrum-global-color-gray-800-rgb: 34, 34, 34;
+    --spectrum-global-color-gray-800: rgb(
+        var(--spectrum-global-color-gray-800-rgb)
+    );
+    --spectrum-global-color-gray-900-rgb: 0, 0, 0;
+    --spectrum-global-color-gray-900: rgb(
+        var(--spectrum-global-color-gray-900-rgb)
+    );
+    --spectrum-alias-background-color-primary: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-background-color-secondary: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-background-color-tertiary: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-background-color-modal-overlay: #0006;
+    --spectrum-alias-dropshadow-color: #00000026;
+    --spectrum-alias-background-color-hover-overlay: #0000000a;
+    --spectrum-alias-highlight-hover: #0000000f;
+    --spectrum-alias-highlight-down: #0000001a;
+    --spectrum-alias-highlight-selected: #0265dc1a;
+    --spectrum-alias-highlight-selected-hover: #0265dc33;
+    --spectrum-alias-text-highlight-color: #0265dc33;
+    --spectrum-alias-background-color-quickactions: #f8f8f8e6;
+    --spectrum-alias-border-color-selected: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-alias-border-color-translucent: #0000001a;
+    --spectrum-alias-radial-reaction-color-default: #2229;
+    --spectrum-alias-pasteboard-background-color: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-appframe-border-color: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-appframe-separator-color: var(
+        --spectrum-global-color-gray-300
+    );
+}

--- a/tools/styles/spectrum-two/theme-dark.css
+++ b/tools/styles/spectrum-two/theme-dark.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+@import './spectrum-theme-dark.css';
+
+:host,
+:root {
+    color-scheme: dark;
+}

--- a/tools/styles/spectrum-two/theme-light.css
+++ b/tools/styles/spectrum-two/theme-light.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+@import './spectrum-theme-light.css';
+
+:host,
+:root {
+    color-scheme: light;
+}

--- a/tools/styles/spectrum-two/themes.ts
+++ b/tools/styles/spectrum-two/themes.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import '../../spectrum-two/theme-light.js';
+import '../../spectrum-two/theme-dark.js';
+import '../../spectrum-two/scale-medium.js';
+import '../../spectrum-two/scale-large.js';

--- a/tools/theme/package.json
+++ b/tools/theme/package.json
@@ -158,6 +158,12 @@
             "development": "./src/spectrum-two/core.dev.js",
             "default": "./src/spectrum-two/core.js"
         },
+        "./src/spectrum-two/scale-large-core-tokens.css.js": "./src/spectrum-two/scale-large-core-tokens.css.js",
+        "./src/spectrum-two/scale-medium-core-tokens.css.js": "./src/spectrum-two/scale-medium-core-tokens.css.js",
+        "./src/spectrum-two/theme-core-tokens.css.js": "./src/spectrum-two/theme-core-tokens.css.js",
+        "./src/spectrum-two/theme-dark-core-tokens.css.js": "./src/spectrum-two/theme-dark-core-tokens.css.js",
+        "./src/spectrum-two/theme-light-core-tokens.css.js": "./src/spectrum-two/theme-light-core-tokens.css.js",
+        "./src/spectrum-two/theme.css.js": "./src/spectrum-two/theme.css.js",
         "./src/spectrum-two/themes-core-tokens.js": {
             "development": "./src/spectrum-two/themes-core-tokens.dev.js",
             "default": "./src/spectrum-two/themes-core-tokens.js"

--- a/tools/theme/package.json
+++ b/tools/theme/package.json
@@ -112,17 +112,49 @@
             "development": "./spectrum-two/scale-large-core-tokens.dev.js",
             "default": "./spectrum-two/scale-large-core-tokens.js"
         },
+        "./spectrum-two/scale-large.js": {
+            "development": "./spectrum-two/scale-large.dev.js",
+            "default": "./spectrum-two/scale-large.js"
+        },
         "./spectrum-two/scale-medium-core-tokens.js": {
             "development": "./spectrum-two/scale-medium-core-tokens.dev.js",
             "default": "./spectrum-two/scale-medium-core-tokens.js"
+        },
+        "./spectrum-two/scale-medium.js": {
+            "development": "./spectrum-two/scale-medium.dev.js",
+            "default": "./spectrum-two/scale-medium.js"
         },
         "./spectrum-two/theme-dark-core-tokens.js": {
             "development": "./spectrum-two/theme-dark-core-tokens.dev.js",
             "default": "./spectrum-two/theme-dark-core-tokens.js"
         },
+        "./spectrum-two/theme-dark.js": {
+            "development": "./spectrum-two/theme-dark.dev.js",
+            "default": "./spectrum-two/theme-dark.js"
+        },
+        "./spectrum-two/theme-darkest-core-tokens.js": {
+            "development": "./spectrum-two/theme-darkest-core-tokens.dev.js",
+            "default": "./spectrum-two/theme-darkest-core-tokens.js"
+        },
+        "./spectrum-two/theme-darkest.js": {
+            "development": "./spectrum-two/theme-darkest.dev.js",
+            "default": "./spectrum-two/theme-darkest.js"
+        },
         "./spectrum-two/theme-light-core-tokens.js": {
             "development": "./spectrum-two/theme-light-core-tokens.dev.js",
             "default": "./spectrum-two/theme-light-core-tokens.js"
+        },
+        "./spectrum-two/theme-light.js": {
+            "development": "./spectrum-two/theme-light.dev.js",
+            "default": "./spectrum-two/theme-light.js"
+        },
+        "./spectrum-two/theme-lightest-core-tokens.js": {
+            "development": "./spectrum-two/theme-lightest-core-tokens.dev.js",
+            "default": "./spectrum-two/theme-lightest-core-tokens.js"
+        },
+        "./spectrum-two/theme-lightest.js": {
+            "development": "./spectrum-two/theme-lightest.dev.js",
+            "default": "./spectrum-two/theme-lightest.js"
         },
         "./src/express/core-tokens.js": {
             "development": "./src/express/core-tokens.dev.js",
@@ -159,14 +191,22 @@
             "default": "./src/spectrum-two/core.js"
         },
         "./src/spectrum-two/scale-large-core-tokens.css.js": "./src/spectrum-two/scale-large-core-tokens.css.js",
+        "./src/spectrum-two/scale-large.css.js": "./src/spectrum-two/scale-large.css.js",
         "./src/spectrum-two/scale-medium-core-tokens.css.js": "./src/spectrum-two/scale-medium-core-tokens.css.js",
+        "./src/spectrum-two/scale-medium.css.js": "./src/spectrum-two/scale-medium.css.js",
         "./src/spectrum-two/theme-core-tokens.css.js": "./src/spectrum-two/theme-core-tokens.css.js",
         "./src/spectrum-two/theme-dark-core-tokens.css.js": "./src/spectrum-two/theme-dark-core-tokens.css.js",
+        "./src/spectrum-two/theme-dark.css.js": "./src/spectrum-two/theme-dark.css.js",
         "./src/spectrum-two/theme-light-core-tokens.css.js": "./src/spectrum-two/theme-light-core-tokens.css.js",
+        "./src/spectrum-two/theme-light.css.js": "./src/spectrum-two/theme-light.css.js",
         "./src/spectrum-two/theme.css.js": "./src/spectrum-two/theme.css.js",
         "./src/spectrum-two/themes-core-tokens.js": {
             "development": "./src/spectrum-two/themes-core-tokens.dev.js",
             "default": "./src/spectrum-two/themes-core-tokens.js"
+        },
+        "./src/spectrum-two/themes.js": {
+            "development": "./src/spectrum-two/themes.dev.js",
+            "default": "./src/spectrum-two/themes.js"
         },
         "./core.js": {
             "development": "./core.dev.js",

--- a/tools/theme/spectrum-two/scale-large.ts
+++ b/tools/theme/spectrum-two/scale-large.ts
@@ -10,9 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import largeStyles from '../src/spectrum-two/scale-large.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/spectrum-two/core.js';
+
+Theme.registerThemeFragment('large-spectrum-two', 'scale', largeStyles);

--- a/tools/theme/spectrum-two/scale-medium.ts
+++ b/tools/theme/spectrum-two/scale-medium.ts
@@ -10,9 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import mediumStyles from '../src/spectrum-two/scale-medium.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/spectrum-two/core.js';
+
+Theme.registerThemeFragment('medium-spectrum-two', 'scale', mediumStyles);

--- a/tools/theme/spectrum-two/theme-dark.ts
+++ b/tools/theme/spectrum-two/theme-dark.ts
@@ -10,9 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import darkStyles from '../src/spectrum-two/theme-dark.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/spectrum-two/core.js';
+
+Theme.registerThemeFragment('dark-spectrum-two', 'color', darkStyles);

--- a/tools/theme/spectrum-two/theme-darkest-core-tokens.ts
+++ b/tools/theme/spectrum-two/theme-darkest-core-tokens.ts
@@ -10,9 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import darkStyles from '../src/spectrum-two/theme-dark-core-tokens.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/spectrum-two/core-tokens.js';
+
+Theme.registerThemeFragment('darkest-spectrum-two', 'color', darkStyles);

--- a/tools/theme/spectrum-two/theme-darkest.ts
+++ b/tools/theme/spectrum-two/theme-darkest.ts
@@ -10,9 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import darkStyles from '../src/spectrum-two/theme-dark.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/spectrum-two/core.js';
+
+Theme.registerThemeFragment('darkest-spectrum-two', 'color', darkStyles);

--- a/tools/theme/spectrum-two/theme-light.ts
+++ b/tools/theme/spectrum-two/theme-light.ts
@@ -10,9 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import lightStyles from '../src/spectrum-two/theme-light.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/spectrum-two/core.js';
+
+Theme.registerThemeFragment('light-spectrum-two', 'color', lightStyles);

--- a/tools/theme/spectrum-two/theme-lightest-core-tokens.ts
+++ b/tools/theme/spectrum-two/theme-lightest-core-tokens.ts
@@ -10,9 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import lightStyles from '../src/spectrum-two/theme-light-core-tokens.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/spectrum-two/core-tokens.js';
+
+Theme.registerThemeFragment('lightest-spectrum-two', 'color', lightStyles);

--- a/tools/theme/spectrum-two/theme-lightest.ts
+++ b/tools/theme/spectrum-two/theme-lightest.ts
@@ -10,9 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import lightStyles from '../src/spectrum-two/theme-light.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/spectrum-two/core.js';
+
+Theme.registerThemeFragment('lightest-spectrum-two', 'color', lightStyles);

--- a/tools/theme/src/spectrum-two/scale-large.css
+++ b/tools/theme/src/spectrum-two/scale-large.css
@@ -10,9 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+@import url('@spectrum-web-components/styles/spectrum-two/scale-large.css');
+@import url('@spectrum-web-components/styles/tokens-v2/large-vars.css');
+@import url('@spectrum-web-components/styles/tokens-v2/spectrum/custom-large-vars.css');
+
+:root,
+:host {
+    --spectrum-global-alias-appframe-border-size: 1px;
+    --swc-scale-factor: 1.25;
+}

--- a/tools/theme/src/spectrum-two/scale-medium.css
+++ b/tools/theme/src/spectrum-two/scale-medium.css
@@ -10,9 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+@import url('@spectrum-web-components/styles/spectrum-two/scale-medium.css');
+@import url('@spectrum-web-components/styles/tokens-v2/medium-vars.css');
+@import url('@spectrum-web-components/styles/tokens-v2/spectrum/custom-medium-vars.css');
+
+:root,
+:host {
+    --spectrum-global-alias-appframe-border-size: 2px;
+    --swc-scale-factor: 1;
+}

--- a/tools/theme/src/spectrum-two/theme-dark.css
+++ b/tools/theme/src/spectrum-two/theme-dark.css
@@ -10,9 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+@import url('@spectrum-web-components/styles/spectrum-two/theme-dark.css');
+@import url('@spectrum-web-components/styles/tokens-v2/dark-vars.css');
+@import url('@spectrum-web-components/styles/tokens-v2/spectrum/custom-dark-vars.css');

--- a/tools/theme/src/spectrum-two/theme-light.css
+++ b/tools/theme/src/spectrum-two/theme-light.css
@@ -10,9 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+@import url('@spectrum-web-components/styles/spectrum-two/theme-light.css');
+@import url('@spectrum-web-components/styles/tokens-v2/light-vars.css');
+@import url('@spectrum-web-components/styles/tokens-v2/spectrum/custom-light-vars.css');

--- a/tools/theme/src/spectrum-two/theme.css
+++ b/tools/theme/src/spectrum-two/theme.css
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+@import url('@spectrum-web-components/styles/spectrum-two/core-global.css');
 @import url('@spectrum-web-components/styles/tokens-v2/global-vars.css');
 @import url('@spectrum-web-components/styles/tokens-v2/spectrum/global-vars.css');
 @import url('@spectrum-web-components/styles/tokens-v2/spectrum/custom-vars.css');

--- a/tools/theme/src/spectrum-two/themes.ts
+++ b/tools/theme/src/spectrum-two/themes.ts
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../spectrum-two/theme-light-core-tokens.js';
-import '../../spectrum-two/theme-lightest-core-tokens.js';
-import '../../spectrum-two/theme-dark-core-tokens.js';
-import '../../spectrum-two/theme-darkest-core-tokens.js';
-import '../../spectrum-two/scale-medium-core-tokens.js';
-import '../../spectrum-two/scale-large-core-tokens.js';
+import '../../spectrum-two/theme-light.js';
+import '../../spectrum-two/theme-lightest.js';
+import '../../spectrum-two/theme-dark.js';
+import '../../spectrum-two/theme-darkest.js';
+import '../../spectrum-two/scale-medium.js';
+import '../../spectrum-two/scale-large.js';

--- a/tools/theme/src/theme-interfaces.ts
+++ b/tools/theme/src/theme-interfaces.ts
@@ -51,7 +51,9 @@ export const COLOR_VALUES = [
     'dark-express',
     'darkest-express',
     'light-spectrum-two',
+    'lightest-spectrum-two',
     'dark-spectrum-two',
+    'darkest-spectrum-two',
 ] as const;
 
 export type SystemVariant = (typeof SYSTEM_VARIANT_VALUES)[number];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,7 +3110,7 @@
   dependencies:
     npmlog "^6.0.2"
 
-"@lit-labs/observers@^2.0.0", "@lit-labs/observers@^2.0.2":
+"@lit-labs/observers@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@lit-labs/observers/-/observers-2.0.2.tgz#3f655a86e3dccc3a174f4f0149e8b318beb72025"
   integrity sha512-eZb5+W9Cb0e/Y5m1DNxBSGTvGB2TAVTGMnTxL/IzFhPQEcZIAHewW1eVBhN8W07A5tirRaAmmF6fGL1V20p3gQ==


### PR DESCRIPTION
> **Note: this PR reconstructs and supersedes the previous version, #4731**

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

The `spectrum-two` theme didn't yet have all of the necessary plumbing in `tools/styles` and `tools/theme`.

This PR adds the missing files and updates various build scripts to create a fully functioning `spectrum-two` theme.

Note that the `spectrum-two` theme (like the `spectrum` and `express` themes) includes the `core-global` CSS variables to ensure that application views relying on these variables will not break when migrating to the `spectrum-two` theme. Per the plan of record, these variables remain deprecated and will be removed in a future major version of SWC.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- SWC-348, SWC-466 (internal JIRA)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Allow the `spectrum-two` theme to be used and tested.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested in the Storybook theme switcher, in both SWC and the downstream UEC project.
