### PR TITLE
chore: fix storybook preview runtime error + flaky tests

### DIFF
--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -181,6 +181,7 @@ describe('Submenu', () => {
                 press: testData.openKey,
             });
             await opened;
+            await elementUpdated(this.rootItem);
 
             submenu = this.el.querySelector('[slot="submenu"]') as Menu;
 

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -9,11 +9,13 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { setCustomElementsManifest } from '@storybook/web-components';
 import { swcThemeDecorator } from '@spectrum-web-components/story-decorator/decorator.js';
 import { Locales } from '@spectrum-web-components/story-decorator/src/locales.js';
+import { setCustomElementsManifest } from '@storybook/web-components';
 
-const cem = await import('./custom-elements.json', { with: { type: 'json' } });
+const cem = await import('./custom-elements.json', {
+    assert: { type: 'json' },
+});
 
 setCustomElementsManifest(cem);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Dependencies load versions of Typescript that do not support the `with` assertion for file types that was introduced in V5.3.0.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- resolves #5183

## Motivation and context

- Make Storybook work locally

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Pull branch
    2. run `yarn storybook`
    3. Check there's no error message for the custom-element-manifest.json

-   [X] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)
<img width="744" alt="Screenshot 2025-03-12 at 5 15 00 PM" src="https://github.com/user-attachments/assets/3164d01b-9673-4cbf-bded-710c05983fa3" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
