### PR TITLE
fix(overlay): returning only the first element for slot assignedElements

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -74,22 +74,22 @@ export class OverlayTrigger extends SpectrumElement {
     public receivesFocus: 'true' | 'false' | 'auto' = 'auto';
 
     @state()
-    private clickContent: HTMLElement[] = [];
+    private clickContent: HTMLElement | undefined;
 
     private clickPlacement?: Placement;
 
     @state()
-    private longpressContent: HTMLElement[] = [];
+    private longpressContent: HTMLElement | undefined;
 
     private longpressPlacement?: Placement;
 
     @state()
-    private hoverContent: HTMLElement[] = [];
+    private hoverContent: HTMLElement | undefined;
 
     private hoverPlacement?: Placement;
 
     @state()
-    private targetContent: HTMLElement[] = [];
+    private targetContent: HTMLElement | undefined;
 
     @query('#click-overlay', true)
     clickOverlayElement!: Overlay;
@@ -100,8 +100,12 @@ export class OverlayTrigger extends SpectrumElement {
     @query('#hover-overlay', true)
     hoverOverlayElement!: Overlay;
 
-    private getAssignedElementsFromSlot(slot: HTMLSlotElement): HTMLElement[] {
-        return slot.assignedElements({ flatten: true }) as HTMLElement[];
+    private getAssignedElementsFromSlot(
+        slot: HTMLSlotElement
+    ): HTMLElement | undefined {
+        return slot.assignedElements({ flatten: true })[0] as
+            | HTMLElement
+            | undefined;
     }
 
     private handleTriggerContent(
@@ -155,22 +159,22 @@ export class OverlayTrigger extends SpectrumElement {
     protected override update(changes: PropertyValues): void {
         if (changes.has('clickContent')) {
             this.clickPlacement =
-                ((this.clickContent[0]?.getAttribute('placement') ||
-                    this.clickContent[0]?.getAttribute(
+                ((this.clickContent?.getAttribute('placement') ||
+                    this.clickContent?.getAttribute(
                         'direction'
                     )) as Placement) || undefined;
         }
         if (changes.has('hoverContent')) {
             this.hoverPlacement =
-                ((this.hoverContent[0]?.getAttribute('placement') ||
-                    this.hoverContent[0]?.getAttribute(
+                ((this.hoverContent?.getAttribute('placement') ||
+                    this.hoverContent?.getAttribute(
                         'direction'
                     )) as Placement) || undefined;
         }
         if (changes.has('longpressContent')) {
             this.longpressPlacement =
-                ((this.longpressContent[0]?.getAttribute('placement') ||
-                    this.longpressContent[0]?.getAttribute(
+                ((this.longpressContent?.getAttribute('placement') ||
+                    this.longpressContent?.getAttribute(
                         'direction'
                     )) as Placement) || undefined;
         }
@@ -186,17 +190,17 @@ export class OverlayTrigger extends SpectrumElement {
     protected renderClickOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('click-content');
-        if (!this.clickContent.length) {
+        if (!this.clickContent) {
             return slot;
         }
         return html`
             <sp-overlay
                 id="click-overlay"
-                ?disabled=${this.disabled || !this.clickContent.length}
-                ?open=${this.open === 'click' && !!this.clickContent.length}
+                ?disabled=${this.disabled || !this.clickContent}
+                ?open=${this.open === 'click' && !!this.clickContent}
                 .offset=${this.offset}
                 .placement=${this.clickPlacement || this.placement}
-                .triggerElement=${this.targetContent[0]}
+                .triggerElement=${this.targetContent || null}
                 .triggerInteraction=${'click'}
                 .type=${this.type !== 'modal' ? 'auto' : 'modal'}
                 @beforetoggle=${this.handleBeforetoggle}
@@ -210,19 +214,19 @@ export class OverlayTrigger extends SpectrumElement {
     protected renderHoverOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('hover-content');
-        if (!this.hoverContent.length) {
+        if (!this.hoverContent) {
             return slot;
         }
         return html`
             <sp-overlay
                 id="hover-overlay"
-                ?open=${this.open === 'hover' && !!this.hoverContent.length}
+                ?open=${this.open === 'hover' && !!this.hoverContent}
                 ?disabled=${this.disabled ||
-                !this.hoverContent.length ||
+                !this.hoverContent ||
                 (!!this.open && this.open !== 'hover')}
                 .offset=${this.offset}
                 .placement=${this.hoverPlacement || this.placement}
-                .triggerElement=${this.targetContent[0]}
+                .triggerElement=${this.targetContent || null}
                 .triggerInteraction=${'hover'}
                 .type=${'hint'}
                 @beforetoggle=${this.handleBeforetoggle}
@@ -236,18 +240,17 @@ export class OverlayTrigger extends SpectrumElement {
     protected renderLongpressOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('longpress-content');
-        if (!this.longpressContent.length) {
+        if (!this.longpressContent) {
             return slot;
         }
         return html`
             <sp-overlay
                 id="longpress-overlay"
-                ?disabled=${this.disabled || !this.longpressContent.length}
-                ?open=${this.open === 'longpress' &&
-                !!this.longpressContent.length}
+                ?disabled=${this.disabled || !this.longpressContent}
+                ?open=${this.open === 'longpress' && !!this.longpressContent}
                 .offset=${this.offset}
                 .placement=${this.longpressPlacement || this.placement}
-                .triggerElement=${this.targetContent[0]}
+                .triggerElement=${this.targetContent || null}
                 .triggerInteraction=${'longpress'}
                 .type=${'auto'}
                 @beforetoggle=${this.handleBeforetoggle}

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -74,22 +74,22 @@ export class OverlayTrigger extends SpectrumElement {
     public receivesFocus: 'true' | 'false' | 'auto' = 'auto';
 
     @state()
-    private clickContent: HTMLElement[] = [];
+    private clickContent: HTMLElement | null = null;
 
     private clickPlacement?: Placement;
 
     @state()
-    private longpressContent: HTMLElement[] = [];
+    private longpressContent: HTMLElement | null = null;
 
     private longpressPlacement?: Placement;
 
     @state()
-    private hoverContent: HTMLElement[] = [];
+    private hoverContent: HTMLElement | null = null;
 
     private hoverPlacement?: Placement;
 
     @state()
-    private targetContent: HTMLElement[] = [];
+    private targetContent: HTMLElement | null = null;
 
     @query('#click-overlay', true)
     clickOverlayElement!: Overlay;
@@ -100,11 +100,14 @@ export class OverlayTrigger extends SpectrumElement {
     @query('#hover-overlay', true)
     hoverOverlayElement!: Overlay;
 
-    private getAssignedElementsFromSlot(slot: HTMLSlotElement): HTMLElement[] {
+    private getAssignedElementsFromSlot(
+        slot: HTMLSlotElement
+    ): HTMLElement | null {
         const nodes = slot.assignedNodes({ flatten: true });
-        return [
-            nodes.find((node) => node instanceof HTMLElement),
-        ] as HTMLElement[];
+        const element = nodes.find(
+            (node) => node instanceof HTMLElement
+        ) as HTMLElement;
+        return element ? element : null;
     }
 
     private handleTriggerContent(
@@ -158,22 +161,22 @@ export class OverlayTrigger extends SpectrumElement {
     protected override update(changes: PropertyValues): void {
         if (changes.has('clickContent')) {
             this.clickPlacement =
-                ((this.clickContent[0]?.getAttribute('placement') ||
-                    this.clickContent[0]?.getAttribute(
+                ((this.clickContent?.getAttribute('placement') ||
+                    this.clickContent?.getAttribute(
                         'direction'
                     )) as Placement) || undefined;
         }
         if (changes.has('hoverContent')) {
             this.hoverPlacement =
-                ((this.hoverContent[0]?.getAttribute('placement') ||
-                    this.hoverContent[0]?.getAttribute(
+                ((this.hoverContent?.getAttribute('placement') ||
+                    this.hoverContent?.getAttribute(
                         'direction'
                     )) as Placement) || undefined;
         }
         if (changes.has('longpressContent')) {
             this.longpressPlacement =
-                ((this.longpressContent[0]?.getAttribute('placement') ||
-                    this.longpressContent[0]?.getAttribute(
+                ((this.longpressContent?.getAttribute('placement') ||
+                    this.longpressContent?.getAttribute(
                         'direction'
                     )) as Placement) || undefined;
         }
@@ -189,17 +192,17 @@ export class OverlayTrigger extends SpectrumElement {
     protected renderClickOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('click-content');
-        if (!this.clickContent.length) {
+        if (!this.clickContent) {
             return slot;
         }
         return html`
             <sp-overlay
                 id="click-overlay"
-                ?disabled=${this.disabled || !this.clickContent.length}
-                ?open=${this.open === 'click' && !!this.clickContent.length}
+                ?disabled=${this.disabled || !this.clickContent}
+                ?open=${this.open === 'click' && !!this.clickContent}
                 .offset=${this.offset}
                 .placement=${this.clickPlacement || this.placement}
-                .triggerElement=${this.targetContent[0]}
+                .triggerElement=${this.targetContent}
                 .triggerInteraction=${'click'}
                 .type=${this.type !== 'modal' ? 'auto' : 'modal'}
                 @beforetoggle=${this.handleBeforetoggle}
@@ -213,19 +216,19 @@ export class OverlayTrigger extends SpectrumElement {
     protected renderHoverOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('hover-content');
-        if (!this.hoverContent.length) {
+        if (!this.hoverContent) {
             return slot;
         }
         return html`
             <sp-overlay
                 id="hover-overlay"
-                ?open=${this.open === 'hover' && !!this.hoverContent.length}
+                ?open=${this.open === 'hover' && !!this.hoverContent}
                 ?disabled=${this.disabled ||
-                !this.hoverContent.length ||
+                !this.hoverContent ||
                 (!!this.open && this.open !== 'hover')}
                 .offset=${this.offset}
                 .placement=${this.hoverPlacement || this.placement}
-                .triggerElement=${this.targetContent[0]}
+                .triggerElement=${this.targetContent}
                 .triggerInteraction=${'hover'}
                 .type=${'hint'}
                 @beforetoggle=${this.handleBeforetoggle}
@@ -239,18 +242,17 @@ export class OverlayTrigger extends SpectrumElement {
     protected renderLongpressOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('longpress-content');
-        if (!this.longpressContent.length) {
+        if (!this.longpressContent) {
             return slot;
         }
         return html`
             <sp-overlay
                 id="longpress-overlay"
-                ?disabled=${this.disabled || !this.longpressContent.length}
-                ?open=${this.open === 'longpress' &&
-                !!this.longpressContent.length}
+                ?disabled=${this.disabled || !this.longpressContent}
+                ?open=${this.open === 'longpress' && !!this.longpressContent}
                 .offset=${this.offset}
                 .placement=${this.longpressPlacement || this.placement}
-                .triggerElement=${this.targetContent[0]}
+                .triggerElement=${this.targetContent}
                 .triggerInteraction=${'longpress'}
                 .type=${'auto'}
                 @beforetoggle=${this.handleBeforetoggle}

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -74,22 +74,22 @@ export class OverlayTrigger extends SpectrumElement {
     public receivesFocus: 'true' | 'false' | 'auto' = 'auto';
 
     @state()
-    private clickContent: HTMLElement | undefined;
+    private clickContent: HTMLElement[] = [];
 
     private clickPlacement?: Placement;
 
     @state()
-    private longpressContent: HTMLElement | undefined;
+    private longpressContent: HTMLElement[] = [];
 
     private longpressPlacement?: Placement;
 
     @state()
-    private hoverContent: HTMLElement | undefined;
+    private hoverContent: HTMLElement[] = [];
 
     private hoverPlacement?: Placement;
 
     @state()
-    private targetContent: HTMLElement | undefined;
+    private targetContent: HTMLElement[] = [];
 
     @query('#click-overlay', true)
     clickOverlayElement!: Overlay;
@@ -100,12 +100,11 @@ export class OverlayTrigger extends SpectrumElement {
     @query('#hover-overlay', true)
     hoverOverlayElement!: Overlay;
 
-    private getAssignedElementsFromSlot(
-        slot: HTMLSlotElement
-    ): HTMLElement | undefined {
-        return slot.assignedElements({ flatten: true })[0] as
-            | HTMLElement
-            | undefined;
+    private getAssignedElementsFromSlot(slot: HTMLSlotElement): HTMLElement[] {
+        const nodes = slot.assignedNodes({ flatten: true });
+        return [
+            nodes.find((node) => node instanceof HTMLElement),
+        ] as HTMLElement[];
     }
 
     private handleTriggerContent(
@@ -159,22 +158,22 @@ export class OverlayTrigger extends SpectrumElement {
     protected override update(changes: PropertyValues): void {
         if (changes.has('clickContent')) {
             this.clickPlacement =
-                ((this.clickContent?.getAttribute('placement') ||
-                    this.clickContent?.getAttribute(
+                ((this.clickContent[0]?.getAttribute('placement') ||
+                    this.clickContent[0]?.getAttribute(
                         'direction'
                     )) as Placement) || undefined;
         }
         if (changes.has('hoverContent')) {
             this.hoverPlacement =
-                ((this.hoverContent?.getAttribute('placement') ||
-                    this.hoverContent?.getAttribute(
+                ((this.hoverContent[0]?.getAttribute('placement') ||
+                    this.hoverContent[0]?.getAttribute(
                         'direction'
                     )) as Placement) || undefined;
         }
         if (changes.has('longpressContent')) {
             this.longpressPlacement =
-                ((this.longpressContent?.getAttribute('placement') ||
-                    this.longpressContent?.getAttribute(
+                ((this.longpressContent[0]?.getAttribute('placement') ||
+                    this.longpressContent[0]?.getAttribute(
                         'direction'
                     )) as Placement) || undefined;
         }
@@ -190,17 +189,17 @@ export class OverlayTrigger extends SpectrumElement {
     protected renderClickOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('click-content');
-        if (!this.clickContent) {
+        if (!this.clickContent.length) {
             return slot;
         }
         return html`
             <sp-overlay
                 id="click-overlay"
-                ?disabled=${this.disabled || !this.clickContent}
-                ?open=${this.open === 'click' && !!this.clickContent}
+                ?disabled=${this.disabled || !this.clickContent.length}
+                ?open=${this.open === 'click' && !!this.clickContent.length}
                 .offset=${this.offset}
                 .placement=${this.clickPlacement || this.placement}
-                .triggerElement=${this.targetContent || null}
+                .triggerElement=${this.targetContent[0]}
                 .triggerInteraction=${'click'}
                 .type=${this.type !== 'modal' ? 'auto' : 'modal'}
                 @beforetoggle=${this.handleBeforetoggle}
@@ -214,19 +213,19 @@ export class OverlayTrigger extends SpectrumElement {
     protected renderHoverOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('hover-content');
-        if (!this.hoverContent) {
+        if (!this.hoverContent.length) {
             return slot;
         }
         return html`
             <sp-overlay
                 id="hover-overlay"
-                ?open=${this.open === 'hover' && !!this.hoverContent}
+                ?open=${this.open === 'hover' && !!this.hoverContent.length}
                 ?disabled=${this.disabled ||
-                !this.hoverContent ||
+                !this.hoverContent.length ||
                 (!!this.open && this.open !== 'hover')}
                 .offset=${this.offset}
                 .placement=${this.hoverPlacement || this.placement}
-                .triggerElement=${this.targetContent || null}
+                .triggerElement=${this.targetContent[0]}
                 .triggerInteraction=${'hover'}
                 .type=${'hint'}
                 @beforetoggle=${this.handleBeforetoggle}
@@ -240,17 +239,18 @@ export class OverlayTrigger extends SpectrumElement {
     protected renderLongpressOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('longpress-content');
-        if (!this.longpressContent) {
+        if (!this.longpressContent.length) {
             return slot;
         }
         return html`
             <sp-overlay
                 id="longpress-overlay"
-                ?disabled=${this.disabled || !this.longpressContent}
-                ?open=${this.open === 'longpress' && !!this.longpressContent}
+                ?disabled=${this.disabled || !this.longpressContent.length}
+                ?open=${this.open === 'longpress' &&
+                !!this.longpressContent.length}
                 .offset=${this.offset}
                 .placement=${this.longpressPlacement || this.placement}
-                .triggerElement=${this.targetContent || null}
+                .triggerElement=${this.targetContent[0]}
                 .triggerInteraction=${'longpress'}
                 .type=${'auto'}
                 @beforetoggle=${this.handleBeforetoggle}

--- a/packages/overlay/test/overlay-trigger-longpress.test.ts
+++ b/packages/overlay/test/overlay-trigger-longpress.test.ts
@@ -218,8 +218,9 @@ describe('Overlay Trigger - Longpress', () => {
             // Inject synthetic wait to afford for late replacement of <sp-action-button> with <sp-button>
             await waitUntil(() => {
                 const localName = (
-                    this.el as unknown as { targetContent: HTMLElement[] }
-                ).targetContent[0].localName;
+                    this.el as unknown as { targetContent: HTMLElement }
+                ).targetContent?.localName;
+
                 return localName === 'sp-button';
             });
 
@@ -311,32 +312,30 @@ describe('Overlay Trigger - Longpress', () => {
         expect(closedSpy.calledOnce, 'longpress content returned').to.be.true;
     });
     it('describes longpress interaction accessibly', async () => {
-        const el = await fixture<OverlayTrigger>(
-            html`
-                <overlay-trigger placement="right-start">
-                    <sp-action-button slot="trigger" hold-affordance>
-                        Trigger with hold affordance
-                    </sp-action-button>
-                    <sp-popover slot="longpress-content" tip>
-                        <sp-action-group
-                            selects="single"
-                            vertical
-                            style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
-                        >
-                            <sp-action-button>
-                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
-                            </sp-action-button>
-                            <sp-action-button>
-                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
-                            </sp-action-button>
-                            <sp-action-button>
-                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
-                            </sp-action-button>
-                        </sp-action-group>
-                    </sp-popover>
-                </overlay-trigger>
-            `
-        );
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger placement="right-start">
+                <sp-action-button slot="trigger" hold-affordance>
+                    Trigger with hold affordance
+                </sp-action-button>
+                <sp-popover slot="longpress-content" tip>
+                    <sp-action-group
+                        selects="single"
+                        vertical
+                        style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
+                    >
+                        <sp-action-button>
+                            <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                        </sp-action-button>
+                        <sp-action-button>
+                            <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                        </sp-action-button>
+                        <sp-action-button>
+                            <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                        </sp-action-button>
+                    </sp-action-group>
+                </sp-popover>
+            </overlay-trigger>
+        `);
         await nextFrame();
         await nextFrame();
         const trigger = el.querySelector('[slot="trigger"]') as HTMLElement;
@@ -390,32 +389,30 @@ describe('Overlay Trigger - Longpress', () => {
         );
     });
     it('removes longpress `aria-describedby` description element when longpress content is removed', async () => {
-        const el = await fixture<OverlayTrigger>(
-            html`
-                <overlay-trigger placement="right-start">
-                    <sp-action-button slot="trigger" hold-affordance>
-                        Trigger with hold affordance
-                    </sp-action-button>
-                    <sp-popover slot="longpress-content" tip>
-                        <sp-action-group
-                            selects="single"
-                            vertical
-                            style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
-                        >
-                            <sp-action-button>
-                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
-                            </sp-action-button>
-                            <sp-action-button>
-                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
-                            </sp-action-button>
-                            <sp-action-button>
-                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
-                            </sp-action-button>
-                        </sp-action-group>
-                    </sp-popover>
-                </overlay-trigger>
-            `
-        );
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger placement="right-start">
+                <sp-action-button slot="trigger" hold-affordance>
+                    Trigger with hold affordance
+                </sp-action-button>
+                <sp-popover slot="longpress-content" tip>
+                    <sp-action-group
+                        selects="single"
+                        vertical
+                        style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
+                    >
+                        <sp-action-button>
+                            <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                        </sp-action-button>
+                        <sp-action-button>
+                            <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                        </sp-action-button>
+                        <sp-action-button>
+                            <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                        </sp-action-button>
+                    </sp-action-group>
+                </sp-popover>
+            </overlay-trigger>
+        `);
         const trigger = el.querySelector('[slot="trigger"]') as HTMLElement;
         const content = el.querySelector(
             '[slot="longpress-content"]'
@@ -460,48 +457,42 @@ describe('Overlay Trigger - Longpress', () => {
         expect(el.childNodes.length, 'always').to.equal(6);
     });
     it('recognises multiple overlay triggers in a11y tree', async () => {
-        const el = await fixture<OverlayTrigger>(
-            html`
-                <div id="container">
-                    <overlay-trigger id="first-trigger" placement="right-start">
-                        <sp-action-button slot="trigger" hold-affordance>
-                            First button
-                        </sp-action-button>
-                        <sp-popover slot="longpress-content" tip>
-                            <sp-action-group
-                                selects="single"
-                                vertical
-                                style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
-                            >
-                                <sp-action-button>
-                                    <sp-icon-magnify
-                                        slot="icon"
-                                    ></sp-icon-magnify>
-                                </sp-action-button>
-                            </sp-action-group>
-                        </sp-popover>
-                    </overlay-trigger>
-                    <overlay-trigger id="second-trigger" placement="left-start">
-                        <sp-action-button slot="trigger" hold-affordance>
-                            Second button
-                        </sp-action-button>
-                        <sp-popover slot="longpress-content" tip>
-                            <sp-action-group
-                                selects="single"
-                                vertical
-                                style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
-                            >
-                                <sp-action-button>
-                                    <sp-icon-magnify
-                                        slot="icon"
-                                    ></sp-icon-magnify>
-                                </sp-action-button>
-                            </sp-action-group>
-                        </sp-popover>
-                    </overlay-trigger>
-                </div>
-            `
-        );
+        const el = await fixture<OverlayTrigger>(html`
+            <div id="container">
+                <overlay-trigger id="first-trigger" placement="right-start">
+                    <sp-action-button slot="trigger" hold-affordance>
+                        First button
+                    </sp-action-button>
+                    <sp-popover slot="longpress-content" tip>
+                        <sp-action-group
+                            selects="single"
+                            vertical
+                            style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
+                        >
+                            <sp-action-button>
+                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                            </sp-action-button>
+                        </sp-action-group>
+                    </sp-popover>
+                </overlay-trigger>
+                <overlay-trigger id="second-trigger" placement="left-start">
+                    <sp-action-button slot="trigger" hold-affordance>
+                        Second button
+                    </sp-action-button>
+                    <sp-popover slot="longpress-content" tip>
+                        <sp-action-group
+                            selects="single"
+                            vertical
+                            style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
+                        >
+                            <sp-action-button>
+                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                            </sp-action-button>
+                        </sp-action-group>
+                    </sp-popover>
+                </overlay-trigger>
+            </div>
+        `);
         await elementUpdated(el);
 
         const div = document.getElementById('container') as HTMLElement;
@@ -518,42 +509,34 @@ describe('Overlay Trigger - Longpress', () => {
         );
     });
     it('describes interactions differently to the user', async () => {
-        const test = await fixture<OverlayTrigger>(
-            html`
-                <div>
-                    <input id="first" />
-                    <overlay-trigger placement="right-start">
-                        <sp-action-button slot="trigger" hold-affordance>
-                            Trigger with hold affordance
-                        </sp-action-button>
-                        <sp-popover slot="longpress-content" tip>
-                            <sp-action-group
-                                selects="single"
-                                vertical
-                                style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
-                            >
-                                <sp-action-button>
-                                    <sp-icon-magnify
-                                        slot="icon"
-                                    ></sp-icon-magnify>
-                                </sp-action-button>
-                                <sp-action-button>
-                                    <sp-icon-magnify
-                                        slot="icon"
-                                    ></sp-icon-magnify>
-                                </sp-action-button>
-                                <sp-action-button>
-                                    <sp-icon-magnify
-                                        slot="icon"
-                                    ></sp-icon-magnify>
-                                </sp-action-button>
-                            </sp-action-group>
-                        </sp-popover>
-                    </overlay-trigger>
-                    <input id="last" />
-                </div>
-            `
-        );
+        const test = await fixture<OverlayTrigger>(html`
+            <div>
+                <input id="first" />
+                <overlay-trigger placement="right-start">
+                    <sp-action-button slot="trigger" hold-affordance>
+                        Trigger with hold affordance
+                    </sp-action-button>
+                    <sp-popover slot="longpress-content" tip>
+                        <sp-action-group
+                            selects="single"
+                            vertical
+                            style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
+                        >
+                            <sp-action-button>
+                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                            </sp-action-button>
+                            <sp-action-button>
+                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                            </sp-action-button>
+                            <sp-action-button>
+                                <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                            </sp-action-button>
+                        </sp-action-group>
+                    </sp-popover>
+                </overlay-trigger>
+                <input id="last" />
+            </div>
+        `);
         const el = test.querySelector('overlay-trigger') as OverlayTrigger;
         const first = test.querySelector('#first') as HTMLElement;
         const firstRect = first.getBoundingClientRect();

--- a/packages/radio/src/radio-overrides.css
+++ b/packages/radio/src/radio-overrides.css
@@ -79,21 +79,21 @@
     --spectrum-radio-button-checked-border-color-focus: var(
         --system-radio-button-checked-border-color-focus
     );
+    --spectrum-radio-text-to-control: var(--system-radio-text-to-control);
+    --spectrum-radio-label-top-to-text: var(--system-radio-label-top-to-text);
+    --spectrum-radio-label-bottom-to-text: var(
+        --system-radio-label-bottom-to-text
+    );
+    --spectrum-radio-font-size: var(--system-radio-font-size);
     --spectrum-radio-line-height: var(--system-radio-line-height);
     --spectrum-radio-animation-duration: var(--system-radio-animation-duration);
     --spectrum-radio-height: var(--system-radio-height);
     --spectrum-radio-button-control-size: var(
         --system-radio-button-control-size
     );
-    --spectrum-radio-text-to-control: var(--system-radio-text-to-control);
-    --spectrum-radio-label-top-to-text: var(--system-radio-label-top-to-text);
-    --spectrum-radio-label-bottom-to-text: var(
-        --system-radio-label-bottom-to-text
-    );
     --spectrum-radio-button-top-to-control: var(
         --system-radio-button-top-to-control
     );
-    --spectrum-radio-font-size: var(--system-radio-font-size);
 }
 
 :host(:lang(ja)) {
@@ -114,26 +114,6 @@
     );
 }
 
-:host {
-    --spectrum-radio-height: var(--system-radio-size-m-height);
-    --spectrum-radio-button-control-size: var(
-        --system-radio-size-m-button-control-size
-    );
-    --spectrum-radio-text-to-control: var(
-        --system-radio-size-m-text-to-control
-    );
-    --spectrum-radio-label-top-to-text: var(
-        --system-radio-size-m-label-top-to-text
-    );
-    --spectrum-radio-label-bottom-to-text: var(
-        --system-radio-size-m-label-bottom-to-text
-    );
-    --spectrum-radio-button-top-to-control: var(
-        --system-radio-size-m-button-top-to-control
-    );
-    --spectrum-radio-font-size: var(--system-radio-size-m-font-size);
-}
-
 :host([size='s']) {
     --spectrum-radio-height: var(--system-radio-size-s-height);
     --spectrum-radio-button-control-size: var(
@@ -152,6 +132,26 @@
         --system-radio-size-s-button-top-to-control
     );
     --spectrum-radio-font-size: var(--system-radio-size-s-font-size);
+}
+
+:host {
+    --spectrum-radio-height: var(--system-radio-size-m-height);
+    --spectrum-radio-button-control-size: var(
+        --system-radio-size-m-button-control-size
+    );
+    --spectrum-radio-text-to-control: var(
+        --system-radio-size-m-text-to-control
+    );
+    --spectrum-radio-label-top-to-text: var(
+        --system-radio-size-m-label-top-to-text
+    );
+    --spectrum-radio-label-bottom-to-text: var(
+        --system-radio-size-m-label-bottom-to-text
+    );
+    --spectrum-radio-button-top-to-control: var(
+        --system-radio-size-m-button-top-to-control
+    );
+    --spectrum-radio-font-size: var(--system-radio-size-m-font-size);
 }
 
 :host([size='l']) {

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -153,7 +153,7 @@ governing permissions and limitations under the License.
             var(--spectrum-radio-neutral-content-color)
         )
     );
-    margin-inline-start: 0;
+    margin-inline-start: auto;
 }
 
 :host([emphasized][checked]) #input + #button:before {

--- a/packages/search/src/search-overrides.css
+++ b/packages/search/src/search-overrides.css
@@ -68,16 +68,6 @@
     --spectrum-search-text-to-icon: var(--system-search-text-to-icon);
 }
 
-:host([size='m']) #textfield {
-    --spectrum-search-border-radius: var(--system-search-size-m-border-radius);
-    --spectrum-search-edge-to-visual: var(
-        --system-search-size-m-edge-to-visual
-    );
-    --spectrum-search-block-size: var(--system-search-size-m-block-size);
-    --spectrum-search-icon-size: var(--system-search-size-m-icon-size);
-    --spectrum-search-text-to-icon: var(--system-search-size-m-text-to-icon);
-}
-
 :host([size='s']) #textfield {
     --spectrum-search-border-radius: var(--system-search-size-s-border-radius);
     --spectrum-search-edge-to-visual: var(
@@ -86,6 +76,16 @@
     --spectrum-search-block-size: var(--system-search-size-s-block-size);
     --spectrum-search-icon-size: var(--system-search-size-s-icon-size);
     --spectrum-search-text-to-icon: var(--system-search-size-s-text-to-icon);
+}
+
+:host([size='m']) #textfield {
+    --spectrum-search-border-radius: var(--system-search-size-m-border-radius);
+    --spectrum-search-edge-to-visual: var(
+        --system-search-size-m-edge-to-visual
+    );
+    --spectrum-search-block-size: var(--system-search-size-m-block-size);
+    --spectrum-search-icon-size: var(--system-search-size-m-icon-size);
+    --spectrum-search-text-to-icon: var(--system-search-size-m-text-to-icon);
 }
 
 :host([size='l']) #textfield {

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -269,18 +269,19 @@ governing permissions and limitations under the License.
 }
 
 :host([quiet]) {
-    --spectrum-search-quiet-button-offset: var(
-        --mod-search-quiet-button-offset,
-        calc(
-            var(--mod-search-block-size, var(--spectrum-search-block-size)) / 2 -
-                var(--mod-search-icon-size, var(--spectrum-search-icon-size)) /
-                2
-        )
+    --spectrum-search-quiet-button-offset: calc(
+        var(--mod-search-block-size, var(--spectrum-search-block-size)) / 2 -
+            var(--mod-search-icon-size, var(--spectrum-search-icon-size)) / 2
     );
 }
 
-:host([quiet]) #button .spectrum-ClearButton-icon {
-    transform: translateX(var(--spectrum-search-quiet-button-offset));
+:host([quiet]) #button {
+    transform: translateX(
+        var(
+            --mod-search-quiet-button-offset,
+            var(--spectrum-search-quiet-button-offset)
+        )
+    );
 }
 
 :host([quiet]) #textfield .input {
@@ -301,6 +302,10 @@ governing permissions and limitations under the License.
         var(
                 --mod-search-button-inline-size,
                 var(--spectrum-search-button-inline-size)
-            ) - var(--spectrum-search-quiet-button-offset)
+            ) -
+            var(
+                --mod-search-quiet-button-offset,
+                var(--spectrum-search-quiet-button-offset)
+            )
     );
 }


### PR DESCRIPTION
Only return first element form `assignedElements` instead of an array of elements.

## Description

This PR reverses a helper method that was used in the previous version of the `OverLayTrigger`. In that version, the `slotchange` handler uses `assignedNodes` instead of `assignedElements`. I think using `assignedElements` renders the slot so fast, that our dialog component has not completed loading, leading to forcing a reload, in which it does goes threw the same process.

https://github.com/adobe/spectrum-web-components/blob/a532ff8a410abeefb54d9638a2316ae82570566e/packages/overlay/src/OverlayTrigger.ts#L454

## Related issue(s)
  

[[Bug]: OverlayTrigger can get stuck in a render loop causing page to crash](https://github.com/adobe/spectrum-web-components/issues/4689)



## Motivation and context

Resolves an issue related to endless render loop.


## How has this been tested?

-   [x] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?



## Screenshots (if appropriate)

#### N/A


## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)


## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
