### PR TITLE
docs(radio): updated radio docs for accessibility

### DIFF
--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -1,8 +1,6 @@
-## Description
+## Overview
 
 `<sp-radio>` and `<sp-radio-group>` allow users to select a single option from a list of mutually exclusive options. All possible options are exposed up front for users to compare.
-
-`<sp-radio-group>` holds a list of `<sp-radio>` elements, and is responsible for deselecting radio buttons when a new one is selected, which in turn makes it responsible for keeping track of which one is selected. `<sp-radio>` is responsible for handling user interactions and for visually reflecting if it is the one that is checked or not.
 
 ### Usage
 
@@ -30,162 +28,74 @@ import {
 } from '@spectrum-web-components/radio';
 ```
 
-## Sizes
+### Anatomy
 
-<sp-tabs selected="m" auto label="Size Attribute Options">
-<sp-tab value="s">Small</sp-tab>
-<sp-tab-panel value="s">
+`<sp-radio-group>` holds a list of `<sp-radio>` elements, and is responsible for deselecting radio buttons when a new one is selected, which in turn makes it responsible for keeping track of which one is selected. `<sp-radio>` is responsible for handling user interactions and for visually reflecting if it is the one that is checked or not.
 
 ```html
-<sp-radio-group label="Small" selected="first" name="example">
-    <sp-radio value="first" size="s">Option 1</sp-radio>
-    <sp-radio value="second" size="s">Option 2</sp-radio>
-    <sp-radio value="third" size="s">Option 3</sp-radio>
-    <sp-radio value="fourth" size="s">Option 4</sp-radio>
+<sp-radio-group label="Choose an option" name="anatomy">
+    <sp-radio value="first">Option 1</sp-radio>
+    <sp-radio value="second">Option 2</sp-radio>
+    <sp-radio value="third">Option 3</sp-radio>
+    <sp-radio value="fourth">Option 4</sp-radio>
+</sp-radio-group>
+```
+
+#### Label
+
+The `<sp-radio>` elements are labelled with text in their default slot.
+
+The `<sp-radio-group>` element can be labeled with the `label` property or with an <`sp-field-label>` element:
+
+<sp-tabs selected="property" auto label="Label Anatomy">
+<sp-tab value="property">`label` property</sp-tab>
+<sp-tab-panel value="self">
+
+```html
+<sp-radio-group label="Choose an option" name="anatomy">
+    <sp-radio value="first">Option 1</sp-radio>
+    <sp-radio value="second">Option 2</sp-radio>
+    <sp-radio value="third">Option 3</sp-radio>
+    <sp-radio value="fourth">Option 4</sp-radio>
 </sp-radio-group>
 ```
 
 </sp-tab-panel>
-<sp-tab value="m">Medium</sp-tab>
-<sp-tab-panel value="m">
+<sp-tab value="sp-field-label">Using a field bale</sp-tab>
+<sp-tab-panel value="above">
 
 ```html
-<sp-radio-group label="Medium" selected="first" name="example">
-    <sp-radio value="first" size="m">Option 1</sp-radio>
-    <sp-radio value="second" size="m">Option 2</sp-radio>
-    <sp-radio value="third" size="m">Option 3</sp-radio>
-    <sp-radio value="fourth" size="m">Option 4</sp-radio>
+<sp-field-label for="options">Choose an option</sp-field-label>
+<sp-radio-group id="options" name="anatomy">
+    <sp-radio value="first">Option 1</sp-radio>
+    <sp-radio value="second">Option 2</sp-radio>
+    <sp-radio value="third">Option 3</sp-radio>
+    <sp-radio value="fourth">Option 4</sp-radio>
 </sp-radio-group>
 ```
 
 </sp-tab-panel>
-<sp-tab value="l">Large</sp-tab>
-<sp-tab-panel value="l">
+<sp-tab value="sp-field-label">Using a field bale</sp-tab>
+<sp-tab-panel value="above">
 
 ```html
-<sp-radio-group label="Large" selected="first" name="example">
-    <sp-radio value="first" size="l">Option 1</sp-radio>
-    <sp-radio value="second" size="l">Option 2</sp-radio>
-    <sp-radio value="third" size="l">Option 3</sp-radio>
-    <sp-radio value="fourth" size="l">Option 4</sp-radio>
-</sp-radio-group>
-```
-
-</sp-tab-panel>
-<sp-tab value="xl">Extra Large</sp-tab>
-<sp-tab-panel value="xl">
-
-```html
-<sp-radio-group label="Extra large" selected="first" name="example">
-    <sp-radio value="first" size="xl">Option 1</sp-radio>
-    <sp-radio value="second" size="xl">Option 2</sp-radio>
-    <sp-radio value="third" size="xl">Option 3</sp-radio>
-    <sp-radio value="fourth" size="xl">Option 4</sp-radio>
+<sp-field-label for="options">Choose an option</sp-field-label>
+<sp-radio-group id="options" name="anatomy">
+    <sp-radio value="first">Option 1</sp-radio>
+    <sp-radio value="second">Option 2</sp-radio>
+    <sp-radio value="third">Option 3</sp-radio>
+    <sp-radio value="fourth">Option 4</sp-radio>
 </sp-radio-group>
 ```
 
 </sp-tab-panel>
 </sp-tabs>
 
-### Standard radio buttons
-
-Standard radio buttons are the default style for radio buttons. They are optimal for application panels where all visual elements are monochrome in order to direct focus to the content.
-
-Invalid selections in radio groups are identified using the `negative-help-text` slot. Read more about using [help text](#help-text) below.
-
-```html-live
-<div style="display: flex; justify-content: space-between;">
-    <div style="display: flex; flex-direction: column;">
-        <sp-field-label for="example-1" size="l">
-            <h4 class="spectrum-Heading--subtitle1">Default</h4>
-        </sp-field-label>
-        <sp-radio-group id="example-1" name="example" vertical>
-            <sp-radio value="kittens">Kittens</sp-radio>
-            <sp-radio value="puppies" checked>Puppies</sp-radio>
-        </sp-radio-group>
-    </div>
-
-    <div style="display: flex; flex-direction: column;">
-        <sp-field-label for="example-2" size="l">
-            <h4 class="spectrum-Heading--subtitle1">Invalid</h4>
-        </sp-field-label>
-        <sp-radio-group invalid id="example-2" name="example" vertical>
-            <sp-radio invalid value="kittens">Kittens</sp-radio>
-            <sp-radio invalid value="puppies" checked>Puppies</sp-radio>
-             <sp-help-text slot="negative-help-text" icon>
-                This selection is invalid.
-            </sp-help-text>
-        </sp-radio-group>
-    </div>
-
-    <div style="display: flex; flex-direction: column;">
-        <sp-field-label for="example-3" size="l">
-            <h4 class="spectrum-Heading--subtitle1">Disabled</h4>
-        </sp-fieldlabel>
-        <sp-radio-group id="example-3" name="example" vertical>
-            <sp-radio disabled value="kittens">Kittens</sp-radio>
-            <sp-radio disabled value="puppies" checked>Puppies</sp-radio>
-        </sp-radio-group>
-    </div>
-</div>
-```
-
-### Emphasized radio buttons
-
-Emphasized radio buttons are a secondary style for radio buttons. The blue color provides a visual prominence that is optimal for forms, settings, etc. where the radio buttons need to be noticed.
-
-Invalid selections in radio groups are identified using the `negative-help-text` slot. Read more about using [help text](#help-text) below.
-
-```html-live
-<div style="display: flex; justify-content: space-between;">
-    <div style="display: flex; flex-direction: column;">
-        <sp-field-label for="example-a" size="l">
-            <h4 class="spectrum-Heading--subtitle1">Default</h4>
-        </sp-field-label>
-        <sp-radio-group id="example-a" name="example" vertical>
-            <sp-radio emphasized value="kittens">Kittens</sp-radio>
-            <sp-radio emphasized value="puppies" checked>Puppies</sp-radio>
-        </sp-radio-group>
-    </div>
-
-    <div style="display: flex; flex-direction: column;">
-        <sp-field-label for="example-b" size="l">
-            <h4 class="spectrum-Heading--subtitle1">Invalid</h4>
-        </sp-field-label>
-        <sp-radio-group invalid id="example-b" name="example" vertical>
-            <sp-radio emphasized invalid value="kittens">Kittens</sp-radio>
-            <sp-radio emphasized invalid value="puppies" checked>Puppies</sp-radio>
-            <sp-help-text slot="negative-help-text" icon>
-                This selection is invalid.
-            </sp-help-text>
-        </sp-radio-group>
-    </div>
-
-    <div style="display: flex; flex-direction: column;">
-        <sp-field-label for="example-c" size="l">
-            <h4 class="spectrum-Heading--subtitle1">Disabled</h4>
-        </sp-fieldlabel>
-        <sp-radio-group id="example-c" name="example" vertical>
-            <sp-radio emphasized disabled value="kittens">Kittens</sp-radio>
-            <sp-radio emphasized disabled value="puppies" checked>Puppies</sp-radio>
-        </sp-radio-group>
-    </div>
-</div>
-```
-
-### Handling events
-
-Event handlers for clicks and other user actions can be registered on an `<sp-radio>` similar to a standard `<input type="radio">` element.
-
-```html
-<sp-radio id="radio-example" onclick="spAlert(this, '<sp-radio> clicked!')">
-    Web component
-</sp-radio>
-```
-
-## Help text
+#### Help Text
 
 Help text can be accessibly associated with an `<sp-radio-group>` element by using the `help-text` or `negative-help-text` slots. When using the `negative-help-text` slot, `<sp-radio-group>` will self manage the presence of this content based on the value of the `invalid` property on your `<sp-radio-group>` element. Content within the `help-text` slot will be show by default. When your `<sp-radio-group>` should receive help text based on state outside of the complexity of `invalid` or not, manage the content addressed to the `help-text` from above to ensure that it displays the right messaging and possesses the right `variant`.
+
+Read more about using [help text](../help-text).
 
 <sp-tabs selected="self" auto label="Help text usage in radio groups">
 <sp-tab value="self">Self managed</sp-tab>
@@ -241,6 +151,180 @@ Help text can be accessibly associated with an `<sp-radio-group>` element by usi
 </sp-tab-panel>
 </sp-tabs>
 
-## Accessibility
+### Options
 
-Radio buttons are accessible by default, rendered in HTML using the `<input type="radio">` element. Tabbing into a group of radio buttons places the focus on the first radio button selected. If none of the radio buttons are selected, the focus is set on the first one in the group. Space selects the radio button in focus (if not already selected). Using the arrow keys moves focus and selection to the previous or next radio button in the group (last becomes first, and first becomes last). The new radio button in focus gets selected even if the previous one was not.
+#### Sizes
+
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
+
+```html
+<sp-radio-group label="Small" selected="first" name="small">
+    <sp-radio value="first" size="s">Option 1</sp-radio>
+    <sp-radio value="second" size="s">Option 2</sp-radio>
+    <sp-radio value="third" size="s">Option 3</sp-radio>
+    <sp-radio value="fourth" size="s">Option 4</sp-radio>
+</sp-radio-group>
+```
+
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
+
+```html
+<sp-radio-group label="Medium" selected="first" name="medium">
+    <sp-radio value="first" size="m">Option 1</sp-radio>
+    <sp-radio value="second" size="m">Option 2</sp-radio>
+    <sp-radio value="third" size="m">Option 3</sp-radio>
+    <sp-radio value="fourth" size="m">Option 4</sp-radio>
+</sp-radio-group>
+```
+
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
+
+```html
+<sp-radio-group label="Large" selected="first" name="large">
+    <sp-radio value="first" size="l">Option 1</sp-radio>
+    <sp-radio value="second" size="l">Option 2</sp-radio>
+    <sp-radio value="third" size="l">Option 3</sp-radio>
+    <sp-radio value="fourth" size="l">Option 4</sp-radio>
+</sp-radio-group>
+```
+
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
+
+```html
+<sp-radio-group label="Extra large" selected="first" name="extra-large">
+    <sp-radio value="first" size="xl">Option 1</sp-radio>
+    <sp-radio value="second" size="xl">Option 2</sp-radio>
+    <sp-radio value="third" size="xl">Option 3</sp-radio>
+    <sp-radio value="fourth" size="xl">Option 4</sp-radio>
+</sp-radio-group>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
+#### Styles
+
+Standard radio buttons are the default style for radio buttons. They are optimal for application panels where all visual elements are monochrome in order to direct focus to the content.
+
+**Emphasized** radio buttons are a secondary style for radio buttons. The blue color provides a visual prominence that is optimal for forms, settings, etc. where the radio buttons need to be noticed.
+
+<sp-tabs selected="standard" auto label="Style Options">
+<sp-tab value="standard">Standard</sp-tab>
+<sp-tab-panel value="standard">
+
+```html
+<div style="display: flex; justify-content: space-between;">
+    <div style="display: flex; flex-direction: column;">
+        <sp-field-label for="example-1" size="l">
+            <h4 class="spectrum-Heading--subtitle1">Default</h4>
+        </sp-field-label>
+        <sp-radio-group id="example-1" name="example" vertical>
+            <sp-radio value="kittens">Kittens</sp-radio>
+            <sp-radio value="puppies" checked>Puppies</sp-radio>
+        </sp-radio-group>
+    </div>
+
+    <div style="display: flex; flex-direction: column;">
+        <sp-field-label for="example-2" size="l">
+            <h4 class="spectrum-Heading--subtitle1">Invalid</h4>
+        </sp-field-label>
+        <sp-radio-group invalid id="example-2" name="example" vertical>
+            <sp-radio invalid value="kittens">Kittens</sp-radio>
+            <sp-radio invalid value="puppies" checked>Puppies</sp-radio>
+             <sp-help-text slot="negative-help-text" icon>
+                This selection is invalid.
+            </sp-help-text>
+        </sp-radio-group>
+    </div>
+
+    <div style="display: flex; flex-direction: column;">
+        <sp-field-label for="example-3" size="l">
+            <h4 class="spectrum-Heading--subtitle1">Disabled</h4>
+        </sp-fieldlabel>
+        <sp-radio-group id="example-3" name="example" vertical>
+            <sp-radio disabled value="kittens">Kittens</sp-radio>
+            <sp-radio disabled value="puppies" checked>Puppies</sp-radio>
+        </sp-radio-group>
+    </div>
+</div>
+```
+
+</sp-tab-panel>
+<sp-tab value="emphasized">Emphasized</sp-tab>
+<sp-tab-panel value="emphasized">
+
+```html
+<div style="display: flex; justify-content: space-between;">
+    <div style="display: flex; flex-direction: column;">
+        <sp-field-label for="example-a" size="l">
+            <h4 class="spectrum-Heading--subtitle1">Default</h4>
+        </sp-field-label>
+        <sp-radio-group id="example-a" name="example" vertical>
+            <sp-radio emphasized value="kittens">Kittens</sp-radio>
+            <sp-radio emphasized value="puppies" checked>Puppies</sp-radio>
+        </sp-radio-group>
+    </div>
+
+    <div style="display: flex; flex-direction: column;">
+        <sp-field-label for="example-b" size="l">
+            <h4 class="spectrum-Heading--subtitle1">Invalid</h4>
+        </sp-field-label>
+        <sp-radio-group invalid id="example-b" name="example" vertical>
+            <sp-radio emphasized invalid value="kittens">Kittens</sp-radio>
+            <sp-radio emphasized invalid value="puppies" checked>Puppies</sp-radio>
+            <sp-help-text slot="negative-help-text" icon>
+                This selection is invalid.
+            </sp-help-text>
+        </sp-radio-group>
+    </div>
+
+    <div style="display: flex; flex-direction: column;">
+        <sp-field-label for="example-c" size="l">
+            <h4 class="spectrum-Heading--subtitle1">Disabled</h4>
+        </sp-fieldlabel>
+        <sp-radio-group id="example-c" name="example" vertical>
+            <sp-radio emphasized disabled value="kittens">Kittens</sp-radio>
+            <sp-radio emphasized disabled value="puppies" checked>Puppies</sp-radio>
+        </sp-radio-group>
+    </div>
+</div>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
+### Behaviors
+
+#### Handling events
+
+Event handlers for clicks and other user actions can be registered on an `<sp-radio>` similar to a standard `<input type="radio">` element.
+
+```html
+<sp-radio id="radio-example" onclick="spAlert(this, '<sp-radio> clicked!')">
+    Web component
+</sp-radio>
+```
+
+### Accessibility
+
+Tabbing into a group of radio buttons places the focus on the first radio button selected. If none of the radio buttons are selected, the focus is set on the first one in the group. Space selects the radio button in focus (if not already selected). Using the arrow keys moves focus and selection to the previous or next radio button in the group (last becomes first, and first becomes last). The new radio button in focus gets selected even if the previous one was not.
+
+#### Provide a label
+
+Radio groups and radio items should always have labels.
+
+#### Provide help text in the correct location
+
+Radio groups should use help text for error messaging and descriptions. Descriptions are valuable for giving context behind why a selection is required, or for clarifying the options.
+
+It is [not currently possible](https://w3c.github.io/webcomponents-cg/#cross-root-aria) to provide accessible ARIA references between elements in different shadow roots. To ensure proper association between elements, help text must be included via the `slot="help-text"` or `slot="help-text-negative"`.
+
+See [help text](../help-text) for more information.


### PR DESCRIPTION
## Description

Improving the accessibility documentation of components.

## Motivation and context

Documentation should provide more information and examples that demonstrate how to use the components accessibly. These changes started with #4652

## How has this been tested?

### `<sp-action-button>`

Review [action button docs](https://nikkimk-a11y-docs--spectrum-web-components.netlify.app/components/action-button/)

-  [ ] Do the docs examples give enough context to test for accessibility?
-  [ ] Do the docs examples and text provide information on how to use the component accessibly?
-  [ ] If the component is to be used in the context of another component, do the examples include how that component is used accessibly in that context?
-  [ ] Are the docs headings logical and consistent across these components? ([1](#wave))

<a id="wave">1.</a> You can use the [WAVE browser extension's](https://wave.webaim.org/extension/) **Structure** tab to review heading structure.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
