### PR TITLE
fix(overlay): derive popover placement from host in interaction controller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
     # 3. Commit this change to the PR branch where the changes exist.
     current_golden_images_hash:
         type: string
-        default: 4496c9c10f0ab23425e3b158133628202c70ca8f
+        default: 65776e325781bdcf3c97758d8faf300cf9b0b8b8
     wireit_cache_name:
         type: string
         default: wireit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
     # 3. Commit this change to the PR branch where the changes exist.
     current_golden_images_hash:
         type: string
-        default: 572a1d244c4db47b429c0daa7479ead3f256b361
+        default: 4496c9c10f0ab23425e3b158133628202c70ca8f
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -207,32 +207,37 @@ quiet.args = {
 };
 
 export const forcePopoverOnMobile = (): TemplateResult => html`
-    <h1>Force Popover on Mobile</h1>
-    <p>
-        The forcePopover attribute overrides the mobile device functionality of
-        rendering a tray so that a popover will always render no matter the
-        device.
-    </p>
-    <ol>
-        <li>Open Chrome DevTools (or equivalent).</li>
-        <li>Toggle the Device Toolbar (the phone/tablet icon).</li>
-        <li>Select a device preset (e.g. iPhone 12).</li>
-        <li>
-            Chrome will set user-agent strings, simulate touch, and adjust DPI.
-        </li>
-        <li>Reload the page</li>
-        <li>Click the Action Menu and see a popover</li>
-    </ol>
-    <sp-action-menu forcePopover>
-        <span slot="label">Action Menu</span>
-        <sp-menu-item>Deselect</sp-menu-item>
-        <sp-menu-item>Select Inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
-        <sp-menu-item>Select and Mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save Selection</sp-menu-item>
-        <sp-menu-item disabled>Make Work Path</sp-menu-item>
-    </sp-action-menu>
+    <div style="padding: 40px">
+        <h1>Force Popover on Mobile</h1>
+        <p>
+            The forcePopover attribute overrides the mobile device functionality
+            of rendering a tray so that a popover will always render no matter
+            the device.
+        </p>
+        <ol>
+            <li>Open Chrome DevTools (or equivalent).</li>
+            <li>Toggle the Device Toolbar (the phone/tablet icon).</li>
+            <li>Select a device preset (e.g. iPhone 12).</li>
+            <li>
+                Chrome will set user-agent strings, simulate touch, and adjust
+                DPI.
+            </li>
+            <li>Reload the page</li>
+            <li>Click the Action Menu and see a popover</li>
+        </ol>
+        <sp-action-menu forcePopover>
+            <span slot="icon">
+                <sp-icon-settings></sp-icon-settings>
+            </span>
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+        </sp-action-menu>
+    </div>
 `;
 export const labelOnly = ({
     align = 'start',

--- a/packages/picker/src/InteractionController.ts
+++ b/packages/picker/src/InteractionController.ts
@@ -136,7 +136,7 @@ export class InteractionController implements ReactiveController {
             this.overlay.placement =
                 this.host.isMobile.matches && !this.host.forcePopover
                     ? undefined
-                    : 'bottom';
+                    : this.host.placement;
             this.overlay.receivesFocus = 'true';
             this.overlay.willPreventClose =
                 this.preventNextToggle !== 'no' && this.open;

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -101,7 +101,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
      *
      * @memberof PickerBase
      */
-    @property({ type: Boolean, reflect: true })
+    @property({ type: Boolean, reflect: true, attribute: 'force-popover' })
     public forcePopover = false;
 
     /** Whether the items are currently loading. */

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -98,54 +98,59 @@ export const Default = (args: StoryArgs): TemplateResult => {
 
 export const forcePopoverOnMobile = (args: StoryArgs): TemplateResult => {
     return html`
-        <h1>Force Popover on Mobile</h1>
-        <p>
-            The forcePopover attribute overrides the mobile device functionality
-            of rendering a tray so that a popover will always render no matter
-            the device.
-        </p>
-        <ol>
-            <li>Open Chrome DevTools (or equivalent).</li>
-            <li>Toggle the Device Toolbar (the phone/tablet icon).</li>
-            <li>Select a device preset (e.g. iPhone 12).</li>
-            <li>
-                Chrome will set user-agent strings, simulate touch, and adjust
-                DPI.
-            </li>
-            <li>Reload the page</li>
-            <li>Click the Picker 1 and see a tray</li>
-            <li>Click the Picker 2 and see a popover</li>
-        </ol>
-        <sp-field-label for="picker-1" size=${ifDefined(args.size)}>
-            Do you want to see a tray menu?
-        </sp-field-label>
-        <sp-picker
-            id="picker-1"
-            @change=${handleChange(args)}
-            label="Select an option"
-        >
-            <sp-menu-item value="option-1">Yes</sp-menu-item>
-            <sp-menu-item value="option-2">No</sp-menu-item>
-        </sp-picker>
-        <sp-field-label for="picker-2" size=${ifDefined(args.size)}>
-            Do you want to see a popover menu?
-        </sp-field-label>
-        <sp-picker
-            id="picker-2"
-            forcePopover
-            @change=${handleChange(args)}
-            label="Select an option"
-        >
-            <sp-menu-item value="option-1">Yes</sp-menu-item>
-            <sp-menu-item value="option-2">No</sp-menu-item>
-        </sp-picker>
-        <div>
+        <div style="padding: 40px">
+            <h1>Force Popover on Mobile</h1>
             <p>
-                This button should't be clickable if a popover is open over it.
+                The forcePopover attribute overrides the mobile device
+                functionality of rendering a tray so that a popover will always
+                render no matter the device.
             </p>
-            <sp-button @click=${() => console.log('Whoops! I was clicked.')}>
-                Shouldn't be clickable
-            </sp-button>
+            <ol>
+                <li>Open Chrome DevTools (or equivalent).</li>
+                <li>Toggle the Device Toolbar (the phone/tablet icon).</li>
+                <li>Select a device preset (e.g. iPhone 12).</li>
+                <li>
+                    Chrome will set user-agent strings, simulate touch, and
+                    adjust DPI.
+                </li>
+                <li>Reload the page</li>
+                <li>Click the Picker 1 and see a tray</li>
+                <li>Click the Picker 2 and see a popover</li>
+            </ol>
+            <sp-field-label for="picker-1" size=${ifDefined(args.size)}>
+                Do you want to see a tray menu?
+            </sp-field-label>
+            <sp-picker
+                id="picker-1"
+                @change=${handleChange(args)}
+                label="Select an option"
+            >
+                <sp-menu-item value="option-1">Yes</sp-menu-item>
+                <sp-menu-item value="option-2">No</sp-menu-item>
+            </sp-picker>
+            <sp-field-label for="picker-2" size=${ifDefined(args.size)}>
+                Do you want to see a popover menu?
+            </sp-field-label>
+            <sp-picker
+                id="picker-2"
+                forcePopover
+                @change=${handleChange(args)}
+                label="Select an option"
+            >
+                <sp-menu-item value="option-1">Yes</sp-menu-item>
+                <sp-menu-item value="option-2">No</sp-menu-item>
+            </sp-picker>
+            <div>
+                <p>
+                    This button should't be clickable if a popover is open over
+                    it.
+                </p>
+                <sp-button
+                    @click=${() => console.log('Whoops! I was clicked.')}
+                >
+                    Shouldn't be clickable
+                </sp-button>
+            </div>
         </div>
     `;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes an incorrect hardcoded placement value (`"bottom"`) in `this.overlay.placement`, which was mistakenly introduced while prototyping and made its way to production. This ensures that the placement is correctly derived from `this.host.placement`, maintaining expected behavior for dropdowns in components like ActionMenu, Picker, etc.
Also changed the attribute reflection to adhere to our pattern (`"forcepopover"` -> `"force-popover"`).

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- [SWC-644](https://jira.corp.adobe.com/browse/SWC-644)

## Motivation and context

In https://github.com/adobe/spectrum-web-components/pull/5041, the `forcePopover` feature was introduced to render a popover instead of a tray on mobile. However, the placement was mistakenly set to `"bottom"` instead of using `this.host.placement` (which defaults to `"bottom-start"` in Picker.ts).
This bug was not caught in VRTs because the tests lacked sufficient padding to expose the issue visually. I added the necessary padding in the "force popover" stories until we center the layout of all our stories in a follow-up task.


<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Open [Storybook_](https://ruben-fix-overlay-placement--spectrum-web-components.netlify.app/storybook/)
    1. Verify that ActionMenu, Picker, and other dropdown components now correctly inherit placement from `this.host.placement`.
-   [ ] _Visit the [force popover story](https://ruben-fix-overlay-placement--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--force-popover-on-mobile) and follow the instructions on the story_
    1. Expect the dropdown to start aligned with the icon (as per screenshot below)

-   [x] Did it pass in Desktop?
-   [x] Did it pass in Mobile?
-   [x] Did it pass in iPad?

## Screenshots (if appropriate)
Before (broken):
<img width="559" alt="Screenshot 2025-02-07 at 13 52 08" src="https://github.com/user-attachments/assets/fda40ece-7e21-4387-bc57-9d3aa69afadb" />

After (expected):
<img width="569" alt="Screenshot 2025-02-07 at 13 52 22" src="https://github.com/user-attachments/assets/b1d9926b-7a14-4e7f-bcfc-1f697f89de97" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
