### PR TITLE
build: fixing coveralls

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -23,7 +23,7 @@ jobs:
               run: yarn playwright install --with-deps
 
             - name: Run unit tests with coverage
-              run: yarn test:ci --config web-test-runner.config.ci-chromium.js --group no-memory-ci --coverage
+              run: yarn test:ci --config web-test-runner.config.ci-chromium.js --group coveralls-ci --coverage
               continue-on-error: true
 
             - name: Upload coverage to Coveralls

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -20,6 +20,7 @@ import {
     chromiumWithMemoryTooling,
     chromiumWithMemoryToolingCI,
     configuredVisualRegressionPlugin,
+    coverallsChromium,
     firefox,
     packages,
     vrtGroups,
@@ -163,6 +164,14 @@ export default {
                 '{packages,tools}/**/*.test.js',
                 '!{packages,tools}/**/*-memory.test.js',
             ],
+        },
+        {
+            name: 'coveralls-ci',
+            files: [
+                '{packages,tools}/**/*.test.js',
+                '!{packages,tools}/**/*-memory.test.js',
+            ],
+            browsers: [coverallsChromium],
         },
     ],
     group: 'unit',

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -24,6 +24,11 @@ export const chromium = playwrightLauncher({
         }),
 });
 
+/**
+ * @todo Remove this configuration and its usage in the Coveralls CI workflow
+ * once the Playwright version mismatch between @web/test-runner-playwright
+ * and the installed Playwright version is resolved.
+ */
 export const coverallsChromium = playwrightLauncher({
     product: 'chromium',
     createBrowserContext: ({ browser }) =>
@@ -32,7 +37,6 @@ export const coverallsChromium = playwrightLauncher({
             permissions: ['clipboard-read', 'clipboard-write'],
         }),
     launchOptions: {
-        // TODO: Remove executablePath when we fix Playwright versions mismatch
         executablePath:
             '/home/runner/.cache/ms-playwright/chromium-1148/chrome-linux/chrome',
         headless: true,

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -24,6 +24,21 @@ export const chromium = playwrightLauncher({
         }),
 });
 
+export const coverallsChromium = playwrightLauncher({
+    product: 'chromium',
+    createBrowserContext: ({ browser }) =>
+        browser.newContext({
+            ignoreHTTPSErrors: true,
+            permissions: ['clipboard-read', 'clipboard-write'],
+        }),
+    launchOptions: {
+        // TODO: Remove executablePath when we fix Playwright versions mismatch
+        executablePath:
+            '/home/runner/.cache/ms-playwright/chromium-1148/chrome-linux/chrome',
+        headless: true,
+    },
+});
+
 export const chromiumWithMemoryTooling = playwrightLauncher({
     product: 'chromium',
     createBrowserContext: ({ browser }) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses a temporary issue with the Playwright version mismatch in the Coveralls workflow caused by the recent upgrade of Playwright to 1.49.0. This happens because `@web/test-runner-playwright `expects an older browser binary (`chromium-1117`), but the newer version of Playwright downloads `chromium-1148`.

Longer term fix can involve bypassing the web-test-runner browser configs and accessing the Playwright binaries directly.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- Follow up from https://github.com/adobe/spectrum-web-components/pull/5005

## Motivation and context

The Playwright version mismatch is currently breaking the Coveralls workflow with the error:
Executable doesn't exist at `/home/runner/.cache/ms-playwright/chromium-1117/chrome-linux/chrome`.

I added a new `playwrightLauncher` configuration: "coverallsChromium". This explicitly sets the `executablePath` to point to the correct browser binary (`chromium-1148`) and is isolated for use only in the Coveralls workflow. Additionally, a dedicated test group, `coveralls-ci`, has been added to the web-test-runner configuration to ensure that only Coveralls tests utilize this adjusted Chromium configuration.

A JSDoc (thanks @caseyisonit!) TODO has also been included, marking this temporary configuration for removal once the version mismatch between @web/test-runner-playwright and Playwright is resolved. This fix unblocks the Coveralls workflow errors on our `main` branch.

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?
If the CI checks pass below, this works!


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
