### PR TITLE
build: fix the storybook theme select

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -25,8 +25,12 @@ export const globalTypes = {
         showName: true,
         toolbar: {
             items: [
-                { value: 'spectrum', title: 'Spectrum 2', right: 'default' },
-                { value: 'legacy', title: 'Spectrum 1', right: 'legacy' },
+                {
+                    value: 'spectrum-two',
+                    title: 'Spectrum 2',
+                    right: 'default',
+                },
+                { value: 'spectrum', title: 'Spectrum 1', right: 'legacy' },
                 { value: 'express', title: 'Express' },
             ],
             dynamicTitle: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

update the storybook build to apply `spectrum-two` theme correctly

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- storybook was not updating to `spectrum-two` theme on selection

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Storybook was not working and I was confused as to why spectrum-two and spectrum-one looked exactly the same!

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Test case 1_
    1. Go [here](https://ttomar-storybook--spectrum-web-components.netlify.app/storybook/)
    2. Toggle the theme between s1, s2 and express.
    3. Verify that the theme actually changes now.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
