### PR TITLE
fix(picker): stop the click events from reaching the elements below picker-tray

### DIFF
--- a/packages/overlay/src/AbstractOverlay.ts
+++ b/packages/overlay/src/AbstractOverlay.ts
@@ -338,4 +338,38 @@ export class AbstractOverlay extends SpectrumElement {
         overlay.placement = options.placement;
         overlay.willPreventClose = !!options.notImmediatelyClosable;
     }
+
+    private iosEventPropagationController?: AbortController;
+
+    protected setupIOSEventManagement(): void {
+        // This is a workaround for a bug in iOS <17 where the event leaks out of the dialog to the element below it.
+        // Issue - https://github.com/adobe/spectrum-web-components/issues/5042
+        this.iosEventPropagationController = new AbortController();
+        this.dialogEl.addEventListener(
+            'pointerup',
+            (event) => event.stopPropagation(),
+            {
+                capture: true,
+                signal: this.iosEventPropagationController.signal,
+            }
+        );
+        this.dialogEl.addEventListener(
+            'touchend',
+            (event) => event.stopPropagation(),
+            {
+                capture: true,
+                signal: this.iosEventPropagationController.signal,
+            }
+        );
+    }
+
+    protected cleanupIOSEventManagement(): void {
+        this.iosEventPropagationController?.abort();
+        this.iosEventPropagationController = undefined;
+    }
+
+    override disconnectedCallback(): void {
+        this.cleanupIOSEventManagement();
+        super.disconnectedCallback();
+    }
 }

--- a/packages/overlay/src/OverlayDialog.ts
+++ b/packages/overlay/src/OverlayDialog.ts
@@ -54,6 +54,7 @@ export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
                     if (!targetOpenState) {
                         const close = (): void => {
                             el.removeEventListener('close', close);
+                            this.cleanupIOSEventManagement();
                             finish(el, index);
                         };
                         el.addEventListener('close', close);
@@ -88,6 +89,7 @@ export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
                         return;
                     }
                     this.dialogEl.showModal();
+                    this.setupIOSEventManagement();
                 };
             const finish = (el: OpenableElement, index: number) => (): void => {
                 if (this.open !== targetOpenState) {

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -694,3 +694,29 @@ custom.args = {
     open: true,
 };
 custom.decorators = [isOverlayOpen];
+
+export const BackgroundClickTest = (): TemplateResult => {
+    return html`
+        <div style="display: flex; flex-direction: column;">
+            <sp-picker size="l">
+                <sp-menu-item value="option-1">Deselect</sp-menu-item>
+                <sp-menu-item value="option-2">Select Inverse</sp-menu-item>
+            </sp-picker>
+            <div style="position: absolute; bottom: 50px;">
+                <sp-button
+                    @click=${() => {
+                        console.log(
+                            'this button should not have been clicked...'
+                        );
+                    }}
+                    size="l"
+                >
+                    I shall not be clicked
+                </sp-button>
+            </div>
+        </div>
+    `;
+};
+BackgroundClickTest.swc_vrt = {
+    skip: true,
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Stop the click events to reach the element below tray when we open a picker in iOS <17

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- fixes #5042

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
* Prevents the event leaking out of the dialog to the element below it.
* This is a workaround for a bug in iOS <17 where the event leaks out of the dialog to the element below it. 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Go [here](https://picker-background-click--spectrum-web-components.netlify.app/storybook/?path=/story/picker--background-click-test&globals=color:dark) in iOS<17 
    - [ ] Open the picker and make a selection on the tray.
    - [ ] There should not be any console log from the button getting clicked.

-   Manually Tested. See the attached Video below for before and After:

### Before
[screen-capture.webm](https://github.com/user-attachments/assets/57520995-d025-4042-8c00-988df3519ddf)

### After
[screen-capture (1).webm](https://github.com/user-attachments/assets/d5b9d014-e866-4ece-b496-f260a780247b)

-   [x] Did it pass in Desktop?
-   [x] Did it pass in Mobile?
-   [x] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
