### PR TITLE
fix(slider): make label not disappear when using overlays in Safari

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
     # 3. Commit this change to the PR branch where the changes exist.
     current_golden_images_hash:
         type: string
-        default: 7ecf35bddd42938e48adcb647e029bb9c75f8663
+        default: be83a254993526d25ab8f6dd32639eae6db1c7eb
     wireit_cache_name:
         type: string
         default: wireit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
     # 3. Commit this change to the PR branch where the changes exist.
     current_golden_images_hash:
         type: string
-        default: b2ba0ee6dcde27c136be2afb14a68bec20c6d925
+        default: 7b13cd4e7d4146a00b05ff96c5ba38f447a9c8c8
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -44,7 +44,7 @@ export const variants = ['filled', 'ramp', 'range', 'tick'];
 /**
  * @element sp-slider
  *
- * @slot - text label for the Slider
+ * @slot - @deprecated Text label for the Slider. Use the `label` property instead.
  * @slot handle - optionally accepts two or more sp-slider-handle elements
  */
 export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
@@ -231,6 +231,16 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
     public override connectedCallback(): void {
         super.connectedCallback();
         this.handleController.hostConnected();
+
+        // Deprecation warning for default slot when content is provided
+        if (window.__swc.DEBUG && this.textContent?.trim()) {
+            window.__swc.warn(
+                this,
+                `The default slot for text label in <${this.localName}> has been deprecated and will be removed in a future release. Use the "label" property instead.`,
+                'https://opensource.adobe.com/spectrum-web-components/components/slider/',
+                { level: 'deprecation' }
+            );
+        }
     }
 
     public override disconnectedCallback(): void {

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -265,8 +265,8 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
                     @click=${this.handleLabelClick}
                     size=${this.size}
                 >
-                    ${this.slotHasContent ? nothing : this.label}
-                    <slot>${this.label}</slot>
+                    <span>${this.label}</span>
+                    <slot></slot>
                 </sp-field-label>
                 <sp-field-label
                     class=${classMap({

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -275,7 +275,11 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
                     @click=${this.handleLabelClick}
                     size=${this.size}
                 >
-                    <span>${this.label}</span>
+                    ${this.slotHasContent
+                        ? nothing
+                        : html`
+                              <span>${this.label}</span>
+                          `}
                     <slot></slot>
                 </sp-field-label>
                 <sp-field-label

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -21,6 +21,7 @@ import {
     variants,
 } from '@spectrum-web-components/slider';
 import { spreadProps } from '../../../test/lit-helpers.js';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
 
 export default {
     component: 'sp-slider',
@@ -1256,4 +1257,76 @@ export const focusTabDemo = (args: StoryArgs = {}): TemplateResult => {
             ></sp-slider>
         </div>
     `;
+};
+
+export const WithPopover = (args: StoryArgs = {}): TemplateResult => {
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                id="slider-with-popover"
+                label="Slider without Popover"
+                variant="filled"
+                max="100"
+                min="0"
+                step="5"
+                value="50"
+                editable
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
+                ...=${spreadProps(args)}
+            ></sp-slider>
+            <overlay-trigger placement="top">
+                <sp-slider
+                    slot="trigger"
+                    id="slider-with-popover"
+                    label="Label in attribute"
+                    variant="filled"
+                    max="100"
+                    min="0"
+                    step="5"
+                    value="50"
+                    editable
+                    @input=${handleEvent(args)}
+                    @change=${handleEvent(args)}
+                    ...=${spreadProps(args)}
+                ></sp-slider>
+                <sp-popover slot="hover-content" tip>
+                    Hover content for the slider
+                </sp-popover>
+            </overlay-trigger>
+
+            <overlay-trigger placement="top">
+                <sp-slider
+                    slot="trigger"
+                    id="slider-with-popover"
+                    variant="filled"
+                    max="100"
+                    min="0"
+                    step="5"
+                    value="50"
+                    editable
+                    @input=${handleEvent(args)}
+                    @change=${handleEvent(args)}
+                    ...=${spreadProps(args)}
+                >
+                    Label in slot
+                </sp-slider>
+                <sp-popover slot="hover-content" tip>
+                    Hover content for the slider
+                </sp-popover>
+            </overlay-trigger>
+        </div>
+    `;
+};
+
+WithPopover.args = {
+    variant: 'filled',
+};
+
+WithPopover.parameters = {
+    docs: {
+        description: {
+            story: 'A slider with a popover that appears on hover.',
+        },
+    },
 };

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -1820,4 +1820,34 @@ describe('Slider', () => {
         // now the overlay should be closed
         expect(overlay.open).to.be.false;
     });
+
+    it('warns in Dev Mode when using the default slot for text labels', async () => {
+        const consoleWarnStub = stub(console, 'warn');
+        window.__swc.issuedWarnings = new Set<BrandedSWCWarningID>();
+        const el = await fixture<Slider>(html`
+            <sp-slider min="0" max="100" value="50">
+                This is a deprecated text label
+            </sp-slider>
+        `);
+
+        await elementUpdated(el);
+
+        expect(consoleWarnStub.called).to.be.true;
+        const spyCall = consoleWarnStub.getCall(0);
+        expect(
+            spyCall.args.at(0).includes('default slot'),
+            'confirm "default slot" in message'
+        ).to.be.true;
+        expect(
+            spyCall.args.at(0).includes('deprecated'),
+            'confirm "deprecated" in message'
+        ).to.be.true;
+        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+            data: {
+                localName: 'sp-slider',
+                level: 'deprecation',
+            },
+        });
+        consoleWarnStub.restore();
+    });
 });

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -1754,7 +1754,7 @@ describe('Slider', () => {
             expect(consoleWarnStub.called).to.be.true;
             const spyCall = consoleWarnStub.getCall(0);
             expect(
-                spyCall.args.at(0).includes('default slot'),
+                (spyCall.args.at(0) as string).includes('default slot'),
                 'confirm "default slot" in message'
             ).to.be.true;
             expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
@@ -1801,7 +1801,7 @@ describe('Slider', () => {
             expect(consoleWarnStub.called).to.be.true;
             const spyCall = consoleWarnStub.getCall(0);
             expect(
-                spyCall.args.at(0).includes('previous'),
+                (spyCall.args.at(0) as string).includes('previous'),
                 'confirm "previous" in message'
             ).to.be.true;
             expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
@@ -1848,7 +1848,7 @@ describe('Slider', () => {
             expect(consoleWarnStub.called).to.be.true;
             const spyCall = consoleWarnStub.getCall(0);
             expect(
-                spyCall.args.at(0).includes('next'),
+                (spyCall.args.at(0) as string).includes('next'),
                 'confirm "next" in message'
             ).to.be.true;
             expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -1378,100 +1378,6 @@ describe('Slider', () => {
         await elementUpdated(el);
         expect(el.values).to.deep.equal({ a: 10, b: 10, c: 10 });
     });
-    it('warns in Dev Mode when `min="previous"` is leveraged on first handle', async () => {
-        const consoleWarnStub = stub(console, 'warn');
-        window.__swc.issuedWarnings = new Set<BrandedSWCWarningID>();
-        const el = await fixture<Slider>(html`
-            <sp-slider min="0" max="100">
-                <sp-slider-handle
-                    id="first-handle"
-                    min="previous"
-                    max="next"
-                    slot="handle"
-                    name="a"
-                    value="10"
-                ></sp-slider-handle>
-                <sp-slider-handle
-                    id="middle-handle"
-                    min="previous"
-                    max="next"
-                    slot="handle"
-                    name="b"
-                    value="20"
-                ></sp-slider-handle>
-                <sp-slider-handle
-                    id="last-handle"
-                    min="previous"
-                    slot="handle"
-                    name="c"
-                    value="30"
-                ></sp-slider-handle>
-            </sp-slider>
-        `);
-
-        await elementUpdated(el);
-
-        expect(consoleWarnStub.called).to.be.true;
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            spyCall.args.at(0).includes('previous'),
-            'confirm "previous" in message'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-slider',
-                type: 'api',
-                level: 'default',
-            },
-        });
-        consoleWarnStub.restore();
-    });
-    it('warns in Dev Mode when `max="next"` is leveraged on last handle', async () => {
-        const consoleWarnStub = stub(console, 'warn');
-        window.__swc.issuedWarnings = new Set<BrandedSWCWarningID>();
-        const el = await fixture<Slider>(html`
-            <sp-slider min="0" max="100">
-                <sp-slider-handle
-                    id="first-handle"
-                    max="next"
-                    slot="handle"
-                    name="a"
-                    value="10"
-                ></sp-slider-handle>
-                <sp-slider-handle
-                    id="middle-handle"
-                    min="previous"
-                    max="next"
-                    slot="handle"
-                    name="b"
-                    value="20"
-                ></sp-slider-handle>
-                <sp-slider-handle
-                    id="last-handle"
-                    min="previous"
-                    max="next"
-                    slot="handle"
-                    name="c"
-                    value="30"
-                ></sp-slider-handle>
-            </sp-slider>
-        `);
-
-        await elementUpdated(el);
-
-        expect(consoleWarnStub.called).to.be.true;
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(spyCall.args.at(0).includes('next'), 'confirm "next" in message')
-            .to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-slider',
-                type: 'api',
-                level: 'default',
-            },
-        });
-        consoleWarnStub.restore();
-    });
     it('builds both handles from a <template>', async () => {
         const template = document.createElement('template');
         template.innerHTML = `
@@ -1821,33 +1727,137 @@ describe('Slider', () => {
         expect(overlay.open).to.be.false;
     });
 
-    it('warns in Dev Mode when using the default slot for text labels', async () => {
-        const consoleWarnStub = stub(console, 'warn');
-        window.__swc.issuedWarnings = new Set<BrandedSWCWarningID>();
-        const el = await fixture<Slider>(html`
-            <sp-slider min="0" max="100" value="50">
-                This is a deprecated text label
-            </sp-slider>
-        `);
-
-        await elementUpdated(el);
-
-        expect(consoleWarnStub.called).to.be.true;
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            spyCall.args.at(0).includes('default slot'),
-            'confirm "default slot" in message'
-        ).to.be.true;
-        expect(
-            spyCall.args.at(0).includes('deprecated'),
-            'confirm "deprecated" in message'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-slider',
-                level: 'deprecation',
-            },
+    describe('dev mode', () => {
+        let consoleWarnStub!: ReturnType<typeof stub>;
+        before(() => {
+            window.__swc.verbose = true;
+            consoleWarnStub = stub(console, 'warn');
         });
-        consoleWarnStub.restore();
+        afterEach(() => {
+            consoleWarnStub.resetHistory();
+            window.__swc.issuedWarnings = new Set<BrandedSWCWarningID>();
+        });
+        after(() => {
+            window.__swc.verbose = false;
+            consoleWarnStub.restore();
+        });
+
+        it('warns in Dev Mode when using the default slot for text labels', async () => {
+            const el = await fixture<Slider>(html`
+                <sp-slider min="0" max="100" value="50">
+                    This is a deprecated text label
+                </sp-slider>
+            `);
+
+            await elementUpdated(el);
+
+            expect(consoleWarnStub.called).to.be.true;
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                spyCall.args.at(0).includes('default slot'),
+                'confirm "default slot" in message'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-slider',
+                    level: 'deprecation',
+                    type: 'api',
+                },
+            });
+        });
+
+        it('warns in Dev Mode when `min="previous"` is leveraged on first handle', async () => {
+            window.__swc.issuedWarnings = new Set<BrandedSWCWarningID>();
+            const el = await fixture<Slider>(html`
+                <sp-slider min="0" max="100">
+                    <sp-slider-handle
+                        id="first-handle"
+                        min="previous"
+                        max="next"
+                        slot="handle"
+                        name="a"
+                        value="10"
+                    ></sp-slider-handle>
+                    <sp-slider-handle
+                        id="middle-handle"
+                        min="previous"
+                        max="next"
+                        slot="handle"
+                        name="b"
+                        value="20"
+                    ></sp-slider-handle>
+                    <sp-slider-handle
+                        id="last-handle"
+                        min="previous"
+                        slot="handle"
+                        name="c"
+                        value="30"
+                    ></sp-slider-handle>
+                </sp-slider>
+            `);
+
+            await elementUpdated(el);
+
+            expect(consoleWarnStub.called).to.be.true;
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                spyCall.args.at(0).includes('previous'),
+                'confirm "previous" in message'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-slider',
+                    type: 'api',
+                    level: 'default',
+                },
+            });
+        });
+
+        it('warns in Dev Mode when `max="next"` is leveraged on last handle', async () => {
+            window.__swc.issuedWarnings = new Set<BrandedSWCWarningID>();
+            const el = await fixture<Slider>(html`
+                <sp-slider min="0" max="100">
+                    <sp-slider-handle
+                        id="first-handle"
+                        max="next"
+                        slot="handle"
+                        name="a"
+                        value="10"
+                    ></sp-slider-handle>
+                    <sp-slider-handle
+                        id="middle-handle"
+                        min="previous"
+                        max="next"
+                        slot="handle"
+                        name="b"
+                        value="20"
+                    ></sp-slider-handle>
+                    <sp-slider-handle
+                        id="last-handle"
+                        min="previous"
+                        max="next"
+                        slot="handle"
+                        name="c"
+                        value="30"
+                    ></sp-slider-handle>
+                </sp-slider>
+            `);
+
+            await elementUpdated(el);
+
+            expect(consoleWarnStub.called).to.be.true;
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                spyCall.args.at(0).includes('next'),
+                'confirm "next" in message'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-slider',
+                    type: 'api',
+                    level: 'default',
+                },
+            });
+        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses a Safari-specific issue where slider labels would disappear when a related hover-overlay is triggered and the user moves the pointer away from the slider. The problem was occurring both when using the `label` attribute and when using the default slot for text labels.

The fix ensures that the label element remain visible in the DOM regardless of hover state changes, which prevents Safari's hover state behavior from causing the disappearing label issue.

Additionally, this PR marks the default slot as deprecated, because we don't need two APIs for doing the same thing, so we want to encourage users to use the label property instead of the slot for text labels.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->
- [SWC-694](https://jira.corp.adobe.com/browse/SWC-694)
- Fixes https://github.com/adobe/spectrum-web-components/issues/5117

## Motivation and context

This issue appears to be related to how Safari handles projecting slot content across shadow DOM boundaries (the sp-slider slot inside the sp-field-label) when combined with overlays creating different stacking contexts. Safari seems particularly sensitive to these interactions compared to other browsers. 🤷 

I explored an alternative fix specifically for the slotted content case, which involved moving the slot outside of sp-field-label, hiding its visibility, copying its assigned node content to a state variable, and then rendering that variable instead. However, this approach was overly complex for what's essentially a niche use case that we're deprecating anyway. The current solution is much simpler while still fixing the core issue.

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

I added unit test for the deprecation warning, added a storybook story that demonstrates the fixed behavior in Safari and verified that the label remains visible in Safari when hovering over slider and moving pointer away.

Also tested across Firefox and Chrome to ensure consistent behavior.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

In Safari:
-   [ ] _Go to this new [With Popover story](https://ruben-slider-label-fix--spectrumwc.netlify.app/storybook/?path=/story/slider--with-popover)_
    1. Hover over the multiple Sliders
    2. Verify how "Label in slot" disappears (not fixed, reason described above)
    3. Verify how "Label in attribute" does not disappear (fixed)

-   [x] Did it pass in Desktop?
-   [x] Did it pass in Mobile?
-   [x] Did it pass in iPad?


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
