### PR TITLE
chore: invalidate CircleCI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,11 @@ commands:
                   paths:
                       - ~/.cache/yarn
                       - ~/.cache/ms-playwright
-                  key: v3c-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+                  key: v4c-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
             - save_cache:
                   paths:
                       - .wireit
-                  key: v3b-wireit-{{ arch }}-{{ checksum "package.json" }}-{{ epoch }}
+                  key: v4b-wireit-{{ arch }}-{{ checksum "package.json" }}-{{ epoch }}
             - attach_workspace:
                   at: /
     run-regressions:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ commands:
             - checkout
             - restore_cache:
                   keys:
-                      - v3c-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+                      - v4c-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
             - restore_cache:
                   keys:
-                      - v3b-<< pipeline.parameters.wireit_cache_name >>-{{ arch }}-{{ checksum "package.json" }}-
+                      - v4b-<< pipeline.parameters.wireit_cache_name >>-{{ arch }}-{{ checksum "package.json" }}-
             - run:
                   name: Installing Dependencies
                   command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Incremented the version prefix (`v3c` to `v4c` and `v3b` to `v4b`). This way, CircleCI will treat this as an entirely new cache. The previous caches will still be stored but will no longer be used for builds with the updated key prefix, effectively “clearing” the cache for the new runs.
<!--- Describe your changes in detail -->

## Motivation and context

We observed a specific issue where the transitive dependency `@spectrum-css/preview` would fail to resolve correctly on CircleCI, even though it worked locally. This suggested that an outdated or corrupted cache on CircleCI might be causing the problem. Since CircleCI caches dependencies based on a key (including the `yarn.lock` checksum), old or incompatible versions can persist in the cache, leading to the errors we were seeing.

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
If the check `test-chromium` succeeds, it means this worked!
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
