### PR TITLE
chore: removed lightest and darkest from preview url

### DIFF
--- a/packages/accordion/src/accordion-item.css
+++ b/packages/accordion/src/accordion-item.css
@@ -14,7 +14,6 @@ governing permissions and limitations under the License.
 
 :host {
     display: block;
-    background-color: red;
 }
 
 #heading {

--- a/packages/accordion/src/accordion-item.css
+++ b/packages/accordion/src/accordion-item.css
@@ -14,6 +14,7 @@ governing permissions and limitations under the License.
 
 :host {
     display: block;
+    background-color: red;
 }
 
 #heading {

--- a/tasks/build-preview-urls-comment.js
+++ b/tasks/build-preview-urls-comment.js
@@ -56,7 +56,7 @@ export const buildPreviewURLComment = (ref) => {
     const previewLinks = [];
     const themes = ['Spectrum', 'Express', 'Spectrum-two'];
     const scales = ['Medium', 'Large'];
-    const colors = ['Lightest', 'Light', 'Dark', 'Darkest'];
+    const colors = ['Light', 'Dark'];
     const directions = ['LTR', 'RTL'];
     previewLinks.push(
         `- [High Contrast Mode | Medium | LTR](https://${getHash(
@@ -65,12 +65,6 @@ export const buildPreviewURLComment = (ref) => {
     );
     themes.map((theme) =>
         colors.map((color) => {
-            if (
-                theme === 'Spectrum-two' &&
-                (color === 'Lightest' || color === 'Darkest')
-            ) {
-                return;
-            }
             scales.map((scale) =>
                 directions.map((direction) => {
                     const context = `${branch}-${theme.toLocaleLowerCase()}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 Removed `lightest` and `darkest` from our preview urls comment.

## Motivation and context

`lightest` and `darkest` are deprecated and we don't test them in our VRTs, so I removed them from our preview urls comment.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-  Manually messed up the css and tested that the preview urls didn't contain `lightest` and `darkest`

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
