### PR TITLE
chore: update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8714,8 +8714,8 @@ __metadata:
 
 "@spectrum-web-components/eslint-plugin@file:./linters/eslint::locator=%40adobe%2Fspectrum-web-components%40workspace%3A.":
   version: 1.1.1
-  resolution: "@spectrum-web-components/eslint-plugin@file:./linters/eslint#./linters/eslint::hash=af2f6a&locator=%40adobe%2Fspectrum-web-components%40workspace%3A."
-  checksum: 10c0/4be6b06c2c48a2c8411ba7cc3cf1b5736e480183f6cddab534c6f2eeb45bdb28191dd689265c1c6b63c2e3f88f553a9085850fc82320d766e55edd4c29cf1745
+  resolution: "@spectrum-web-components/eslint-plugin@file:./linters/eslint#./linters/eslint::hash=4ce909&locator=%40adobe%2Fspectrum-web-components%40workspace%3A."
+  checksum: 10c0/97d2092c11770a6c7943273c71d4654ec895059222f97e286168908dae639ae9186c584f4a99ceb86cf6cca04bc5e751675e8461742341accbf45746506437bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the `yarn.lock` file, fixing the resolution and checksum values for `@spectrum-web-components/eslint-plugin`. I suspect this mismatch was due to stale cache issues (going from yarn classic to yarn 4), causing this incorrect resolution.


## Motivation and Context
Fixing `yarn.lock` for everyone and unblocking the CI pipeline!


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Cleared the Yarn cache (`yarn cache clean`) and removed `.yarn/cache/`.
- Reinstalled dependencies using `yarn install`.
- Verified that the lockfile changes were limited to expected updates and match the expected values in CI:
  - https://github.com/adobe/spectrum-web-components/actions/runs/13036796355/job/36369154247


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
