### PR TITLE
fix(action-group): add null check for slotElement in manageButtons

### DIFF
--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -403,6 +403,9 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
     private hasManaged = false;
 
     private manageButtons = (): void => {
+        if (!this.slotElement) {
+            return;
+        }
         const assignedElements = this.slotElement.assignedElements({
             flatten: true,
         });

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -122,7 +122,7 @@ async function multipleSelectedActionGroup(
 }
 
 describe('ActionGroup', () => {
-    it('throws an error if slotElement is null', async () => {
+    it('does not throw an error if slotElement is null', async () => {
         // To verify that this test is not evergreen, you can temporarily disable the safeguard
         // clause in `manageButtons` by commenting out the following lines:
         // if (!this.slotElement) { return; }

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -126,6 +126,7 @@ describe('ActionGroup', () => {
         // To verify that this test is not evergreen, you can temporarily disable the safeguard
         // clause in `manageButtons` by commenting out the following lines:
         // if (!this.slotElement) { return; }
+
         const el = await fixture<ActionGroup>(html`
             <sp-action-group>
                 <sp-action-button value="first">First</sp-action-button>
@@ -135,18 +136,14 @@ describe('ActionGroup', () => {
 
         // Stub the slotElement getter to return null
         const slotElementStub = sinon.stub(el, 'slotElement').get(() => null);
+        await elementUpdated(el);
 
-        // Call manageButtons and expect a TypeError
-        expect(() => Reflect.get(el, 'manageButtons').call(el)).not.to.throw(
-            TypeError,
-            // Different browsers throw slightly different error messages when slotElement is null:
-            // - Chrome: "Cannot read properties of null"
-            // - Firefox: "this.slotElement is null"
-            // - WebKit: "null is not an object (evaluating 'this.slotElement.assignedElements')"
-            /(cannot read properties of null|this\.slotElement is null|null is not an object \(evaluating 'this\.slotElement\.assignedElements'\))/i
-        );
-
-        // Restore the original slotElement getter
+        // trigger a slotchange event
+        while (el.firstChild) {
+            el.removeChild(el.firstChild);
+        }
+        await elementUpdated(el);
+        expect(el.children.length).to.equal(0);
         slotElementStub.restore();
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a guard to the `manageButtons` function in the `ActionGroup` component to handle cases where `slotElement` is `null`. This prevents potential runtime errors when the `MutationObserver` triggers `manageButtons` before the component is fully rendered.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- [SWC-595](https://jira.corp.adobe.com/browse/SWC-595)

## Motivation and context
We have gotten reports from customers that they were seeing this error under some circumstances:
<img width="778" alt="Screenshot 2024-11-08 at 14 48 25" src="https://github.com/user-attachments/assets/d31c149b-182a-4928-ac5f-02b4f0a13e27">

Adding this `null` check allows the component to handle this scenario gracefully.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Added a test case in action-group.test.ts_
    To check it is not evergreen, comment out the newly added safeguard clause.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
