### PR TITLE
chore: create s2 bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/s2_report.yaml
+++ b/.github/ISSUE_TEMPLATE/s2_report.yaml
@@ -16,14 +16,14 @@ body:
           options:
               - label: I agree to follow this project's code of conduct.
                 required: true
-    - type: checkboxes
-      id: reviewed-issues
-      attributes:
-          label: Reviewed open issues
-          description: Before submitting this issue, please confirm that you have looked through the [existing Spectrum 2 issues](https://github.com/adobe/spectrum-web-components/labels/Spectrum%202) and confirmed that this is not a duplicate ticket.
-          options:
-              - label: I have confirmed that this is a new issue.
-                required: true
+    - type: dropdown
+  id: reviewed-issues
+  attributes:
+      label: Have you reviewed existing [existing Spectrum 2 issues](https://github.com/adobe/spectrum-web-components/labels/Spectrum%202)?
+      description: Please confirm if you've reviewed existing issues to avoid duplicates.
+      options:
+          - Yes, I’ve reviewed existing issues.
+          - Oops, I’ll check now.
     - type: input
       id: components
       attributes:

--- a/.github/ISSUE_TEMPLATE/s2_report.yaml
+++ b/.github/ISSUE_TEMPLATE/s2_report.yaml
@@ -1,5 +1,5 @@
 name: Spectrum 2 Bug Report
-description: Report an issue with the Spectrum 2 theme in SWC 1.0
+description: Report an issue with the Spectrum 2 system
 title: '[S2 Bug]: '
 labels: [bug, triage, needs jira ticket, Spectrum 2]
 # assignees:

--- a/.github/ISSUE_TEMPLATE/s2_report.yaml
+++ b/.github/ISSUE_TEMPLATE/s2_report.yaml
@@ -1,0 +1,88 @@
+name: Spectrum 2 Bug Report
+description: Report an issue with the Spectrum 2 theme in SWC 1.0
+title: '[S2 Bug]: '
+labels: [bug, triage, needs jira ticket, Spectrum 2]
+# assignees:
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this bug report! Your issue will be triaged within a week of filing the issue.
+    - type: checkboxes
+      id: terms
+      attributes:
+          label: Code of conduct
+          description: By submitting this issue, you agree to follow our [code of conduct](https://github.com/adobe/spectrum-web-components/blob/main/CODE_OF_CONDUCT.md#adobe-code-of-conduct).
+          options:
+              - label: I agree to follow this project's code of conduct.
+                required: true
+          label: Reviewed open issues
+          description: Before submitting this issue, please confirm that you have looked through the [existing Spectrum 2 issues](https://github.com/adobe/spectrum-web-components/labels/Spectrum%202) and confirmed that this is not a duplicate ticket.
+          options:
+              - label: I have confirmed that this is a new issue.
+                required: true
+    - type: input
+      id: components
+      attributes:
+          label: Impacted component(s)
+          description: Please list the component(s) impacted by this issue.
+      validations:
+          required: true
+    - type: textarea
+      id: expected-behavior
+      attributes:
+          label: Expected behavior
+          description: A brief description of what you expected to happen.
+    - type: textarea
+      id: actual-behavior
+      attributes:
+          label: Actual behavior
+      validations:
+          required: true
+    - type: textarea
+      id: screenshot
+      attributes:
+          label: Screenshots
+          description: You can attach images by clicking this area to highlight it and then dragging files in.
+    - type: dropdown
+      id: browsers
+      attributes:
+          label: What browsers are you seeing the problem in?
+          multiple: true
+          options:
+              - Firefox
+              - Chrome
+              - Safari
+              - Microsoft Edge
+    - type: textarea
+      id: code
+      attributes:
+          label: Sample code or abstract reproduction which illustrates the problem
+          description: Please use [webcomponents.dev](https://studio.webcomponents.dev/workspace/adobe) to abstract the issue in an isolated environment. In most cases, a video or code block is not sufficient enough for us to diagnose the problem.
+    - type: textarea
+      id: reproduce
+      attributes:
+          label: How can we reproduce this issue?
+          value: |
+              1. Go to '...'
+              2. Click on '....'
+              3. Scroll to '....'
+              4. Check console
+              5. See error
+    
+    - type: dropdown
+      id: severity
+      attributes:
+          label: Severity
+          description: Please select the severity level of this issue. For descriptions of each level, refer to our [documentation](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md#issue-severity-classification)
+          options:
+              - SEV 1
+              - SEV 2
+              - SEV 3
+              - SEV 4
+              - SEV 5
+    - type: textarea
+      id: logs
+      attributes:
+          label: Logs taken while reproducing problem
+          description: You can attach log files by clicking this area to highlight it and then dragging files in.

--- a/.github/ISSUE_TEMPLATE/s2_report.yaml
+++ b/.github/ISSUE_TEMPLATE/s2_report.yaml
@@ -16,6 +16,9 @@ body:
           options:
               - label: I agree to follow this project's code of conduct.
                 required: true
+    - type: checkboxes
+      id: reviewed-issues
+      attributes:
           label: Reviewed open issues
           description: Before submitting this issue, please confirm that you have looked through the [existing Spectrum 2 issues](https://github.com/adobe/spectrum-web-components/labels/Spectrum%202) and confirmed that this is not a duplicate ticket.
           options:
@@ -86,3 +89,10 @@ body:
       attributes:
           label: Logs taken while reproducing problem
           description: You can attach log files by clicking this area to highlight it and then dragging files in.
+    - type: checkboxes
+      id: jira-number
+      attributes:
+          label: Jira ticket
+          description: If you would like to track this issue in Jira, check this box and we will comment the Jira ticket ID once the issue has been triaged.
+          options:
+              - label: Yes, please tell me the ticket number!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I made a template for bug reports for SWC 1.0. The "I checked for existing issues" checkbox might be overkill, but I want people to make sure they're not filing duplicate bugs. There's probably a nicer way to "suggest" this instead of making them check a box lol, so I'm open to hearing your thoughts.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This way, we don't need to add a separate label to our existing bugs and will keep everything nice and neat :^) 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
