### PR TITLE
build: add index-base fallback and filecheck for CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,9 @@
                 "packages/**/*.css",
                 "tools/**/*.css",
                 "tasks/build-css.js",
-                "tasks/css-tools.js"
+                "tasks/css-tools.js",
+                ".prettierrc.yaml",
+                ".stylelintrc.json"
             ],
             "output": [
                 "packages/**/*.css.ts",

--- a/packages/accordion/src/accordion-item-overrides.css
+++ b/packages/accordion/src/accordion-item-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/accordion/src/accordion-overrides.css
+++ b/packages/accordion/src/accordion-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/accordion/src/spectrum-accordion-item.css
+++ b/packages/accordion/src/spectrum-accordion-item.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/accordion/src/spectrum-accordion.css
+++ b/packages/accordion/src/spectrum-accordion.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/action-bar/src/action-bar-overrides.css
+++ b/packages/action-bar/src/action-bar-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/action-bar/src/spectrum-action-bar.css
+++ b/packages/action-bar/src/spectrum-action-bar.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/action-button/src/action-button-overrides.css
+++ b/packages/action-button/src/action-button-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/action-button/src/spectrum-config.js
+++ b/packages/action-button/src/spectrum-config.js
@@ -27,7 +27,6 @@ const config = {
             inPackage: '@spectrum-css/actionbutton',
             outPackage: 'action-button',
             fileName: 'action-button',
-            systemOverrides: true,
             excludeByComponents: [
                 {
                     type: 'type',

--- a/packages/action-group/src/action-group-overrides.css
+++ b/packages/action-group/src/action-group-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/action-group/src/spectrum-action-group.css
+++ b/packages/action-group/src/spectrum-action-group.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/alert-banner/src/alert-banner-overrides.css
+++ b/packages/alert-banner/src/alert-banner-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/alert-banner/src/spectrum-alert-banner.css
+++ b/packages/alert-banner/src/spectrum-alert-banner.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/alert-banner/src/spectrum-config.js
+++ b/packages/alert-banner/src/spectrum-config.js
@@ -24,7 +24,6 @@ const config = {
             inPackage: '@spectrum-css/alertbanner',
             outPackage: 'alert-banner',
             fileName: 'alert-banner',
-            systemOverrides: true,
             components: [
                 converter.classToHost(),
                 converter.classToAttribute('is-open', 'open'),

--- a/packages/alert-dialog/src/alert-dialog-overrides.css
+++ b/packages/alert-dialog/src/alert-dialog-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/alert-dialog/src/spectrum-alert-dialog.css
+++ b/packages/alert-dialog/src/spectrum-alert-dialog.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/asset/src/asset-overrides.css
+++ b/packages/asset/src/asset-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/asset/src/spectrum-asset.css
+++ b/packages/asset/src/spectrum-asset.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/avatar/src/avatar-overrides.css
+++ b/packages/avatar/src/avatar-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/avatar/src/spectrum-avatar.css
+++ b/packages/avatar/src/spectrum-avatar.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/badge/src/badge-overrides.css
+++ b/packages/badge/src/badge-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/badge/src/spectrum-badge.css
+++ b/packages/badge/src/spectrum-badge.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/breadcrumbs/src/breadcrumbs-item-overrides.css
+++ b/packages/breadcrumbs/src/breadcrumbs-item-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/breadcrumbs/src/breadcrumbs-overrides.css
+++ b/packages/breadcrumbs/src/breadcrumbs-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/breadcrumbs/src/spectrum-breadcrumbs-item.css
+++ b/packages/breadcrumbs/src/spectrum-breadcrumbs-item.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #separator {

--- a/packages/breadcrumbs/src/spectrum-breadcrumbs.css
+++ b/packages/breadcrumbs/src/spectrum-breadcrumbs.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/button-group/src/button-group-overrides.css
+++ b/packages/button-group/src/button-group-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/button-group/src/spectrum-button-group.css
+++ b/packages/button-group/src/spectrum-button-group.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/button/src/button-overrides.css
+++ b/packages/button/src/button-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/button/src/spectrum-config.js
+++ b/packages/button/src/spectrum-config.js
@@ -27,7 +27,6 @@ const config = {
             inPackage: '@spectrum-css/button',
             outPackage: 'button',
             fileName: 'button',
-            systemOverrides: true,
             excludeByComponents: [
                 builder.element('a'),
                 {

--- a/packages/card/src/card-overrides.css
+++ b/packages/card/src/card-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/card/src/spectrum-card.css
+++ b/packages/card/src/spectrum-card.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/checkbox/src/checkbox-overrides.css
+++ b/packages/checkbox/src/checkbox-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/clear-button/src/clear-button-overrides.css
+++ b/packages/clear-button/src/clear-button-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/clear-button/src/spectrum-clear-button.css
+++ b/packages/clear-button/src/spectrum-clear-button.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/close-button/src/close-button-overrides.css
+++ b/packages/close-button/src/close-button-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/coachmark/src/coach-indicator-overrides.css
+++ b/packages/coachmark/src/coach-indicator-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/coachmark/src/coachmark-overrides.css
+++ b/packages/coachmark/src/coachmark-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/coachmark/src/spectrum-coach-indicator.css
+++ b/packages/coachmark/src/spectrum-coach-indicator.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/coachmark/src/spectrum-coachmark.css
+++ b/packages/coachmark/src/spectrum-coachmark.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/color-area/src/color-area-overrides.css
+++ b/packages/color-area/src/color-area-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/color-area/src/spectrum-color-area.css
+++ b/packages/color-area/src/spectrum-color-area.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/color-handle/src/color-handle-overrides.css
+++ b/packages/color-handle/src/color-handle-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/color-handle/src/spectrum-color-handle.css
+++ b/packages/color-handle/src/spectrum-color-handle.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/color-loupe/src/color-loupe-overrides.css
+++ b/packages/color-loupe/src/color-loupe-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/color-loupe/src/spectrum-color-loupe.css
+++ b/packages/color-loupe/src/spectrum-color-loupe.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/color-slider/src/color-slider-overrides.css
+++ b/packages/color-slider/src/color-slider-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/color-slider/src/spectrum-color-slider.css
+++ b/packages/color-slider/src/spectrum-color-slider.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/color-wheel/src/color-wheel-overrides.css
+++ b/packages/color-wheel/src/color-wheel-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/color-wheel/src/spectrum-color-wheel.css
+++ b/packages/color-wheel/src/spectrum-color-wheel.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/combobox/src/combobox-overrides.css
+++ b/packages/combobox/src/combobox-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/combobox/src/spectrum-combobox.css
+++ b/packages/combobox/src/spectrum-combobox.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/contextual-help/src/contextual-help-overrides.css
+++ b/packages/contextual-help/src/contextual-help-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/contextual-help/src/spectrum-contextual-help.css
+++ b/packages/contextual-help/src/spectrum-contextual-help.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .popover {

--- a/packages/dialog/src/dialog-overrides.css
+++ b/packages/dialog/src/dialog-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/dialog/src/spectrum-dialog.css
+++ b/packages/dialog/src/spectrum-dialog.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/divider/src/divider-overrides.css
+++ b/packages/divider/src/divider-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/divider/src/spectrum-divider.css
+++ b/packages/divider/src/spectrum-divider.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/dropzone/src/dropzone-overrides.css
+++ b/packages/dropzone/src/dropzone-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/dropzone/src/spectrum-dropzone.css
+++ b/packages/dropzone/src/spectrum-dropzone.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/field-group/src/field-group-overrides.css
+++ b/packages/field-group/src/field-group-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/field-group/src/spectrum-field-group.css
+++ b/packages/field-group/src/spectrum-field-group.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .group {

--- a/packages/field-label/src/field-label-overrides.css
+++ b/packages/field-label/src/field-label-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/field-label/src/spectrum-field-label.css
+++ b/packages/field-label/src/spectrum-field-label.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host,

--- a/packages/help-text/src/help-text-overrides.css
+++ b/packages/help-text/src/help-text-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/help-text/src/spectrum-help-text.css
+++ b/packages/help-text/src/spectrum-help-text.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/icon/src/icon-arrow-overrides.css
+++ b/packages/icon/src/icon-arrow-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-asterisk-overrides.css
+++ b/packages/icon/src/icon-asterisk-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-checkmark-overrides.css
+++ b/packages/icon/src/icon-checkmark-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-chevron-overrides.css
+++ b/packages/icon/src/icon-chevron-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-corner-triangle-overrides.css
+++ b/packages/icon/src/icon-corner-triangle-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-cross-overrides.css
+++ b/packages/icon/src/icon-cross-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-dash-overrides.css
+++ b/packages/icon/src/icon-dash-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-double-gripper-overrides.css
+++ b/packages/icon/src/icon-double-gripper-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-overrides.css
+++ b/packages/icon/src/icon-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-single-gripper-overrides.css
+++ b/packages/icon/src/icon-single-gripper-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/icon-triple-gripper-overrides.css
+++ b/packages/icon/src/icon-triple-gripper-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/spectrum-icon-arrow.css
+++ b/packages/icon/src/spectrum-icon-arrow.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-UIIcon-ArrowRight75 {

--- a/packages/icon/src/spectrum-icon-asterisk.css
+++ b/packages/icon/src/spectrum-icon-asterisk.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-UIIcon-Asterisk75 {

--- a/packages/icon/src/spectrum-icon-checkmark.css
+++ b/packages/icon/src/spectrum-icon-checkmark.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-UIIcon-Checkmark50 {

--- a/packages/icon/src/spectrum-icon-chevron.css
+++ b/packages/icon/src/spectrum-icon-chevron.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-UIIcon-ChevronRight50 {

--- a/packages/icon/src/spectrum-icon-corner-triangle.css
+++ b/packages/icon/src/spectrum-icon-corner-triangle.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-UIIcon-CornerTriangle75 {

--- a/packages/icon/src/spectrum-icon-cross.css
+++ b/packages/icon/src/spectrum-icon-cross.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-UIIcon-Cross75 {

--- a/packages/icon/src/spectrum-icon-dash.css
+++ b/packages/icon/src/spectrum-icon-dash.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-UIIcon-Dash50 {

--- a/packages/icon/src/spectrum-icon-double-gripper.css
+++ b/packages/icon/src/spectrum-icon-double-gripper.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/spectrum-icon-single-gripper.css
+++ b/packages/icon/src/spectrum-icon-single-gripper.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/spectrum-icon-triple-gripper.css
+++ b/packages/icon/src/spectrum-icon-triple-gripper.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/icon/src/spectrum-icon.css
+++ b/packages/icon/src/spectrum-icon.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/illustrated-message/src/illustratedmessage-overrides.css
+++ b/packages/illustrated-message/src/illustratedmessage-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/illustrated-message/src/spectrum-illustratedmessage.css
+++ b/packages/illustrated-message/src/spectrum-illustratedmessage.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/infield-button/src/infield-button-overrides.css
+++ b/packages/infield-button/src/infield-button-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/infield-button/src/spectrum-infield-button.css
+++ b/packages/infield-button/src/spectrum-infield-button.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/link/src/link-overrides.css
+++ b/packages/link/src/link-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/link/src/spectrum-link.css
+++ b/packages/link/src/spectrum-link.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/menu/src/checkmark-overrides.css
+++ b/packages/menu/src/checkmark-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/menu/src/chevron-overrides.css
+++ b/packages/menu/src/chevron-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/menu/src/menu-divider-overrides.css
+++ b/packages/menu/src/menu-divider-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/menu/src/menu-item-overrides.css
+++ b/packages/menu/src/menu-item-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/menu/src/menu-overrides.css
+++ b/packages/menu/src/menu-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/menu/src/menu-sectionHeading-overrides.css
+++ b/packages/menu/src/menu-sectionHeading-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/menu/src/spectrum-checkmark.css
+++ b/packages/menu/src/spectrum-checkmark.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .checkmark {

--- a/packages/menu/src/spectrum-chevron.css
+++ b/packages/menu/src/spectrum-chevron.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .chevron {

--- a/packages/menu/src/spectrum-menu-divider.css
+++ b/packages/menu/src/spectrum-menu-divider.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 ::slotted([slot='icon']) {

--- a/packages/menu/src/spectrum-menu-sectionHeading.css
+++ b/packages/menu/src/spectrum-menu-sectionHeading.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Menu-back:focus-visible {

--- a/packages/menu/src/spectrum-menu.css
+++ b/packages/menu/src/spectrum-menu.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/meter/src/meter-overrides.css
+++ b/packages/meter/src/meter-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/meter/src/progress-bar-overrides.css
+++ b/packages/meter/src/progress-bar-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/meter/src/spectrum-meter.css
+++ b/packages/meter/src/spectrum-meter.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/meter/src/spectrum-progress-bar.css
+++ b/packages/meter/src/spectrum-progress-bar.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/modal/src/modal-overrides.css
+++ b/packages/modal/src/modal-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/modal/src/modal-wrapper-overrides.css
+++ b/packages/modal/src/modal-wrapper-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/modal/src/spectrum-modal-wrapper.css
+++ b/packages/modal/src/spectrum-modal-wrapper.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/modal/src/spectrum-modal.css
+++ b/packages/modal/src/spectrum-modal.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/number-field/src/number-field-overrides.css
+++ b/packages/number-field/src/number-field-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/number-field/src/spectrum-number-field.css
+++ b/packages/number-field/src/spectrum-number-field.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/picker-button/src/picker-button-overrides.css
+++ b/packages/picker-button/src/picker-button-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .root {

--- a/packages/picker-button/src/spectrum-picker-button.css
+++ b/packages/picker-button/src/spectrum-picker-button.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .root {

--- a/packages/picker/src/picker-overrides.css
+++ b/packages/picker/src/picker-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #button {

--- a/packages/popover/src/popover-overrides.css
+++ b/packages/popover/src/popover-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/popover/src/spectrum-popover.css
+++ b/packages/popover/src/spectrum-popover.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/progress-bar/src/progress-bar-overrides.css
+++ b/packages/progress-bar/src/progress-bar-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/progress-bar/src/spectrum-progress-bar.css
+++ b/packages/progress-bar/src/spectrum-progress-bar.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/progress-circle/src/progress-circle-overrides.css
+++ b/packages/progress-circle/src/progress-circle-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/progress-circle/src/spectrum-progress-circle.css
+++ b/packages/progress-circle/src/spectrum-progress-circle.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/radio/src/radio-overrides.css
+++ b/packages/radio/src/radio-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/search/src/search-overrides.css
+++ b/packages/search/src/search-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #textfield {

--- a/packages/sidenav/src/sidenav-heading-overrides.css
+++ b/packages/sidenav/src/sidenav-heading-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #list {

--- a/packages/sidenav/src/sidenav-item-overrides.css
+++ b/packages/sidenav/src/sidenav-item-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #list {

--- a/packages/sidenav/src/sidenav-overrides.css
+++ b/packages/sidenav/src/sidenav-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/sidenav/src/spectrum-sidenav-heading.css
+++ b/packages/sidenav/src/spectrum-sidenav-heading.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/sidenav/src/spectrum-sidenav.css
+++ b/packages/sidenav/src/spectrum-sidenav.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/slider/src/slider-overrides.css
+++ b/packages/slider/src/slider-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/slider/src/spectrum-slider.css
+++ b/packages/slider/src/spectrum-slider.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/split-view/src/spectrum-split-view.css
+++ b/packages/split-view/src/spectrum-split-view.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/split-view/src/split-view-overrides.css
+++ b/packages/split-view/src/split-view-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([dir]) {

--- a/packages/status-light/src/status-light-overrides.css
+++ b/packages/status-light/src/status-light-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([dir]) {

--- a/packages/swatch/src/spectrum-swatch-group.css
+++ b/packages/swatch/src/spectrum-swatch-group.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/swatch/src/spectrum-swatch.css
+++ b/packages/swatch/src/spectrum-swatch.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/swatch/src/swatch-group-overrides.css
+++ b/packages/swatch/src/swatch-group-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/swatch/src/swatch-overrides.css
+++ b/packages/swatch/src/swatch-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([size='l']) {

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/switch/src/switch-overrides.css
+++ b/packages/switch/src/switch-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/table/src/spectrum-table-body.css
+++ b/packages/table/src/spectrum-table-body.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/table/src/spectrum-table-cell.css
+++ b/packages/table/src/spectrum-table-cell.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/table/src/spectrum-table-checkbox-cell.css
+++ b/packages/table/src/spectrum-table-checkbox-cell.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/table/src/spectrum-table-head-cell.css
+++ b/packages/table/src/spectrum-table-head-cell.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .sortedIcon {

--- a/packages/table/src/spectrum-table-head.css
+++ b/packages/table/src/spectrum-table-head.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/table/src/spectrum-table-row.css
+++ b/packages/table/src/spectrum-table-row.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/table/src/spectrum-table.css
+++ b/packages/table/src/spectrum-table.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/table/src/table-body-overrides.css
+++ b/packages/table/src/table-body-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/table/src/table-cell-overrides.css
+++ b/packages/table/src/table-cell-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/table/src/table-checkbox-cell-overrides.css
+++ b/packages/table/src/table-checkbox-cell-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/table/src/table-head-cell-overrides.css
+++ b/packages/table/src/table-head-cell-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/table/src/table-head-overrides.css
+++ b/packages/table/src/table-head-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/table/src/table-overrides.css
+++ b/packages/table/src/table-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/table/src/table-row-overrides.css
+++ b/packages/table/src/table-row-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/tabs/src/spectrum-tab.css
+++ b/packages/tabs/src/spectrum-tab.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/tabs/src/spectrum-tabs-sizes.css
+++ b/packages/tabs/src/spectrum-tabs-sizes.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([size='s']) #list.spectrum-Tabs--compact {

--- a/packages/tabs/src/spectrum-tabs.css
+++ b/packages/tabs/src/spectrum-tabs.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #list {

--- a/packages/tabs/src/tab-overrides.css
+++ b/packages/tabs/src/tab-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/tabs/src/tabs-overrides.css
+++ b/packages/tabs/src/tabs-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #list {

--- a/packages/tabs/src/tabs-sizes-overrides.css
+++ b/packages/tabs/src/tabs-sizes-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([size='s']) #list {

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/tags/src/spectrum-tags.css
+++ b/packages/tags/src/spectrum-tags.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/tags/src/tag-overrides.css
+++ b/packages/tags/src/tag-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/tags/src/tags-overrides.css
+++ b/packages/tags/src/tags-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/textfield/src/textfield-overrides.css
+++ b/packages/textfield/src/textfield-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/thumbnail/src/spectrum-thumbnail.css
+++ b/packages/thumbnail/src/spectrum-thumbnail.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host,

--- a/packages/thumbnail/src/thumbnail-overrides.css
+++ b/packages/thumbnail/src/thumbnail-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/toast/src/spectrum-toast.css
+++ b/packages/toast/src/spectrum-toast.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/packages/toast/src/toast-overrides.css
+++ b/packages/toast/src/toast-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/tooltip/src/spectrum-tooltip.css
+++ b/packages/tooltip/src/spectrum-tooltip.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #tooltip {

--- a/packages/tooltip/src/tooltip-overrides.css
+++ b/packages/tooltip/src/tooltip-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #tooltip {

--- a/packages/tray/src/spectrum-tray-wrapper.css
+++ b/packages/tray/src/spectrum-tray-wrapper.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/tray/src/spectrum-tray.css
+++ b/packages/tray/src/spectrum-tray.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .tray {

--- a/packages/tray/src/tray-overrides.css
+++ b/packages/tray/src/tray-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/tray/src/tray-wrapper-overrides.css
+++ b/packages/tray/src/tray-wrapper-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/packages/underlay/src/spectrum-underlay.css
+++ b/packages/underlay/src/spectrum-underlay.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/packages/underlay/src/underlay-overrides.css
+++ b/packages/underlay/src/underlay-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/scripts/spectrum-vars.js
+++ b/scripts/spectrum-vars.js
@@ -1,37 +1,137 @@
 #!/usr/bin/env node
 
-/*
-Copyright 2020 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 import path from 'path';
 import fs from 'fs-extra';
-import { transform } from 'lightningcss';
-import { fileURLToPath } from 'url';
+
+import { composeVisitors, transform } from 'lightningcss';
 import fg from 'fast-glob';
+import 'colors';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import {
+    dirs,
+    getBaseCSS,
+    getPackagePath,
+    log,
+    printRelativePath,
+} from '../tasks/css-tools.js';
+import {
+    removeUnusedVariables,
+    replaceGlobalSelectors,
+} from '../tasks/lightningcss-plugins.js';
 
-let removedVariableDeclarations = 0;
-
-const varRegex = /--spectrum-[^:,)\s]+/g;
+const fsp = fs.promises;
 
 /**
- * Construct an array of the all the CSS custom properties leveraged in packages
- * that ARE NOT the styles or theme packages.
- * @returns string[]
+ * A utility to run the CSS through a selector transformation and remove unused custom properties
+ * @param {string} data - The CSS content to process
+ * @param {string} [identifier] - Any additional selectors to replace with :root/:host
+ * @param {Set} [usedVariables=new Set()] - A set of custom properties used in the project
+ * @param {(RegExp|string)[]} [excludedPatterns=[]] - An array of patterns to exclude from removal
+ * @returns {Promise<string>} The processed CSS result after transformation
  */
-const findUsedVars = async () => {
-    const usedVariables = new Set();
+export async function transformCSS(
+    data,
+    identifier = undefined,
+    usedVariables = new Set(),
+    excludedPatterns = [
+        // Manually include Spectrum Vars, for now...
+        /^--spectrum-global-/,
+        /^--spectrum-alias-/,
+        /^--spectrum-semantic/,
+        // Manually include Typography values, while we do not ship a "package" for these...
+        /^--spectrum-font/,
+        /^--spectrum-heading/,
+        /^--spectrum-body/,
+        /^--spectrum-detail/,
+        /^--spectrum-code/,
+        /^--mod-/,
+    ]
+) {
+    /**
+     * @note lit-html is a JS literal, so `\` escapes by default.
+     * for there to be unicode characters, the escape must escape itself
+     */
+    let result = data.replace(/\\/g, '\\\\');
+
+    const transformedResult = transform({
+        code: Buffer.from(result),
+        visitor: composeVisitors([
+            removeUnusedVariables(excludedPatterns, usedVariables),
+            // Replace global scope classes with a :root/:host selector
+            replaceGlobalSelectors(identifier),
+        ]),
+    });
+
+    return transformedResult.code.toString();
+}
+
+/**
+ * A utility function to read in a CSS file, process it, and write it to a destination file
+ * @param {string[]} paths - The source file path(s) to read the CSS content; if more than one, they will be concatenated
+ * @param {string[]} destinationPaths - The destination file path(s) to write the processed CSS
+ * @param {string} [identifier=':root']
+ * @param {Set} [usedVariables=new Set()]
+ * @returns {Promise<Set<string>} - The distinct list of removed custom property declarations
+ */
+async function processCSS(
+    paths,
+    destinationPaths,
+    identifier = ':root',
+    usedVariables = new Set()
+) {
+    const data = await Promise.all(
+        paths.map(async (path) => {
+            if (!fs.existsSync(path)) {
+                return Promise.resolve('');
+            }
+
+            const content = await fs.readFile(path, 'utf8');
+            return Promise.resolve(content);
+        })
+    ).then((data) => data.join('\n\n'));
+
+    // Pass the content to the transformation function
+    const result = await transformCSS(
+        data,
+        identifier,
+        usedVariables,
+        destinationPaths
+    );
+
+    return Promise.all(
+        destinationPaths.map((dstPath) => writeCSSFile(dstPath, result))
+    );
+}
+
+async function writeCSSFile(filePath, content) {
+    // Ensure the directory exists
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+
+    return fsp.writeFile(filePath, content, { encoding: 'utf8' });
+}
+
+/**
+ * The entry point for the script that processes Spectrum CSS variables
+ */
+async function main() {
+    const systems = ['spectrum', 'spectrum-two', 'express'];
+    const processes = [];
+
+    const foundVars = new Set();
     for (const cssPath of await fg(`./packages/*/src/*.css`)) {
+        // Skip the styles and theme packages
         if (
             cssPath.includes('tools/styles') ||
             cssPath.includes('tools/theme')
@@ -39,202 +139,91 @@ const findUsedVars = async () => {
             continue;
         }
         const originCSS = fs.readFileSync(cssPath, 'utf8');
-        const foundVars = originCSS.matchAll(varRegex);
-        for (const variable of foundVars) {
-            usedVariables.add(variable[0]);
+        for (const variable of originCSS.matchAll(/--spectrum-[^:,)\s]+/g)) {
+            foundVars.add(variable[0]);
         }
     }
-    return usedVariables;
-};
 
-const processCSSData = async (
-    data,
-    identifier,
-    from,
-    usedVariables = undefined
-) => {
-    /* lit-html is a JS literal, so `\` escapes by default.
-     * for there to be unicode characters, the escape must
-     * escape itself...
-     */
-    let result = data.replace(/\\/g, '\\\\');
+    systems.forEach((system) => {
+        const packageDir = system !== 'spectrum' ? [system] : [];
 
-    // possible selectors to replace
-    const selector1 =
-        identifier == ':root ' ? identifier : `.spectrum--${identifier}`;
+        const varsPath = path.dirname(
+            getPackagePath(
+                `@spectrum-css/${system === 'express' ? 'expressvars' : 'vars'}`
+            )
+        );
 
-    // new selector values
-    const shadowSelector = ':root,\n:host';
-
-    if (data.indexOf(selector1) >= 0) {
-        result = result.replace(selector1, shadowSelector);
-    }
-    result = result.replaceAll(
-        /(?:\.spectrum(--(?:express|light(?:est)?|dark(?:est)?|medium|large)?,?(\n|\s)*)?)+\s?(?={)/g,
-        shadowSelector
-    );
-
-    ({ code: result } = transform({
-        code: Buffer.from(result),
-        visitor: {
-            Declaration(declaration) {
+        log.notice(`\nProcessing ${system.cyan} variables`);
+        Object.entries({
+            theme: ['lightest', 'light', 'dark', 'darkest'],
+            scale: ['medium', 'large'],
+            core: ['global'],
+        }).forEach(([context, values]) => {
+            values.forEach((value) => {
                 if (
-                    declaration.property === 'custom' &&
-                    // Manually include Spectrum Vars, for now...
-                    !declaration.value.name.startsWith('--spectrum-global-') &&
-                    !declaration.value.name.startsWith('--spectrum-alias-') &&
-                    !declaration.value.name.startsWith('--spectrum-semantic') &&
-                    // Manually include Typography values, while we do not ship a "package" for these...
-                    !declaration.value.name.startsWith('--spectrum-font') &&
-                    !declaration.value.name.startsWith('--spectrum-heading') &&
-                    !declaration.value.name.startsWith('--spectrum-body') &&
-                    !declaration.value.name.startsWith('--spectrum-detail') &&
-                    !declaration.value.name.startsWith('--spectrum-code') &&
-                    !usedVariables?.has(declaration.value.name)
+                    context === 'theme' &&
+                    system !== 'spectrum' &&
+                    ['lightest', 'darkest'].includes(value)
                 ) {
-                    removedVariableDeclarations += 1;
-                    return [];
+                    return;
                 }
-            },
-        },
-    }));
 
-    return result;
-};
+                const srcPath = path.join(varsPath, `spectrum-${value}.css`);
+                const dstPath = path.join(
+                    dirs.styles,
+                    ...packageDir,
+                    `spectrum-${context}-${value}.css`
+                );
+                log.notice(
+                    `- ${context}: ${value.yellow} ${`[src: ${printRelativePath(srcPath)}]`.gray}`
+                );
+                processes.push(
+                    processCSS(
+                        [srcPath],
+                        [dstPath],
+                        value,
+                        context === 'scale' ? foundVars : undefined
+                    )
+                );
+            });
+        });
+    });
 
-const processCSS = async (
-    srcPath,
-    dstPath,
-    identifier,
-    from,
-    usedVariables = undefined
-) => {
-    const data = fs.readFileSync(srcPath, 'utf8');
-    const result = await processCSSData(data, identifier, from, usedVariables);
-    fs.writeFileSync(dstPath, result, 'utf8');
-};
-
-const processTypography = async (
-    baseSrcPath,
-    overridesSrcPath,
-    dstPath,
-    identifier,
-    from,
-    usedVariables = undefined
-) => {
-    const baseData = fs.readFileSync(baseSrcPath, 'utf8');
-    const overridesData = fs.readFileSync(overridesSrcPath, 'utf8');
-    const data = baseData + overridesData;
-    const result = await processCSSData(data, identifier, from, usedVariables);
-    fs.writeFileSync(dstPath, result, 'utf8');
-
-    const fontPath = path.resolve(
-        path.join(__dirname, '..', 'tools', 'styles', 'fonts.css')
+    // Typography
+    const typographyPath = path.dirname(
+        getPackagePath('@spectrum-css/typography')
     );
-    fs.writeFileSync(fontPath, result, 'utf8');
-};
-
-const systems = ['spectrum', 'spectrum-two', 'express'];
-const themes = ['lightest', 'light', 'dark', 'darkest'];
-const scales = ['medium', 'large'];
-const cores = ['global'];
-const processes = [];
-
-const foundVars = await findUsedVars();
-
-systems.forEach((system) => {
-    const varsPackage = system === 'express' ? 'expressvars' : 'vars';
-    const varsPath = path
-        .dirname(import.meta.resolve(`@spectrum-css/${varsPackage}`))
-        .replace(/^file:/, '');
-    const packageDir = ['styles'];
-    if (system !== 'spectrum') {
-        packageDir.push(system);
-    }
-    themes.forEach((theme) => {
-        if (system !== 'spectrum' && ['lightest', 'darkest'].includes(theme)) {
-            return;
-        }
-        const srcPath = path.join(varsPath, `spectrum-${theme}.css`);
-        const dstPath = path.resolve(
-            path.join(
-                __dirname,
-                '..',
-                'tools',
-                ...packageDir,
-                `spectrum-theme-${theme}.css`
-            )
-        );
-
-        console.log(`processing theme ${srcPath}`);
-        processes.push(processCSS(srcPath, dstPath, theme));
-    });
-
-    scales.forEach((scale) => {
-        const srcPath = path.join(varsPath, `spectrum-${scale}.css`);
-        const dstPath = path.resolve(
-            path.join(
-                __dirname,
-                '..',
-                'tools',
-                ...packageDir,
-                `spectrum-scale-${scale}.css`
-            )
-        );
-        console.log(`processing scale  ${srcPath}`);
-        processes.push(
-            processCSS(srcPath, dstPath, scale, undefined, foundVars)
-        );
-    });
-
-    cores.forEach((core) => {
-        const srcPath = path.join(varsPath, `spectrum-${core}.css`);
-        const dstPath = path.resolve(
-            path.join(
-                __dirname,
-                '..',
-                'tools',
-                ...packageDir,
-                `spectrum-core-${core}.css`
-            )
-        );
-        console.log(`processing core ${srcPath}`);
-        processes.push(processCSS(srcPath, dstPath, core));
-    });
-});
-
-async function processSpectrumVars() {
-    {
-        // Typography
-        const typographyPath = path.join(
-            __dirname,
-            '..',
-            'node_modules',
-            '@spectrum-css',
-            'typography',
-            'dist'
-        );
-        const baseSrcPath = path.join(typographyPath, 'index-base.css');
-        const overridesSrcPath = path.join(typographyPath, 'index-theme.css');
-        const dstPath = path.resolve(
-            path.join(__dirname, '..', 'tools', 'styles', 'typography.css')
-        );
-        console.log(`processing typography`);
-        processes.push(
-            processTypography(
-                baseSrcPath,
-                overridesSrcPath,
-                dstPath,
-                'typography'
-            )
-        );
+    let baseSrcPath;
+    try {
+        baseSrcPath = getBaseCSS(typographyPath);
+    } catch (error) {
+        log.fail(error);
+        return;
     }
 
-    await Promise.all(processes).then(() => {
-        console.log(
-            `Spectrum Vars processed. ${removedVariableDeclarations} Custom Property declarations were removed as unused.`
-        );
-    });
+    log.notice(
+        `\nProcessing ${'typography'.cyan} ${`[src: ${printRelativePath(baseSrcPath)}]`.gray}\n`
+    );
+    processes.push(
+        processCSS(
+            [baseSrcPath, path.join(typographyPath, 'index-theme.css')],
+            [
+                path.join(dirs.styles, 'typography.css'),
+                path.join(dirs.styles, 'fonts.css'),
+            ],
+            'typography'
+        )
+    );
+
+    return Promise.all(processes)
+        .then(() => {
+            log.success('Successfully processed.');
+            process.exit(0);
+        })
+        .catch((error) => {
+            log.fail(error);
+            process.exit(1);
+        });
 }
 
-processSpectrumVars();
+main();

--- a/tasks/css-tools.js
+++ b/tasks/css-tools.js
@@ -21,12 +21,44 @@ import 'colors';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
-const log = {
-    success: (message) => console.log(`${'✓'.green}  ${message}`),
-    fail: (message) => console.log(`${'✗'.red}  ${message}`),
+/**
+ * The local workspace directories to read and write content
+ * @type {Object}
+ * @property {string} tools - The directory containing the CSS tools packages
+ * @property {string} styles - The directory containing the theme and typography CSS
+ */
+export const dirs = {
+    root: path.resolve(__dirname, '..'),
+    styles: path.resolve(__dirname, '..', 'tools', 'styles'),
 };
 
-const getPackagePath = (packageName) => {
+export const printRelativePath = (filePath) => {
+    return path.relative(dirs.root, filePath);
+};
+
+// eslint-disable no-console
+/**
+ * This utility logs messages to the console with a standardized format
+ * @type {Object}
+ * @property {Function} success - Logs a success message
+ * @property {Function} fail - Logs a failure message
+ */
+export const log = {
+    success: (message) => console.log(`${'✓'.green}  ${message}`),
+    fail: (message) => console.log(`${'✗'.red}  ${message}`),
+    warn: (message) => console.log(`${'⚠️'.yellow}  ${message}`),
+    notice: (message) => console.log(`${message}`),
+};
+// eslint-enable no-console
+
+/**
+ * This utility function has a built-in escape hatch for local packages
+ * but falls back to the standard require.resolve for dependencies. This returns
+ * the full filepath to the provided package.
+ * @param {string} packageName - The full name of the package (e.g. @spectrum-web-components/button)
+ * @returns {string} The path to the package
+ */
+export const getPackagePath = (packageName) => {
     let filepath;
 
     // Escape hatch for local packages: @spectrum-web-components
@@ -44,6 +76,29 @@ const getPackagePath = (packageName) => {
     }
 
     return filepath;
+};
+
+/**
+ * Determine the file path for the core CSS asset in a @spectrum-css component
+ * @param {string} packageDirectory - The name of the package to resolve
+ * @returns {string} The path to the core CSS asset
+ */
+export const getBaseCSS = (packageDirectory) => {
+    // Start by checking for the existence of the `index-base.css` file;
+    // this only exists if the component supports theming
+    if (fs.existsSync(path.resolve(packageDirectory, 'index-base.css'))) {
+        return path.resolve(packageDirectory, 'index-base.css');
+    }
+
+    // If the `index-base.css` file does not exist and the `index.css` file does not exist,
+    // then we need to throw an error because the package is not a valid @spectrum-css component
+    if (!fs.existsSync(path.resolve(packageDirectory, 'index.css'))) {
+        const message = `Could not find the core CSS asset for ${packageDirectory}`;
+        log.fail(message);
+        return new Error(message);
+    }
+
+    return path.resolve(packageDirectory, 'index.css');
 };
 
 const wrapCSSResult = (content) => {
@@ -66,10 +121,10 @@ if (fs.existsSync(licensePath)) {
 /**
  * Processes a CSS file using lightningcss, minifies it, and outputs a TypeScript module.
  * The output module includes license headers and wraps the CSS in a template literal.
- * 
+ *
  * @param {string} cssPath - Path to the CSS file to process
  * @returns {Promise<void>} A promise that resolves when processing is complete
- * 
+ *
  */
 export const processCSS = async (cssPath) => {
     return bundleAsync({

--- a/tasks/lightningcss-plugins.js
+++ b/tasks/lightningcss-plugins.js
@@ -1,0 +1,137 @@
+/*
+Copyright 2025 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/**
+ *
+ */
+export const replaceGlobalSelectors = (identifier) => ({
+    Rule(rule) {
+        if (rule?.type !== 'style') {
+            return rule;
+        }
+
+        rule?.value?.selectors?.forEach((selector) => {
+            if (!Array.isArray(selector)) {
+                selector = [selector];
+            }
+
+            selector.forEach((facet, idx) => {
+                // We're only validating classes
+                if (facet?.type !== 'class') {
+                    return;
+                }
+
+                // Replace all global scope classes with a :root/:host selector
+                if (
+                    /^spectrum(--(express|light(est)?|dark(est)?|medium|large|legacy))?$/.test(
+                        facet?.name
+                    ) ||
+                    (identifier && facet?.name === `spectrum--${identifier}`)
+                ) {
+                    // Remove this selector
+                    selector.splice(idx, 1);
+
+                    ['root', 'host'].forEach((kind) => {
+                        // Check if selector is already present
+                        if (
+                            !rule.value.selectors.some((s) => {
+                                // Check each array for an exact object match
+                                return s.some(
+                                    (i) =>
+                                        i?.type === 'pseudo-class' &&
+                                        i?.kind === kind &&
+                                        // Check that i does not have any other properties
+                                        Object.keys(i).length === 2
+                                );
+                            })
+                        ) {
+                            rule?.value?.selectors.push([
+                                {
+                                    type: 'pseudo-class',
+                                    kind,
+                                },
+                            ]);
+                        }
+                    });
+                }
+            });
+
+            // Remove empty arrays
+            rule.value.selectors = rule.value.selectors.filter((s) => s.length);
+        });
+
+        return rule;
+    },
+});
+
+/**
+ *
+ */
+export const removeUnusedVariables = (
+    excludedPatterns,
+    usedVariables = new Set()
+) => ({
+    Variable(variable) {
+        const checkForFallback = (fallback) => {
+            fallback.forEach(({ type, value }) => {
+                if (type && type === 'var') {
+                    if (value?.name?.ident) {
+                        usedVariables.add(value.name.ident);
+                    }
+
+                    if (value?.fallback) {
+                        checkForFallback(value.fallback);
+                    }
+                }
+            });
+        };
+
+        if (Array.isArray(variable?.fallback) && variable?.fallback.length) {
+            checkForFallback(variable.fallback);
+        }
+
+        return {
+            type: 'var',
+            value: variable,
+        };
+    },
+    // Remove unused custom properties
+    VariableExit(variable) {
+        const { name } = variable;
+        // Check if this is a preserved custom property
+        if (
+            excludedPatterns.some((p) => {
+                if (typeof p === 'string') {
+                    p = new RegExp(p);
+                }
+                return p.test(name.ident);
+            })
+        ) {
+            return {
+                type: 'var',
+                value: variable,
+            };
+        }
+
+        // Check if the declaration is not used in the project
+        if (usedVariables.has(name.ident)) {
+            return {
+                type: 'var',
+                value: variable,
+            };
+        }
+
+        // Track removed custom properties
+        // removedVariableDeclarations.add(name.ident);
+        return;
+    },
+});

--- a/tasks/process-spectrum-utils.js
+++ b/tasks/process-spectrum-utils.js
@@ -23,6 +23,12 @@ export const converterFor = (component) => {
             enumAttributes(attributes, name, operator, component),
         notToAttribute: (name, value) =>
             convertNotToAttribute(name, value, component),
+        notToPseudoClass: (kind) =>
+            convertNotToAny(
+                { type: 'pseudo-class', kind },
+                { type: 'pseudo-class', kind },
+                true
+            ),
         pseudoToAttribute: (name, value) =>
             convertPseudoToAttribute(name, value),
     };
@@ -44,7 +50,6 @@ export const builder = {
                 name,
             });
         if (value) {
-            // @ts-ignore
             component.operation = {
                 operator,
                 value,
@@ -81,7 +86,6 @@ export const builder = {
         }
         return {
             type: 'combinator',
-            // @ts-ignore
             value,
         };
     },
@@ -110,7 +114,6 @@ export const builder = {
      */
     pseudoClass: (kind) => ({
         type: 'pseudo-class',
-        // @ts-ignore
         kind,
     }),
     /**
@@ -120,7 +123,6 @@ export const builder = {
      */
     pseudoElement: (kind) => ({
         type: 'pseudo-element',
-        // @ts-ignore
         kind,
     }),
     /**
@@ -136,7 +138,6 @@ export const builder = {
                 selector: [{ type: 'universal' }],
             });
         if (value) {
-            // @ts-ignore
             slotted.selector = [builder.attribute('slot', value)];
         }
         return slotted;
@@ -223,6 +224,27 @@ export const convertNotToAttribute = (name, value, component) => ({
 });
 
 /**
+ * A more abstract version of convertNotToAttribute that can be used for any type of selector
+ * @param {import('./spectrum-css-converter').HostSelectorComponent} from
+ * @param {import('./spectrum-css-converter').HostSelectorComponent} to - The name of the attribute to convert to
+ * @param {boolean} [hoist=true] - Whether to hoist the conversion to the top level
+ * @returns {import('./spectrum-css-converter').SelectorConversion}
+ */
+export const convertNotToAny = (from, to, hoist = true) => ({
+    find: {
+        type: 'pseudo-class',
+        kind: 'not',
+        selectors: [[from]],
+    },
+    replace: {
+        kind: 'not',
+        type: 'pseudo-class',
+        selectors: [[to]],
+    },
+    hoist,
+});
+
+/**
  * @param {import('lightningcss').PseudoClass['kind']} kind
  * @param {string} value
  * @returns {import('./spectrum-css-converter').SelectorConversion}
@@ -230,7 +252,6 @@ export const convertNotToAttribute = (name, value, component) => ({
 export const convertPseudoToAttribute = (kind, value) => ({
     find: {
         type: 'pseudo-class',
-        // @ts-ignore
         kind,
     },
     replace: {
@@ -309,7 +330,6 @@ export const enumAttributes = (
  */
 export const slottedSlot = (name, value) => {
     return {
-        // @ts-ignore
         find: builder.class(name),
         replace: builder.slotted(value),
     };

--- a/tasks/process-spectrum.js
+++ b/tasks/process-spectrum.js
@@ -12,26 +12,38 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import fg from 'fast-glob';
-import 'colors';
-import { transform } from 'lightningcss';
 import path from 'path';
 import fs from 'fs';
-import { createRequire } from 'module';
-import { fileURLToPath } from 'url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import fg from 'fast-glob';
+import { transform } from 'lightningcss';
+import 'colors';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import stylelint from 'stylelint';
+import prettier from 'prettier';
 
-const root = path.resolve(__dirname, '../');
+const argv = yargs(hideBin(process.argv)).parse();
 
-const require = createRequire(import.meta.url);
+import {
+    dirs,
+    getBaseCSS,
+    getPackagePath,
+    log,
+    printRelativePath,
+} from '../tasks/css-tools.js';
+
+const fsp = fs.promises;
 
 /**
- * @to-do: normalize deep comparison old vs new usage when recursing.
+ * @todo: normalize deep comparison old vs new usage when recursing
+ * @param {any} oldSelector
+ * @param {any} newSelector
+ * @returns {boolean}
  */
 const compareSelectors = (oldSelector, newSelector) => {
     let matches = true;
-    if (Array.isArray(oldSelector)) {
+    if (oldSelector && Array.isArray(oldSelector)) {
         oldSelector.forEach((value, index) => {
             matches = compareSelectors(newSelector[index], value) && matches;
         });
@@ -45,35 +57,14 @@ const compareSelectors = (oldSelector, newSelector) => {
     return matches;
 };
 
-const isThemeOnlyRule = (rule) => {
-    return (
-        rule.value.selectors?.[0][0].name === 'spectrum--express' ||
-        rule.value.selectors?.[0][0].name === 'spectrum' ||
-        rule.value.selectors?.[0][0].name === 'spectrum--light' ||
-        rule.value.selectors?.[0][0].name === 'spectrum--dark' ||
-        rule.value.selectors?.[0][0].name === 'spectrum--darkest'
-    );
-};
-
-const isHost = (component) => {
-    return component?.type === 'pseudo-class' && component?.kind === 'host';
-};
-
-const isCombinator = (component) => {
-    return component?.type === 'combinator';
-};
-
-const isDirAttr = (component) => {
-    return component.type === 'attribute' && component.name === 'dir';
-};
-
-const isFocusRing = (component) => {
-    return component.type === 'class' && component.name === 'focus-ring';
-};
-
-const isPseudo = (component) => {
-    return component?.type?.startsWith('pseudo');
-};
+const isHost = (component) =>
+    component?.type === 'pseudo-class' && component?.kind === 'host';
+const isCombinator = (component) => component?.type === 'combinator';
+const isDirAttr = (component) =>
+    component.type === 'attribute' && component.name === 'dir';
+const isFocusRing = (component) =>
+    component.type === 'class' && component.name === 'focus-ring';
+const isPseudo = (component) => component?.type?.startsWith('pseudo');
 
 const isHoistedPseudoClass = (component) => {
     return (
@@ -89,9 +80,7 @@ const nullRuleFromRule = (rule) => ({
     value: {
         selectors: [],
         rules: [],
-        loc: {
-            ...rule.value.loc,
-        },
+        loc: rule.value.loc,
     },
 });
 
@@ -120,7 +109,7 @@ function conditionSelector(newSelector) {
      * Collapse attached ::slotted() components, e.g.
      * ::slotted(x)::slotted(y)
      */
-    selector = selector.reduce((acc, component, index) => {
+    return selector.reduce((acc, component, index) => {
         const previous = acc[index - 1];
         if (!previous) {
             acc.push(component);
@@ -146,708 +135,611 @@ function conditionSelector(newSelector) {
         }
         return acc;
     }, []);
-    return selector;
 }
 
-async function processComponent(componentPath) {
-    const { default: config } = await import(
-        path.join(componentPath, 'spectrum-config.js')
-    );
-    /**
-     * @type { import('./spectrum-css-converter').SpectrumCSSConverter}
-     */
-    const { conversions } = config;
-
-    /**
-     * @type { import('./spectrum-css-converter').SpectrumCSSConverter}
-     */
-    for await (const conversion of conversions) {
-        // The default package file is index.css but index-base.css contains the base styles compatible with theme switching.
-        let sourcePath = require
-            .resolve(conversion.inPackage)
-            .replace('index.css', 'index-base.css');
-
-        let sourceCSS = '';
-
-        // try to find the index-base.css file
-        try {
-            sourceCSS = fs.readFileSync(sourcePath, 'utf-8');
-        } catch (error) {
-            // if failed, try to find the index.css file
-            sourcePath = require.resolve(conversion.inPackage);
-            sourceCSS = fs.readFileSync(sourcePath, 'utf-8');
+/**
+ * Process the selectors array and return the processed selectors
+ * @param {import('lightningcss').Selector} selector
+ * @param {(import('./spectrum-css-converter').SelectorConversion | import('./spectrum-css-converter').ComplexSelectorConversion)[]} components
+ * @returns {import('lightningcss').Selector} processed selectors
+ */
+function processSelector(selector, components) {
+    const matches = Array(selector.length);
+    let injected = 0;
+    selector.forEach((component, selectorIndex) => {
+        let index = selectorIndex + injected;
+        const match = [...(matches[index] || [])];
+        if (isDirAttr(component)) {
+            match.push({
+                hoist: true,
+                find: {
+                    type: 'attribute',
+                    name: 'dir',
+                },
+                replace: {
+                    ...component,
+                },
+            });
+        } else if (isFocusRing(component)) {
+            match.push({
+                hoist: true,
+                find: {
+                    type: 'class',
+                    name: 'focus-ring',
+                },
+                replace: {
+                    type: 'pseudo-class',
+                    kind: 'focus-visible',
+                },
+            });
         }
 
-        const outputPath = path.join(
-            ...(Array.isArray(conversion.outPackage)
-                ? conversion.outPackage
-                : ['packages', conversion.outPackage]),
-            'src',
-            `spectrum-${conversion.fileName}.css`
-        );
-        const processSelectorV2 = (selector) => {
-            const matches = Array(selector.length);
-            let injected = 0;
-            selector.forEach((component, selectorIndex) => {
-                let index = selectorIndex + injected;
-                const match = [...(matches[index] || [])];
-                if (isDirAttr(component)) {
-                    match.push({
-                        hoist: true,
-                        find: {
-                            type: 'attribute',
-                            name: 'dir',
-                        },
-                        replace: {
-                            ...component,
-                        },
-                    });
-                } else if (isFocusRing(component)) {
-                    match.push({
-                        hoist: true,
-                        find: {
-                            type: 'class',
-                            name: 'focus-ring',
-                        },
-                        replace: {
-                            type: 'pseudo-class',
-                            kind: 'focus-visible',
-                        },
-                    });
-                }
-                conversion.components.forEach((componentConversion) => {
-                    if (Array.isArray(componentConversion.find)) {
-                        const complexConversion =
-                            /** @type {import('./spectrum-css-converter').ComplexSelectorConversion} */ (
-                                componentConversion
-                            );
-                        let found = true;
-                        complexConversion.find.forEach((find, findIndex) => {
-                            found =
-                                found &&
-                                selector[index + findIndex - injected] &&
-                                compareSelectors(
-                                    find,
-                                    selector[index + findIndex - injected]
-                                );
-                        });
-                        if (found && complexConversion.exactSelector) {
-                            found =
-                                found &&
-                                complexConversion.find.length ===
-                                    selector.length &&
-                                complexConversion.find.every(
-                                    (component, exactIndex) =>
-                                        compareSelectors(
-                                            component,
-                                            selector[exactIndex]
-                                        )
-                                );
-                        }
-                        if (found) {
-                            if (complexConversion.expandSelector) {
-                                let lengthDelta = Array.isArray(
-                                    complexConversion.replace
-                                )
-                                    ? complexConversion.replace.length -
-                                      complexConversion.find.length
-                                    : 0;
-                                while (lengthDelta > 0) {
-                                    matches.splice(index, 0, []);
-                                    lengthDelta -= 1;
-                                }
-                            }
-                            if (complexConversion.collapseSelector) {
-                                let lengthDelta = Array.isArray(
-                                    complexConversion.replace
-                                )
-                                    ? complexConversion.find.length -
-                                      complexConversion.replace.length
-                                    : 0;
-                                matches.splice(index - injected, lengthDelta);
-                                injected -= lengthDelta;
-                            }
-                            complexConversion.replace.forEach(
-                                (replace, findIndex) => {
-                                    if (findIndex === 0) {
-                                        match.unshift({
-                                            ...(replace === 'take'
-                                                ? {
-                                                      replace: selector[index],
-                                                  }
-                                                : replace),
-                                        });
-                                    } else {
-                                        injected +=
-                                            complexConversion.expandSelector
-                                                ? 1
-                                                : 0;
-                                        matches[index + findIndex] = [
-                                            ...(matches[index + findIndex] ||
-                                                []),
-                                        ];
-                                        matches[index + findIndex].unshift({
-                                            ...(replace === 'take'
-                                                ? {
-                                                      replace:
-                                                          selector[
-                                                              index + findIndex
-                                                          ],
-                                                  }
-                                                : replace),
-                                        });
-                                    }
-                                }
-                            );
-                        }
-                    } else if (
-                        componentConversion.find &&
-                        compareSelectors(componentConversion.find, component)
-                    ) {
-                        const newMatch = {
-                            ...componentConversion,
-                        };
-                        if (!newMatch.replace) {
-                            newMatch.replace = component;
-                        }
-                        match.push(newMatch);
-                    }
+        components.forEach((componentConversion) => {
+            if (Array.isArray(componentConversion.find)) {
+                const complexConversion =
+                    /** @type {import('./spectrum-css-converter').ComplexSelectorConversion} */ (
+                        componentConversion
+                    );
+                let found = true;
+                complexConversion.find.forEach((find, findIndex) => {
+                    found =
+                        found &&
+                        selector[index + findIndex - injected] &&
+                        compareSelectors(
+                            find,
+                            selector[index + findIndex - injected]
+                        );
                 });
-                if (!match.length) {
-                    match.push({
-                        replace: { ...component },
-                    });
+                if (found && complexConversion.exactSelector) {
+                    found =
+                        found &&
+                        complexConversion.find.length === selector.length &&
+                        complexConversion.find.every((component, exactIndex) =>
+                            compareSelectors(component, selector[exactIndex])
+                        );
                 }
-                matches[index] = match;
-            });
-            return matches;
-        };
-
-        const buildSelectorsV2 = (metadata) => {
-            const selectors = [];
-            metadata.forEach((selector) => {
-                const newSelector = [];
-                /**
-                 * @type {import('./spectrum-css-converter').HostSelectorComponent}
-                 */
-                let host;
-                selector.forEach((componentProcesses) => {
-                    const component = componentProcesses[0];
-                    if (component.replace) {
-                        const replacenentIsHost = isHost(component.replace);
-                        if (
-                            component.hoist ||
-                            (typeof component.hoist === 'undefined' &&
-                                component.replace.type === 'attribute') ||
-                            replacenentIsHost
-                        ) {
-                            if (!host) {
-                                host = {
-                                    type: 'pseudo-class',
-                                    kind: 'host',
-                                };
-                            }
-                            if (replacenentIsHost) {
-                                if (component.replace.selectors?.length) {
-                                    host.selectors = host.selectors || [];
-                                    host.selectors.push(
-                                        ...component.replace.selectors
-                                    );
-                                }
-                            } else {
-                                host.selectors = host.selectors || [];
-                                host.selectors.push({
-                                    ...component.replace,
-                                });
-                                if (component.emphasize) {
-                                    host.selectors.push({
-                                        ...component.replace,
-                                    });
-                                }
-                            }
+                if (found) {
+                    if (complexConversion.expandSelector) {
+                        let lengthDelta = Array.isArray(
+                            complexConversion.replace
+                        )
+                            ? complexConversion.replace.length -
+                              complexConversion.find.length
+                            : 0;
+                        while (lengthDelta > 0) {
+                            matches.splice(index, 0, []);
+                            lengthDelta -= 1;
+                        }
+                    }
+                    if (complexConversion.collapseSelector) {
+                        let lengthDelta = Array.isArray(
+                            complexConversion.replace
+                        )
+                            ? complexConversion.find.length -
+                              complexConversion.replace.length
+                            : 0;
+                        matches.splice(index - injected, lengthDelta);
+                        injected -= lengthDelta;
+                    }
+                    complexConversion.replace.forEach((replace, findIndex) => {
+                        if (findIndex === 0) {
+                            match.unshift({
+                                ...(replace === 'take'
+                                    ? {
+                                          replace: selector[index],
+                                      }
+                                    : replace),
+                            });
                         } else {
-                            if (component.replace.type !== 'combinator') {
-                                newSelector.push({
-                                    ...component.replace,
-                                });
-                            } else {
-                                // Assume that the last combinator in is the "correct" combinator.
-                                // This is due to "left over" combinators when hoisting components.
-                                const hasCombinatorLast =
-                                    newSelector.at(-1)?.type === 'combinator';
-                                if (hasCombinatorLast) {
-                                    newSelector.pop();
-                                }
-                                newSelector.push({
-                                    ...component.replace,
-                                });
-                            }
+                            injected += complexConversion.expandSelector
+                                ? 1
+                                : 0;
+                            matches[index + findIndex] = [
+                                ...(matches[index + findIndex] || []),
+                            ];
+                            matches[index + findIndex].unshift({
+                                ...(replace === 'take'
+                                    ? {
+                                          replace: selector[index + findIndex],
+                                      }
+                                    : replace),
+                            });
                         }
-                    }
-                });
-
-                if (host) {
-                    if (
-                        newSelector.length &&
-                        isHoistedPseudoClass(newSelector[0])
-                    ) {
-                        host.selectors = host.selectors || [];
-                        host.selectors?.push(newSelector.shift());
-                    }
-                    const firstIsPseudo = isPseudo(newSelector[0]);
-                    const firstIsNotSlotted =
-                        newSelector[0]?.value !== 'slotted';
-                    const firstIsCombinator = isCombinator(newSelector[0]);
-                    if (!newSelector.length) {
-                        newSelector.push(host);
-                    } else if (
-                        !firstIsPseudo &&
-                        firstIsNotSlotted &&
-                        !firstIsCombinator
-                    ) {
-                        newSelector.unshift({
-                            type: 'combinator',
-                            value: 'descendant',
-                        });
-                        newSelector.unshift(host);
-                    } else if (host.selectors?.length || firstIsPseudo) {
-                        newSelector.unshift(host);
-                    }
+                    });
                 }
-                if (isCombinator(newSelector[0])) {
-                    newSelector.shift();
+            } else if (
+                componentConversion.find &&
+                compareSelectors(componentConversion.find, component)
+            ) {
+                const newMatch = {
+                    ...componentConversion,
+                };
+                if (!newMatch.replace) {
+                    newMatch.replace = component;
                 }
-                selectors.push(conditionSelector(newSelector));
+                match.push(newMatch);
+            }
+        });
+        if (!match.length) {
+            match.push({
+                replace: { ...component },
             });
+        }
+        matches[index] = match;
+    });
 
-            return selectors;
-        };
+    return matches;
+}
 
-        const processSelectors = (selectors) => {
-            const selectorMetadata = selectors.map(processSelectorV2);
-            return buildSelectorsV2(selectorMetadata);
-        };
-        if (conversion.systemOverrides !== false) {
-            // The default package file is index.css but index-theme.css contains the --system custom property mappings that facilitate theme switching.
-            const bridgepath = require
-                .resolve(conversion.inPackage)
-                .replace('index.css', 'index-theme.css');
+/**
+ * Process the selectors array and return the processed selectors
+ * @param {import('lightningcss').Selector[]} metadata
+ * @returns {(import('./spectrum-css-converter').SelectorConversion | import('./spectrum-css-converter').ComplexSelectorConversion)[]}
+ */
+function buildSelectors(metadata) {
+    const selectors = [];
+    metadata.forEach((selector) => {
+        const newSelector = [];
+        /**
+         * @type {import('./spectrum-css-converter').HostSelectorComponent|undefined}
+         */
+        let host;
 
-            const overridesPath = path.join(
-                ...(Array.isArray(conversion.outPackage)
-                    ? conversion.outPackage
-                    : ['packages', conversion.outPackage]),
-                'src',
-                `${conversion.fileName}-overrides.css`
-            );
+        for (const componentProcesses of selector) {
+            const component = componentProcesses[0];
+            if (!component.replace) {
+                continue;
+            }
 
-            if (fs.existsSync(bridgepath)) {
-                let bridgeCss = fs.readFileSync(bridgepath, 'utf8');
-                const { code } = transform({
-                    code: Buffer.from(bridgeCss),
-                    visitor: {
-                        // @ts-expect-error - this is a valid visitor
-                        Rule(rule) {
-                            if (
-                                !conversion.allowThemeRules &&
-                                isThemeOnlyRule(rule)
-                            ) {
-                                return nullRuleFromRule(rule);
-                            }
-                            if (
-                                rule.type === 'style' &&
-                                rule.value.selectors?.length
-                            ) {
-                                if (
-                                    conversion.hoistCustomPropertiesFrom &&
-                                    rule.value.selectors.length === 1 &&
-                                    rule.value.selectors[0].length === 1 &&
-                                    rule.value.selectors[0][0].type ===
-                                        'class' &&
-                                    rule.value.selectors[0][0].name ===
-                                        conversion.hoistCustomPropertiesFrom &&
-                                    rule.value.declarations.declarations.every(
-                                        (declaration) =>
-                                            declaration.property === 'custom'
-                                    )
-                                ) {
-                                    return {
-                                        ...rule,
-                                        value: {
-                                            ...rule.value,
-                                            selectors: [
-                                                [
-                                                    {
-                                                        type: 'pseudo-class',
-                                                        kind: 'host',
-                                                    },
-                                                ],
-                                            ],
-                                        },
-                                    };
-                                }
-                                const currentSelectors = [
-                                    ...rule.value.selectors,
-                                ];
-                                const nextSelectors = [];
-                                currentSelectors.forEach((selector) => {
-                                    let include = true;
-                                    conversion.excludeByWholeSelector?.forEach(
-                                        (exclusion) => {
-                                            include =
-                                                include &&
-                                                !(
-                                                    exclusion.length ===
-                                                        selector.length &&
-                                                    exclusion.every(
-                                                        (
-                                                            component,
-                                                            exclusionIndex
-                                                        ) =>
-                                                            compareSelectors(
-                                                                component,
-                                                                selector[
-                                                                    exclusionIndex
-                                                                ]
-                                                            )
-                                                    )
-                                                );
-                                        }
-                                    );
-                                    conversion.excludeByComponents?.forEach(
-                                        (exclusion) => {
-                                            if (exclusion.regex) {
-                                                include =
-                                                    include &&
-                                                    !selector.find(
-                                                        (component) => {
-                                                            return (
-                                                                component.type ===
-                                                                    'class' &&
-                                                                component.type ===
-                                                                    exclusion.type &&
-                                                                component.name.search(
-                                                                    /** @type {RegExp} */ (
-                                                                        exclusion.regex
-                                                                    )
-                                                                ) > -1
-                                                            );
-                                                        }
-                                                    );
-                                            } else {
-                                                include =
-                                                    include &&
-                                                    !selector.find(
-                                                        (component) =>
-                                                            compareSelectors(
-                                                                exclusion,
-                                                                component
-                                                            )
-                                                    );
-                                            }
-                                        }
-                                    );
-                                    conversion.requireComponentPresence?.forEach(
-                                        (required) => {
-                                            if (required.regex) {
-                                                include =
-                                                    include &&
-                                                    !!selector.find(
-                                                        (component) => {
-                                                            return (
-                                                                component.type ===
-                                                                    'class' &&
-                                                                component.type ===
-                                                                    required.type &&
-                                                                component.name.search(
-                                                                    /** @type {RegExp} */ (
-                                                                        required.regex
-                                                                    )
-                                                                ) > -1
-                                                            );
-                                                        }
-                                                    );
-                                            } else {
-                                                include =
-                                                    include &&
-                                                    !!selector.find(
-                                                        (component) =>
-                                                            compareSelectors(
-                                                                required,
-                                                                component
-                                                            )
-                                                    );
-                                            }
-                                        }
-                                    );
-                                    if (!include) {
-                                        conversion.includeByWholeSelector?.forEach(
-                                            (inclusion) => {
-                                                const sameLength =
-                                                    inclusion.length ===
-                                                    selector.length;
-                                                if (!sameLength) {
-                                                    return;
-                                                }
-                                                const selectorSameAsComponent =
-                                                    inclusion.every(
-                                                        (
-                                                            component,
-                                                            inclusionIndex
-                                                        ) =>
-                                                            compareSelectors(
-                                                                selector[
-                                                                    inclusionIndex
-                                                                ],
-                                                                component
-                                                            )
-                                                    );
-                                                include =
-                                                    include ||
-                                                    (sameLength &&
-                                                        selectorSameAsComponent);
-                                            }
-                                        );
-                                    }
-                                    if (include) {
-                                        nextSelectors.push(selector);
-                                    }
-                                });
-                                if (!nextSelectors.length) {
-                                    return nullRuleFromRule(rule);
-                                }
-                                const selectors =
-                                    processSelectors(nextSelectors);
-                                return {
-                                    ...rule,
-                                    value: {
-                                        ...rule.value,
-                                        selectors,
-                                    },
-                                };
-                            }
-                        },
-                    },
-                    filename: overridesPath,
-                });
-                // Note: We write the overrides file even if it's empty.
-                // This is to ensure that we don't end up with stale overrides
-                // files in the case where the bridge file previously contained
-                // overrides but no longer does.
-                writeMachineGeneratedSourceFile(overridesPath, code);
+            const replacementIsHost = isHost(component.replace);
+
+            if (
+                component.hoist ||
+                (typeof component.hoist === 'undefined' &&
+                    component.replace.type === 'attribute') ||
+                replacementIsHost
+            ) {
+                if (!host) {
+                    host = {
+                        type: 'pseudo-class',
+                        kind: 'host',
+                    };
+                }
+                if (replacementIsHost) {
+                    if (component.replace.selectors?.length) {
+                        host.selectors = host.selectors || [];
+                        host.selectors.push(...component.replace.selectors);
+                    }
+                } else {
+                    host.selectors = host.selectors || [];
+                    host.selectors.push({
+                        ...component.replace,
+                    });
+                    if (component.emphasize) {
+                        host.selectors.push({
+                            ...component.replace,
+                        });
+                    }
+                }
             } else {
-                // For the same reason, we write an empty file if the bridge file
-                // doesn't exist (in case it previously did).
-                writeMachineGeneratedSourceFile(overridesPath, '');
+                if (component.replace.type !== 'combinator') {
+                    newSelector.push({
+                        ...component.replace,
+                    });
+                } else {
+                    // Assume that the last combinator in is the "correct" combinator.
+                    // This is due to "left over" combinators when hoisting components.
+                    const hasCombinatorLast =
+                        newSelector.at(-1)?.type === 'combinator';
+                    if (hasCombinatorLast) {
+                        newSelector.pop();
+                    }
+                    newSelector.push({
+                        ...component.replace,
+                    });
+                }
             }
         }
 
-        const { code } = transform({
-            code: Buffer.from(sourceCSS),
-            visitor: {
-                // @ts-expect-error - this is a valid visitor
-                Rule(rule) {
-                    if (!conversion.allowThemeRules && isThemeOnlyRule(rule)) {
-                        return nullRuleFromRule(rule);
-                    }
-                    if (rule.type === 'style' && rule.value.selectors?.length) {
-                        if (
-                            conversion.hoistCustomPropertiesFrom &&
-                            rule.value.selectors.length === 1 &&
-                            rule.value.selectors[0].length === 1 &&
-                            rule.value.selectors[0][0].type === 'class' &&
-                            rule.value.selectors[0][0].name ===
-                                conversion.hoistCustomPropertiesFrom &&
-                            rule.value.declarations.declarations.every(
-                                (declaration) =>
-                                    declaration.property === 'custom'
-                            )
-                        ) {
-                            return {
-                                ...rule,
-                                value: {
-                                    ...rule.value,
-                                    selectors: [
-                                        [
-                                            {
-                                                type: 'pseudo-class',
-                                                kind: 'host',
-                                            },
-                                        ],
-                                    ],
-                                },
-                            };
-                        }
-                        const currentSelectors = [...rule.value.selectors];
-                        const nextSelectors = [];
-                        currentSelectors.forEach((selector) => {
-                            let include = true;
-                            conversion.excludeByWholeSelector?.forEach(
-                                (exclusion) => {
-                                    include =
-                                        include &&
-                                        !(
-                                            exclusion.length ===
-                                                selector.length &&
-                                            exclusion.every(
-                                                (component, exclusionIndex) =>
-                                                    compareSelectors(
-                                                        component,
-                                                        selector[exclusionIndex]
-                                                    )
-                                            )
-                                        );
-                                }
-                            );
-                            conversion.excludeByComponents?.forEach(
-                                (exclusion) => {
-                                    if (exclusion.regex) {
-                                        include =
-                                            include &&
-                                            !selector.find((component) => {
-                                                return (
-                                                    component.type ===
-                                                        'class' &&
-                                                    component.type ===
-                                                        exclusion.type &&
-                                                    component.name.search(
-                                                        /** @type {RegExp} */ (
-                                                            exclusion.regex
-                                                        )
-                                                    ) > -1
-                                                );
-                                            });
-                                    } else {
-                                        include =
-                                            include &&
-                                            !selector.find((component) =>
-                                                compareSelectors(
-                                                    exclusion,
-                                                    component
-                                                )
-                                            );
-                                    }
-                                }
-                            );
-                            conversion.requireComponentPresence?.forEach(
-                                (required) => {
-                                    if (required.regex) {
-                                        include =
-                                            include &&
-                                            !!selector.find((component) => {
-                                                return (
-                                                    component.type ===
-                                                        'class' &&
-                                                    component.type ===
-                                                        required.type &&
-                                                    component.name.search(
-                                                        /** @type {RegExp} */ (
-                                                            required.regex
-                                                        )
-                                                    ) > -1
-                                                );
-                                            });
-                                    } else {
-                                        include =
-                                            include &&
-                                            !!selector.find((component) =>
-                                                compareSelectors(
-                                                    required,
-                                                    component
-                                                )
-                                            );
-                                    }
-                                }
-                            );
-                            if (!include) {
-                                conversion.includeByWholeSelector?.forEach(
-                                    (inclusion) => {
-                                        const sameLength =
-                                            inclusion.length ===
-                                            selector.length;
-                                        if (!sameLength) {
-                                            return;
-                                        }
-                                        const selectorSameAsComponent =
-                                            inclusion.every(
-                                                (component, inclusionIndex) =>
-                                                    compareSelectors(
-                                                        selector[
-                                                            inclusionIndex
-                                                        ],
-                                                        component
-                                                    )
-                                            );
-                                        include =
-                                            include ||
-                                            (sameLength &&
-                                                selectorSameAsComponent);
-                                    }
-                                );
-                            }
-                            if (include) {
-                                nextSelectors.push(selector);
-                            }
-                        });
-                        if (!nextSelectors.length) {
-                            return nullRuleFromRule(rule);
-                        }
-                        const selectors = processSelectors(nextSelectors);
+        if (host) {
+            if (newSelector.length && isHoistedPseudoClass(newSelector[0])) {
+                host.selectors = host.selectors || [];
+                host.selectors?.push(newSelector.shift());
+            }
+            const firstIsPseudo = isPseudo(newSelector[0]);
+            const firstIsNotSlotted = newSelector[0]?.value !== 'slotted';
+            const firstIsCombinator = isCombinator(newSelector[0]);
+            if (!newSelector.length) {
+                newSelector.push(host);
+            } else if (
+                !firstIsPseudo &&
+                firstIsNotSlotted &&
+                !firstIsCombinator
+            ) {
+                newSelector.unshift({
+                    type: 'combinator',
+                    value: 'descendant',
+                });
+                newSelector.unshift(host);
+            } else if (host.selectors?.length || firstIsPseudo) {
+                newSelector.unshift(host);
+            }
+        }
+
+        if (isCombinator(newSelector[0])) {
+            newSelector.shift();
+        }
+
+        const cleanSelector = conditionSelector(newSelector);
+        selectors.push(cleanSelector);
+    });
+
+    return selectors;
+}
+
+async function transformAsset(filename, sourcePath, conversion) {
+    // Pull out the properties in the conversion object
+    const {
+        components = [],
+        // optional:
+        hoistCustomPropertiesFrom,
+        // An array of the selectors to ignore during the transformation
+        excludeByComponents = [],
+        includeByWholeSelector = [],
+        excludeByWholeSelector = [],
+        requireComponentPresence = [],
+    } = conversion;
+
+    // Add some default components to the list
+    components.push(
+        {
+            hoist: true,
+            find: {
+                type: 'attribute',
+                name: 'dir',
+            },
+        },
+        {
+            hoist: true,
+            find: {
+                type: 'class',
+                name: 'focus-ring',
+            },
+            replace: {
+                type: 'pseudo-class',
+                kind: 'focus-visible',
+            },
+        }
+    );
+
+    const { code } = transform({
+        filename,
+        code: await fsp
+            .readFile(sourcePath, 'utf8')
+            .then((content) => Buffer.from(content)),
+        visitor: {
+            // @ts-expect-error - this is a valid visitor
+            Rule(rule) {
+                if (rule.type === 'style' && rule.value.selectors?.length) {
+                    if (
+                        hoistCustomPropertiesFrom &&
+                        rule.value.selectors.length === 1 &&
+                        rule.value.selectors[0].length === 1 &&
+                        rule.value.selectors[0][0].type === 'class' &&
+                        rule.value.selectors[0][0].name ===
+                            hoistCustomPropertiesFrom &&
+                        rule.value.declarations.declarations.every(
+                            (declaration) => declaration.property === 'custom'
+                        )
+                    ) {
                         return {
                             ...rule,
                             value: {
                                 ...rule.value,
-                                selectors,
+                                selectors: [
+                                    [
+                                        {
+                                            type: 'pseudo-class',
+                                            kind: 'host',
+                                        },
+                                    ],
+                                ],
                             },
                         };
                     }
-                },
+
+                    /** @type {import('lightningcss').Selector[]} */
+                    const nextSelectors = [];
+                    [...rule.value.selectors].forEach((selector) => {
+                        let include = true;
+
+                        excludeByWholeSelector.forEach((exclusion) => {
+                            include =
+                                include &&
+                                !(
+                                    exclusion.length === selector.length &&
+                                    exclusion.every(
+                                        (component, exclusionIndex) =>
+                                            compareSelectors(
+                                                component,
+                                                selector[exclusionIndex]
+                                            )
+                                    )
+                                );
+                        });
+
+                        excludeByComponents.forEach((exclusion) => {
+                            if (exclusion.regex) {
+                                include =
+                                    include &&
+                                    !selector.find((component) => {
+                                        return (
+                                            component.type === 'class' &&
+                                            component.type === exclusion.type &&
+                                            component.name.search(
+                                                /** @type {RegExp} */ (
+                                                    exclusion.regex
+                                                )
+                                            ) > -1
+                                        );
+                                    });
+                            } else {
+                                include =
+                                    include &&
+                                    !selector.find((component) =>
+                                        compareSelectors(exclusion, component)
+                                    );
+                            }
+                        });
+
+                        requireComponentPresence.forEach((required) => {
+                            if (required.regex) {
+                                include =
+                                    include &&
+                                    !!selector.find((component) => {
+                                        return (
+                                            component.type === 'class' &&
+                                            component.type === required.type &&
+                                            component.name.search(
+                                                /** @type {RegExp} */ (
+                                                    required.regex
+                                                )
+                                            ) > -1
+                                        );
+                                    });
+                            } else {
+                                include =
+                                    include &&
+                                    !!selector.find((component) =>
+                                        compareSelectors(required, component)
+                                    );
+                            }
+                        });
+
+                        if (!include) {
+                            includeByWholeSelector.forEach((inclusion) => {
+                                const sameLength =
+                                    inclusion.length === selector.length;
+                                if (!sameLength) {
+                                    return;
+                                }
+                                const selectorSameAsComponent = inclusion.every(
+                                    (component, inclusionIndex) =>
+                                        compareSelectors(
+                                            selector[inclusionIndex],
+                                            component
+                                        )
+                                );
+                                include =
+                                    include ||
+                                    (sameLength && selectorSameAsComponent);
+                            });
+                        }
+
+                        if (include) {
+                            nextSelectors.push(selector);
+                        }
+                    });
+
+                    if (!nextSelectors.length) {
+                        return nullRuleFromRule(rule);
+                    }
+
+                    const selectors = buildSelectors(
+                        nextSelectors.map((s) => processSelector(s, components))
+                    );
+
+                    return {
+                        ...rule,
+                        value: {
+                            ...rule.value,
+                            selectors,
+                        },
+                    };
+                }
             },
-            filename: outputPath,
+        },
+    });
+
+    return Promise.resolve(code?.toString() ?? '');
+}
+
+/**
+ *
+ * @param {import('./spectrum-css-converter').Conversion} conversion
+ * @returns
+ */
+async function convertStyles(conversion) {
+    // Pull out the properties in the conversion object
+    const {
+        // This is the Spectrum CSS package to fetch the source CSS from
+        inPackage,
+        // The Spectrum Web Components package name(s) to write the converted CSS to
+        outPackage,
+        // The Spectrum Web Components component name to use in the file name
+        fileName,
+    } = conversion;
+
+    // The default package file is index.css but index-base.css contains the base styles compatible with theme switching.
+    const sourceDirectory = path.dirname(getPackagePath(inPackage));
+    const sourcePath = getBaseCSS(sourceDirectory);
+    const outputPath = path.join(
+        ...(Array.isArray(outPackage) ? outPackage : ['packages', outPackage]),
+        'src',
+        `spectrum-${fileName}.css`
+    );
+    const overridesPath = path.join(
+        ...(Array.isArray(outPackage) ? outPackage : ['packages', outPackage]),
+        'src',
+        `${fileName}-overrides.css`
+    );
+
+    // Note: We write the overrides file even if it's empty.
+    // This is to ensure that we don't end up with stale overrides
+    // files in the case where the bridge file previously contained
+    // overrides but no longer does.
+    let transformedBridge = '';
+    const promises = [];
+    if (fs.existsSync(path.join(sourceDirectory, 'index-theme.css'))) {
+        // The default package file is index.css but index-theme.css contains the --system custom properties mappings that facilitate theme switching.
+        const bridgepath = path.join(sourceDirectory, 'index-theme.css');
+
+        if (fs.existsSync(bridgepath)) {
+            transformedBridge = await transformAsset(
+                overridesPath,
+                bridgepath,
+                conversion
+            );
+        }
+    }
+
+    promises.push(
+        writeMachineGeneratedSourceFile(overridesPath, transformedBridge ?? ''),
+        transformAsset(outputPath, sourcePath, conversion).then((result) =>
+            writeMachineGeneratedSourceFile(outputPath, result)
+        )
+    );
+
+    return Promise.all(promises);
+}
+
+/**
+ *
+ * @param {string} componentPath
+ * @returns
+ */
+async function processComponent(componentPath) {
+    /**
+     * Read in the spectrum-config.js file; this file contains the configuration for the component
+     * @note This file will exist because the original search pattern in the main function is for this file
+     */
+    const { default: config } = await import(
+        path.join(componentPath, 'spectrum-config.js')
+    );
+
+    /**
+     * @type { import('./spectrum-css-converter').SpectrumCSSConverter}
+     */
+    const { conversions = [] } = config;
+
+    const componentFolder = printRelativePath(path.resolve(componentPath, '..'))
+        ?.split(path.sep)
+        ?.pop();
+
+    log.notice(
+        `- ${(componentFolder ?? '').cyan} ${'with'.gray} ${conversions.length} ${'custom conversion(s)'.gray}`
+    );
+
+    // Iterate over each conversion and process the provided settings
+    return Promise.all(conversions.map(convertStyles));
+}
+
+/**
+ * Write the machine generated source file with the license header
+ * @param {any} outputPath
+ * @param {any} code
+ * @returns {Promise<void>}
+ */
+async function writeMachineGeneratedSourceFile(outputPath, code) {
+    const prettierConfig = await prettier.resolveConfig(outputPath);
+    // Before writing, lint and prettier the code
+    const formatted = await stylelint
+        .lint({
+            code: `/* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */\n${code}`,
+            fix: true,
+        })
+        .then(({ code: result }) => {
+            return prettier.format(result ?? '', {
+                parser: 'css',
+                ...prettierConfig,
+            });
         });
 
-        writeMachineGeneratedSourceFile(outputPath, code);
-    }
+    return fsp.writeFile(outputPath, formatted, {
+        encoding: 'utf8',
+    });
 }
 
-function writeMachineGeneratedSourceFile(outputPath, code) {
-    fs.writeFileSync(
-        outputPath,
-        `/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
+/**
+ * The entry point for the script that processes Spectrum CSS variables
+ */
+async function main(components = []) {
+    log.notice('\nStarting component style conversions\n');
 
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
-
-/* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-${code}
-`.replace(/\/\*![\w|\W]*\*\//, '')
+    const configurations = await fg(
+        `${dirs.root}/{packages,tools}/*/src/spectrum-config.js`
     );
-}
 
-async function processComponents() {
-    const promises = [];
-    // eslint-disable-next-line no-console
-    console.log('Processing Spectrum Components'.green);
-    for (const configPath of await fg(
-        `${root}/{packages,tools}/*/src/spectrum-config.js`
-    )) {
-        promises.push(processComponent(path.join(configPath, '..')));
+    if (!configurations.length) {
+        log.notice('No Spectrum Components to process'.yellow);
+        process.exit(0);
     }
-    await Promise.all(promises);
-    // eslint-disable-next-line no-console
-    console.log('Done'.green);
+
+    let directories = configurations.map((configPath) =>
+        path.join(configPath, '..')
+    );
+
+    if (components.length > 0) {
+        let fullSet = directories;
+        directories = directories.filter((dir) => {
+            // Capture the 2nd-to-last directory in the path
+            const componentName = dir.split(path.sep).slice(-2, -1)[0];
+            // Check if the component name is in the list of components to process
+            // so we can filter the list of directories to process
+            return components.includes(componentName);
+        });
+
+        if (directories.length === 0) {
+            directories = fullSet;
+        }
+    }
+
+    return Promise.all(directories.map(processComponent))
+        .then(() => {
+            log.notice('');
+            log.success(
+                `Successfully processed ${directories.length} components\n`
+            );
+            process.exit(0);
+        })
+        .catch((error) => {
+            log.fail(error);
+            process.exit(1);
+        });
 }
 
-async function main() {
-    await processComponents();
-    process.exit(0);
-}
+const inputs = argv._?.map((input) => {
+    // Remove the @spectrum-web-components/ prefix from the input if it exists
+    input = input
+        ?.toString()
+        ?.trim()
+        ?.replaceAll('@spectrum-web-components/', '');
 
-main();
+    // Check if any of the inputs include comma-separated values and split them into separate inputs
+    if (input.includes(',')) {
+        const splitInputs = input.split(',');
+        return splitInputs;
+    }
+    return input;
+})?.flat();
+main(inputs);

--- a/tasks/spectrum-css-converter.d.ts
+++ b/tasks/spectrum-css-converter.d.ts
@@ -33,7 +33,7 @@ type ReplacementComponent = {
     replace: SelectorComponent;
 };
 
-type ComplexSelectorConversion = {
+export type ComplexSelectorConversion = {
     find: SelectorComponent[];
     /**
      * Remove Selector Components from the final selector so that it matches the
@@ -52,7 +52,7 @@ type ComplexSelectorConversion = {
     replace: ('take' | ReplacementComponent)[];
 };
 
-type SelectorConversion = ReplacementComponent & {
+export type SelectorConversion = ReplacementComponent & {
     find: SelectorComponent;
 };
 
@@ -63,11 +63,7 @@ type SelectorComponentWithRegex = SelectorComponent & {
     regex?: RegExp;
 };
 
-type Conversion = {
-    /**
-     * By defaults `.spectrum`, `.spectrum--dark`, etc. are excluded
-     */
-    allowThemeRules?: boolean;
+export type Conversion = {
     components: (SelectorConversion | ComplexSelectorConversion)[];
     /**
      * Selectors exactly matching the array of Selector Components present will be excluded
@@ -93,10 +89,6 @@ type Conversion = {
      * Exclude Selectors that do not feature the Selector Components included herein
      */
     requireComponentPresence?: SelectorComponentWithRegex[];
-    /**
-     * Create a system-overrides.css file that acts as a bridge between different themes
-     */
-    systemOverrides?: boolean;
 };
 
 export type SpectrumCSSConverter = {

--- a/tools/opacity-checkerboard/src/is-opacity-checkerboard-overrides.css
+++ b/tools/opacity-checkerboard/src/is-opacity-checkerboard-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/tools/opacity-checkerboard/src/opacity-checkerboard-overrides.css
+++ b/tools/opacity-checkerboard/src/opacity-checkerboard-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/tools/opacity-checkerboard/src/spectrum-is-opacity-checkerboard.css
+++ b/tools/opacity-checkerboard/src/spectrum-is-opacity-checkerboard.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {

--- a/tools/opacity-checkerboard/src/spectrum-opacity-checkerboard.css
+++ b/tools/opacity-checkerboard/src/spectrum-opacity-checkerboard.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .opacity-checkerboard {

--- a/tools/styles/express/spectrum-core-global.css
+++ b/tools/styles/express/spectrum-core-global.css
@@ -3243,3 +3243,75 @@
         --spectrum-global-color-static-yellow-200
     );
 }
+
+:root,
+:host {
+    --spectrum-colorloupe-express-visibility: block;
+    --spectrum-colorloupe-spectrum-visibility: none;
+    --spectrum-colorloupe-outer-border-color: transparent;
+    --spectrum-colorloupe-outer-border-size: 0;
+    --spectrum-colorloupe-outer-stroke-color: #00000026;
+    --spectrum-colorloupe-outer-stroke-width: 6px;
+    --spectrum-colorhandle-size: var(--spectrum-global-dimension-size-250);
+    --spectrum-colorhandle-background-offset: 0px;
+    --spectrum-colorhandle-inner-shadow-color: #00000026;
+    --spectrum-colorhandle-outer-shadow-color: #0000004d;
+    --spectrum-colorhandle-outer-shadow-blur: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-colorhandle-outer-shadow-spread: 0;
+    --spectrum-colorslider-height: var(--spectrum-global-dimension-size-200);
+    --spectrum-colorslider-vertical-width: var(--spectrum-colorslider-height);
+    --spectrum-colorslider-border-radius: var(
+        --spectrum-alias-border-radius-small
+    );
+    --spectrum-colorcontrol-checkerboard-light-color: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-colorcontrol-checkerboard-dark-color: var(
+        --spectrum-global-color-static-gray-200
+    );
+    --spectrum-slider-label-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-slider-m-handle-gap: 0px;
+    --spectrum-slider-m-handle-border-radius: 100%;
+    --spectrum-slider-m-track-border-radius: var(
+        --spectrum-alias-border-radius-xsmall
+    );
+    --spectrum-slider-m-track-inside-border-radius: 0px;
+    --spectrum-slider-m-track-height: var(--spectrum-global-dimension-size-50);
+    --spectrum-slider-m-track-color: var(--spectrum-global-color-gray-200);
+    --spectrum-slider-m-track-fill-color: var(--spectrum-global-color-gray-600);
+    --spectrum-slider-m-tick-mark-color: var(--spectrum-global-color-gray-200);
+    --spectrum-slider-m-track-color-disabled: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-slider-m-handle-background-color: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-slider-m-handle-border-color: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-slider-m-handle-border-color-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-slider-m-handle-border-color-disabled: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-slider-label-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-fieldlabel-s-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-fieldlabel-m-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-fieldlabel-l-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-fieldlabel-xl-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+}

--- a/tools/styles/express/spectrum-scale-large.css
+++ b/tools/styles/express/spectrum-scale-large.css
@@ -268,10 +268,6106 @@
     --spectrum-alias-avatar-size-100: 26px;
     --spectrum-alias-avatar-size-400: 36px;
     --spectrum-alias-avatar-size-600: 46px;
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-badge-s-fuchsia-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-fuchsia-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-fuchsia-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-m-fuchsia-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-indigo-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-informative-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-magenta-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-negative-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-neutral-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-positive-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-purple-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-seafoam-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-yellow-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-fuchsia-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-fuchsia-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-breadcrumb-s-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-multiline-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-breadcrumb-s-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-breadcrumb-s-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-multiline-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-breadcrumb-l-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-breadcrumb-l-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-checkbox-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-checkbox-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-checkbox-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-checkbox-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-colorloupe-colorhandle-gap: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorloupe-offset-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorslider-vertical-touch-hit-x: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorslider-touch-hit-y: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-min-size: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-colorwheel-touch-hit-outer: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-touch-hit-inner: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-min-width: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-colorwheel-min-height: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-combobox-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-cyclebutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-cyclebutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
     --spectrum-dialog-confirm-title-text-size: var(
         --spectrum-alias-heading-xs-text-size
     );
     --spectrum-dialog-confirm-description-text-size: var(
         --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-confirm-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-confirm-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-confirm-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-destructive-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-destructive-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-destructive-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-destructive-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-destructive-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-error-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-error-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-error-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-error-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-error-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-info-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-info-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-info-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-info-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-info-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-fullscreen-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-fullscreen-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-fullscreen-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreen-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-fullscreen-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-fullscreentakeover-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-fullscreentakeover-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-fullscreentakeover-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreentakeover-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-fullscreentakeover-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dragthumb-swatch-width: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-dragthumb-swatch-height: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-helptext-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-xl-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-infieldbutton-l-left-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-infieldbutton-l-right-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-infieldbutton-l-none-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-texticon-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textonly-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textthumbnail-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-meter-s-negative-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-negative-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-notice-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-notice-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-positive-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-positive-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-l-negative-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-negative-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-notice-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-notice-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-positive-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-positive-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-xl-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-pagination-page-button-line-height: 32px;
+    --spectrum-pagination-button-page-button-line-height: 32px;
+    --spectrum-pagination-explicit-page-button-line-height: 32px;
+    --spectrum-pagination-listing-page-button-line-height: 32px;
+    --spectrum-panel-s-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-s-header-height: var(--spectrum-global-dimension-size-550);
+    --spectrum-panel-s-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-s-spacious-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-header-height: var(--spectrum-global-dimension-size-550);
+    --spectrum-panel-l-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-spacious-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-picker-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-indeterminate-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-l-indeterminate-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-indeterminate-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-xl-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progresscircle-s-indeterminate-overbackground-border-size: 3px;
+    --spectrum-progresscircle-s-indeterminate-border-size: 3px;
+    --spectrum-progresscircle-s-overbackground-border-size: 3px;
+    --spectrum-progresscircle-s-border-size: 3px;
+    --spectrum-progresscircle-m-indeterminate-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-indeterminate-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-radio-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-radio-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-radio-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-radio-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-rating-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-rating-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-search-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-s-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-m-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-m-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-search-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-l-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-search-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-l-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-xl-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-xl-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-searchwithin-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-searchwithin-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-searchwithin-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-searchwithin-l-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-searchwithin-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-searchwithin-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-sidenav-multilevel-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-multilevel-main-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-main-item-touch-hit-bottom: 3px;
+    --spectrum-slider-s-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-statuslight-s-celery-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-chartreuse-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-fuchsia-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-indigo-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-info-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-magenta-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-neutral-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-negative-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-notice-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-positive-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-purple-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-seafoam-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-yellow-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-l-celery-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-celery-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-chartreuse-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-chartreuse-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-fuchsia-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-fuchsia-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-indigo-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-indigo-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-info-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-info-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-magenta-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-magenta-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-neutral-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-neutral-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-negative-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-negative-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-notice-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-notice-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-positive-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-positive-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-purple-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-purple-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-seafoam-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-seafoam-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-yellow-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-yellow-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-celery-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-chartreuse-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-fuchsia-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-indigo-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-info-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-magenta-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-neutral-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-negative-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-notice-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-positive-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-purple-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-seafoam-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-yellow-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-switch-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-switch-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-s-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-s-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-s-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-s-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-texticon-margin-left: -9px;
+    --spectrum-tabs-s-texticon-margin-right: -9px;
+    --spectrum-tabs-s-textonly-margin-left: -9px;
+    --spectrum-tabs-s-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-textonly-margin-right: -9px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-m-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-m-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-m-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-m-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-texticon-margin-left: -11px;
+    --spectrum-tabs-m-texticon-margin-right: -11px;
+    --spectrum-tabs-m-textonly-margin-left: -11px;
+    --spectrum-tabs-m-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-textonly-margin-right: -11px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-l-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-l-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-l-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-l-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-texticon-margin-left: -11px;
+    --spectrum-tabs-l-texticon-margin-right: -11px;
+    --spectrum-tabs-l-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-textonly-margin-left: -11px;
+    --spectrum-tabs-l-textonly-margin-right: -11px;
+    --spectrum-tabs-l-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-textonly-margin-right: -12px;
+    --spectrum-tag-m-removable-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-s-multiline-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tooltip-neutral-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tooltip-info-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tooltip-positive-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tooltip-negative-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-treeview-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-treeview-l-item-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-treeview-l-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
     );
 }

--- a/tools/styles/express/spectrum-scale-medium.css
+++ b/tools/styles/express/spectrum-scale-medium.css
@@ -272,10 +272,6158 @@
     --spectrum-alias-avatar-size-100: var(--spectrum-global-dimension-size-250);
     --spectrum-alias-avatar-size-400: var(--spectrum-global-dimension-size-350);
     --spectrum-alias-avatar-size-600: var(--spectrum-global-dimension-size-450);
+    --spectrum-dragthumb-swatch-width: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-dragthumb-swatch-height: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-badge-s-fuchsia-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-fuchsia-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-fuchsia-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-m-fuchsia-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-indigo-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-informative-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-magenta-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-negative-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-neutral-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-positive-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-purple-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-seafoam-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-yellow-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-l-fuchsia-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-fuchsia-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-fuchsia-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-breadcrumb-s-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-multiline-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-breadcrumb-s-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-breadcrumb-s-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-multiline-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-breadcrumb-l-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-breadcrumb-l-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-checkbox-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-checkbox-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-checkbox-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-checkbox-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorloupe-colorhandle-gap: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-colorloupe-offset-y: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-colorslider-vertical-touch-hit-x: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorslider-touch-hit-y: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-min-size: var(--spectrum-global-dimension-size-2400);
+    --spectrum-colorwheel-touch-hit-outer: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-touch-hit-inner: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-min-width: var(--spectrum-global-dimension-size-2400);
+    --spectrum-colorwheel-min-height: var(
+        --spectrum-global-dimension-size-2400
+    );
+    --spectrum-combobox-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-combobox-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-combobox-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-combobox-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-cyclebutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-cyclebutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
     --spectrum-dialog-confirm-title-text-size: var(
         --spectrum-alias-heading-s-text-size
     );
     --spectrum-dialog-confirm-description-text-size: var(
         --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-confirm-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-confirm-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-confirm-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-destructive-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-destructive-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-destructive-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-destructive-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-destructive-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-error-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-error-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-error-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-error-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-error-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-info-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-info-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-info-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-info-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-info-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreen-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-fullscreen-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-fullscreen-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-fullscreen-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-fullscreen-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreentakeover-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-fullscreentakeover-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-fullscreentakeover-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-fullscreentakeover-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-fullscreentakeover-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-helptext-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-xl-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-infieldbutton-l-left-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-infieldbutton-l-right-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-infieldbutton-l-none-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-listitem-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-listitem-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-texticon-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textonly-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textthumbnail-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-meter-s-negative-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-negative-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-notice-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-notice-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-positive-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-positive-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-m-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-l-negative-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-negative-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-notice-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-notice-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-positive-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-positive-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-xl-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-pagination-page-button-line-height: 26px;
+    --spectrum-pagination-button-page-button-line-height: 26px;
+    --spectrum-pagination-explicit-page-button-line-height: 26px;
+    --spectrum-pagination-listing-page-button-line-height: 26px;
+    --spectrum-panel-s-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-s-header-height: var(--spectrum-global-dimension-size-600);
+    --spectrum-panel-s-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-s-spacious-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-header-height: var(--spectrum-global-dimension-size-600);
+    --spectrum-panel-l-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-spacious-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-picker-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-indeterminate-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-m-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-l-indeterminate-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-indeterminate-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-xl-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progresscircle-s-indeterminate-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-indeterminate-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-m-indeterminate-overbackground-border-size: 3px;
+    --spectrum-progresscircle-m-indeterminate-border-size: 3px;
+    --spectrum-progresscircle-m-overbackground-border-size: 3px;
+    --spectrum-progresscircle-m-border-size: 3px;
+    --spectrum-radio-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-radio-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-radio-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-radio-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-radio-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-rating-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-rating-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-search-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-s-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-m-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-m-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-search-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-l-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-search-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-l-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-xl-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-xl-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-searchwithin-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-searchwithin-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-searchwithin-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-searchwithin-l-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-searchwithin-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-searchwithin-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-sidenav-multilevel-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-multilevel-main-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-main-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-slider-s-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-statuslight-s-celery-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-chartreuse-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-fuchsia-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-indigo-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-info-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-magenta-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-neutral-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-negative-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-notice-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-positive-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-purple-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-seafoam-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-yellow-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-l-celery-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-celery-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-chartreuse-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-chartreuse-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-fuchsia-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-fuchsia-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-indigo-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-indigo-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-info-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-info-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-magenta-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-magenta-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-neutral-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-neutral-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-negative-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-negative-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-notice-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-notice-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-positive-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-positive-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-purple-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-purple-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-seafoam-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-seafoam-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-yellow-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-yellow-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-xl-celery-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-chartreuse-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-fuchsia-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-indigo-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-info-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-magenta-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-neutral-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-negative-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-notice-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-positive-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-purple-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-seafoam-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-yellow-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-switch-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-switch-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-switch-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-switch-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-switch-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-quiet-texticon-margin-left: -7px;
+    --spectrum-tabs-s-quiet-texticon-margin-right: -7px;
+    --spectrum-tabs-s-quiet-textonly-margin-left: -7px;
+    --spectrum-tabs-s-quiet-textonly-margin-right: -7px;
+    --spectrum-tabs-s-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-texticon-margin-left: -7px;
+    --spectrum-tabs-s-texticon-margin-right: -7px;
+    --spectrum-tabs-s-textonly-margin-left: -7px;
+    --spectrum-tabs-s-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-textonly-margin-right: -7px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-quiet-texticon-margin-left: -8px;
+    --spectrum-tabs-m-quiet-texticon-margin-right: -8px;
+    --spectrum-tabs-m-quiet-textonly-margin-left: -8px;
+    --spectrum-tabs-m-quiet-textonly-margin-right: -8px;
+    --spectrum-tabs-m-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-texticon-margin-left: -8px;
+    --spectrum-tabs-m-texticon-margin-right: -8px;
+    --spectrum-tabs-m-textonly-margin-left: -8px;
+    --spectrum-tabs-m-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-textonly-margin-right: -8px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-l-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-l-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-l-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-l-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-texticon-margin-left: -9px;
+    --spectrum-tabs-l-texticon-margin-right: -9px;
+    --spectrum-tabs-l-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-textonly-margin-left: -9px;
+    --spectrum-tabs-l-textonly-margin-right: -9px;
+    --spectrum-tabs-l-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-textonly-margin-right: -10px;
+    --spectrum-tag-m-removable-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-tag-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-textarea-s-multiline-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-textfield-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tooltip-neutral-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tooltip-info-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tooltip-positive-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tooltip-negative-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-treeview-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-treeview-l-item-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-treeview-l-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
     );
 }

--- a/tools/styles/express/spectrum-theme-dark.css
+++ b/tools/styles/express/spectrum-theme-dark.css
@@ -297,4 +297,63 @@
     --spectrum-alias-appframe-separator-color: var(
         --spectrum-global-color-gray-50
     );
+    --spectrum-scrollbar-mac-s-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-scrollbar-mac-m-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-scrollbar-mac-l-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-radial-reaction-color: #ebebeb99;
+    --spectrum-well-background-color: #ebebeb05;
+    --spectrum-well-border-color: #ffffff0d;
 }

--- a/tools/styles/express/spectrum-theme-light.css
+++ b/tools/styles/express/spectrum-theme-light.css
@@ -297,4 +297,63 @@
     --spectrum-alias-appframe-separator-color: var(
         --spectrum-global-color-gray-300
     );
+    --spectrum-scrollbar-mac-s-track-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-scrollbar-mac-m-track-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-scrollbar-mac-l-track-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-tick-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-s-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-radial-reaction-color: #2229;
+    --spectrum-slider-m-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-tick-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-m-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-radial-reaction-color: #2229;
+    --spectrum-slider-l-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-tick-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-l-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-radial-reaction-color: #2229;
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-tick-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-xl-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-radial-reaction-color: #2229;
+    --spectrum-well-background-color: #22222205;
+    --spectrum-well-border-color: #0000000d;
 }

--- a/tools/styles/fonts.css
+++ b/tools/styles/fonts.css
@@ -41,6 +41,24 @@
     );
 }
 
+@media (forced-colors: active) {
+    .spectrum-Heading {
+        --highcontrast-heading-font-color: Text;
+    }
+
+    .spectrum-Body {
+        --highcontrast-body-font-color: Text;
+    }
+
+    .spectrum-Detail {
+        --highcontrast-detail-font-color: Text;
+    }
+
+    .spectrum-Code {
+        --highcontrast-code-font-color: Text;
+    }
+}
+
 .spectrum-Heading {
     font-family: var(
         --mod-heading-sans-serif-font-family,

--- a/tools/styles/spectrum-core-global.css
+++ b/tools/styles/spectrum-core-global.css
@@ -3239,3 +3239,40 @@
         --spectrum-global-color-static-yellow-200
     );
 }
+
+:root,
+:host {
+    --spectrum-colorloupe-express-visibility: none;
+    --spectrum-colorloupe-spectrum-visibility: block;
+    --spectrum-colorloupe-outer-border-color: transparent;
+    --spectrum-colorloupe-outer-border-size: 0;
+    --spectrum-colorloupe-outer-stroke-color: var(
+        --spectrum-global-color-static-transparent-black-200
+    );
+    --spectrum-colorloupe-outer-stroke-width: var(
+        --spectrum-alias-border-size-thick
+    );
+    --spectrum-colorhandle-background-offset: calc(
+        -1 * var(--spectrum-global-dimension-static-size-25)
+    );
+    --spectrum-colorhandle-inner-shadow-color: var(
+        --spectrum-colorhandle-outer-shadow-color
+    );
+    --spectrum-colorhandle-outer-shadow-color: #0000006b;
+    --spectrum-colorhandle-outer-shadow-blur: 0;
+    --spectrum-colorhandle-outer-shadow-spread: var(
+        --spectrum-alias-border-size-thin
+    );
+    --spectrum-colorcontrol-checkerboard-light-color: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-colorcontrol-checkerboard-dark-color: var(
+        --spectrum-global-color-static-gray-300
+    );
+    --spectrum-slider-m-track-inside-border-radius: var(
+        --spectrum-slider-m-track-border-radius
+    );
+    --spectrum-slider-label-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+}

--- a/tools/styles/spectrum-scale-large.css
+++ b/tools/styles/spectrum-scale-large.css
@@ -279,10 +279,6106 @@
     --spectrum-alias-tag-focusring-border-radius: var(
         --spectrum-global-dimension-static-size-75
     );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-badge-s-fuchsia-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-fuchsia-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-fuchsia-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-m-fuchsia-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-indigo-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-informative-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-magenta-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-negative-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-neutral-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-positive-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-purple-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-seafoam-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-yellow-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-fuchsia-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-fuchsia-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-breadcrumb-s-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-multiline-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-breadcrumb-s-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-breadcrumb-s-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-multiline-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-breadcrumb-l-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-breadcrumb-l-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-checkbox-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-checkbox-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-checkbox-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-checkbox-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-colorloupe-colorhandle-gap: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorloupe-offset-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorslider-vertical-touch-hit-x: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorslider-touch-hit-y: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-min-size: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-colorwheel-touch-hit-outer: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-touch-hit-inner: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-min-width: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-colorwheel-min-height: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-combobox-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-cyclebutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-cyclebutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
     --spectrum-dialog-confirm-title-text-size: var(
         --spectrum-alias-heading-xs-text-size
     );
     --spectrum-dialog-confirm-description-text-size: var(
         --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-confirm-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-confirm-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-confirm-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-destructive-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-destructive-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-destructive-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-destructive-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-destructive-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-error-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-error-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-error-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-error-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-error-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-info-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-info-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-info-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-info-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-info-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-fullscreen-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-fullscreen-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-fullscreen-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreen-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-fullscreen-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-fullscreentakeover-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-fullscreentakeover-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-fullscreentakeover-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreentakeover-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-fullscreentakeover-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dragthumb-swatch-width: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-dragthumb-swatch-height: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-helptext-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-xl-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-infieldbutton-l-left-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-infieldbutton-l-right-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-infieldbutton-l-none-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-texticon-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textonly-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textthumbnail-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-meter-s-negative-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-negative-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-notice-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-notice-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-positive-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-positive-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-l-negative-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-negative-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-notice-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-notice-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-positive-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-positive-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-xl-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-pagination-page-button-line-height: 32px;
+    --spectrum-pagination-button-page-button-line-height: 32px;
+    --spectrum-pagination-explicit-page-button-line-height: 32px;
+    --spectrum-pagination-listing-page-button-line-height: 32px;
+    --spectrum-panel-s-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-s-header-height: var(--spectrum-global-dimension-size-550);
+    --spectrum-panel-s-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-s-spacious-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-header-height: var(--spectrum-global-dimension-size-550);
+    --spectrum-panel-l-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-spacious-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-picker-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-indeterminate-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-l-indeterminate-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-indeterminate-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-xl-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progresscircle-s-indeterminate-overbackground-border-size: 3px;
+    --spectrum-progresscircle-s-indeterminate-border-size: 3px;
+    --spectrum-progresscircle-s-overbackground-border-size: 3px;
+    --spectrum-progresscircle-s-border-size: 3px;
+    --spectrum-progresscircle-m-indeterminate-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-indeterminate-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-radio-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-radio-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-radio-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-radio-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-rating-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-rating-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-search-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-s-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-m-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-m-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-search-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-l-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-search-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-l-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-xl-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-xl-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-searchwithin-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-searchwithin-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-searchwithin-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-searchwithin-l-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-searchwithin-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-searchwithin-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-sidenav-multilevel-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-multilevel-main-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-main-item-touch-hit-bottom: 3px;
+    --spectrum-slider-s-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-statuslight-s-celery-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-chartreuse-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-fuchsia-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-indigo-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-info-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-magenta-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-neutral-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-negative-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-notice-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-positive-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-purple-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-seafoam-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-yellow-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-l-celery-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-celery-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-chartreuse-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-chartreuse-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-fuchsia-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-fuchsia-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-indigo-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-indigo-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-info-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-info-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-magenta-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-magenta-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-neutral-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-neutral-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-negative-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-negative-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-notice-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-notice-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-positive-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-positive-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-purple-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-purple-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-seafoam-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-seafoam-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-yellow-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-yellow-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-celery-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-chartreuse-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-fuchsia-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-indigo-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-info-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-magenta-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-neutral-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-negative-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-notice-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-positive-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-purple-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-seafoam-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-yellow-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-switch-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-switch-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-s-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-s-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-s-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-s-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-texticon-margin-left: -9px;
+    --spectrum-tabs-s-texticon-margin-right: -9px;
+    --spectrum-tabs-s-textonly-margin-left: -9px;
+    --spectrum-tabs-s-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-textonly-margin-right: -9px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-m-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-m-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-m-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-m-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-texticon-margin-left: -11px;
+    --spectrum-tabs-m-texticon-margin-right: -11px;
+    --spectrum-tabs-m-textonly-margin-left: -11px;
+    --spectrum-tabs-m-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-textonly-margin-right: -11px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-l-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-l-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-l-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-l-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-texticon-margin-left: -11px;
+    --spectrum-tabs-l-texticon-margin-right: -11px;
+    --spectrum-tabs-l-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-textonly-margin-left: -11px;
+    --spectrum-tabs-l-textonly-margin-right: -11px;
+    --spectrum-tabs-l-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-textonly-margin-right: -12px;
+    --spectrum-tag-m-removable-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-s-multiline-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tooltip-neutral-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tooltip-info-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tooltip-positive-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tooltip-negative-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-treeview-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-treeview-l-item-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-treeview-l-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
     );
 }

--- a/tools/styles/spectrum-scale-medium.css
+++ b/tools/styles/spectrum-scale-medium.css
@@ -277,10 +277,6158 @@
     --spectrum-alias-tag-focusring-border-radius: var(
         --spectrum-global-dimension-static-size-65
     );
+    --spectrum-dragthumb-swatch-width: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-dragthumb-swatch-height: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-badge-s-fuchsia-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-fuchsia-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-fuchsia-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-m-fuchsia-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-indigo-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-informative-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-magenta-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-negative-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-neutral-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-positive-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-purple-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-seafoam-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-yellow-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-l-fuchsia-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-fuchsia-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-fuchsia-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-breadcrumb-s-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-multiline-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-breadcrumb-s-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-breadcrumb-s-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-multiline-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-breadcrumb-l-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-breadcrumb-l-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-checkbox-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-checkbox-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-checkbox-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-checkbox-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorloupe-colorhandle-gap: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-colorloupe-offset-y: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-colorslider-vertical-touch-hit-x: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorslider-touch-hit-y: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-min-size: var(--spectrum-global-dimension-size-2400);
+    --spectrum-colorwheel-touch-hit-outer: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-touch-hit-inner: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-min-width: var(--spectrum-global-dimension-size-2400);
+    --spectrum-colorwheel-min-height: var(
+        --spectrum-global-dimension-size-2400
+    );
+    --spectrum-combobox-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-combobox-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-combobox-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-combobox-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-cyclebutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-cyclebutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
     --spectrum-dialog-confirm-title-text-size: var(
         --spectrum-alias-heading-s-text-size
     );
     --spectrum-dialog-confirm-description-text-size: var(
         --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-confirm-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-confirm-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-confirm-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-destructive-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-destructive-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-destructive-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-destructive-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-destructive-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-error-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-error-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-error-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-error-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-error-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-info-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-info-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-info-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-info-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-info-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreen-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-fullscreen-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-fullscreen-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-fullscreen-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-fullscreen-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreentakeover-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-fullscreentakeover-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-fullscreentakeover-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-fullscreentakeover-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-fullscreentakeover-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-helptext-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-xl-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-infieldbutton-l-left-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-infieldbutton-l-right-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-infieldbutton-l-none-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-listitem-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-listitem-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-texticon-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textonly-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textthumbnail-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-meter-s-negative-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-negative-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-notice-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-notice-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-positive-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-positive-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-m-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-l-negative-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-negative-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-notice-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-notice-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-positive-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-positive-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-xl-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-pagination-page-button-line-height: 26px;
+    --spectrum-pagination-button-page-button-line-height: 26px;
+    --spectrum-pagination-explicit-page-button-line-height: 26px;
+    --spectrum-pagination-listing-page-button-line-height: 26px;
+    --spectrum-panel-s-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-s-header-height: var(--spectrum-global-dimension-size-600);
+    --spectrum-panel-s-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-s-spacious-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-header-height: var(--spectrum-global-dimension-size-600);
+    --spectrum-panel-l-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-spacious-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-picker-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-indeterminate-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-m-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-l-indeterminate-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-indeterminate-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-xl-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progresscircle-s-indeterminate-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-indeterminate-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-m-indeterminate-overbackground-border-size: 3px;
+    --spectrum-progresscircle-m-indeterminate-border-size: 3px;
+    --spectrum-progresscircle-m-overbackground-border-size: 3px;
+    --spectrum-progresscircle-m-border-size: 3px;
+    --spectrum-radio-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-radio-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-radio-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-radio-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-radio-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-rating-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-rating-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-search-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-s-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-m-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-m-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-search-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-l-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-search-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-l-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-xl-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-xl-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-searchwithin-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-searchwithin-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-searchwithin-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-searchwithin-l-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-searchwithin-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-searchwithin-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-sidenav-multilevel-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-multilevel-main-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-main-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-slider-s-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-statuslight-s-celery-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-chartreuse-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-fuchsia-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-indigo-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-info-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-magenta-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-neutral-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-negative-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-notice-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-positive-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-purple-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-seafoam-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-yellow-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-l-celery-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-celery-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-chartreuse-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-chartreuse-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-fuchsia-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-fuchsia-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-indigo-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-indigo-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-info-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-info-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-magenta-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-magenta-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-neutral-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-neutral-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-negative-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-negative-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-notice-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-notice-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-positive-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-positive-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-purple-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-purple-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-seafoam-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-seafoam-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-yellow-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-yellow-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-xl-celery-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-chartreuse-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-fuchsia-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-indigo-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-info-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-magenta-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-neutral-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-negative-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-notice-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-positive-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-purple-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-seafoam-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-yellow-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-switch-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-switch-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-switch-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-switch-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-switch-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-quiet-texticon-margin-left: -7px;
+    --spectrum-tabs-s-quiet-texticon-margin-right: -7px;
+    --spectrum-tabs-s-quiet-textonly-margin-left: -7px;
+    --spectrum-tabs-s-quiet-textonly-margin-right: -7px;
+    --spectrum-tabs-s-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-texticon-margin-left: -7px;
+    --spectrum-tabs-s-texticon-margin-right: -7px;
+    --spectrum-tabs-s-textonly-margin-left: -7px;
+    --spectrum-tabs-s-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-textonly-margin-right: -7px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-quiet-texticon-margin-left: -8px;
+    --spectrum-tabs-m-quiet-texticon-margin-right: -8px;
+    --spectrum-tabs-m-quiet-textonly-margin-left: -8px;
+    --spectrum-tabs-m-quiet-textonly-margin-right: -8px;
+    --spectrum-tabs-m-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-texticon-margin-left: -8px;
+    --spectrum-tabs-m-texticon-margin-right: -8px;
+    --spectrum-tabs-m-textonly-margin-left: -8px;
+    --spectrum-tabs-m-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-textonly-margin-right: -8px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-l-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-l-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-l-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-l-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-texticon-margin-left: -9px;
+    --spectrum-tabs-l-texticon-margin-right: -9px;
+    --spectrum-tabs-l-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-textonly-margin-left: -9px;
+    --spectrum-tabs-l-textonly-margin-right: -9px;
+    --spectrum-tabs-l-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-textonly-margin-right: -10px;
+    --spectrum-tag-m-removable-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-tag-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-textarea-s-multiline-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-textfield-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tooltip-neutral-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tooltip-info-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tooltip-positive-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tooltip-negative-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-treeview-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-treeview-l-item-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-treeview-l-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
     );
 }

--- a/tools/styles/spectrum-theme-dark.css
+++ b/tools/styles/spectrum-theme-dark.css
@@ -290,4 +290,63 @@
     --spectrum-alias-appframe-separator-color: var(
         --spectrum-global-color-gray-50
     );
+    --spectrum-scrollbar-mac-s-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-scrollbar-mac-m-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-scrollbar-mac-l-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-radial-reaction-color: #ebebeb99;
+    --spectrum-well-background-color: #ebebeb05;
+    --spectrum-well-border-color: #ffffff0d;
 }

--- a/tools/styles/spectrum-theme-darkest.css
+++ b/tools/styles/spectrum-theme-darkest.css
@@ -290,4 +290,62 @@
     --spectrum-alias-appframe-separator-color: var(
         --spectrum-global-color-gray-50
     );
+    --spectrum-scrollbar-mac-s-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-scrollbar-mac-m-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-scrollbar-mac-l-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-radial-reaction-color: #ebebeb99;
+    --spectrum-well-background-color: #ebebeb05;
 }

--- a/tools/styles/spectrum-theme-light.css
+++ b/tools/styles/spectrum-theme-light.css
@@ -290,4 +290,62 @@
     --spectrum-alias-appframe-separator-color: var(
         --spectrum-global-color-gray-300
     );
+    --spectrum-scrollbar-mac-s-track-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-scrollbar-mac-m-track-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-scrollbar-mac-l-track-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-tick-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-s-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-radial-reaction-color: #2229;
+    --spectrum-slider-m-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-tick-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-m-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-radial-reaction-color: #2229;
+    --spectrum-slider-l-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-tick-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-l-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-radial-reaction-color: #2229;
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-tick-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-xl-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-radial-reaction-color: #2229;
+    --spectrum-well-background-color: #22222205;
 }

--- a/tools/styles/spectrum-two/spectrum-core-global.css
+++ b/tools/styles/spectrum-two/spectrum-core-global.css
@@ -3239,3 +3239,40 @@
         --spectrum-global-color-static-yellow-200
     );
 }
+
+:root,
+:host {
+    --spectrum-colorloupe-express-visibility: none;
+    --spectrum-colorloupe-spectrum-visibility: block;
+    --spectrum-colorloupe-outer-border-color: transparent;
+    --spectrum-colorloupe-outer-border-size: 0;
+    --spectrum-colorloupe-outer-stroke-color: var(
+        --spectrum-global-color-static-transparent-black-200
+    );
+    --spectrum-colorloupe-outer-stroke-width: var(
+        --spectrum-alias-border-size-thick
+    );
+    --spectrum-colorhandle-background-offset: calc(
+        -1 * var(--spectrum-global-dimension-static-size-25)
+    );
+    --spectrum-colorhandle-inner-shadow-color: var(
+        --spectrum-colorhandle-outer-shadow-color
+    );
+    --spectrum-colorhandle-outer-shadow-color: #0000006b;
+    --spectrum-colorhandle-outer-shadow-blur: 0;
+    --spectrum-colorhandle-outer-shadow-spread: var(
+        --spectrum-alias-border-size-thin
+    );
+    --spectrum-colorcontrol-checkerboard-light-color: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-colorcontrol-checkerboard-dark-color: var(
+        --spectrum-global-color-static-gray-300
+    );
+    --spectrum-slider-m-track-inside-border-radius: var(
+        --spectrum-slider-m-track-border-radius
+    );
+    --spectrum-slider-label-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+}

--- a/tools/styles/spectrum-two/spectrum-scale-large.css
+++ b/tools/styles/spectrum-two/spectrum-scale-large.css
@@ -279,10 +279,6106 @@
     --spectrum-alias-tag-focusring-border-radius: var(
         --spectrum-global-dimension-static-size-75
     );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-badge-s-fuchsia-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-fuchsia-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-fuchsia-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-m-fuchsia-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-indigo-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-informative-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-magenta-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-negative-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-neutral-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-positive-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-purple-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-seafoam-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-yellow-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-fuchsia-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-fuchsia-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-breadcrumb-s-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-multiline-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-breadcrumb-s-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-breadcrumb-s-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-multiline-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-breadcrumb-l-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-breadcrumb-l-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-texticon-padding-left: 17px;
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-accent-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-padding-left: 27px;
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-checkbox-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-checkbox-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-checkbox-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-checkbox-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-colorloupe-colorhandle-gap: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorloupe-offset-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorslider-vertical-touch-hit-x: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorslider-touch-hit-y: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-min-size: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-colorwheel-touch-hit-outer: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-touch-hit-inner: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-min-width: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-colorwheel-min-height: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-combobox-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-combobox-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-cyclebutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-cyclebutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
     --spectrum-dialog-confirm-title-text-size: var(
         --spectrum-alias-heading-xs-text-size
     );
     --spectrum-dialog-confirm-description-text-size: var(
         --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-confirm-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-confirm-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-confirm-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-destructive-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-destructive-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-destructive-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-destructive-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-destructive-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-error-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-error-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-error-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-error-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-error-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-info-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-info-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-info-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-info-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-info-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-fullscreen-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-fullscreen-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-fullscreen-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreen-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-fullscreen-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-fullscreentakeover-title-text-size: var(
+        --spectrum-alias-heading-xs-text-size
+    );
+    --spectrum-dialog-fullscreentakeover-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-fullscreentakeover-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreentakeover-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-fullscreentakeover-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dragthumb-swatch-width: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-dragthumb-swatch-height: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-helptext-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-xl-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-infieldbutton-l-left-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-infieldbutton-l-right-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-infieldbutton-l-none-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-texticon-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textonly-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textthumbnail-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-meter-s-negative-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-negative-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-notice-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-notice-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-positive-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-positive-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-l-negative-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-negative-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-notice-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-notice-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-positive-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-positive-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-xl-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-pagination-page-button-line-height: 32px;
+    --spectrum-pagination-button-page-button-line-height: 32px;
+    --spectrum-pagination-explicit-page-button-line-height: 32px;
+    --spectrum-pagination-listing-page-button-line-height: 32px;
+    --spectrum-panel-s-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-s-header-height: var(--spectrum-global-dimension-size-550);
+    --spectrum-panel-s-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-s-spacious-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-header-height: var(--spectrum-global-dimension-size-550);
+    --spectrum-panel-l-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-spacious-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-picker-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-indeterminate-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-l-indeterminate-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-indeterminate-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-xl-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progresscircle-s-indeterminate-overbackground-border-size: 3px;
+    --spectrum-progresscircle-s-indeterminate-border-size: 3px;
+    --spectrum-progresscircle-s-overbackground-border-size: 3px;
+    --spectrum-progresscircle-s-border-size: 3px;
+    --spectrum-progresscircle-m-indeterminate-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-indeterminate-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-radio-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-radio-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-radio-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-radio-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-rating-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-rating-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-search-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-s-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-m-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-m-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-search-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-l-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-search-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-l-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-xl-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-xl-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-searchwithin-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-searchwithin-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-searchwithin-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-searchwithin-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-searchwithin-l-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-searchwithin-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-searchwithin-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-sidenav-multilevel-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-multilevel-main-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-main-item-touch-hit-bottom: 3px;
+    --spectrum-slider-s-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-statuslight-s-celery-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-chartreuse-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-fuchsia-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-indigo-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-info-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-magenta-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-neutral-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-negative-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-notice-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-positive-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-purple-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-seafoam-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-s-yellow-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-statuslight-l-celery-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-celery-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-chartreuse-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-chartreuse-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-fuchsia-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-fuchsia-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-indigo-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-indigo-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-info-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-info-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-magenta-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-magenta-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-neutral-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-neutral-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-negative-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-negative-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-notice-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-notice-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-positive-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-positive-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-purple-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-purple-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-seafoam-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-seafoam-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-yellow-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-yellow-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-celery-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-chartreuse-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-fuchsia-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-indigo-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-info-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-magenta-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-neutral-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-negative-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-notice-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-positive-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-purple-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-seafoam-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-yellow-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-switch-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-switch-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-s-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-s-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-s-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-s-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-texticon-margin-left: -9px;
+    --spectrum-tabs-s-texticon-margin-right: -9px;
+    --spectrum-tabs-s-textonly-margin-left: -9px;
+    --spectrum-tabs-s-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-s-compact-texticon-margin-left: -9px;
+    --spectrum-tabs-s-compact-texticon-margin-right: -9px;
+    --spectrum-tabs-s-compact-textonly-margin-left: -9px;
+    --spectrum-tabs-s-compact-textonly-margin-right: -9px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-m-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-m-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-m-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-m-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-texticon-margin-left: -11px;
+    --spectrum-tabs-m-texticon-margin-right: -11px;
+    --spectrum-tabs-m-textonly-margin-left: -11px;
+    --spectrum-tabs-m-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-m-compact-texticon-margin-left: -11px;
+    --spectrum-tabs-m-compact-texticon-margin-right: -11px;
+    --spectrum-tabs-m-compact-textonly-margin-left: -11px;
+    --spectrum-tabs-m-compact-textonly-margin-right: -11px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-l-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-l-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-l-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-l-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-texticon-margin-left: -11px;
+    --spectrum-tabs-l-texticon-margin-right: -11px;
+    --spectrum-tabs-l-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-textonly-margin-left: -11px;
+    --spectrum-tabs-l-textonly-margin-right: -11px;
+    --spectrum-tabs-l-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-texticon-margin-left: -11px;
+    --spectrum-tabs-l-compact-texticon-margin-right: -11px;
+    --spectrum-tabs-l-compact-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-textonly-margin-left: -11px;
+    --spectrum-tabs-l-compact-textonly-margin-right: -11px;
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-right: -12px;
+    --spectrum-tabs-xl-compact-texticon-margin-left: -12px;
+    --spectrum-tabs-xl-compact-texticon-margin-right: -12px;
+    --spectrum-tabs-xl-compact-textonly-margin-left: -12px;
+    --spectrum-tabs-xl-compact-textonly-margin-right: -12px;
+    --spectrum-tag-m-removable-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-s-multiline-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tooltip-neutral-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tooltip-info-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tooltip-positive-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tooltip-negative-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-treeview-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-treeview-l-item-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-treeview-l-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
     );
 }

--- a/tools/styles/spectrum-two/spectrum-scale-medium.css
+++ b/tools/styles/spectrum-two/spectrum-scale-medium.css
@@ -277,10 +277,6158 @@
     --spectrum-alias-tag-focusring-border-radius: var(
         --spectrum-global-dimension-static-size-65
     );
+    --spectrum-dragthumb-swatch-width: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-dragthumb-swatch-height: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-badge-s-fuchsia-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-fuchsia-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-fuchsia-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-m-fuchsia-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-indigo-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-informative-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-magenta-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-negative-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-neutral-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-positive-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-purple-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-seafoam-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-yellow-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-l-fuchsia-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-fuchsia-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-fuchsia-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-breadcrumb-s-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-multiline-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-breadcrumb-s-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-breadcrumb-s-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-multiline-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-breadcrumb-l-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-breadcrumb-l-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-white-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-white-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-white-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-white-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-fill-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-fill-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-black-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-black-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-accent-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-outline-black-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-texticon-padding-left: 21px;
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-accent-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-outline-black-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-checkbox-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-checkbox-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-checkbox-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-checkbox-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorloupe-colorhandle-gap: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-colorloupe-offset-y: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-colorslider-vertical-touch-hit-x: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorslider-touch-hit-y: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-min-size: var(--spectrum-global-dimension-size-2400);
+    --spectrum-colorwheel-touch-hit-outer: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-touch-hit-inner: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-min-width: var(--spectrum-global-dimension-size-2400);
+    --spectrum-colorwheel-min-height: var(
+        --spectrum-global-dimension-size-2400
+    );
+    --spectrum-combobox-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-combobox-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-combobox-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-combobox-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-combobox-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-cyclebutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-cyclebutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
     --spectrum-dialog-confirm-title-text-size: var(
         --spectrum-alias-heading-s-text-size
     );
     --spectrum-dialog-confirm-description-text-size: var(
         --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-confirm-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-confirm-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-confirm-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-destructive-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-destructive-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-destructive-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-destructive-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-destructive-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-error-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-error-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-error-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-error-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-error-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-info-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-info-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-info-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-info-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-info-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreen-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-fullscreen-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-fullscreen-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-fullscreen-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-fullscreen-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreentakeover-title-text-size: var(
+        --spectrum-alias-heading-s-text-size
+    );
+    --spectrum-dialog-fullscreentakeover-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-fullscreentakeover-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-fullscreentakeover-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-fullscreentakeover-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-helptext-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-xl-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-infieldbutton-l-left-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-infieldbutton-l-right-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-infieldbutton-l-none-fill-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-listitem-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-listitem-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-texticon-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textonly-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textthumbnail-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-meter-s-negative-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-negative-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-notice-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-notice-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-positive-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-positive-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-m-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-l-negative-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-negative-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-notice-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-notice-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-positive-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-positive-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-xl-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-pagination-page-button-line-height: 26px;
+    --spectrum-pagination-button-page-button-line-height: 26px;
+    --spectrum-pagination-explicit-page-button-line-height: 26px;
+    --spectrum-pagination-listing-page-button-line-height: 26px;
+    --spectrum-panel-s-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-s-header-height: var(--spectrum-global-dimension-size-600);
+    --spectrum-panel-s-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-s-spacious-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-header-height: var(--spectrum-global-dimension-size-600);
+    --spectrum-panel-l-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-spacious-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-picker-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textthumbnail-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-textthumbnail-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-indeterminate-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-m-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-l-indeterminate-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-indeterminate-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-xl-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progresscircle-s-indeterminate-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-indeterminate-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-m-indeterminate-overbackground-border-size: 3px;
+    --spectrum-progresscircle-m-indeterminate-border-size: 3px;
+    --spectrum-progresscircle-m-overbackground-border-size: 3px;
+    --spectrum-progresscircle-m-border-size: 3px;
+    --spectrum-radio-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-radio-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-radio-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-radio-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-radio-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-rating-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-rating-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-search-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-s-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-m-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-m-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-search-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-l-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-search-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-l-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-xl-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-xl-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-searchwithin-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-searchwithin-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-searchwithin-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-searchwithin-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-searchwithin-l-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-searchwithin-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-searchwithin-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-sidenav-multilevel-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-multilevel-main-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-main-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-slider-s-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-statuslight-s-celery-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-chartreuse-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-fuchsia-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-indigo-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-info-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-magenta-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-neutral-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-negative-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-notice-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-positive-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-purple-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-seafoam-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-s-yellow-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-statuslight-l-celery-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-celery-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-chartreuse-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-chartreuse-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-fuchsia-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-fuchsia-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-indigo-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-indigo-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-info-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-info-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-magenta-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-magenta-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-neutral-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-neutral-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-negative-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-negative-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-notice-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-notice-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-positive-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-positive-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-purple-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-purple-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-seafoam-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-seafoam-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-l-yellow-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-yellow-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-statuslight-xl-celery-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-chartreuse-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-fuchsia-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-indigo-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-info-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-magenta-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-neutral-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-negative-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-notice-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-positive-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-purple-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-seafoam-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-yellow-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-switch-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-switch-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-switch-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-switch-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-switch-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-quiet-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-quiet-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-quiet-texticon-margin-left: -7px;
+    --spectrum-tabs-s-quiet-texticon-margin-right: -7px;
+    --spectrum-tabs-s-quiet-textonly-margin-left: -7px;
+    --spectrum-tabs-s-quiet-textonly-margin-right: -7px;
+    --spectrum-tabs-s-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-texticon-margin-left: -7px;
+    --spectrum-tabs-s-texticon-margin-right: -7px;
+    --spectrum-tabs-s-textonly-margin-left: -7px;
+    --spectrum-tabs-s-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-emphasized-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-emphasized-textonly-margin-right: -7px;
+    --spectrum-tabs-s-compact-texticon-margin-left: -7px;
+    --spectrum-tabs-s-compact-texticon-margin-right: -7px;
+    --spectrum-tabs-s-compact-textonly-margin-left: -7px;
+    --spectrum-tabs-s-compact-textonly-margin-right: -7px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-quiet-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-quiet-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-quiet-texticon-margin-left: -8px;
+    --spectrum-tabs-m-quiet-texticon-margin-right: -8px;
+    --spectrum-tabs-m-quiet-textonly-margin-left: -8px;
+    --spectrum-tabs-m-quiet-textonly-margin-right: -8px;
+    --spectrum-tabs-m-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-texticon-margin-left: -8px;
+    --spectrum-tabs-m-texticon-margin-right: -8px;
+    --spectrum-tabs-m-textonly-margin-left: -8px;
+    --spectrum-tabs-m-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-emphasized-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-emphasized-textonly-margin-right: -8px;
+    --spectrum-tabs-m-compact-texticon-margin-left: -8px;
+    --spectrum-tabs-m-compact-texticon-margin-right: -8px;
+    --spectrum-tabs-m-compact-textonly-margin-left: -8px;
+    --spectrum-tabs-m-compact-textonly-margin-right: -8px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-l-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-l-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-l-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-l-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-texticon-margin-left: -9px;
+    --spectrum-tabs-l-texticon-margin-right: -9px;
+    --spectrum-tabs-l-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-textonly-margin-left: -9px;
+    --spectrum-tabs-l-textonly-margin-right: -9px;
+    --spectrum-tabs-l-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-emphasized-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-emphasized-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-texticon-margin-left: -9px;
+    --spectrum-tabs-l-compact-texticon-margin-right: -9px;
+    --spectrum-tabs-l-compact-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-textonly-margin-left: -9px;
+    --spectrum-tabs-l-compact-textonly-margin-right: -9px;
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-texticon-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-textonly-tabitem-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-emphasized-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-emphasized-textonly-margin-right: -10px;
+    --spectrum-tabs-xl-compact-texticon-margin-left: -10px;
+    --spectrum-tabs-xl-compact-texticon-margin-right: -10px;
+    --spectrum-tabs-xl-compact-textonly-margin-left: -10px;
+    --spectrum-tabs-xl-compact-textonly-margin-right: -10px;
+    --spectrum-tag-m-removable-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-tag-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-textarea-s-multiline-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-quiet-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-quiet-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-texticon-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-textonly-placeholder-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-textfield-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-texticon-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-textonly-placeholder-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tooltip-neutral-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tooltip-info-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tooltip-positive-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tooltip-negative-text-margin-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-treeview-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-treeview-l-item-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-treeview-l-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
     );
 }

--- a/tools/styles/spectrum-two/spectrum-theme-dark.css
+++ b/tools/styles/spectrum-two/spectrum-theme-dark.css
@@ -290,4 +290,63 @@
     --spectrum-alias-appframe-separator-color: var(
         --spectrum-global-color-gray-50
     );
+    --spectrum-scrollbar-mac-s-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-scrollbar-mac-m-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-scrollbar-mac-l-track-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-s-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-m-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-l-range-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-tick-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-editable-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-ramp-radial-reaction-color: #ebebeb99;
+    --spectrum-slider-xl-range-radial-reaction-color: #ebebeb99;
+    --spectrum-well-background-color: #ebebeb05;
+    --spectrum-well-border-color: #ffffff0d;
 }

--- a/tools/styles/spectrum-two/spectrum-theme-light.css
+++ b/tools/styles/spectrum-two/spectrum-theme-light.css
@@ -290,4 +290,62 @@
     --spectrum-alias-appframe-separator-color: var(
         --spectrum-global-color-gray-300
     );
+    --spectrum-scrollbar-mac-s-track-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-scrollbar-mac-m-track-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-scrollbar-mac-l-track-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-tick-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-s-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-s-radial-reaction-color: #2229;
+    --spectrum-slider-s-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-s-range-radial-reaction-color: #2229;
+    --spectrum-slider-m-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-tick-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-m-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-m-radial-reaction-color: #2229;
+    --spectrum-slider-m-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-m-range-radial-reaction-color: #2229;
+    --spectrum-slider-l-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-tick-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-l-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-l-radial-reaction-color: #2229;
+    --spectrum-slider-l-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-l-range-radial-reaction-color: #2229;
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-tick-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-tick-radial-reaction-color: #2229;
+    --spectrum-slider-xl-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-editable-radial-reaction-color: #2229;
+    --spectrum-slider-xl-radial-reaction-color: #2229;
+    --spectrum-slider-xl-ramp-radial-reaction-color: #2229;
+    --spectrum-slider-xl-range-radial-reaction-color: #2229;
+    --spectrum-well-background-color: #22222205;
 }

--- a/tools/styles/src/body-overrides.css
+++ b/tools/styles/src/body-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Body {

--- a/tools/styles/src/code-overrides.css
+++ b/tools/styles/src/code-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Code {

--- a/tools/styles/src/detail-overrides.css
+++ b/tools/styles/src/detail-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Detail {

--- a/tools/styles/src/heading-overrides.css
+++ b/tools/styles/src/heading-overrides.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Heading {

--- a/tools/styles/src/lang-overrides.css
+++ b/tools/styles/src/lang-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/tools/styles/src/spectrum-body.css
+++ b/tools/styles/src/spectrum-body.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Typography .spectrum-Body {

--- a/tools/styles/src/spectrum-code.css
+++ b/tools/styles/src/spectrum-code.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {

--- a/tools/styles/src/spectrum-config.js
+++ b/tools/styles/src/spectrum-config.js
@@ -12,23 +12,28 @@ governing permissions and limitations under the License.
 */
 
 /**
- * @property {string} fileName
- * @property {RegExp} regex
- * @returns {import('../../../tasks/spectrum-css-converter').Conversion}
+ * Generates a style configuration object.
+ *
+ * @param {string} fileName - The name of the file.
+ * @param {RegExp} regex - The regular expression to match class names.
+ * @returns {import('../../../tasks/spectrum-css-converter.js').Conversion} The style configuration object.
  */
-const styleType = (fileName, regex) => ({
-    inPackage: '@spectrum-css/typography',
-    outPackage: ['tools', 'styles'],
-    fileName,
-    requireComponentPresence: [
-        {
-            type: 'class',
-            name: regex,
-            regex,
-        },
-    ],
-    components: [],
-});
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- it's there but not being picked up
+function styleType(fileName, regex) {
+    return {
+        inPackage: '@spectrum-css/typography',
+        outPackage: ['tools', 'styles'],
+        fileName,
+        requireComponentPresence: [
+            {
+                type: 'class',
+                name: regex,
+                regex,
+            },
+        ],
+        components: [],
+    };
+}
 
 /**
  * @type { import('../../../tasks/spectrum-css-converter').SpectrumCSSConverter }
@@ -44,7 +49,6 @@ const config = {
             inPackage: '@spectrum-css/typography',
             outPackage: ['tools', 'styles'],
             fileName: 'lang',
-            allowThemeRules: true,
             requireComponentPresence: [
                 /** @type {import('lightningcss').SelectorComponent} */ ({
                     type: 'pseudo-class',

--- a/tools/styles/src/spectrum-detail.css
+++ b/tools/styles/src/spectrum-detail.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Typography .spectrum-Detail {

--- a/tools/styles/src/spectrum-heading.css
+++ b/tools/styles/src/spectrum-heading.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Typography .spectrum-Heading {

--- a/tools/styles/src/spectrum-lang.css
+++ b/tools/styles/src/spectrum-lang.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Typography:lang(ar) {

--- a/tools/styles/src/spectrum-typography.css
+++ b/tools/styles/src/spectrum-typography.css
@@ -1,14 +1,14 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Typography {

--- a/tools/styles/src/typography-overrides.css
+++ b/tools/styles/src/typography-overrides.css
@@ -1,13 +1,13 @@
-/*
-Copyright 2023 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
+/*!
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License./
+ */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */

--- a/tools/styles/typography.css
+++ b/tools/styles/typography.css
@@ -41,6 +41,24 @@
     );
 }
 
+@media (forced-colors: active) {
+    .spectrum-Heading {
+        --highcontrast-heading-font-color: Text;
+    }
+
+    .spectrum-Body {
+        --highcontrast-body-font-color: Text;
+    }
+
+    .spectrum-Detail {
+        --highcontrast-detail-font-color: Text;
+    }
+
+    .spectrum-Code {
+        --highcontrast-code-font-color: Text;
+    }
+}
+
 .spectrum-Heading {
     font-family: var(
         --mod-heading-sans-serif-font-family,


### PR DESCRIPTION
## Description

This update removes a few hardcoded assumptions for the spectrum processing scripts. 

- Removes the manual `systemOverrides` from the `spectrum-config.js`, which is meant to be `true` whenever the `dist/index-theme.css` file is present. Instead, the `tasks/process-spectrum.js` script now checks for the presence of the `dist/index-theme.css` file in the installed `node_modules` package and creates the necessary files when it is present.
- Looks first for a `dist/index-base.css` file and when none is available, falls back to the `dist/index.css` file in the Spectrum CSS packages.
- Pulls duplicative processing between the `process-spectrum.js` and `spectrum-vars.js` scripts out into the `css-tools.js` source.
- JSDoc comments added throughout

## How has this been tested?

-   [x] _Validate no build regressions_
    1. `yarn process-spectrum` (bonus: expect a more thorough console output)
    2. `yarn build`

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
