### PR TITLE
fix(dialog, dialog-wrapper): remove dialog error property deprecation

### DIFF
--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -22,16 +22,16 @@ import {
     query,
 } from '@spectrum-web-components/base/src/decorators.js';
 
-import '@spectrum-web-components/divider/sp-divider.js';
-import '@spectrum-web-components/button/sp-close-button.js';
 import '@spectrum-web-components/button-group/sp-button-group.js';
+import '@spectrum-web-components/button/sp-close-button.js';
+import '@spectrum-web-components/divider/sp-divider.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 import { ObserveSlotPresence } from '@spectrum-web-components/shared';
 
-import styles from './dialog.css.js';
-import type { CloseButton } from '@spectrum-web-components/button';
 import { AlertDialog } from '@spectrum-web-components/alert-dialog/src/AlertDialog.js';
 import { classMap } from '@spectrum-web-components/base/src/directives.js';
+import type { CloseButton } from '@spectrum-web-components/button';
+import styles from './dialog.css.js';
 
 /**
  * @element sp-dialog
@@ -55,9 +55,6 @@ export class Dialog extends ObserveSlotPresence(AlertDialog, [
     @query('.close-button')
     closeButton?: CloseButton;
 
-    /**
-     * @deprecated Use the Alert Dialog component with `variant="error"` instead.
-     */
     @property({ type: Boolean, reflect: true })
     public error = false;
 
@@ -176,15 +173,5 @@ export class Dialog extends ObserveSlotPresence(AlertDialog, [
 
     protected override updated(changes: PropertyValues): void {
         super.updated(changes);
-        if (changes.has('error') && this.error) {
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "error" attribute of <${this.localName}> has been deprecated. Use the Alert Dialog component with the "variant='error'" instead. "error" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/alert-dialog/#error',
-                    { level: 'deprecation' }
-                );
-            }
-        }
     }
 }

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -19,13 +19,13 @@ import {
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
-import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/underlay/sp-underlay.js';
 
 // Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
 import '@spectrum-web-components/dialog/sp-dialog.js';
-import { DialogBase } from './DialogBase.js';
 import { Dialog } from './Dialog.js';
+import { DialogBase } from './DialogBase.js';
 
 /**
  * @element sp-dialog-wrapper
@@ -41,9 +41,6 @@ export class DialogWrapper extends DialogBase {
         return [...super.styles];
     }
 
-    /**
-     * @deprecated Use the Alert Dialog component with `variant="error"` instead.
-     */
     @property({ type: Boolean, reflect: true })
     public error = false;
 

--- a/packages/dialog/test/dialog.test.ts
+++ b/packages/dialog/test/dialog.test.ts
@@ -27,7 +27,7 @@ import {
     fullscreen,
     small,
 } from '../stories/dialog.stories.js';
-import { spy, stub } from 'sinon';
+import { spy } from 'sinon';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
 describe('Dialog', () => {
@@ -258,40 +258,5 @@ describe('Dialog', () => {
 
         const container = el.shadowRoot.querySelector('#dismiss-container');
         expect(container).to.not.be.null;
-    });
-});
-
-describe('dev mode', () => {
-    let consoleWarnStub!: ReturnType<typeof stub>;
-    before(() => {
-        window.__swc.verbose = true;
-        consoleWarnStub = stub(console, 'warn');
-    });
-    afterEach(() => {
-        consoleWarnStub.resetHistory();
-    });
-    after(() => {
-        window.__swc.verbose = false;
-        consoleWarnStub.restore();
-    });
-
-    it('warns that `error` is deprecated', async () => {
-        const el = await fixture<Dialog>(alertError());
-
-        await elementUpdated(el);
-
-        expect(consoleWarnStub.called).to.be.true;
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            (spyCall.args.at(0) as string).includes('"error"'),
-            'confirm error-centric message'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-dialog',
-                type: 'api',
-                level: 'deprecation',
-            },
-        });
     });
 });

--- a/projects/documentation/content/migrations/2024-10-31 (1.0.0).md
+++ b/projects/documentation/content/migrations/2024-10-31 (1.0.0).md
@@ -188,20 +188,6 @@ See the example below for the migration:
 
 Make sure to update all instances of `sp-thumbnail` using the deprecated `size` values.
 
-### 12. Dialog and Dialog Wrapper (`sp-dialog` and `sp-dialog-wrapper`)
-
-The `error` attribute for `sp-dialog` and `sp-dialog-wrapper` has been removed.
-
-**Action Required**: Use the [Alert Dialog](/components/alert-dialog/#error) component with the `variant="error"` instead. See the example below:
-
-```ts
-// Before
-<sp-dialog error></sp-dialog>
-
-// After
-<sp-alert-dialog variant="error"></sp-alert-dialog>
-```
-
 ## Final Notes
 
 Please ensure your project is fully compatible with Spectrum Web Components 1.0.0 before upgrading. Test thoroughly and review any deprecated or removed functionality as outlined above. If you encounter any issues during migration, consult the documentation or reach out to the team for support.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `error` property was not properly deprecated with a full migration plan in place. This has caused confusion and false sense of urgency for consumers to migrate. We are removing it to eliminate those pain points for consumers while we take a deep look at our dialogs and patterns. 

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- resolves https://github.com/adobe/spectrum-web-components/issues/4935

## Motivation and context

reduce confusion and false urgency

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go to dialog error story
    2. don't see a deprecation warning

-   [ ] _Test case 2_
    1. Go to dialog-wrapper error story
    2. don't see a deprecation warning

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
