### PR TITLE
build: fix chromatic build workflow github actions

### DIFF
--- a/.github/workflows/chromatic-vrt.yml
+++ b/.github/workflows/chromatic-vrt.yml
@@ -32,15 +32,14 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup Node 20
-              uses: actions/setup-node@v4
-              with:
-                  node-version: '20'
-                  cache: 'yarn'
-                  registry-url: 'https://registry.npmjs.org'
+            - name: Setup Job and Install Dependencies
+              uses: ./.github/actions/setup-job
 
-            - name: Install dependencies
-              run: yarn --immutable
+            - name: Generate Custom Elements Manifest
+              run: yarn docs:analyze
+
+            - name: Move CEM to Storybook directory
+              run: cp projects/documentation/custom-elements.json storybook/
 
             - name: Publish to Chromatic
               id: chromatic


### PR DESCRIPTION
## Description

Workflow action for Chromatic was using an outdated workflow that did not include the custom element assets being moved into the storybook directory. This fixes that.

## Types of changes

-   [x] Build

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [n/a] I have added tests to cover my changes.
-   [n/a] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
