### PR TITLE
chore(reactive-controllers): add missing progress-circle dependency

### DIFF
--- a/tools/reactive-controllers/README.md
+++ b/tools/reactive-controllers/README.md
@@ -10,4 +10,5 @@
 -   LanguageResolutionController
 -   [MatchMediaController](../match-media)
 -   [RovingTabindexController](../roving-tab-index)
+-   [PendingStateController](../pending-state)
 -   SystemContextResolutionController

--- a/tools/reactive-controllers/package.json
+++ b/tools/reactive-controllers/package.json
@@ -84,7 +84,8 @@
         "reactive controllers"
     ],
     "dependencies": {
-        "lit": "^3.1.3"
+        "lit": "^3.1.3",
+        "@spectrum-web-components/progress-circle": "^1.0.1"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/tools/reactive-controllers/pending-state.md
+++ b/tools/reactive-controllers/pending-state.md
@@ -25,20 +25,25 @@ import { PendingStateController } from '@spectrum-web-components/reactive-contro
 
 ```js
 import { LitElement } from 'lit';
-import { PendingStateController } from '@spectrum-web-components/reactive-controllers/src/PendingState.js';
-class Host extends LitElement{
+import { PendingStateController, HostWithPendingState } from '@spectrum-web-components/reactive-controllers/src/PendingState.js';
+
+class Host extends LitElement<HostWithPendingState> {
 
     /** Whether the items are currently loading. */
     @property({ type: Boolean, reflect: true })
     public pending = false;
 
-    /** Defines a string value that labels the Picker while it is in pending state. */
+    /** Whether the host is disabled. */
+    @property({type: boolean})
+    public disabled = false;
+
+    /** Defines a string value that labels the while it is in pending state. */
     @property({ type: String, attribute: 'pending-label' })
     public pendingLabel = 'Pending';
     public pendingStateController: PendingStateController<this>;
 
     /**
-     * Initializes the `PendingStateController` for the Picker component.
+     * Initializes the `PendingStateController` for the component.
      * The `PendingStateController` manages the pending state of the Component.
      */
     constructor() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added missing `sp-progress-circle` dependency to the `reactive-controllers` package. This dependency is being used in the `pending-state` controller.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- Missing Dependency.

## Motivation and context

Missing dependencies cause errors for our consumers.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
