### PR TITLE
feat: screen reader support for Calendar and DateTimePicker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 6cf394321bc91b3ff632cc09694eddac71e59366
+        default: 9f0a0eae0e5577722caf09b8683dfe3a00a58103
     wireit_cache_name:
         type: string
         default: wireit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: e5761b668fbcb5a97e8f5b297c91b4e2e72c35bd
+        default: 6cf394321bc91b3ff632cc09694eddac71e59366
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/calendar/src/Calendar.ts
+++ b/packages/calendar/src/Calendar.ts
@@ -530,11 +530,7 @@ export class Calendar extends SpectrumElement {
                     data-value=${calendarDate.toString()}
                     @mousedown=${this.handleDaySelect}
                 >
-                    <span
-                        role="presentation"
-                        class=${classMap(dayClasses)}
-                        data-test-id="calendar-day"
-                    >
+                    <span role="presentation" class=${classMap(dayClasses)}>
                         ${this.formatNumber(calendarDate.day)}
                     </span>
                 </span>
@@ -576,15 +572,13 @@ export class Calendar extends SpectrumElement {
             return;
         }
 
-        const dateCell = (event.target as Element).closest(
-            'td.table-cell'
-        ) as HTMLTableCellElement;
-
-        const cellButton = dateCell.querySelector(
+        const cellButton = (event.target as HTMLElement).closest(
             'span[role="button"]'
         ) as HTMLSpanElement;
 
-        const dateString = cellButton.dataset.value!;
+        const dateString = cellButton && cellButton.dataset.value;
+        if (!dateString) return;
+
         const calendarDateEngaged = parseDate(dateString);
         const isAlreadySelected =
             this.value && isSameDay(this.value, calendarDateEngaged);

--- a/packages/calendar/src/Calendar.ts
+++ b/packages/calendar/src/Calendar.ts
@@ -53,6 +53,7 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-chevron-left.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-chevron-right.js';
 
 import {
+    CalendarLabels,
     CalendarValue,
     CalendarWeekday,
     DateCellProperties,
@@ -99,6 +100,18 @@ export class Calendar extends SpectrumElement {
     public disabled = false;
 
     /**
+     * Labels read by screen readers. The default values are in English
+     * and can be overridden to localize the content.
+     */
+    @property({ attribute: false })
+    labels: CalendarLabels = {
+        previous: 'Previous',
+        next: 'Next',
+        today: 'Today',
+        selected: 'Selected',
+    };
+
+    /**
      * The date that indicates the current position in the calendar.
      */
     @state()
@@ -120,7 +133,6 @@ export class Calendar extends SpectrumElement {
         return this.languageResolver.language;
     }
 
-    // TODO: Implement a cache mechanism to store the value of `today`
     private timeZone: string = getLocalTimeZone();
     public get today(): CalendarDate {
         return today(this.timeZone);
@@ -311,11 +323,10 @@ export class Calendar extends SpectrumElement {
                     ${this.monthAndYear}
                 </h2>
 
-                <!-- TODO: Translate the "Previous" text -->
                 <sp-action-button
                     quiet
                     size="s"
-                    label="Previous"
+                    label=${this.labels.previous}
                     class="prevMonth"
                     data-test-id="prev-btn"
                     ?disabled=${this.isPreviousMonthDisabled}
@@ -328,11 +339,10 @@ export class Calendar extends SpectrumElement {
                     </div>
                 </sp-action-button>
 
-                <!-- TODO: Translate the "Next" text -->
                 <sp-action-button
                     quiet
                     size="s"
-                    label="Next"
+                    label=${this.labels.next}
                     class="nextMonth"
                     data-test-id="next-btn"
                     ?disabled=${this.isNextMonthDisabled}
@@ -495,9 +505,9 @@ export class Calendar extends SpectrumElement {
         };
 
         let currentDayLabelPrefix = '';
-        // TODO: translate the "Today" and "Selected" strings
-        if (isToday) currentDayLabelPrefix = 'Today, ';
-        else if (isSelected) currentDayLabelPrefix = 'Selected, ';
+        if (isToday) currentDayLabelPrefix = `${this.labels.today}, `;
+        else if (isSelected)
+            currentDayLabelPrefix = `${this.labels.selected}, `;
 
         const currentDayLabel =
             currentDayLabelPrefix +

--- a/packages/calendar/src/Calendar.ts
+++ b/packages/calendar/src/Calendar.ts
@@ -134,7 +134,7 @@ export class Calendar extends SpectrumElement {
     }
 
     private timeZone: string = getLocalTimeZone();
-    public get today(): CalendarDate {
+    private get today(): CalendarDate {
         return today(this.timeZone);
     }
 
@@ -316,7 +316,7 @@ export class Calendar extends SpectrumElement {
             <div class="header" @focusin=${this.resetDateFocusIntent}>
                 <h2
                     class="title"
-                    aria-live="assertive"
+                    aria-live="polite"
                     aria-atomic="true"
                     data-test-id="calendar-title"
                 >

--- a/packages/calendar/src/calendar.css
+++ b/packages/calendar/src/calendar.css
@@ -11,3 +11,10 @@ governing permissions and limitations under the License.
 */
 
 @import url('./spectrum-calendar.css');
+
+.table-cell span[role='button'] {
+    border-radius: var(
+        --mod-calendar-day-width,
+        var(--spectrum-calendar-day-width)
+    );
+}

--- a/packages/calendar/src/spectrum-calendar.css
+++ b/packages/calendar/src/spectrum-calendar.css
@@ -188,7 +188,7 @@ governing permissions and limitations under the License.
     user-select: none;
 }
 
-.tableCell {
+.table-cell {
     text-align: center;
     box-sizing: content-box;
     block-size: var(
@@ -206,7 +206,7 @@ governing permissions and limitations under the License.
     position: relative;
 }
 
-.tableCell:focus {
+.table-cell:focus {
     outline: 0;
 }
 
@@ -612,7 +612,7 @@ governing permissions and limitations under the License.
     );
 }
 
-.tableCell:focus-within .date:not(.is-range-selection) {
+.table-cell:focus-within .date:not(.is-range-selection) {
     background: var(
         --highcontrast-calendar-day-background-color-key-focus,
         var(
@@ -636,7 +636,7 @@ governing permissions and limitations under the License.
     );
 }
 
-.tableCell:focus-within .date:not(.is-range-selection).is-today {
+.table-cell:focus-within .date:not(.is-range-selection).is-today {
     border-color: var(
         --highcontrast-calendar-day-border-color-key-focus,
         var(
@@ -646,8 +646,8 @@ governing permissions and limitations under the License.
     );
 }
 
-.tableCell:focus-within .date:not(.is-range-selection):active,
-.tableCell:focus-within .date:not(.is-range-selection).is-selected {
+.table-cell:focus-within .date:not(.is-range-selection):active,
+.table-cell:focus-within .date:not(.is-range-selection).is-selected {
     color: var(
         --highcontrast-calendar-day-text-color-selected,
         var(
@@ -671,7 +671,7 @@ governing permissions and limitations under the License.
     );
 }
 
-.tableCell:focus-within .date.is-selected:before {
+.table-cell:focus-within .date.is-selected:before {
     background: var(
         --highcontrast-calendar-day-background-color-selected-hover,
         var(
@@ -681,7 +681,7 @@ governing permissions and limitations under the License.
     );
 }
 
-.tableCell:focus-within .date.is-range-selection:before {
+.table-cell:focus-within .date.is-range-selection:before {
     background: var(
         --highcontrast-calendar-day-background-color-selected-hover,
         var(
@@ -691,7 +691,7 @@ governing permissions and limitations under the License.
     );
 }
 
-.tableCell:focus-within .date:before {
+.table-cell:focus-within .date:before {
     border-color: var(
         --highcontrast-calendar-day-border-color-key-focus,
         var(

--- a/packages/calendar/src/spectrum-config.js
+++ b/packages/calendar/src/spectrum-config.js
@@ -37,7 +37,7 @@ const config = {
                     ],
                     replace: [
                         {
-                            replace: builder.class('tableCell'),
+                            replace: builder.class('table-cell'),
                         },
                         {
                             replace: builder.pseudoClass('focus-within'),
@@ -69,7 +69,7 @@ const config = {
                 converter.classToClass('spectrum-Calendar-table', 'table'),
                 converter.classToClass(
                     'spectrum-Calendar-tableCell',
-                    'tableCell'
+                    'table-cell'
                 ),
                 converter.classToClass('spectrum-Calendar-date', 'date'),
             ],

--- a/packages/calendar/src/types.ts
+++ b/packages/calendar/src/types.ts
@@ -31,3 +31,10 @@ export interface DateCellProperties {
     isDisabled: boolean;
     isTabbable: boolean;
 }
+
+export interface CalendarLabels {
+    previous: string;
+    next: string;
+    today: string;
+    selected: string;
+}

--- a/packages/calendar/test/calendar.test.ts
+++ b/packages/calendar/test/calendar.test.ts
@@ -32,6 +32,7 @@ import {
     expectSameDates,
     fixtureElement,
     getElementCenter,
+    getFocusableDay,
     sendKeyMultipleTimes,
 } from './helpers.js';
 
@@ -157,9 +158,7 @@ describe('Calendar', () => {
         let prevButton: ActionButton;
 
         beforeEach(() => {
-            focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            focusableDay = getFocusableDay(element);
             nextButton =
                 element.shadowRoot.querySelector(NEXT_BUTTON_SELECTOR)!;
             prevButton =
@@ -257,9 +256,7 @@ describe('Calendar', () => {
             nextButton =
                 element.shadowRoot.querySelector(NEXT_BUTTON_SELECTOR)!;
 
-            focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            )!;
+            focusableDay = getFocusableDay(element);
         });
 
         afterEach(async () => {
@@ -577,9 +574,7 @@ describe('Calendar', () => {
             element = await fixtureElement({
                 props: { min, max },
             });
-            const focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            const focusableDay = getFocusableDay(element);
             focusableDay.focus();
             await sendKeyMultipleTimes('ArrowRight', dayOffset + 3);
             await elementUpdated(element);
@@ -591,9 +586,7 @@ describe('Calendar', () => {
             element = await fixtureElement({
                 props: { min, max },
             });
-            const focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            const focusableDay = getFocusableDay(element);
             focusableDay.focus();
             await sendKeyMultipleTimes('ArrowLeft', dayOffset + 3);
             await elementUpdated(element);
@@ -605,9 +598,7 @@ describe('Calendar', () => {
             element = await fixtureElement({
                 props: { min, max },
             });
-            const focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            const focusableDay = getFocusableDay(element);
             focusableDay.focus();
             await sendKeyMultipleTimes(
                 'ArrowUp',
@@ -622,9 +613,7 @@ describe('Calendar', () => {
             element = await fixtureElement({
                 props: { min, max },
             });
-            const focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            const focusableDay = getFocusableDay(element);
             focusableDay.focus();
             await sendKeyMultipleTimes(
                 'ArrowDown',
@@ -654,7 +643,9 @@ describe('Calendar', () => {
         it('should update value when an available day is clicked', async () => {
             await sendMouse({
                 type: 'click',
-                position: getElementCenter(availableDayElement),
+                position: getElementCenter(
+                    availableDayElement.querySelector('span') as HTMLElement
+                ),
             });
             await elementUpdated(element);
 
@@ -712,7 +703,9 @@ describe('Calendar', () => {
         it("should dispatch 'change' when an available day is selected by clicking", async () => {
             await sendMouse({
                 type: 'click',
-                position: getElementCenter(availableDayElement),
+                position: getElementCenter(
+                    availableDayElement.querySelector('span') as HTMLElement
+                ),
             });
             await elementUpdated(element);
 
@@ -819,9 +812,7 @@ describe('Calendar', () => {
         });
 
         it('should not have focusable days', () => {
-            const focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            const focusableDay = getFocusableDay(element);
 
             expect(focusableDay).to.be.null;
         });
@@ -871,9 +862,7 @@ describe('Calendar', () => {
         it('should not navigate to BC era - ArrowUp', async () => {
             const value = new CalendarDate(1, 1, 5);
             element = await fixtureElement({ props: { value } });
-            const focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            const focusableDay = getFocusableDay(element);
 
             focusableDay.focus();
             await sendKeyMultipleTimes(
@@ -888,9 +877,7 @@ describe('Calendar', () => {
         it('should not navigate to BC era - ArrowLeft', async () => {
             const value = new CalendarDate(1, 1, 5);
             element = await fixtureElement({ props: { value } });
-            const focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            const focusableDay = getFocusableDay(element);
 
             focusableDay.focus();
             await sendKeyMultipleTimes('ArrowLeft', value.day + 3);
@@ -914,9 +901,7 @@ describe('Calendar', () => {
             value = value.set({ year: value.calendar.getYearsInEra(value) });
             const lastDate = endOfMonth(value);
             element = await fixtureElement({ props: { value } });
-            const focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            const focusableDay = getFocusableDay(element);
 
             focusableDay.focus();
             await sendKeyMultipleTimes(
@@ -933,9 +918,7 @@ describe('Calendar', () => {
             value = value.set({ year: value.calendar.getYearsInEra(value) });
             const lastDate = endOfMonth(value);
             element = await fixtureElement({ props: { value } });
-            const focusableDay = element.shadowRoot.querySelector(
-                "td.tableCell[tabindex='0']"
-            ) as HTMLElement;
+            const focusableDay = getFocusableDay(element);
 
             focusableDay.focus();
             await sendKeyMultipleTimes(

--- a/packages/calendar/test/helpers.ts
+++ b/packages/calendar/test/helpers.ts
@@ -79,3 +79,12 @@ export function expectSameDates(
 ): void {
     expect(isSameDay(a, b), message).to.be.true;
 }
+
+/**
+ * Queries the calendar for the focusable day element.
+ */
+export function getFocusableDay(calendar: Calendar): HTMLElement {
+    return calendar.shadowRoot.querySelector(
+        'td.table-cell span[tabindex="0"]'
+    ) as HTMLElement;
+}

--- a/packages/date-time-picker/src/DateTimePicker.ts
+++ b/packages/date-time-picker/src/DateTimePicker.ts
@@ -281,10 +281,12 @@ export class DateTimePicker extends ManageHelpText(
 
         if (changesDisabled && this.isCalendarOpen) this.isCalendarOpen = false;
 
-        const selectedDate =
+        const selectedDateLabel =
             this.value &&
-            this.ariaDateFormatter.format(dateValueToDate(this.value));
-        this.setAttribute('aria-label', selectedDate ?? this.labels.empty);
+            this.labels.selected +
+                ': ' +
+                this.ariaDateFormatter.format(dateValueToDate(this.value));
+        this.setAttribute('aria-label', selectedDateLabel ?? this.labels.empty);
     }
 
     /**

--- a/packages/date-time-picker/src/DateTimePicker.ts
+++ b/packages/date-time-picker/src/DateTimePicker.ts
@@ -499,6 +499,7 @@ export class DateTimePicker extends ManageHelpText(
             <span
                 class="literal-segment"
                 data-test-id=${segment.type}
+                aria-hidden="true"
             >${segment.formatted}</span>
         `;
     }
@@ -541,6 +542,13 @@ export class DateTimePicker extends ManageHelpText(
         return html`
             <div
                 role="spinbutton"
+                aria-valuenow=${ifDefined(segment.value)}
+                aria-valuemin=${segment.minValue}
+                aria-valuemax=${segment.maxValue}
+                aria-label=${segment.label}
+                aria-valuetext=${ifDefined(
+                    segment.value === undefined ? 'Empty' : undefined
+                )}
                 contenteditable=${ifDefined(isActive ? true : undefined)}
                 inputmode=${ifDefined(isActive ? inputMode : undefined)}
                 tabindex=${ifDefined(isActive ? '0' : undefined)}

--- a/packages/date-time-picker/src/DateTimePicker.ts
+++ b/packages/date-time-picker/src/DateTimePicker.ts
@@ -69,23 +69,24 @@ import {
     isCalendarDate,
     isCalendarDateTime,
     isZonedDateTime,
-} from './helpers.js';
-import { DateTimeSegments } from './segments/DateTimeSegments.js';
-import { EditableSegment } from './segments/EditableSegment.js';
-import { LiteralSegment } from './segments/LiteralSegment.js';
-import { SegmentsFactory } from './segments/SegmentsFactory.js';
-import { ClearModifier } from './segments/modifiers/ClearModifier.js';
-import { DecrementModifier } from './segments/modifiers/DecrementModifier.js';
-import { IncrementModifier } from './segments/modifiers/IncrementModifier.js';
-import { InputModifier } from './segments/modifiers/InputModifier.js';
-import { type SegmentsModifierParams } from './segments/modifiers/SegmentsModifier.js';
+} from './helpers';
+import { DateTimeSegments } from './segments/DateTimeSegments';
+import { EditableSegment } from './segments/EditableSegment';
+import { LiteralSegment } from './segments/LiteralSegment';
+import { SegmentsFactory } from './segments/SegmentsFactory';
+import { ClearModifier } from './segments/modifiers/ClearModifier';
+import { DecrementModifier } from './segments/modifiers/DecrementModifier';
+import { IncrementModifier } from './segments/modifiers/IncrementModifier';
+import { InputModifier } from './segments/modifiers/InputModifier';
+import { type SegmentsModifierParams } from './segments/modifiers/SegmentsModifier';
 import {
+    DateTimePickerLabels,
     DateTimePickerValue,
     EditableSegmentType,
     Precision,
     Precisions,
     SegmentTypes,
-} from './types.js';
+} from './types';
 
 /**
  * @element sp-date-time-picker
@@ -160,6 +161,20 @@ export class DateTimePicker extends ManageHelpText(
      */
     @property({ type: Boolean, reflect: true })
     public quiet = false;
+
+    /**
+     * Labels read by screen readers. The default values are in English
+     * and can be overridden to localize the content.
+     */
+    @property({ attribute: false })
+    labels: DateTimePickerLabels = {
+        previous: 'Previous',
+        next: 'Next',
+        today: 'Today',
+        selected: 'Selected',
+        empty: 'Empty',
+        calendar: 'Calendar',
+    };
 
     /**
      * @private
@@ -415,6 +430,7 @@ export class DateTimePicker extends ManageHelpText(
                 ?invalid=${this.invalid}
                 ?disabled=${this.disabled}
                 @click=${() => (this.isCalendarOpen = true)}
+                label=${this.labels.calendar}
             >
                 <slot name="calendar-icon" slot="icon">
                     <sp-icon-calendar></sp-icon-calendar>
@@ -435,6 +451,7 @@ export class DateTimePicker extends ManageHelpText(
                             .value=${this.value}
                             .min=${this.min}
                             .max=${this.max}
+                            .labels=${this.labels}
                             @change=${this.handleChange}
                         ></sp-calendar>
                     </div>
@@ -547,7 +564,9 @@ export class DateTimePicker extends ManageHelpText(
                 aria-valuemax=${segment.maxValue}
                 aria-label=${segment.label}
                 aria-valuetext=${ifDefined(
-                    segment.value === undefined ? 'Empty' : undefined
+                    segment.value !== undefined
+                        ? segment.formatted
+                        : this.labels.empty
                 )}
                 contenteditable=${ifDefined(isActive ? true : undefined)}
                 inputmode=${ifDefined(isActive ? inputMode : undefined)}

--- a/packages/date-time-picker/src/helpers.ts
+++ b/packages/date-time-picker/src/helpers.ts
@@ -53,3 +53,19 @@ export function equalSegmentValues(
         a.length === b.length && a.every((value, index) => value === b[index])
     );
 }
+
+export function dateValueToDate(dateValue: DateValue): Date {
+    if (isCalendarDate(dateValue)) {
+        // Month is 0-indexed in Date but 1-indexed in DateValue
+        return new Date(dateValue.year, dateValue.month - 1, dateValue.day);
+    }
+
+    return new Date(
+        dateValue.year,
+        dateValue.month - 1,
+        dateValue.day,
+        dateValue.hour,
+        dateValue.minute,
+        dateValue.second
+    );
+}

--- a/packages/date-time-picker/src/segments/EditableSegment.ts
+++ b/packages/date-time-picker/src/segments/EditableSegment.ts
@@ -23,13 +23,15 @@ export abstract class EditableSegment {
     public type: EditableSegmentType;
     public formatted: string;
     public placeholder: SegmentPlaceholder;
+    public label: string;
     public abstract minValue: number;
     public abstract maxValue: number;
     public abstract value?: number;
 
-    constructor(type: EditableSegmentType, formatted: string) {
+    constructor(type: EditableSegmentType, formatted: string, label: string) {
         this.type = type;
         this.formatted = formatted;
+        this.label = label;
         this.placeholder = SegmentPlaceholders[type];
     }
 

--- a/packages/date-time-picker/src/segments/EditableSegment.ts
+++ b/packages/date-time-picker/src/segments/EditableSegment.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import { ZonedDateTime } from '@internationalized/date';
 import { NumberParser } from '@internationalized/number';
 import {
+    EditableSegmentLimits,
     EditableSegmentType,
     SegmentPlaceholder,
     SegmentPlaceholders,
@@ -81,10 +82,7 @@ export abstract class EditableSegment {
         return value >= minValue && value <= maxValue;
     }
 
-    protected get inputValidationLimits(): {
-        minValue: number;
-        maxValue: number;
-    } {
+    public get inputValidationLimits(): EditableSegmentLimits {
         return {
             minValue: this.minValue,
             maxValue: this.maxValue,

--- a/packages/date-time-picker/src/segments/SegmentsFactory.ts
+++ b/packages/date-time-picker/src/segments/SegmentsFactory.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import { DateFormatter, ZonedDateTime } from '@internationalized/date';
 import { NumberFormatter } from '@internationalized/number';
+import { dateValueToDate } from '../helpers';
 import {
     EditableSegmentType,
     LiteralSegmentType,
@@ -19,7 +20,6 @@ import {
     SegmentTypes,
 } from '../types';
 import { DateTimeSegments, Segment } from './DateTimeSegments';
-import { EditableSegment } from './EditableSegment';
 import { LiteralSegment } from './LiteralSegment';
 import { DaySegment } from './date/DaySegment';
 import { MonthSegment } from './date/MonthSegment';
@@ -55,14 +55,7 @@ export class SegmentsFactory {
         currentDate: ZonedDateTime,
         setValues: boolean = false
     ): DateTimeSegments {
-        const date = new Date(
-            currentDate.year,
-            currentDate.month - 1, // 0-indexed in Date but 1-indexed in ZonedDateTime
-            currentDate.day,
-            currentDate.hour,
-            currentDate.minute,
-            currentDate.second
-        );
+        const date = dateValueToDate(currentDate);
 
         const createdSegments = this.dateFormatter
             .formatToParts(date)
@@ -124,28 +117,26 @@ export class SegmentsFactory {
         type: EditableSegmentType | LiteralSegmentType,
         formatted: string
     ): Segment {
-        const editableSegmentConstructors: Record<
-            EditableSegmentType,
-            new (formatted: string, label: string) => EditableSegment
-        > = {
-            [SegmentTypes.Year]: YearSegment,
-            [SegmentTypes.Month]: MonthSegment,
-            [SegmentTypes.Day]: DaySegment,
-            [SegmentTypes.Hour]: HourSegment,
-            [SegmentTypes.Minute]: MinuteSegment,
-            [SegmentTypes.Second]: SecondSegment,
-            [SegmentTypes.DayPeriod]: DayPeriodSegment,
-        };
+        if (type === SegmentTypes.Literal) return new LiteralSegment(formatted);
 
-        if (type !== SegmentTypes.Literal) {
-            const SegmentConstructor = editableSegmentConstructors[type];
-            return new SegmentConstructor(
-                formatted,
-                this.displayNameOfType(type)
-            );
+        const label = this.displayNameOfType(type);
+
+        switch (type) {
+            case SegmentTypes.Year:
+                return new YearSegment(formatted, label);
+            case SegmentTypes.Month:
+                return new MonthSegment(formatted, label);
+            case SegmentTypes.Day:
+                return new DaySegment(formatted, label);
+            case SegmentTypes.Hour:
+                return new HourSegment(formatted, label);
+            case SegmentTypes.Minute:
+                return new MinuteSegment(formatted, label);
+            case SegmentTypes.Second:
+                return new SecondSegment(formatted, label);
+            case SegmentTypes.DayPeriod:
+                return new DayPeriodSegment(formatted, label);
         }
-
-        return new LiteralSegment(formatted);
     }
 
     private displayNameOfType(type: EditableSegmentType): string {

--- a/packages/date-time-picker/src/segments/date/DaySegment.ts
+++ b/packages/date-time-picker/src/segments/date/DaySegment.ts
@@ -28,8 +28,8 @@ export class DaySegment extends EditableSegment {
     public maxValue: number = 31;
     public value?: number;
 
-    constructor(formatted: string) {
-        super(SegmentTypes.Day, formatted);
+    constructor(formatted: string, label: string) {
+        super(SegmentTypes.Day, formatted, label);
     }
 
     public setLimits(

--- a/packages/date-time-picker/src/segments/date/MonthSegment.ts
+++ b/packages/date-time-picker/src/segments/date/MonthSegment.ts
@@ -19,8 +19,8 @@ export class MonthSegment extends EditableSegment {
     public maxValue: number = 12;
     public value?: number;
 
-    constructor(formatted: string) {
-        super(SegmentTypes.Month, formatted);
+    constructor(formatted: string, label: string) {
+        super(SegmentTypes.Month, formatted, label);
     }
 
     public setLimits(currentDate: ZonedDateTime): void {

--- a/packages/date-time-picker/src/segments/date/YearSegment.ts
+++ b/packages/date-time-picker/src/segments/date/YearSegment.ts
@@ -19,8 +19,8 @@ export class YearSegment extends EditableSegment {
     public maxValue: number = 9999;
     public value?: number;
 
-    constructor(formatted: string) {
-        super(SegmentTypes.Year, formatted);
+    constructor(formatted: string, label: string) {
+        super(SegmentTypes.Year, formatted, label);
     }
 
     public setLimits(currentDate: ZonedDateTime): void {

--- a/packages/date-time-picker/src/segments/time/DayPeriodSegment.ts
+++ b/packages/date-time-picker/src/segments/time/DayPeriodSegment.ts
@@ -11,9 +11,9 @@ governing permissions and limitations under the License.
 */
 
 import { DateFormatter, ZonedDateTime } from '@internationalized/date';
-import { EditableSegment } from '../EditableSegment';
-import { AM, PM, SegmentTypes } from '../../types';
 import { getDayPeriodModifier } from '../../helpers';
+import { AM, PM, SegmentTypes } from '../../types';
+import { EditableSegment } from '../EditableSegment';
 
 export class DayPeriodSegment extends EditableSegment {
     public minValue: typeof AM = AM;

--- a/packages/date-time-picker/src/segments/time/DayPeriodSegment.ts
+++ b/packages/date-time-picker/src/segments/time/DayPeriodSegment.ts
@@ -22,8 +22,8 @@ export class DayPeriodSegment extends EditableSegment {
     private localizedMinValue: string = 'AM';
     private localizedMaxValue: string = 'PM';
 
-    constructor(formatted: string) {
-        super(SegmentTypes.DayPeriod, formatted);
+    constructor(formatted: string, label: string) {
+        super(SegmentTypes.DayPeriod, formatted, label);
     }
 
     private toggleAmPm(): void {

--- a/packages/date-time-picker/src/segments/time/HourSegment.ts
+++ b/packages/date-time-picker/src/segments/time/HourSegment.ts
@@ -20,8 +20,8 @@ export class HourSegment extends EditableSegment {
     public maxValue: number = 23;
     public value?: number;
 
-    constructor(formatted: string) {
-        super(SegmentTypes.Hour, formatted);
+    constructor(formatted: string, label: string) {
+        super(SegmentTypes.Hour, formatted, label);
     }
 
     public setLimits(is12HourClock?: boolean): void {

--- a/packages/date-time-picker/src/segments/time/HourSegment.ts
+++ b/packages/date-time-picker/src/segments/time/HourSegment.ts
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import { ZonedDateTime } from '@internationalized/date';
-import { SegmentTypes } from '../../types';
+import { EditableSegmentLimits, SegmentTypes } from '../../types';
 import { EditableSegment } from '../EditableSegment';
 import { getDayPeriodModifier } from '../../helpers';
 
@@ -53,10 +53,7 @@ export class HourSegment extends EditableSegment {
      * the hour value of 0 should be displayed as 12. Therefore, in the 12h format, the user should be able to type in "12" but not "00",
      * for the 00 time, which is represented by the value of 0 of the hour segment.
      */
-    protected override get inputValidationLimits(): {
-        minValue: number;
-        maxValue: number;
-    } {
+    public override get inputValidationLimits(): EditableSegmentLimits {
         const isAmPm = this.maxValue === 11;
 
         return {

--- a/packages/date-time-picker/src/segments/time/MinuteSegment.ts
+++ b/packages/date-time-picker/src/segments/time/MinuteSegment.ts
@@ -18,7 +18,7 @@ export class MinuteSegment extends EditableSegment {
     public maxValue: number = 59;
     public value?: number;
 
-    constructor(formatted: string) {
-        super(SegmentTypes.Minute, formatted);
+    constructor(formatted: string, label: string) {
+        super(SegmentTypes.Minute, formatted, label);
     }
 }

--- a/packages/date-time-picker/src/segments/time/SecondSegment.ts
+++ b/packages/date-time-picker/src/segments/time/SecondSegment.ts
@@ -18,7 +18,7 @@ export class SecondSegment extends EditableSegment {
     public maxValue: number = 59;
     public value?: number;
 
-    constructor(formatted: string) {
-        super(SegmentTypes.Second, formatted);
+    constructor(formatted: string, label: string) {
+        super(SegmentTypes.Second, formatted, label);
     }
 }

--- a/packages/date-time-picker/src/types.ts
+++ b/packages/date-time-picker/src/types.ts
@@ -23,9 +23,14 @@ export const SegmentTypes = {
     Literal: 'literal',
 } as const;
 
-export type SegmentType = (typeof SegmentTypes)[keyof typeof SegmentTypes];
+export type LiteralSegmentType = 'literal';
 
-export type EditableSegmentType = Exclude<SegmentType, 'literal'>;
+export type EditableSegmentType = Exclude<
+    (typeof SegmentTypes)[keyof typeof SegmentTypes],
+    LiteralSegmentType
+>;
+
+export type SegmentType = EditableSegmentType | LiteralSegmentType;
 
 export const SegmentPlaceholders: Readonly<
     Record<EditableSegmentType, string>

--- a/packages/date-time-picker/src/types.ts
+++ b/packages/date-time-picker/src/types.ts
@@ -8,7 +8,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { DateValue } from '@spectrum-web-components/calendar';
+import { CalendarLabels, DateValue } from '@spectrum-web-components/calendar';
 
 export type DateTimePickerValue = DateValue;
 
@@ -55,6 +55,16 @@ export const Precisions = {
 } as const;
 
 export type Precision = (typeof Precisions)[keyof typeof Precisions];
+
+export type EditableSegmentLimits = {
+    minValue: number;
+    maxValue: number;
+};
+
+export type DateTimePickerLabels = CalendarLabels & {
+    empty: string;
+    calendar: string;
+};
 
 /** AM modifier: `0` hours */
 export const AM = 0;

--- a/packages/date-time-picker/stories/date-time-picker.stories.ts
+++ b/packages/date-time-picker/stories/date-time-picker.stories.ts
@@ -31,6 +31,7 @@ import {
 import { spreadProps } from '../../../test/lit-helpers.js';
 
 import '@spectrum-web-components/date-time-picker/sp-date-time-picker.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/help-text/sp-help-text.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 
@@ -150,8 +151,12 @@ const computeProps = (args: StoryArgs): ComponentArgs => {
 };
 
 const Template = (args: StoryArgs = {}): TemplateResult => {
+    const idNumber = Math.random().toString(36);
+    const id = `date-picker-${idNumber}`;
     return html`
+        <sp-field-label for=${id}>Event date</sp-field-label>
         <sp-date-time-picker
+            id=${id}
             @change=${args.onChange}
             @input=${args.onInput}
             ...=${spreadProps(computeProps(args))}
@@ -188,7 +193,9 @@ autofocus.args = {
 
 export const preselectedValue = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="date-picker">Event date</sp-field-label>
         <sp-date-time-picker
+            id="date-picker-preselected"
             .value=${new CalendarDateTime(2020, 2, 16, 8, 20)}
             ...=${spreadProps(computeProps(args))}
         ></sp-date-time-picker>
@@ -197,7 +204,9 @@ export const preselectedValue = (args: StoryArgs): TemplateResult => {
 
 export const minDate = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="date-picker-min">Event date</sp-field-label>
         <sp-date-time-picker
+            id="date-picker-min"
             .value=${new CalendarDate(2022, 4, 16)}
             .min=${new CalendarDate(2022, 4, 12)}
             ...=${spreadProps(computeProps(args))}
@@ -207,7 +216,9 @@ export const minDate = (args: StoryArgs): TemplateResult => {
 
 export const maxDate = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="date-picker-max">Event date</sp-field-label>
         <sp-date-time-picker
+            id="date-picker-max"
             .value=${new CalendarDate(2022, 4, 16)}
             .max=${new CalendarDateTime(2022, 4, 19, 20, 30)}
             ...=${spreadProps(computeProps(args))}
@@ -217,7 +228,9 @@ export const maxDate = (args: StoryArgs): TemplateResult => {
 
 export const minAndMaxDates = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="date-picker-min-max">Event date</sp-field-label>
         <sp-date-time-picker
+            id="date-picker-min-max"
             .value=${new CalendarDate(2022, 4, 16)}
             .min=${toZoned(
                 new CalendarDateTime(2022, 4, 12, 9, 15),
@@ -231,7 +244,9 @@ export const minAndMaxDates = (args: StoryArgs): TemplateResult => {
 
 export const secondPrecision = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="date-picker-precision">Event date</sp-field-label>
         <sp-date-time-picker
+            id="date-picker-precision"
             .value=${new CalendarDate(2022, 4, 16)}
             precision="second"
             ...=${spreadProps(computeProps(args))}
@@ -241,7 +256,9 @@ export const secondPrecision = (args: StoryArgs): TemplateResult => {
 
 export const helpText = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="date-picker-help">Event date</sp-field-label>
         <sp-date-time-picker
+            id="date-picker-help"
             precision="day"
             ...=${spreadProps(computeProps(args))}
         >
@@ -254,7 +271,9 @@ export const helpText = (args: StoryArgs): TemplateResult => {
 
 export const negativeHelpText = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="date-picker-negative">Event date</sp-field-label>
         <sp-date-time-picker
+            id="date-picker-negative"
             .min=${new CalendarDate(2020, 0, 1)}
             .max=${new CalendarDate(2025, 0, 1)}
             ...=${spreadProps(computeProps(args))}
@@ -271,7 +290,11 @@ export const negativeHelpText = (args: StoryArgs): TemplateResult => {
 
 export const customIcon = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-date-time-picker ...=${spreadProps(computeProps(args))}>
+        <sp-field-label for="date-picker-icon">Event date</sp-field-label>
+        <sp-date-time-picker
+            id="date-picker-icon"
+            ...=${spreadProps(computeProps(args))}
+        >
             <sp-icon-alert slot="calendar-icon"></sp-icon-alert>
         </sp-date-time-picker>
     `;
@@ -279,7 +302,7 @@ export const customIcon = (args: StoryArgs): TemplateResult => {
 
 export const customWidth = (args: StoryArgs): TemplateResult[] => {
     return ['100%', '50%', '350px', 'auto'].map((width, index) => {
-        const id = `date-time-picker--${index}`;
+        const id = `date-picker--${index}`;
         const styles = css`
             sp-date-time-picker#${unsafeCSS(id)} {
                 inline-size: ${unsafeCSS(width)};
@@ -290,7 +313,9 @@ export const customWidth = (args: StoryArgs): TemplateResult[] => {
             <style>
                 ${styles}
             </style>
-            <p>Width: ${width}</p>
+            <sp-field-label for=${id}>
+                Event date - width: ${width}
+            </sp-field-label>
             <div>
                 <sp-date-time-picker
                     id=${id}


### PR DESCRIPTION
## Description

This PR aims to offer screen reader support for the most common use-cases of these components.

### The calendar:
- Announces when a date is selected
- Announces when the month is changed
- Announces when the user navigates using Arrows or VO + Arrows
- Announces the month and year when going into the component
- Announces the type of action on previous/next month buttons
- New `labels` property to override english-default labels

### The DateTimePicker:
- Announces the current focused segment as a stepper with the correct type translated according to the locale ('year'/'month' etc.)
- Announces if the current focused segment is Empty
- Announces the new value of the segment when it gets changed 
- Announces the type of button 'Calendar'
- Announces the spelled out date value (or 'Empty') when going into the component
- New `labels` property to override english-default labels

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/2559
- https://github.com/adobe/spectrum-web-components/issues/2560

## Motivation and context

Screen reader is one of the basic testings - the minimum level expected for any product of Adobe. 

## How has this been tested?

mainly Chrome with macOS VoiceOver (cmd + F5)

-   [ ] _Test case 1_
    1. Go to the Calendar storybook 
    2. Tab to the Calendar component
    3. Observe that the month and year get announced
    4. Tab to the days grid and use VO + Arrows to navigate through the dates
    5. Observe that the VoiceOver announces the full dates for each day in the grid
    6. Select a date using VO + space
    7. Observe that the new selected value is announced
-   [ ] _Test case 2_
    1. Go to the Calendar storybook
    2. Tab to the next/previous month buttons
    3. Observe that the action is announced ('Previous'/'Next')
    4. Change the month using VO + space
    5. Observe that the new month and year get announced
-   [ ] _Test case 3_
    1. Go to the DateTimePicker storybook
    2. Tab to the DateTimePicker component
    3. Observe that the value gets announced (or 'Empty')
    4. Tab through the segments (year/month/hour etc.)
    6. Observe that the type of the segment gets announced along with the value
    7. Change the value of the segment using Arrow Up/ Arrow Down or Type In
    8. Observe that the new value gets announced


-   [x] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ x New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
