### PR TITLE
fix(menu): focuson mouseover

### DIFF
--- a/.changeset/moody-points-speak.md
+++ b/.changeset/moody-points-speak.md
@@ -2,4 +2,4 @@
 '@spectrum-web-components/menu': patch
 ---
 
-`<sp-menu>` - fixes `<sp-menu-item>` focus on hover
+`<sp-menu>` - fixes `<sp-menu-item>` focus on hover ([#5180](https://github.com/adobe/spectrum-web-components/issues/5180))

--- a/.changeset/moody-points-speak.md
+++ b/.changeset/moody-points-speak.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/menu': patch
+---
+
+`<sp-menu>` - fixes `<sp-menu-item>` focus on hover

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -386,6 +386,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
         );
 
         this.addEventListener('click', this.handleClick);
+        this.addEventListener('mouseover', this.handleMouseover);
         this.addEventListener('focusout', this.handleFocusout);
         this.addEventListener('sp-menu-item-keydown', this.handleKeydown);
         this.addEventListener('pointerup', this.handlePointerup);
@@ -437,6 +438,17 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
     // if the click and pointerup events are on the same target, we should not
     // handle the click event.
     private pointerUpTarget = null as EventTarget | null;
+
+    private handleMouseover(event: MouseEvent): void {
+        const { target } = event;
+        const menuItem = target as MenuItem;
+        if (
+            this.childItems.includes(menuItem) &&
+            this.isFocusableElement(menuItem)
+        ) {
+            this.rovingTabindexController?.focusOnItem(menuItem);
+        }
+    }
 
     private handleFocusout(): void {
         if (!this.matches(':focus-within'))

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -323,29 +323,23 @@ describe('Menu', () => {
         );
     });
 
-    it('handle hover and keyboard input', async () => {
+    it('handles hover and keyboard input', async () => {
         const el = await fixture<Menu>(html`
             <sp-menu>
                 <sp-menu-item>Deselect</sp-menu-item>
                 <sp-menu-item>Select Inverse</sp-menu-item>
-                <sp-menu-item>Feather...</sp-menu-item>
-                <sp-menu-item>Select and Mask...</sp-menu-item>
-                <sp-menu-divider></sp-menu-divider>
-                <sp-menu-item>Save Selection</sp-menu-item>
-                <sp-menu-item disabled>Make Work Path</sp-menu-item>
             </sp-menu>
         `);
 
         await waitUntil(
-            () => el.childItems.length == 6,
-            'expected menu to manage 6 items'
+            () => el.childItems.length == 2,
+            'expected menu to manage 2 items'
         );
-        await elementUpdated(el);
 
         const firstItem = el.querySelector(
             'sp-menu-item:nth-of-type(1)'
         ) as MenuItem;
-        const secondtItem = el.querySelector(
+        const secondItem = el.querySelector(
             'sp-menu-item:nth-of-type(2)'
         ) as MenuItem;
 
@@ -355,9 +349,9 @@ describe('Menu', () => {
         expect(document.activeElement === firstItem, 'active element').to.be
             .true;
         expect(firstItem.focused, 'first item focused').to.be.true;
-        const rect = secondtItem.getBoundingClientRect();
+        const rect = secondItem.getBoundingClientRect();
 
-        await sendMouse({
+        sendMouse({
             steps: [
                 {
                     position: [
@@ -370,13 +364,12 @@ describe('Menu', () => {
         });
 
         expect(
-            document.activeElement === secondtItem,
+            document.activeElement === secondItem,
             'active element after arrow up'
-        ).to.equal(secondtItem);
-        expect(secondtItem.focused, 'third to last item focused').to.be.true;
+        ).to.equal(secondItem);
+        expect(secondItem.focused, 'third to last item focused').to.be.true;
 
-        el.dispatchEvent(arrowUpEvent());
-        await elementUpdated(el);
+        await sendKeys({ press: 'ArrowUp' });
 
         expect(document.activeElement === firstItem, 'active element').to.be
             .true;

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -44,24 +44,19 @@ describe('Menu', () => {
 
         const anchor = el.querySelector('a') as HTMLAnchorElement;
         await elementUpdated(el);
-        expect(document.activeElement === el, 'self not focused, 1').to.be
-            .false;
-        expect(document.activeElement === anchor, 'child not focused, 1').to.be
-            .false;
+        expect(document.activeElement).to.not.equal(el);
+        expect(document.activeElement).to.not.equal(anchor);
 
         expect(el.getAttribute('role')).to.equal('menu');
 
         el.focus();
         await elementUpdated(el);
-        expect(document.activeElement === el, 'self not focused, 2').to.be
-            .false;
-        expect(document.activeElement === anchor, 'child not focused, 2').to.be
-            .false;
+        expect(document.activeElement).to.not.equal(el);
+        expect(document.activeElement).to.not.equal(anchor);
 
         anchor.focus();
-        expect(document.activeElement === el, 'self not focused, 3').to.be
-            .false;
-        expect(document.activeElement === anchor, 'anchor').to.be.true;
+        expect(document.activeElement).to.not.equal(el);
+        expect(document.activeElement).to.equal(anchor);
     });
     it('renders w/ [disabled] menu items', async () => {
         const focusinSpy = spy();
@@ -72,13 +67,11 @@ describe('Menu', () => {
         `);
 
         await elementUpdated(el);
-        expect(document.activeElement === el, 'self not focused, 1').to.be
-            .false;
+        expect(document.activeElement).to.not.equal(el);
 
         el.focus();
         await elementUpdated(el);
-        expect(document.activeElement === el, 'self not focused, 2').to.be
-            .false;
+        expect(document.activeElement).to.not.equal(el);
         expect(focusinSpy.callCount).to.equal(0);
     });
     it('renders w/ all [disabled] menu items', async () => {
@@ -92,18 +85,15 @@ describe('Menu', () => {
         const firstItem = el.querySelector('sp-menu-item') as MenuItem;
 
         await elementUpdated(el);
-        expect(document.activeElement === el, 'self not focused, 1').to.be
-            .false;
+        expect(document.activeElement).to.not.equal(el);
 
         el.focus();
         await elementUpdated(el);
-        expect(document.activeElement === el, 'self not focused, 2').to.be
-            .false;
+        expect(document.activeElement).to.not.equal(el);
         expect(focusinSpy.callCount).to.equal(0);
         firstItem.focus();
         await elementUpdated(el);
-        expect(document.activeElement === el, 'self not focused, 2').to.be
-            .false;
+        expect(document.activeElement).to.not.equal(el);
         expect(focusinSpy.callCount).to.equal(0);
         expect(el.matches(':focus-within')).to.be.false;
     });
@@ -291,8 +281,7 @@ describe('Menu', () => {
         el.focus();
         await elementUpdated(el);
 
-        expect(document.activeElement === firstItem, 'active element').to.be
-            .true;
+        expect(document.activeElement).to.equal(firstItem);
         expect(firstItem.focused, 'first item focused').to.be.true;
         expect(firstItem.textContent, 'focused item text').to.equal('Deselect');
 
@@ -346,12 +335,11 @@ describe('Menu', () => {
         el.focus();
         await elementUpdated(el);
 
-        expect(document.activeElement === firstItem, 'active element').to.be
-            .true;
+        expect(document.activeElement).to.equal(firstItem);
         expect(firstItem.focused, 'first item focused').to.be.true;
         const rect = secondItem.getBoundingClientRect();
 
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     position: [
@@ -363,16 +351,14 @@ describe('Menu', () => {
             ],
         });
 
-        expect(
-            document.activeElement === secondItem,
-            'active element after arrow up'
-        ).to.equal(secondItem);
-        expect(secondItem.focused, 'third to last item focused').to.be.true;
+        expect(document.activeElement, 'active element after hover').to.equal(
+            secondItem
+        );
+        expect(secondItem.focused, 'second item focused').to.be.true;
 
         await sendKeys({ press: 'ArrowUp' });
 
-        expect(document.activeElement === firstItem, 'active element').to.be
-            .true;
+        expect(document.activeElement).to.equal(firstItem);
         expect(firstItem.focused, 'first item focused').to.be.true;
     });
 
@@ -398,8 +384,7 @@ describe('Menu', () => {
 
         await elementUpdated(el);
 
-        expect(document.activeElement === initialLoadedItem, 'active element')
-            .to.be.true;
+        expect(document.activeElement).to.equal(initialLoadedItem);
         expect(initialLoadedItem.focused, 'visually focused').to.be.true;
         expect(initialLoadedItem.textContent, 'focused item text').to.equal(
             'Deselect'

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -323,6 +323,66 @@ describe('Menu', () => {
         );
     });
 
+    it('handle hover and keyboard input', async () => {
+        const el = await fixture<Menu>(html`
+            <sp-menu>
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-menu>
+        `);
+
+        await waitUntil(
+            () => el.childItems.length == 6,
+            'expected menu to manage 6 items'
+        );
+        await elementUpdated(el);
+
+        const firstItem = el.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const secondtItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        el.focus();
+        await elementUpdated(el);
+
+        expect(document.activeElement === firstItem, 'active element').to.be
+            .true;
+        expect(firstItem.focused, 'first item focused').to.be.true;
+        const rect = secondtItem.getBoundingClientRect();
+
+        await sendMouse({
+            steps: [
+                {
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                    type: 'move',
+                },
+            ],
+        });
+
+        expect(
+            document.activeElement === secondtItem,
+            'active element after arrow up'
+        ).to.equal(secondtItem);
+        expect(secondtItem.focused, 'third to last item focused').to.be.true;
+
+        el.dispatchEvent(arrowUpEvent());
+        await elementUpdated(el);
+
+        expect(document.activeElement === firstItem, 'active element').to.be
+            .true;
+        expect(firstItem.focused, 'first item focused').to.be.true;
+    });
+
     it('handle focus and late descendant additions', async () => {
         const el = await fixture<Menu>(html`
             <sp-menu>


### PR DESCRIPTION
## Description

- Mouse click, arrow keys, and mouseover should set the focused item.
- The visual focus is based on the focused item.
- If the keyboard last set the focus but the mouse is still over the menu, there will be an item with focus styling and an item with hover styling.

## Related issue(s)

- #5180

## Motivation and context

Currently users are not able to mouseover to open submenus and set selected items.

## How has this been tested?

-   [ ] Using your mouse...
    1. Go to https://nikkimk-fix-submenu-mouseover--spectrumwc.netlify.app/storybook/index.html?path=/story/action-menu--submenu
    2. Click on action menu
    3. Select item with submenu
    4. Notice that focus styling follows the mouse
    5. Reopen action menu again
    6. See correct item is focused

## Screenshots (if appropriate)

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
