### PR TITLE
fix(tooltip): make tooltip delivery consistent across all browsers

### DIFF
--- a/packages/tooltip/src/tooltip.css
+++ b/packages/tooltip/src/tooltip.css
@@ -15,11 +15,11 @@ governing permissions and limitations under the License.
 
 :host {
     display: contents;
-    white-space: initial;
 }
 
 #tooltip {
     width: fit-content;
+    white-space: initial;
     max-width: var(--spectrum-tooltip-max-inline-size);
 }
 

--- a/packages/tooltip/src/tooltip.css
+++ b/packages/tooltip/src/tooltip.css
@@ -19,7 +19,8 @@ governing permissions and limitations under the License.
 }
 
 #tooltip {
-    inline-size: max-content;
+    width: fit-content;
+    max-width: var(--spectrum-tooltip-max-inline-size);
 }
 
 #tip {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR will fix two things - 

1.  #4803 ([Bug][Firefox]: Long tooltip text results in tooltip offset to the left )
2. Long tooltip was updating the trigger element width in Safari.

I've replaced the `inline-size: max-content;` to `white-space: initial;
    max-width: var(--spectrum-tooltip-max-inline-size);` to make sure firefox is supported.


## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #4803 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Delivering tooltip consistently across all browsers.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   Tooltip Delivery Testing
    -  Open [this link](https://ttomar-tooltip-positioning--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--self-managed&globals=color:dark) in Firefox
        - [x] Verify that the tooltip is center aligned
    - Open [this link](https://ttomar-tooltip-positioning--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--self-managed&globals=color:dark) in Safari
        - [x] Verify that the tooltip is not affecting the button's width
   - Open [this link](https://ttomar-tooltip-positioning--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--self-managed&globals=color:dark) in chrome
        - [x] Verify that tooltip delivery is exactly the same as it used to earlier.

-   [x] Did it pass in Desktop?


## Screenshots (if appropriate)
Firefox Before: 

<img width="595" alt="Screenshot 2025-01-30 at 5 40 42 PM" src="https://github.com/user-attachments/assets/914cb221-0709-4eb2-a8cf-2c4c39fce21e" />

Firefox After: 
<img width="575" alt="Screenshot 2025-01-30 at 5 41 08 PM" src="https://github.com/user-attachments/assets/10f0ef36-ef7d-4f1f-8e7f-e7e6ca7c3ad7" />

Safari Before: 
<img width="508" alt="Screenshot 2025-01-30 at 5 41 42 PM" src="https://github.com/user-attachments/assets/3e6dfc3e-3657-4f88-8278-9fb812b02a75" />

Safari After:
<img width="503" alt="Screenshot 2025-01-30 at 5 42 05 PM" src="https://github.com/user-attachments/assets/6043f6a8-a688-4bff-9322-67d028a0defa" />



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
