### PR TITLE
chore: update icons-demo to filter only workflow icons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: a8ced11362413ae39b0ec8779ffec065b27082a4
+        default: 5ab4db0cb7a707b3465bbcc85b02edaa5c8b96ae
     wireit_cache_name:
         type: string
         default: wireit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 08de0cb86affdc8cec2cb320aa9899b07032fcf8
+        default: a8ced11362413ae39b0ec8779ffec065b27082a4
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/icons-ui/stories/icons-ui.stories.ts
+++ b/packages/icons-ui/stories/icons-ui.stories.ts
@@ -49,6 +49,7 @@ export const elements = ({ color, size }: Properties): TemplateResult => {
                 style="color: ${color}"
                 size=${size}
                 .icons=${iconManifest.iconManifest}
+                name="ui"
             ></icons-demo>
         `
     );

--- a/packages/icons-workflow/stories/icons-workflow.stories.ts
+++ b/packages/icons-workflow/stories/icons-workflow.stories.ts
@@ -48,6 +48,7 @@ export const elements = ({ color, size }: Properties): TemplateResult => {
                 style="color: ${color}"
                 size=${size}
                 .icons=${iconManifest.iconManifest}
+                name="workflow"
             ></icons-demo>
         `
     );

--- a/packages/iconset/stories/icons-demo.ts
+++ b/packages/iconset/stories/icons-demo.ts
@@ -242,7 +242,7 @@ export class IconsDemo extends SpectrumElement {
 
         const iconVersion = this.spectrumVersion === 2 ? 's2' : 's1';
         // Filter out icons that are not in the current version for workflow icons
-        if (this.package === 'workflow') {
+        if (this.name === 'workflow') {
             matchingIcons = matchingIcons.filter((icon) => {
                 const iconName = icon.name.replace(/\s/g, '').toLowerCase();
                 return iconsList[iconVersion].includes(iconName);

--- a/packages/iconset/stories/icons-demo.ts
+++ b/packages/iconset/stories/icons-demo.ts
@@ -241,11 +241,13 @@ export class IconsDemo extends SpectrumElement {
             : this.icons;
 
         const iconVersion = this.spectrumVersion === 2 ? 's2' : 's1';
-        // Filter out icons that are not in the current version
-        matchingIcons = matchingIcons.filter((icon) => {
-            const iconName = icon.name.replace(/\s/g, '').toLowerCase();
-            return iconsList[iconVersion].includes(iconName);
-        });
+        // Filter out icons that are not in the current version for workflow icons
+        if (this.package === 'workflow') {
+            matchingIcons = matchingIcons.filter((icon) => {
+                const iconName = icon.name.replace(/\s/g, '').toLowerCase();
+                return iconsList[iconVersion].includes(iconName);
+            });
+        }
 
         return html`
             <div class="search" part="search">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated `icons-demo` class to filter workflow icons only.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

Our [Doc site](https://opensource.adobe.com/spectrum-web-components/components/icons-ui/) was not showing ui-icons.

## Motivation and context

Fix the storybook and doc site examples for ui-icons.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   Go [here](https://ttomar-icons-ui-devsite--spectrum-web-components.netlify.app/components/icons-ui/) and scroll down to see the ui-icons being displayed correctly.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
