### PR TITLE
chore: simplify beta docs deployment steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,8 +229,17 @@ jobs:
         steps:
             - downstream
             - run:
-                  name: Generate Beta Docs
-                  command: yarn docs:preview
+                  name: Generate Custom Elements Manifest
+                  command: yarn docs:analyze
+            - run:
+                  name: Move CEM to Storybook directory
+                  command: cp projects/documentation/custom-elements.json storybook/
+            - run:
+                  name: Build documentation
+                  command: yarn docs:build
+            - run:
+                  name: Build Storybook
+                  command: yarn storybook:build
             - run: echo '/*    /index.html   200' > projects/documentation/dist/_redirects
             - run: |
                   branch=$(git symbolic-ref --short HEAD)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With the introduction of Yarn 4, we need to update the build steps for deploying our documentation website in CI. This PR [aligns the implementation](https://github.com/adobe/spectrum-web-components/pull/5010/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R209-R219) with the changes already merged for deploying the documentation website and Storybook previews in each PR.

## Motivation and context

Did you know? We automatically deploy a beta documentation website every time we merge to `main`.
You can visit it here: [https://beta–spectrum-web-components.netlify.app/](https://beta--spectrum-web-components.netlify.app/)
Without this fix, the beta documentation website won’t be deployed.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
