### PR TITLE
chore: add prelerna-publish to beta releases

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
             - main
-            - ruben/add-prelerna-publish-to-beta-releases
 
 jobs:
     release:
@@ -81,5 +80,4 @@ jobs:
               run: |
                   git commit -am "chore: publish beta version ${{ steps.calculate_next_beta_version.outputs.beta_version }}"
                   yarn prelerna-publish
-                  node scripts/verify-build-artifacts.js
                   yarn lerna publish from-package --dist-tag beta --no-git-tag-version --no-push --yes

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - ruben/add-prelerna-publish-to-beta-releases
 
 jobs:
     release:
@@ -79,4 +80,5 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: |
                   git commit -am "chore: publish beta version ${{ steps.calculate_next_beta_version.outputs.beta_version }}"
+                  yarn prelerna-publish
                   yarn lerna publish from-package --dist-tag beta --no-git-tag-version --no-push --yes

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -81,4 +81,5 @@ jobs:
               run: |
                   git commit -am "chore: publish beta version ${{ steps.calculate_next_beta_version.outputs.beta_version }}"
                   yarn prelerna-publish
+                  node scripts/verify-build-artifacts.js
                   yarn lerna publish from-package --dist-tag beta --no-git-tag-version --no-push --yes

--- a/package.json
+++ b/package.json
@@ -90,9 +90,9 @@
         "update:spectrum-css": "node ./scripts/update-spectrum-css.js --latest || yarn update:spectrum-css:cleanup",
         "update:spectrum-css:cleanup": "yarn lint:packagejson && yarn --ignore-scripts && yarn process-spectrum",
         "update:spectrum-css:nonbreaking": "node ./scripts/update-spectrum-css.js || yarn update:spectrum-css:cleanup",
+        "verify-build-artifacts": "node ./scripts/verify-build-artifacts.js",
         "vrt:preview": "yarn wds --config test/visual/wds-vrt.config.js",
-        "vrt:quick-link": "yarn netlify deploy --alias=vrt --dir=projects/vrt-quick-link",
-        "verify-build-artifacts": "node ./scripts/verify-build-artifacts.js"
+        "vrt:quick-link": "yarn netlify deploy --alias=vrt --dir=projects/vrt-quick-link"
     },
     "peerDependencies": {
         "common-tags": "^1.8.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We want `beta` release artifacts to be 1:1 with those in `latest`, so we need to add the `prelerna-publish` command which generates the `custom-elements.json` manifests and runs the script to verify the build artifacts.

<!--- Describe your changes in detail -->


## Motivation and context

Without this, the manifests do not get published.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
You can see the build artifacts of a beta test release here: https://www.npmjs.com/package/@spectrum-web-components/button/v/1.2.0-beta.3?activeTab=code

And you can see the action run here: https://github.com/adobe/spectrum-web-components/actions/runs/13309656501/job/37168759349?pr=5094


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
