### PR TITLE
Fix(Toast): Adds iconLabel to address accessibility

### DIFF
--- a/packages/icon/src/IconBase.ts
+++ b/packages/icon/src/IconBase.ts
@@ -39,7 +39,7 @@ export class IconBase extends SpectrumElement {
     @state()
     public spectrumVersion = 1;
 
-    @property()
+    @property({ reflect: true })
     public label = '';
 
     @property({ reflect: true })

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -56,20 +56,34 @@ export class Toast extends FocusVisiblePolyfillMixin(SpectrumElement) {
         return [toastStyles];
     }
 
+    /**
+     * The `open` property indicates whether the toast is visible or hidden.
+     *
+     * The `reflect` option is set to `true`, which means that changes to the `open` property will be reflected in the corresponding `open` attribute on the HTML element. This ensures that the property and attribute are always in sync.
+     *
+     * @param {Boolean} open
+     */
     @property({ type: Boolean, reflect: true })
     public open = false;
 
     /**
-     * When a timeout is provided it represents the number of milliseconds from when
+     * When a timeout is provided, it represents the number of milliseconds from when
      * the Toast was placed on the page before it will automatically dismiss itself.
+     *
      * Accessibility concerns require that a Toast is available for at least 6000ms
      * before being dismissed, so any timeout of less than 6000ms will be raised to
-     * that baseline. It is suggested that messages longer than 120 words should
-     * receive another 1000ms in their timeout for each additional 120 words in the
-     * message. E.G. 240 words = 7000ms, 360 words = 8000ms, etc.
+     * that baseline.
      *
-     * @param {Number} timeout
+     * It is suggested that messages longer than 120 words should receive an additional
+     * 1000ms in their timeout for each additional 120 words in the message.
+     *
+     * For example, a message with 240 words should have a timeout of 7000ms,
+     * and a message with 360 words should have a timeout of 8000ms.
+     *
+     * @param {Number | null} timeout
+     * @default null
      */
+    //TODO(#4939): Align on the timeout minimum with design
     @property({ type: Number })
     public set timeout(timeout: number | null) {
         const hasTimeout = typeof timeout !== null && (timeout as number) > 0;
@@ -88,7 +102,7 @@ export class Toast extends FocusVisiblePolyfillMixin(SpectrumElement) {
         return this._timeout;
     }
 
-    public _timeout: number | null = null;
+    private _timeout: number | null = null;
 
     /**
      * The variant applies specific styling when set to `negative`, `positive`, `info`, `error`, or `warning`.
@@ -118,6 +132,7 @@ export class Toast extends FocusVisiblePolyfillMixin(SpectrumElement) {
 
     private _variant: ToastVariants = '';
 
+    //TODO(#4931): Address the deprecated variants or remove the flags
     private renderIcon(variant: string): TemplateResult {
         switch (variant) {
             case 'info':
@@ -129,9 +144,12 @@ export class Toast extends FocusVisiblePolyfillMixin(SpectrumElement) {
                 `;
             case 'negative':
             case 'error': // deprecated
-            case 'warning': // deprecated
                 return html`
                     <sp-icon-alert label="Error" class="type"></sp-icon-alert>
+                `;
+            case 'warning': // deprecated
+                return html`
+                    <sp-icon-alert label="Warning" class="type"></sp-icon-alert>
                 `;
             case 'positive':
             case 'success': // deprecated

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -59,8 +59,6 @@ export class Toast extends FocusVisiblePolyfillMixin(SpectrumElement) {
     /**
      * The `open` property indicates whether the toast is visible or hidden.
      *
-     * The `reflect` option is set to `true`, which means that changes to the `open` property will be reflected in the corresponding `open` attribute on the HTML element. This ensures that the property and attribute are always in sync.
-     *
      * @param {Boolean} open
      */
     @property({ type: Boolean, reflect: true })
@@ -106,56 +104,56 @@ export class Toast extends FocusVisiblePolyfillMixin(SpectrumElement) {
 
     /**
      * The variant applies specific styling when set to `negative`, `positive`, `info`, `error`, or `warning`.
+     *
      * `variant` attribute is removed when not matching one of the above.
      *
      * @param {String} variant
      */
-    @property({ type: String })
-    public set variant(variant: ToastVariants) {
-        if (variant === this.variant) {
-            return;
-        }
-        const oldValue = this.variant;
-        if (toastVariants.includes(variant)) {
-            this.setAttribute('variant', variant);
-            this._variant = variant;
-        } else {
-            this.removeAttribute('variant');
-            this._variant = '';
-        }
-        this.requestUpdate('variant', oldValue);
-    }
+    @property({ type: String, reflect: true })
+    public variant: ToastVariants = '';
 
-    public get variant(): ToastVariants {
-        return this._variant;
-    }
-
-    private _variant: ToastVariants = '';
+    /**
+     * The `iconLabel` property is used to set the `label` attribute on the icon element. This is used to provide a text alternative for the icon to ensure accessibility.
+     *
+     * If the `iconLabel` property is not set, the icon will use the `variant` to dynamically set the `label`.
+     *
+     * @param {String} iconLabel
+     */
+    @property({ type: String, attribute: 'icon-label' })
+    public iconLabel?: string;
 
     //TODO(#4931): Address the deprecated variants or remove the flags
-    private renderIcon(variant: string): TemplateResult {
+    private renderIcon(
+        variant: ToastVariants,
+        iconLabel?: string
+    ): TemplateResult {
         switch (variant) {
             case 'info':
                 return html`
                     <sp-icon-info
-                        label="Information"
+                        label=${iconLabel || 'Information'}
                         class="type"
                     ></sp-icon-info>
                 `;
             case 'negative':
             case 'error': // deprecated
                 return html`
-                    <sp-icon-alert label="Error" class="type"></sp-icon-alert>
+                    <sp-icon-alert
+                        label=${iconLabel || 'Error'}
+                        class="type"
+                    ></sp-icon-alert>
                 `;
             case 'warning': // deprecated
                 return html`
-                    <sp-icon-alert label="Warning" class="type"></sp-icon-alert>
+                    <sp-icon-alert
+                        label=${iconLabel || 'Warning'}
+                        class="type"
+                    ></sp-icon-alert>
                 `;
             case 'positive':
-            case 'success': // deprecated
                 return html`
                     <sp-icon-checkmark-circle
-                        label="Success"
+                        label=${iconLabel || 'Success'}
                         class="type"
                     ></sp-icon-checkmark-circle>
                 `;
@@ -223,7 +221,7 @@ export class Toast extends FocusVisiblePolyfillMixin(SpectrumElement) {
 
     protected override render(): TemplateResult {
         return html`
-            ${this.renderIcon(this.variant)}
+            ${this.renderIcon(this.variant, this.iconLabel)}
             <div class="body" role="alert">
                 <div class="content">
                     <slot></slot>

--- a/packages/toast/src/toast.css
+++ b/packages/toast/src/toast.css
@@ -34,3 +34,27 @@ governing permissions and limitations under the License.
     transition-delay: 0s;
     visibility: visible;
 }
+
+:host([variant='error']),
+:host([variant='warning']) {
+    background-color: var(
+        --highcontrast-toast-negative-background-color-default,
+        var(
+            --mod-toast-negative-background-color-default,
+            var(--spectrum-toast-negative-background-color-default)
+        )
+    );
+}
+
+:host([variant='negative']),
+:host([variant='negative']) .closeButton:focus-visible:not(:active),
+:host([variant='warning']),
+:host([variant='warning']) .closeButton:focus-visible:not(:active) {
+    color: var(
+        --highcontrast-toast-negative-background-color-default,
+        var(
+            --mod-toast-negative-background-color-default,
+            var(--spectrum-toast-negative-background-color-default)
+        )
+    );
+}

--- a/packages/toast/stories/toast.stories.ts
+++ b/packages/toast/stories/toast.stories.ts
@@ -23,6 +23,8 @@ const toast = ({
     variant = '',
     open = true,
     content = '',
+    timeout = 0,
+    iconLabel = '',
 }): TemplateResult => html`
     <sp-toast
         variant=${variant as
@@ -33,6 +35,8 @@ const toast = ({
             | 'error'
             | 'warning'}
         ?open=${open}
+        timeout=${ifDefined(timeout)}
+        .iconLabel=${iconLabel}
     >
         ${content}
         <sp-button
@@ -61,7 +65,6 @@ export default {
                 type: { summary: 'string' },
                 defaultValue: { summary: '' },
             },
-            control: 'text',
         },
         open: {
             name: 'open',
@@ -70,8 +73,16 @@ export default {
                 type: { summary: 'boolean' },
                 defaultValue: { summary: false },
             },
+        },
+        variant: {
+            name: 'variant',
+            options: ['', 'negative', 'positive', 'info', 'error', 'warning'],
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: '' },
+            },
             control: {
-                type: 'boolean',
+                type: 'select',
             },
         },
         timeout: {
@@ -81,8 +92,13 @@ export default {
                 type: { summary: 'number' },
                 defaultValue: { summary: null },
             },
-            control: {
-                type: 'number',
+        },
+        iconLabel: {
+            name: 'iconLabel',
+            type: { name: 'string', required: false },
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: '' },
             },
         },
     },
@@ -93,6 +109,7 @@ interface Properties {
     open: boolean;
     content: string;
     timeout: number;
+    iconLabel: string;
     onClose: (event: Event) => void;
 }
 
@@ -100,16 +117,20 @@ export const Default = ({
     variant,
     open,
     content,
+    timeout,
+    iconLabel,
 }: Properties): TemplateResult => {
-    return toast({ variant, open, content });
+    return toast({ variant, open, content, timeout, iconLabel });
 };
 
 const variantDemo = ({
     variant,
     open,
     content,
+    timeout,
+    iconLabel,
 }: Properties): TemplateResult => {
-    return toast({ variant, open, content });
+    return toast({ variant, open, content, timeout, iconLabel });
 };
 
 export const Positive = (args: Properties): TemplateResult =>

--- a/packages/toast/stories/toast.stories.ts
+++ b/packages/toast/stories/toast.stories.ts
@@ -66,13 +66,23 @@ export default {
         open: {
             name: 'open',
             type: { name: 'boolean', required: false },
-            description: 'Whether the toast is open.',
             table: {
                 type: { summary: 'boolean' },
                 defaultValue: { summary: false },
             },
             control: {
                 type: 'boolean',
+            },
+        },
+        timeout: {
+            name: 'timeout',
+            type: { name: 'number', required: false },
+            table: {
+                type: { summary: 'number' },
+                defaultValue: { summary: null },
+            },
+            control: {
+                type: 'number',
             },
         },
     },
@@ -82,6 +92,7 @@ interface Properties {
     variant: '' | 'negative' | 'positive' | 'info' | 'error' | 'warning';
     open: boolean;
     content: string;
+    timeout: number;
     onClose: (event: Event) => void;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixes the accessibility of icon `label` in `Toast`.
- `warning` variant reads 'warning'.
- consumers can provide a custom `iconLabel` to override the `label` on the icon.
- sets up controls for the `Toast` default story 

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- resolves #3406 
- relates to #1975 

## Motivation and context

Makes toast more accessible

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go to Toast Default story
    2. Change the variant to `error`
    3. Make sure the `label` on icon matches 
    4. make sure the CSS renders `negative`
-   [ ] _Test case 2_
    1. Go to Toast Default story
    2. Change the variant to `warning`
    3. Make sure the `label` on icon matches 
    4. make sure the CSS renders `negative`
-   [ ] _Test case 3_
    1. Go to Toast Default story
    2. Change the variant to anything but `''`
    3. Change the string on `iconLabel` 
    4. Make sure the `label` on icon matches 
    5. make sure the CSS renders `negative`
-   [ ] _Test case 4_
    1. Go to Toast Default story
    2. Change the variant to anything but `''`
    3. check dev tools that variant attribute is on `sp-toast`
    4. Change the variant to `''`
    5. check dev tools that variant attribute is removed from `sp-toast`

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
