### PR TITLE
feat(sp-button-group): sp-button-group react to size updates

### DIFF
--- a/packages/button-group/src/ButtonGroup.ts
+++ b/packages/button-group/src/ButtonGroup.ts
@@ -13,11 +13,15 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    PropertyValues,
     SizedMixin,
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import { property } from '@spectrum-web-components/base/src/decorators.js';
+import {
+    property,
+    query,
+} from '@spectrum-web-components/base/src/decorators.js';
 import type { Button } from '@spectrum-web-components/button';
 
 import styles from './button-group.css.js';
@@ -36,9 +40,24 @@ export class ButtonGroup extends SizedMixin(SpectrumElement, {
     @property({ type: Boolean, reflect: true })
     public vertical = false;
 
+    @query('slot')
+    slotElement!: HTMLSlotElement;
+
+    protected override updated(changedProperties: PropertyValues): void {
+        super.updated(changedProperties);
+
+        if (changedProperties.has('size')) {
+            this.manageChildrenSize(this.slotElement);
+        }
+    }
+
     protected handleSlotchange({
         target: slot,
     }: Event & { target: HTMLSlotElement }): void {
+        this.manageChildrenSize(slot);
+    }
+
+    private manageChildrenSize(slot: HTMLSlotElement): void {
         const assignedElements = slot.assignedElements() as Button[];
         assignedElements.forEach((button) => {
             button.size = this.size;

--- a/packages/button-group/test/button-group.test.ts
+++ b/packages/button-group/test/button-group.test.ts
@@ -37,4 +37,21 @@ describe('Buttongroup', () => {
 
         await expect(el).to.be.accessible();
     });
+    it(`manages its children's size`, async () => {
+        const el = await fixture<ButtonGroup>(buttons(buttons.args));
+        await elementUpdated(el);
+
+        let children = el.querySelectorAll('sp-button');
+        children.forEach((button) => {
+            expect(button.size).to.equal('m');
+        });
+
+        el.size = 's';
+        await elementUpdated(el);
+
+        children = el.querySelectorAll('sp-button');
+        children.forEach((button) => {
+            expect(button.size).to.equal('s');
+        });
+    });
 });

--- a/tools/base/test/sizedMixin.test.ts
+++ b/tools/base/test/sizedMixin.test.ts
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    ElementSize,
+    SizedMixin,
+    SpectrumElement,
+    TemplateResult,
+} from '../src/index.js';
+import { html } from '@open-wc/testing';
+import { elementUpdated, expect, fixture } from '@open-wc/testing';
+
+export class FancySizedComponent extends SizedMixin(SpectrumElement, {
+    defaultSize: 'm',
+    validSizes: ['xs', 's', 'm', 'l', 'xl'],
+}) {
+    public override render(): TemplateResult {
+        return html`
+            I an wearing size ${this.size}
+        `;
+    }
+}
+
+customElements.define('fancy-sized-component', FancySizedComponent);
+
+describe('sizedMixin', () => {
+    it('allows any given size in the validSizes array', async () => {
+        const validSizesChecks = (
+            ['xs', 's', 'm', 'l', 'xl'] as ElementSize[]
+        ).map(async (size) => {
+            const el = await fixture<FancySizedComponent>(html`
+                <fancy-sized-component></fancy-sized-component>
+            `);
+            await elementUpdated(el);
+
+            el.size = size;
+            await elementUpdated(el);
+            expect(el.shadowRoot?.textContent).to.include(
+                `I an wearing size ${size}`
+            );
+        });
+
+        await Promise.all(validSizesChecks);
+    });
+
+    it('fallbacks to default size if the provided size is invalid', async () => {
+        const el = await fixture<FancySizedComponent>(html`
+            <fancy-sized-component size="xxl"></fancy-sized-component>
+        `);
+        await elementUpdated(el);
+
+        // Fallback is 'm', as defined by `defaultSize`.
+        expect(el.shadowRoot?.textContent).to.include('I an wearing size m');
+    });
+
+    it('fallbacks to default size if no size is provided', async () => {
+        const el = await fixture<FancySizedComponent>(html`
+            <fancy-sized-component></fancy-sized-component>
+        `);
+        await elementUpdated(el);
+
+        // Default is 'm', as defined by `defaultSize`.
+        expect(el.shadowRoot?.textContent).to.include('I an wearing size m');
+    });
+
+    it('applies the given size if it is a valid one', async () => {
+        const el = await fixture<FancySizedComponent>(html`
+            <fancy-sized-component size="l"></fancy-sized-component>
+        `);
+        await elementUpdated(el);
+
+        expect(el.shadowRoot?.textContent).to.include('I an wearing size l');
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Makes `sp-button-group` react to changes in `size` attribute.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/5030

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

https://github.com/adobe/spectrum-web-components/issues/5030

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://rocss-5030--spectrum-web-components.netlify.app/storybook/?path=/story/button-group--buttons)
    2. Using the Controls Addon, change the size
    3. Observe the component reacts to the change accordingly


-   [x] Did it pass in Desktop?
-   [x] Did it pass in Mobile?
-   [x] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
