### PR TITLE
chore: improve css import results; optimize precommit runs

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -28,3 +28,5 @@ jobs:
 
             - name: Upload coverage to Coveralls
               uses: coverallsapp/github-action@v2
+              with:
+                  allow-empty: true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,13 @@
 STAGED_FILES_TO_LINT=$(git diff --name-only --cached --diff-filter=d -- "*.ts" "*.js")
+STAGED_FILES_TO_ANALYZE=$(git diff --name-only --cached --diff-filter=d -- "{packages,tools}/*/src/**/!(*.css).ts")
+STAGED_CSS_FILES=$(git diff --name-only --cached --diff-filter=d -- "{packages,tools}/**/*.css")
 VERSION_FILE=$(dirname "$0")/../tools/base/src/version.js
-yarn eslint -f pretty $STAGED_FILES_TO_LINT
-yarn analyze
-yarn lint:css
+
+[[ -z "$STAGED_FILES_TO_LINT" ]] || yarn eslint -f pretty $STAGED_FILES_TO_LINT
+[[ -z "$STAGED_FILES_TO_ANALYZE" ]] || yarn lit-analyzer $STAGED_FILES_TO_ANALYZE
+[[ -z "$STAGED_CSS_FILES" ]] || yarn stylelint $STAGED_CSS_FILES
+
 yarn pretty-quick --staged
+
 yarn genversion --es6 --semi $VERSION_FILE
 git add $VERSION_FILE

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -6,3 +6,7 @@ trailingComma: es5
 bracketSpacing: true
 arrowParens: always
 htmlWhitespaceSensitivity: ignore
+overrides:
+    - files: '{tools,packages}/*/src/spectrum-*.css'
+      options:
+          printWidth: 500

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,27 +1,33 @@
 {
     "plugins": ["stylelint-header"],
-    "extends": ["stylelint-config-standard"],
+    "extends": [],
     "rules": {
-        "header/header": ["config/license.js", {}],
-        "length-zero-no-unit": [true, { "ignore": "custom-properties" }],
-        "selector-type-no-unknown": [true, { "ignore": ["custom-elements"] }],
-        "selector-pseudo-element-colon-notation": ["single", {}],
-        "custom-property-pattern": "^_?([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
-        "no-duplicate-selectors": null,
-        "selector-class-pattern": null,
-        "no-descending-specificity": null,
-        "declaration-block-no-redundant-longhand-properties": null
+        "header/header": ["config/license.js", {}]
     },
     "overrides": [
         {
             "files": [
-                "packages/**/src/spectrum-*.css",
-                "tools/**/src/spectrum-*.css",
-                "tools/styles/**/*.css"
+                "!packages/**/src/spectrum-*.css",
+                "!tools/**/src/spectrum-*.css",
+                "!tools/styles/**/*.css"
             ],
-            "extends": [],
+            "extends": ["stylelint-config-standard"],
             "rules": {
-                "header/header": ["config/license.js", {}]
+                "header/header": ["config/license.js", {}],
+                "length-zero-no-unit": [
+                    true,
+                    { "ignore": "custom-properties" }
+                ],
+                "selector-type-no-unknown": [
+                    true,
+                    { "ignore": ["custom-elements"] }
+                ],
+                "selector-pseudo-element-colon-notation": ["single", {}],
+                "custom-property-pattern": "^_?([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
+                "no-duplicate-selectors": null,
+                "selector-class-pattern": null,
+                "no-descending-specificity": null,
+                "declaration-block-no-redundant-longhand-properties": null
             }
         }
     ]

--- a/package.json
+++ b/package.json
@@ -66,9 +66,6 @@
         "process-spectrum": "wireit",
         "publish:react": "yarn changeset publish --no-git-tag --tag snapshot --no-push",
         "push-to-remote": "git add . && git commit -m \"chore: release new versions #publish\" && git push",
-        "spectrum-css": "wireit",
-        "spectrum-tokens": "wireit",
-        "spectrum-vars": "wireit",
         "start": "yarn storybook",
         "storybook": "wireit",
         "storybook:build": "NODE_ENV=production storybook build -o projects/documentation/dist/storybook -c storybook",
@@ -96,9 +93,6 @@
         "verify-build-artifacts": "node ./scripts/verify-build-artifacts.js",
         "vrt:preview": "yarn wds --config test/visual/wds-vrt.config.js",
         "vrt:quick-link": "yarn netlify deploy --alias=vrt --dir=projects/vrt-quick-link"
-    },
-    "peerDependencies": {
-        "common-tags": "^1.8.0"
     },
     "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
@@ -387,7 +381,7 @@
             ]
         },
         "process-spectrum": {
-            "command": "node ./scripts/spectrum-vars.js && node ./tasks/process-spectrum.js && node ./scripts/generate-tokens.js && yarn lint:css --fix && pretty-quick --pattern \"{packages,tools}/**/*.css\" && pretty-quick --pattern \"packages/dialog/src/spectrum-dialog.css\"",
+            "command": "node ./scripts/spectrum-vars.js && node ./tasks/process-spectrum.js && node ./scripts/generate-tokens.js && yarn lint:css --fix && pretty-quick --pattern \"{packages,tools}/**/*.css\"",
             "files": [
                 "tasks/process-spectrum.js",
                 "packages/**/spectrum-config.js",
@@ -397,7 +391,9 @@
                 "scripts/generate-tokens-wrapper.js",
                 "node_modules/@spectrum-css/**/*.css",
                 "scripts/spectrum-vars.js",
-                "tools/styles/package.json"
+                "tools/styles/package.json",
+                ".prettierrc.yaml",
+                ".stylelintrc.json"
             ],
             "output": [
                 "packages/*/src/spectrum-*.css",

--- a/packages/accordion/src/spectrum-accordion-item.css
+++ b/packages/accordion/src/spectrum-accordion-item.css
@@ -13,37 +13,19 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     z-index: inherit;
-    min-block-size: var(
-        --mod-accordion-item-height,
-        var(--spectrum-accordion-item-height)
-    );
-    min-inline-size: var(
-        --mod-accordion-item-width,
-        var(--spectrum-accordion-item-width)
-    );
+    min-block-size: var(--mod-accordion-item-height, var(--spectrum-accordion-item-height));
+    min-inline-size: var(--mod-accordion-item-width, var(--spectrum-accordion-item-width));
     border-block-end: 1px solid #0000;
-    border-color: var(
-        --mod-accordion-divider-color,
-        var(--spectrum-accordion-divider-color)
-    );
-    border-width: var(
-        --mod-accordion-divider-thickness,
-        var(--spectrum-divider-thickness-small)
-    );
+    border-color: var(--mod-accordion-divider-color, var(--spectrum-accordion-divider-color));
+    border-width: var(--mod-accordion-divider-thickness, var(--spectrum-divider-thickness-small));
     margin: 0;
     position: relative;
 }
 
 :host(:first-child) {
     border-block-start: 1px solid #0000;
-    border-color: var(
-        --mod-accordion-divider-color,
-        var(--spectrum-accordion-divider-color)
-    );
-    border-width: var(
-        --mod-accordion-divider-thickness,
-        var(--spectrum-divider-thickness-small)
-    );
+    border-color: var(--mod-accordion-divider-color, var(--spectrum-accordion-divider-color));
+    border-width: var(--mod-accordion-divider-thickness, var(--spectrum-divider-thickness-small));
 }
 
 #heading {
@@ -53,43 +35,15 @@ governing permissions and limitations under the License.
 }
 
 .iconContainer {
-    inline-size: var(
-        --mod-accordion-disclosure-indicator-height,
-        var(--spectrum-accordion-disclosure-indicator-height)
-    );
-    block-size: var(
-        --mod-accordion-disclosure-indicator-height,
-        var(--spectrum-accordion-disclosure-indicator-height)
-    );
-    color: var(
-        --mod-accordion-item-header-color-default,
-        var(--spectrum-accordion-item-header-color-default)
-    );
+    inline-size: var(--mod-accordion-disclosure-indicator-height, var(--spectrum-accordion-disclosure-indicator-height));
+    block-size: var(--mod-accordion-disclosure-indicator-height, var(--spectrum-accordion-disclosure-indicator-height));
+    color: var(--mod-accordion-item-header-color-default, var(--spectrum-accordion-item-header-color-default));
     justify-content: center;
     align-items: center;
-    padding-inline-start: var(
-        --mod-accordion-edge-to-disclosure-indicator-space,
-        var(--spectrum-accordion-edge-to-disclosure-indicator-space)
-    );
+    padding-inline-start: var(--mod-accordion-edge-to-disclosure-indicator-space, var(--spectrum-accordion-edge-to-disclosure-indicator-space));
     display: flex;
     position: absolute;
-    inset-block-start: max(
-        0px,
-        calc(
-            (
-                    var(
-                            --mod-accordion-min-block-size,
-                            var(--spectrum-accordion-min-block-size)
-                        ) -
-                        var(
-                            --mod-accordion-disclosure-indicator-height,
-                            var(
-                                --spectrum-accordion-disclosure-indicator-height
-                            )
-                        )
-                ) / 2
-        )
-    );
+    inset-block-start: max(0px, calc((var(--mod-accordion-min-block-size, var(--spectrum-accordion-min-block-size)) - var(--mod-accordion-disclosure-indicator-height, var(--spectrum-accordion-disclosure-indicator-height))) / 2));
 }
 
 .iconContainer:dir(rtl),
@@ -98,113 +52,38 @@ governing permissions and limitations under the License.
 }
 
 #content {
-    padding-block: var(
-            --mod-accordion-item-content-area-top-to-content,
-            var(--spectrum-accordion-item-content-area-top-to-content)
-        )
-        var(
-            --mod-accordion-item-content-area-bottom-to-content,
-            var(--spectrum-accordion-item-content-area-bottom-to-content)
-        );
-    padding-inline: var(
-            --mod-accordion-component-edge-to-text,
-            var(--spectrum-accordion-component-edge-to-text)
-        )
-        var(
-            --mod-accordion-component-edge-to-text,
-            var(--spectrum-accordion-component-edge-to-text)
-        );
-    color: var(
-        --mod-accordion-item-content-color,
-        var(--spectrum-accordion-item-content-color)
-    );
-    font-weight: var(
-        --mod-accordion-item-content-font-weight,
-        var(--spectrum-accordion-item-content-font-weight)
-    );
-    font-style: var(
-        --mod-accordion-item-content-font-style,
-        var(--spectrum-accordion-item-content-font-style)
-    );
-    font-size: var(
-        --mod-accordion-item-content-font-size,
-        var(--spectrum-accordion-item-content-font-size)
-    );
-    font-family: var(
-        --mod-accordion-item-content-font,
-        var(--spectrum-accordion-item-content-font)
-    );
-    line-height: var(
-        --mod-accordion-item-content-line-height,
-        var(--spectrum-accordion-item-content-line-height)
-    );
+    padding-block: var(--mod-accordion-item-content-area-top-to-content, var(--spectrum-accordion-item-content-area-top-to-content)) var(--mod-accordion-item-content-area-bottom-to-content, var(--spectrum-accordion-item-content-area-bottom-to-content));
+    padding-inline: var(--mod-accordion-component-edge-to-text, var(--spectrum-accordion-component-edge-to-text)) var(--mod-accordion-component-edge-to-text, var(--spectrum-accordion-component-edge-to-text));
+    color: var(--mod-accordion-item-content-color, var(--spectrum-accordion-item-content-color));
+    font-weight: var(--mod-accordion-item-content-font-weight, var(--spectrum-accordion-item-content-font-weight));
+    font-style: var(--mod-accordion-item-content-font-style, var(--spectrum-accordion-item-content-font-style));
+    font-size: var(--mod-accordion-item-content-font-size, var(--spectrum-accordion-item-content-font-size));
+    font-family: var(--mod-accordion-item-content-font, var(--spectrum-accordion-item-content-font));
+    line-height: var(--mod-accordion-item-content-line-height, var(--spectrum-accordion-item-content-line-height));
     display: none;
 }
 
 #header {
     box-sizing: border-box;
-    padding-block: var(
-            --mod-accordion-item-header-top-to-text-space,
-            var(--spectrum-accordion-item-header-top-to-text-space)
-        )
-        var(
-            --mod-accordion-item-header-bottom-to-text-space,
-            var(--spectrum-accordion-item-header-bottom-to-text-space)
-        );
-    min-block-size: var(
-        --mod-accordion-min-block-size,
-        var(--spectrum-accordion-min-block-size)
-    );
-    line-height: var(
-        --mod-accordion-item-header-line-height,
-        var(--spectrum-accordion-item-header-line-height)
-    );
+    padding-block: var(--mod-accordion-item-header-top-to-text-space, var(--spectrum-accordion-item-header-top-to-text-space)) var(--mod-accordion-item-header-bottom-to-text-space, var(--spectrum-accordion-item-header-bottom-to-text-space));
+    min-block-size: var(--mod-accordion-min-block-size, var(--spectrum-accordion-min-block-size));
+    line-height: var(--mod-accordion-item-header-line-height, var(--spectrum-accordion-item-header-line-height));
     text-overflow: ellipsis;
     cursor: pointer;
-    font-size: var(
-        --mod-accordion-item-header-font-size,
-        var(--spectrum-accordion-item-header-font-size)
-    );
-    font-weight: var(
-        --mod-accordion-item-header-font-weight,
-        var(--spectrum-accordion-item-header-font-weight)
-    );
-    font-style: var(
-        --mod-accordion-item-header-font-style,
-        var(--spectrum-accordion-item-header-font-style)
-    );
-    font-family: var(
-        --mod-accordion-item-header-font,
-        var(--spectrum-accordion-item-header-font)
-    );
+    font-size: var(--mod-accordion-item-header-font-size, var(--spectrum-accordion-item-header-font-size));
+    font-weight: var(--mod-accordion-item-header-font-weight, var(--spectrum-accordion-item-header-font-weight));
+    font-style: var(--mod-accordion-item-header-font-style, var(--spectrum-accordion-item-header-font-style));
+    font-family: var(--mod-accordion-item-header-font, var(--spectrum-accordion-item-header-font));
     appearance: none;
     text-align: start;
     inline-size: 100%;
-    color: var(
-        --mod-accordion-item-header-color-default,
-        var(--spectrum-accordion-item-header-color-default)
-    );
-    background-color: var(
-        --mod-accordion-background-color-default,
-        var(--spectrum-accordion-background-color-default)
-    );
+    color: var(--mod-accordion-item-header-color-default, var(--spectrum-accordion-item-header-color-default));
+    background-color: var(--mod-accordion-background-color-default, var(--spectrum-accordion-background-color-default));
     border: 0;
     justify-content: flex-start;
     align-items: center;
-    padding-inline-start: calc(
-        var(
-                --mod-accordion-disclosure-indicator-to-text-space,
-                var(--spectrum-accordion-disclosure-indicator-to-text-space)
-            ) +
-            var(
-                --mod-accordion-disclosure-indicator-height,
-                var(--spectrum-accordion-disclosure-indicator-height)
-            )
-    );
-    padding-inline-end: var(
-        --mod-accordion-edge-to-text-space,
-        var(--spectrum-accordion-edge-to-text-space)
-    );
+    padding-inline-start: calc(var(--mod-accordion-disclosure-indicator-to-text-space, var(--spectrum-accordion-disclosure-indicator-to-text-space)) + var(--mod-accordion-disclosure-indicator-height, var(--spectrum-accordion-disclosure-indicator-height)));
+    padding-inline-end: var(--mod-accordion-edge-to-text-space, var(--spectrum-accordion-edge-to-text-space));
     display: flex;
     position: relative;
 }
@@ -220,99 +99,50 @@ governing permissions and limitations under the License.
 }
 
 #header:focus-visible {
-    border-radius: var(
-        --mod-accordion-corner-radius,
-        var(--spectrum-accordion-corner-radius)
-    );
-    outline: var(
-            --mod-accordion-focus-indicator-thickness,
-            var(--spectrum-accordion-focus-indicator-thickness)
-        )
-        solid
-        var(
-            --mod-accordion-focus-indicator-color,
-            var(--spectrum-accordion-focus-indicator-color)
-        );
-    background-color: var(
-        --mod-accordion-background-color-key-focus,
-        var(--spectrum-accordion-background-color-key-focus)
-    );
-    color: var(
-        --mod-accordion-item-header-color-key-focus,
-        var(--spectrum-accordion-item-header-color-key-focus)
-    );
-    outline-offset: calc(
-        var(
-                --mod-accordion-focus-indicator-gap,
-                var(--spectrum-accordion-focus-indicator-gap)
-            ) * -1
-    );
+    border-radius: var(--mod-accordion-corner-radius, var(--spectrum-accordion-corner-radius));
+    outline: var(--mod-accordion-focus-indicator-thickness, var(--spectrum-accordion-focus-indicator-thickness)) solid var(--mod-accordion-focus-indicator-color, var(--spectrum-accordion-focus-indicator-color));
+    background-color: var(--mod-accordion-background-color-key-focus, var(--spectrum-accordion-background-color-key-focus));
+    color: var(--mod-accordion-item-header-color-key-focus, var(--spectrum-accordion-item-header-color-key-focus));
+    outline-offset: calc(var(--mod-accordion-focus-indicator-gap, var(--spectrum-accordion-focus-indicator-gap)) * -1);
 }
 
 #header:active {
-    background-color: var(
-        --mod-accordion-background-color-down,
-        var(--spectrum-accordion-background-color-down)
-    );
-    color: var(
-        --mod-accordion-item-header-color-down,
-        var(--spectrum-accordion-item-header-color-down)
-    );
+    background-color: var(--mod-accordion-background-color-down, var(--spectrum-accordion-background-color-down));
+    color: var(--mod-accordion-item-header-color-down, var(--spectrum-accordion-item-header-color-down));
 }
 
 :host([disabled]) #header,
 :host([disabled]) #header:focus-visible {
-    color: var(
-        --mod-accordion-item-header-disabled-color,
-        var(--spectrum-accordion-item-header-disabled-color)
-    );
+    color: var(--mod-accordion-item-header-disabled-color, var(--spectrum-accordion-item-header-disabled-color));
     background-color: initial;
 }
 
 @media (hover: hover) {
     #header:hover {
-        background-color: var(
-            --mod-accordion-background-color-hover,
-            var(--spectrum-accordion-background-color-hover)
-        );
+        background-color: var(--mod-accordion-background-color-hover, var(--spectrum-accordion-background-color-hover));
     }
 
     #header:hover,
     #header:hover + .iconContainer {
-        color: var(
-            --mod-accordion-item-header-color-hover,
-            var(--spectrum-accordion-item-header-color-hover)
-        );
+        color: var(--mod-accordion-item-header-color-hover, var(--spectrum-accordion-item-header-color-hover));
     }
 
     :host([open]) #header:hover {
-        background-color: var(
-            --mod-accordion-background-color-hover,
-            var(--spectrum-accordion-background-color-hover)
-        );
+        background-color: var(--mod-accordion-background-color-hover, var(--spectrum-accordion-background-color-hover));
     }
 
     :host([disabled]) #header:hover {
-        color: var(
-            --mod-accordion-item-header-disabled-color,
-            var(--spectrum-accordion-item-header-disabled-color)
-        );
+        color: var(--mod-accordion-item-header-disabled-color, var(--spectrum-accordion-item-header-disabled-color));
         background-color: initial;
     }
 }
 
 :host([disabled]) #header + .iconContainer {
-    color: var(
-        --mod-accordion-item-header-disabled-color,
-        var(--spectrum-accordion-item-header-disabled-color)
-    );
+    color: var(--mod-accordion-item-header-disabled-color, var(--spectrum-accordion-item-header-disabled-color));
 }
 
 :host([disabled]) #content {
-    color: var(
-        --mod-accordion-item-content-disabled-color,
-        var(--spectrum-accordion-item-content-disabled-color)
-    );
+    color: var(--mod-accordion-item-content-disabled-color, var(--spectrum-accordion-item-content-disabled-color));
 }
 
 :host([open]) > #heading > .iconContainer > .indicator,

--- a/packages/accordion/src/spectrum-accordion.css
+++ b/packages/accordion/src/spectrum-accordion.css
@@ -14,24 +14,7 @@ governing permissions and limitations under the License.
 :host {
     --spectrum-accordion-min-block-size: max(
         var(--mod-accordion-item-height, var(--spectrum-accordion-item-height)),
-        calc(
-            var(
-                    --mod-accordion-item-header-top-to-text-space,
-                    var(--spectrum-accordion-item-header-top-to-text-space)
-                ) +
-                var(
-                    --mod-accordion-item-header-bottom-to-text-space,
-                    var(--spectrum-accordion-item-header-bottom-to-text-space)
-                ) +
-                var(
-                    --mod-accordion-item-header-font-size,
-                    var(--spectrum-accordion-item-header-font-size)
-                ) *
-                var(
-                    --mod-accordion-item-header-line-height,
-                    var(--spectrum-accordion-item-header-line-height)
-                )
-        )
+        calc(var(--mod-accordion-item-header-top-to-text-space, var(--spectrum-accordion-item-header-top-to-text-space)) + var(--mod-accordion-item-header-bottom-to-text-space, var(--spectrum-accordion-item-header-bottom-to-text-space)) + var(--mod-accordion-item-header-font-size, var(--spectrum-accordion-item-header-font-size)) * var(--mod-accordion-item-header-line-height, var(--spectrum-accordion-item-header-line-height)))
     );
     margin: 0;
     padding: 0;
@@ -42,12 +25,8 @@ governing permissions and limitations under the License.
 :host:lang(ja),
 :host:lang(ko),
 :host:lang(zh) {
-    --spectrum-accordion-item-header-line-height: var(
-        --spectrum-accordion-item-header-line-height-cjk
-    );
-    --spectrum-accordion-item-content-line-height: var(
-        --spectrum-accordion-item-content-line-height-cjk
-    );
+    --spectrum-accordion-item-header-line-height: var(--spectrum-accordion-item-header-line-height-cjk);
+    --spectrum-accordion-item-content-line-height: var(--spectrum-accordion-item-content-line-height-cjk);
 }
 
 :host:dir(rtl),

--- a/packages/action-bar/src/spectrum-action-bar.css
+++ b/packages/action-bar/src/spectrum-action-bar.css
@@ -19,11 +19,7 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    padding: 0
-        var(
-            --mod-actionbar-spacing-outer-edge,
-            var(--spectrum-actionbar-spacing-outer-edge)
-        );
+    padding: 0 var(--mod-actionbar-spacing-outer-edge, var(--spectrum-actionbar-spacing-outer-edge));
     z-index: 1;
     box-sizing: border-box;
     pointer-events: none;
@@ -33,12 +29,7 @@ governing permissions and limitations under the License.
 }
 
 :host([open]) {
-    block-size: calc(
-        var(
-                --mod-actionbar-spacing-outer-edge,
-                var(--spectrum-actionbar-spacing-outer-edge)
-            ) + var(--mod-actionbar-height, var(--spectrum-actionbar-height))
-    );
+    block-size: calc(var(--mod-actionbar-spacing-outer-edge, var(--spectrum-actionbar-spacing-outer-edge)) + var(--mod-actionbar-height, var(--spectrum-actionbar-height)));
     opacity: 1;
 }
 
@@ -46,39 +37,10 @@ governing permissions and limitations under the License.
     block-size: var(--mod-actionbar-height, var(--spectrum-actionbar-height));
     box-sizing: border-box;
     inline-size: 100%;
-    border-radius: var(
-        --mod-actionbar-corner-radius,
-        var(--spectrum-actionbar-corner-radius)
-    );
-    border-color: var(
-        --highcontrast-actionbar-popover-border-color,
-        var(
-            --mod-actionbar-popover-border-color,
-            var(--spectrum-actionbar-popover-border-color)
-        )
-    );
-    background-color: var(
-        --mod-actionbar-popover-background-color,
-        var(--spectrum-actionbar-popover-background-color)
-    );
-    filter: drop-shadow(
-        var(
-                --mod-actionbar-shadow-horizontal,
-                var(--spectrum-actionbar-shadow-horizontal)
-            )
-            var(
-                --mod-actionbar-shadow-vertical,
-                var(--spectrum-actionbar-shadow-vertical)
-            )
-            var(
-                --mod-actionbar-shadow-blur,
-                var(--spectrum-actionbar-shadow-blur)
-            )
-            var(
-                --mod-actionbar-shadow-color,
-                var(--spectrum-actionbar-shadow-color)
-            )
-    );
+    border-radius: var(--mod-actionbar-corner-radius, var(--spectrum-actionbar-corner-radius));
+    border-color: var(--highcontrast-actionbar-popover-border-color, var(--mod-actionbar-popover-border-color, var(--spectrum-actionbar-popover-border-color)));
+    background-color: var(--mod-actionbar-popover-background-color, var(--spectrum-actionbar-popover-background-color));
+    filter: drop-shadow(var(--mod-actionbar-shadow-horizontal, var(--spectrum-actionbar-shadow-horizontal)) var(--mod-actionbar-shadow-vertical, var(--spectrum-actionbar-shadow-vertical)) var(--mod-actionbar-shadow-blur, var(--spectrum-actionbar-shadow-blur)) var(--mod-actionbar-shadow-color, var(--spectrum-actionbar-shadow-color)));
     pointer-events: auto;
     flex-direction: row;
     margin: auto;
@@ -89,79 +51,40 @@ governing permissions and limitations under the License.
 
 .close-button {
     flex-shrink: 0;
-    margin-block-start: var(
-        --mod-actionbar-spacing-close-button-top,
-        var(--spectrum-actionbar-spacing-close-button-top)
-    );
-    margin-inline-start: var(
-        --mod-actionbar-spacing-close-button-start,
-        var(--spectrum-actionbar-spacing-close-button-start)
-    );
-    margin-inline-end: var(
-        --mod-actionbar-spacing-close-button-end,
-        var(--spectrum-actionbar-spacing-close-button-end)
-    );
+    margin-block-start: var(--mod-actionbar-spacing-close-button-top, var(--spectrum-actionbar-spacing-close-button-top));
+    margin-inline-start: var(--mod-actionbar-spacing-close-button-start, var(--spectrum-actionbar-spacing-close-button-start));
+    margin-inline-end: var(--mod-actionbar-spacing-close-button-end, var(--spectrum-actionbar-spacing-close-button-end));
 }
 
 .field-label {
-    font-size: var(
-        --mod-actionbar-item-counter-font-size,
-        var(--spectrum-actionbar-item-counter-font-size)
-    );
-    color: var(
-        --mod-actionbar-item-counter-color,
-        var(--spectrum-actionbar-item-counter-color)
-    );
-    line-height: var(
-        --mod-actionbar-item-counter-line-height,
-        var(--spectrum-actionbar-item-counter-line-height)
-    );
-    margin-block-start: var(
-        --mod-actionbar-spacing-item-counter-top,
-        var(--spectrum-actionbar-spacing-item-counter-top)
-    );
-    margin-inline-end: var(
-        --mod-actionbar-spacing-item-counter-end,
-        var(--spectrum-actionbar-spacing-item-counter-end)
-    );
+    font-size: var(--mod-actionbar-item-counter-font-size, var(--spectrum-actionbar-item-counter-font-size));
+    color: var(--mod-actionbar-item-counter-color, var(--spectrum-actionbar-item-counter-color));
+    line-height: var(--mod-actionbar-item-counter-line-height, var(--spectrum-actionbar-item-counter-line-height));
+    margin-block-start: var(--mod-actionbar-spacing-item-counter-top, var(--spectrum-actionbar-spacing-item-counter-top));
+    margin-inline-end: var(--mod-actionbar-spacing-item-counter-end, var(--spectrum-actionbar-spacing-item-counter-end));
     padding: 0;
 }
 
 .field-label:lang(ja),
 .field-label:lang(ko),
 .field-label:lang(zh) {
-    line-height: var(
-        --mod-actionbar-item-counter-line-height-cjk,
-        var(--spectrum-actionbar-item-counter-line-height-cjk)
-    );
+    line-height: var(--mod-actionbar-item-counter-line-height-cjk, var(--spectrum-actionbar-item-counter-line-height-cjk));
 }
 
 .action-group {
-    margin-block-start: var(
-        --mod-actionbar-spacing-action-group-top,
-        var(--spectrum-actionbar-spacing-action-group-top)
-    );
+    margin-block-start: var(--mod-actionbar-spacing-action-group-top, var(--spectrum-actionbar-spacing-action-group-top));
     margin-inline-start: auto;
-    margin-inline-end: var(
-        --mod-actionbar-spacing-action-group-end,
-        var(--spectrum-actionbar-spacing-action-group-end)
-    );
+    margin-inline-end: var(--mod-actionbar-spacing-action-group-end, var(--spectrum-actionbar-spacing-action-group-end));
 }
 
 :host([emphasized]) #popover {
     filter: none;
-    background-color: var(
-        --mod-actionbar-emphasized-background-color,
-        var(--spectrum-actionbar-emphasized-background-color)
-    );
+    background-color: var(--mod-actionbar-emphasized-background-color, var(--spectrum-actionbar-emphasized-background-color));
     border-color: #0000;
 }
 
 :host([emphasized]) .field-label {
-    color: var(
-        --mod-actionbar-emphasized-item-counter-color,
-        var(--spectrum-actionbar-emphasized-item-counter-color)
-    );
+    color: var(--mod-actionbar-emphasized-item-counter-color, var(--spectrum-actionbar-emphasized-item-counter-color));
 }
 
 :host([variant='sticky']) {

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -16,59 +16,18 @@ governing permissions and limitations under the License.
     -webkit-user-select: none;
     user-select: none;
     box-sizing: border-box;
-    font-family: var(
-        --mod-button-font-family,
-        var(
-            --mod-sans-font-family-stack,
-            var(--spectrum-sans-font-family-stack)
-        )
-    );
+    font-family: var(--mod-button-font-family, var(--mod-sans-font-family-stack, var(--spectrum-sans-font-family-stack)));
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    line-height: var(
-        --mod-button-line-height,
-        var(--mod-line-height-100, var(--spectrum-line-height-100))
-    );
+    line-height: var(--mod-button-line-height, var(--mod-line-height-100, var(--spectrum-line-height-100)));
     text-transform: none;
     vertical-align: top;
     -webkit-appearance: button;
     transition:
-        background
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        border-color
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        color
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        box-shadow
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out;
+        background var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        border-color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        box-shadow var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out;
     border-style: solid;
     justify-content: center;
     align-items: center;
@@ -133,50 +92,14 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    --spectrum-actionbutton-background-color: var(
-        --highcontrast-actionbutton-background-color,
-        var(
-            --mod-actionbutton-background-color-default,
-            var(--spectrum-actionbutton-background-color-default)
-        )
-    );
-    --spectrum-actionbutton-border-color: var(
-        --highcontrast-actionbutton-border-color,
-        var(
-            --mod-actionbutton-border-color-default,
-            var(--spectrum-actionbutton-border-color-default)
-        )
-    );
-    --spectrum-actionbutton-content-color: var(
-        --highcontrast-actionbutton-content-color,
-        var(
-            --mod-actionbutton-content-color-default,
-            var(--spectrum-neutral-content-color-default)
-        )
-    );
-    --spectrum-actionbutton-border-radius: var(
-        --mod-actionbutton-border-radius,
-        var(--spectrum-actionbutton-border-radius)
-    );
-    --spectrum-actionbutton-border-width: var(
-        --mod-actionbutton-border-width,
-        var(--spectrum-border-width-100)
-    );
-    --spectrum-actionbutton-focus-indicator-gap: var(
-        --mod-actionbutton-focus-indicator-gap,
-        var(--spectrum-focus-indicator-gap)
-    );
-    --spectrum-actionbutton-focus-indicator-thickness: var(
-        --mod-actionbutton-focus-indicator-thickness,
-        var(--spectrum-focus-indicator-thickness)
-    );
-    --spectrum-actionbutton-focus-indicator-color: var(
-        --highcontrast-actionbutton-focus-indicator-color,
-        var(
-            --mod-actionbutton-focus-indicator-color,
-            var(--spectrum-focus-indicator-color)
-        )
-    );
+    --spectrum-actionbutton-background-color: var(--highcontrast-actionbutton-background-color, var(--mod-actionbutton-background-color-default, var(--spectrum-actionbutton-background-color-default)));
+    --spectrum-actionbutton-border-color: var(--highcontrast-actionbutton-border-color, var(--mod-actionbutton-border-color-default, var(--spectrum-actionbutton-border-color-default)));
+    --spectrum-actionbutton-content-color: var(--highcontrast-actionbutton-content-color, var(--mod-actionbutton-content-color-default, var(--spectrum-neutral-content-color-default)));
+    --spectrum-actionbutton-border-radius: var(--mod-actionbutton-border-radius, var(--spectrum-actionbutton-border-radius));
+    --spectrum-actionbutton-border-width: var(--mod-actionbutton-border-width, var(--spectrum-border-width-100));
+    --spectrum-actionbutton-focus-indicator-gap: var(--mod-actionbutton-focus-indicator-gap, var(--spectrum-focus-indicator-gap));
+    --spectrum-actionbutton-focus-indicator-thickness: var(--mod-actionbutton-focus-indicator-thickness, var(--spectrum-focus-indicator-thickness));
+    --spectrum-actionbutton-focus-indicator-color: var(--highcontrast-actionbutton-focus-indicator-color, var(--mod-actionbutton-focus-indicator-color, var(--spectrum-focus-indicator-color)));
 }
 
 :host:dir(rtl),
@@ -189,436 +112,176 @@ governing permissions and limitations under the License.
 }
 
 :host([emphasized]:not([static-color='black'], [static-color='white'])) {
-    --mod-actionbutton-background-color-default-selected: var(
-        --mod-actionbutton-background-color-default-selected-emphasized,
-        var(--spectrum-accent-background-color-default)
-    );
-    --mod-actionbutton-background-color-hover-selected: var(
-        --mod-actionbutton-background-color-hover-selected-emphasized,
-        var(--spectrum-accent-background-color-hover)
-    );
-    --mod-actionbutton-background-color-down-selected: var(
-        --mod-actionbutton-background-color-down-selected-emphasized,
-        var(--spectrum-accent-background-color-down)
-    );
-    --mod-actionbutton-background-color-focus-selected: var(
-        --mod-actionbutton-background-color-focus-selected-emphasized,
-        var(--spectrum-accent-background-color-key-focus)
-    );
-    --mod-actionbutton-content-color-default-selected: var(
-        --mod-actionbutton-content-color-default-selected-emphasized,
-        var(--spectrum-white)
-    );
-    --mod-actionbutton-content-color-hover-selected: var(
-        --mod-actionbutton-content-color-hover-selected-emphasized,
-        var(--spectrum-white)
-    );
-    --mod-actionbutton-content-color-down-selected: var(
-        --mod-actionbutton-content-color-down-selected-emphasized,
-        var(--spectrum-white)
-    );
-    --mod-actionbutton-content-color-focus-selected: var(
-        --mod-actionbutton-content-color-focus-selected-emphasized,
-        var(--spectrum-white)
-    );
+    --mod-actionbutton-background-color-default-selected: var(--mod-actionbutton-background-color-default-selected-emphasized, var(--spectrum-accent-background-color-default));
+    --mod-actionbutton-background-color-hover-selected: var(--mod-actionbutton-background-color-hover-selected-emphasized, var(--spectrum-accent-background-color-hover));
+    --mod-actionbutton-background-color-down-selected: var(--mod-actionbutton-background-color-down-selected-emphasized, var(--spectrum-accent-background-color-down));
+    --mod-actionbutton-background-color-focus-selected: var(--mod-actionbutton-background-color-focus-selected-emphasized, var(--spectrum-accent-background-color-key-focus));
+    --mod-actionbutton-content-color-default-selected: var(--mod-actionbutton-content-color-default-selected-emphasized, var(--spectrum-white));
+    --mod-actionbutton-content-color-hover-selected: var(--mod-actionbutton-content-color-hover-selected-emphasized, var(--spectrum-white));
+    --mod-actionbutton-content-color-down-selected: var(--mod-actionbutton-content-color-down-selected-emphasized, var(--spectrum-white));
+    --mod-actionbutton-content-color-focus-selected: var(--mod-actionbutton-content-color-focus-selected-emphasized, var(--spectrum-white));
 }
 
 :host([static-color='black']) {
-    --mod-actionbutton-background-color-default-selected: var(
-        --spectrum-transparent-black-800
-    );
-    --mod-actionbutton-background-color-hover-selected: var(
-        --spectrum-transparent-black-900
-    );
-    --mod-actionbutton-background-color-down-selected: var(
-        --spectrum-transparent-black-900
-    );
-    --mod-actionbutton-background-color-focus-selected: var(
-        --spectrum-transparent-black-900
-    );
+    --mod-actionbutton-background-color-default-selected: var(--spectrum-transparent-black-800);
+    --mod-actionbutton-background-color-hover-selected: var(--spectrum-transparent-black-900);
+    --mod-actionbutton-background-color-down-selected: var(--spectrum-transparent-black-900);
+    --mod-actionbutton-background-color-focus-selected: var(--spectrum-transparent-black-900);
     --mod-actionbutton-content-color-default: var(--spectrum-black);
     --mod-actionbutton-content-color-hover: var(--spectrum-black);
     --mod-actionbutton-content-color-down: var(--spectrum-black);
     --mod-actionbutton-content-color-focus: var(--spectrum-black);
-    --mod-actionbutton-content-color-disabled: var(
-        --spectrum-disabled-static-black-content-color
-    );
-    --mod-actionbutton-content-color-default-selected: var(
-        --mod-actionbutton-static-content-color,
-        var(--spectrum-white)
-    );
-    --mod-actionbutton-content-color-hover-selected: var(
-        --mod-actionbutton-static-content-color,
-        var(--spectrum-white)
-    );
-    --mod-actionbutton-content-color-down-selected: var(
-        --mod-actionbutton-static-content-color,
-        var(--spectrum-white)
-    );
-    --mod-actionbutton-content-color-focus-selected: var(
-        --mod-actionbutton-static-content-color,
-        var(--spectrum-white)
-    );
-    --mod-actionbutton-focus-indicator-color: var(
-        --spectrum-static-black-focus-indicator-color
-    );
+    --mod-actionbutton-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
+    --mod-actionbutton-content-color-default-selected: var(--mod-actionbutton-static-content-color, var(--spectrum-white));
+    --mod-actionbutton-content-color-hover-selected: var(--mod-actionbutton-static-content-color, var(--spectrum-white));
+    --mod-actionbutton-content-color-down-selected: var(--mod-actionbutton-static-content-color, var(--spectrum-white));
+    --mod-actionbutton-content-color-focus-selected: var(--mod-actionbutton-static-content-color, var(--spectrum-white));
+    --mod-actionbutton-focus-indicator-color: var(--spectrum-static-black-focus-indicator-color);
 }
 
 :host([static-color='white']) {
-    --mod-actionbutton-background-color-default-selected: var(
-        --spectrum-transparent-white-800
-    );
-    --mod-actionbutton-background-color-hover-selected: var(
-        --spectrum-transparent-white-900
-    );
-    --mod-actionbutton-background-color-down-selected: var(
-        --spectrum-transparent-white-900
-    );
-    --mod-actionbutton-background-color-focus-selected: var(
-        --spectrum-transparent-white-900
-    );
+    --mod-actionbutton-background-color-default-selected: var(--spectrum-transparent-white-800);
+    --mod-actionbutton-background-color-hover-selected: var(--spectrum-transparent-white-900);
+    --mod-actionbutton-background-color-down-selected: var(--spectrum-transparent-white-900);
+    --mod-actionbutton-background-color-focus-selected: var(--spectrum-transparent-white-900);
     --mod-actionbutton-content-color-default: var(--spectrum-white);
     --mod-actionbutton-content-color-hover: var(--spectrum-white);
     --mod-actionbutton-content-color-down: var(--spectrum-white);
     --mod-actionbutton-content-color-focus: var(--spectrum-white);
-    --mod-actionbutton-content-color-disabled: var(
-        --spectrum-disabled-static-white-content-color
-    );
-    --mod-actionbutton-content-color-default-selected: var(
-        --mod-actionbutton-static-content-color,
-        var(--spectrum-black)
-    );
-    --mod-actionbutton-content-color-hover-selected: var(
-        --mod-actionbutton-static-content-color,
-        var(--spectrum-black)
-    );
-    --mod-actionbutton-content-color-down-selected: var(
-        --mod-actionbutton-static-content-color,
-        var(--spectrum-black)
-    );
-    --mod-actionbutton-content-color-focus-selected: var(
-        --mod-actionbutton-static-content-color,
-        var(--spectrum-black)
-    );
-    --mod-actionbutton-focus-indicator-color: var(
-        --spectrum-static-white-focus-indicator-color
-    );
+    --mod-actionbutton-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
+    --mod-actionbutton-content-color-default-selected: var(--mod-actionbutton-static-content-color, var(--spectrum-black));
+    --mod-actionbutton-content-color-hover-selected: var(--mod-actionbutton-static-content-color, var(--spectrum-black));
+    --mod-actionbutton-content-color-down-selected: var(--mod-actionbutton-static-content-color, var(--spectrum-black));
+    --mod-actionbutton-content-color-focus-selected: var(--mod-actionbutton-static-content-color, var(--spectrum-black));
+    --mod-actionbutton-focus-indicator-color: var(--spectrum-static-white-focus-indicator-color);
 }
 
 :host([selected]) {
-    --mod-actionbutton-background-color-default: var(
-        --mod-actionbutton-background-color-default-selected,
-        var(--spectrum-actionbutton-background-color-selected)
-    );
-    --mod-actionbutton-background-color-hover: var(
-        --mod-actionbutton-background-color-hover-selected,
-        var(--spectrum-actionbutton-background-color-selected-hover)
-    );
-    --mod-actionbutton-background-color-down: var(
-        --mod-actionbutton-background-color-down-selected,
-        var(--spectrum-actionbutton-background-color-selected-down)
-    );
-    --mod-actionbutton-background-color-focus: var(
-        --mod-actionbutton-background-color-focus-selected,
-        var(--spectrum-actionbutton-background-color-selected-focus)
-    );
-    --mod-actionbutton-background-color-disabled: var(
-        --spectrum-actionbutton-background-color-selected-disabled
-    );
+    --mod-actionbutton-background-color-default: var(--mod-actionbutton-background-color-default-selected, var(--spectrum-actionbutton-background-color-selected));
+    --mod-actionbutton-background-color-hover: var(--mod-actionbutton-background-color-hover-selected, var(--spectrum-actionbutton-background-color-selected-hover));
+    --mod-actionbutton-background-color-down: var(--mod-actionbutton-background-color-down-selected, var(--spectrum-actionbutton-background-color-selected-down));
+    --mod-actionbutton-background-color-focus: var(--mod-actionbutton-background-color-focus-selected, var(--spectrum-actionbutton-background-color-selected-focus));
+    --mod-actionbutton-background-color-disabled: var(--spectrum-actionbutton-background-color-selected-disabled);
     --mod-actionbutton-border-color-default: transparent;
     --mod-actionbutton-border-color-hover: transparent;
     --mod-actionbutton-border-color-down: transparent;
     --mod-actionbutton-border-color-focus: transparent;
     --mod-actionbutton-border-color-disabled: transparent;
-    --mod-actionbutton-content-color-default: var(
-        --mod-actionbutton-content-color-default-selected,
-        var(--spectrum-actionbutton-content-color-selected)
-    );
-    --mod-actionbutton-content-color-hover: var(
-        --mod-actionbutton-content-color-hover-selected,
-        var(--spectrum-actionbutton-content-color-selected)
-    );
-    --mod-actionbutton-content-color-down: var(
-        --mod-actionbutton-content-color-down-selected,
-        var(--spectrum-actionbutton-content-color-selected)
-    );
-    --mod-actionbutton-content-color-focus: var(
-        --mod-actionbutton-content-color-focus-selected,
-        var(--spectrum-actionbutton-content-color-selected)
-    );
+    --mod-actionbutton-content-color-default: var(--mod-actionbutton-content-color-default-selected, var(--spectrum-actionbutton-content-color-selected));
+    --mod-actionbutton-content-color-hover: var(--mod-actionbutton-content-color-hover-selected, var(--spectrum-actionbutton-content-color-selected));
+    --mod-actionbutton-content-color-down: var(--mod-actionbutton-content-color-down-selected, var(--spectrum-actionbutton-content-color-selected));
+    --mod-actionbutton-content-color-focus: var(--mod-actionbutton-content-color-focus-selected, var(--spectrum-actionbutton-content-color-selected));
 }
 
 @media (hover: hover) {
     :host(:hover) {
-        --mod-actionbutton-background-color-default: var(
-            --mod-actionbutton-background-color-hover,
-            var(--spectrum-actionbutton-background-color-hover)
-        );
-        --mod-actionbutton-border-color-default: var(
-            --mod-actionbutton-border-color-hover,
-            var(--spectrum-actionbutton-border-color-hover)
-        );
-        --mod-actionbutton-content-color-default: var(
-            --mod-actionbutton-content-color-hover,
-            var(--spectrum-neutral-content-color-hover)
-        );
+        --mod-actionbutton-background-color-default: var(--mod-actionbutton-background-color-hover, var(--spectrum-actionbutton-background-color-hover));
+        --mod-actionbutton-border-color-default: var(--mod-actionbutton-border-color-hover, var(--spectrum-actionbutton-border-color-hover));
+        --mod-actionbutton-content-color-default: var(--mod-actionbutton-content-color-hover, var(--spectrum-neutral-content-color-hover));
     }
 }
 
 :host(:focus-visible) {
-    --mod-actionbutton-background-color-default: var(
-        --mod-actionbutton-background-color-focus,
-        var(--spectrum-actionbutton-background-color-focus)
-    );
-    --mod-actionbutton-border-color-default: var(
-        --mod-actionbutton-border-color-focus,
-        var(--spectrum-actionbutton-border-color-focus)
-    );
-    --mod-actionbutton-content-color-default: var(
-        --mod-actionbutton-content-color-focus,
-        var(--spectrum-neutral-content-color-key-focus)
-    );
+    --mod-actionbutton-background-color-default: var(--mod-actionbutton-background-color-focus, var(--spectrum-actionbutton-background-color-focus));
+    --mod-actionbutton-border-color-default: var(--mod-actionbutton-border-color-focus, var(--spectrum-actionbutton-border-color-focus));
+    --mod-actionbutton-content-color-default: var(--mod-actionbutton-content-color-focus, var(--spectrum-neutral-content-color-key-focus));
 }
 
 :host(:is(:active, [active])) {
-    --mod-actionbutton-background-color-default: var(
-        --mod-actionbutton-background-color-down,
-        var(--spectrum-actionbutton-background-color-down)
-    );
-    --mod-actionbutton-border-color-default: var(
-        --mod-actionbutton-border-color-down,
-        var(--spectrum-actionbutton-border-color-down)
-    );
-    --mod-actionbutton-content-color-default: var(
-        --mod-actionbutton-content-color-down,
-        var(--spectrum-neutral-content-color-down)
-    );
+    --mod-actionbutton-background-color-default: var(--mod-actionbutton-background-color-down, var(--spectrum-actionbutton-background-color-down));
+    --mod-actionbutton-border-color-default: var(--mod-actionbutton-border-color-down, var(--spectrum-actionbutton-border-color-down));
+    --mod-actionbutton-content-color-default: var(--mod-actionbutton-content-color-down, var(--spectrum-neutral-content-color-down));
 }
 
 :host([disabled]),
 :host([disabled]) {
-    --mod-actionbutton-background-color-default: var(
-        --mod-actionbutton-background-color-disabled,
-        var(--spectrum-actionbutton-background-color-disabled)
-    );
-    --mod-actionbutton-border-color-default: var(
-        --mod-actionbutton-border-color-disabled,
-        var(--spectrum-actionbutton-border-color-disabled)
-    );
-    --mod-actionbutton-content-color-default: var(
-        --mod-actionbutton-content-color-disabled,
-        var(--spectrum-disabled-content-color)
-    );
+    --mod-actionbutton-background-color-default: var(--mod-actionbutton-background-color-disabled, var(--spectrum-actionbutton-background-color-disabled));
+    --mod-actionbutton-border-color-default: var(--mod-actionbutton-border-color-disabled, var(--spectrum-actionbutton-border-color-disabled));
+    --mod-actionbutton-content-color-default: var(--mod-actionbutton-content-color-disabled, var(--spectrum-disabled-content-color));
 }
 
 :host,
 :host {
     --spectrum-actionbutton-sized-height: var(--spectrum-component-height-100);
-    --spectrum-actionbutton-sized-icon-size: var(
-        --spectrum-workflow-icon-size-100
-    );
+    --spectrum-actionbutton-sized-icon-size: var(--spectrum-workflow-icon-size-100);
     --spectrum-actionbutton-sized-font-size: var(--spectrum-font-size-100);
-    --spectrum-actionbutton-sized-text-to-visual: var(
-        --spectrum-text-to-visual-100
-    );
-    --spectrum-actionbutton-sized-edge-to-hold-icon: var(
-        --spectrum-action-button-edge-to-hold-icon-medium
-    );
-    --spectrum-actionbutton-sized-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-100
-    );
-    --spectrum-actionbutton-sized-edge-to-text: var(
-        --spectrum-component-edge-to-text-100
-    );
-    --spectrum-actionbutton-sized-edge-to-visual-only: var(
-        --spectrum-component-edge-to-visual-only-100
-    );
+    --spectrum-actionbutton-sized-text-to-visual: var(--spectrum-text-to-visual-100);
+    --spectrum-actionbutton-sized-edge-to-hold-icon: var(--spectrum-action-button-edge-to-hold-icon-medium);
+    --spectrum-actionbutton-sized-edge-to-visual: var(--spectrum-component-edge-to-visual-100);
+    --spectrum-actionbutton-sized-edge-to-text: var(--spectrum-component-edge-to-text-100);
+    --spectrum-actionbutton-sized-edge-to-visual-only: var(--spectrum-component-edge-to-visual-only-100);
 }
 
 :host([size='xs']) {
     --spectrum-actionbutton-sized-height: var(--spectrum-component-height-50);
-    --spectrum-actionbutton-sized-icon-size: var(
-        --spectrum-workflow-icon-size-50
-    );
+    --spectrum-actionbutton-sized-icon-size: var(--spectrum-workflow-icon-size-50);
     --spectrum-actionbutton-sized-font-size: var(--spectrum-font-size-50);
-    --spectrum-actionbutton-sized-text-to-visual: var(
-        --spectrum-text-to-visual-50
-    );
-    --spectrum-actionbutton-sized-edge-to-hold-icon: var(
-        --spectrum-action-button-edge-to-hold-icon-extra-small
-    );
-    --spectrum-actionbutton-sized-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-50
-    );
-    --spectrum-actionbutton-sized-edge-to-text: var(
-        --spectrum-component-edge-to-text-50
-    );
-    --spectrum-actionbutton-sized-edge-to-visual-only: var(
-        --spectrum-component-edge-to-visual-only-50
-    );
+    --spectrum-actionbutton-sized-text-to-visual: var(--spectrum-text-to-visual-50);
+    --spectrum-actionbutton-sized-edge-to-hold-icon: var(--spectrum-action-button-edge-to-hold-icon-extra-small);
+    --spectrum-actionbutton-sized-edge-to-visual: var(--spectrum-component-edge-to-visual-50);
+    --spectrum-actionbutton-sized-edge-to-text: var(--spectrum-component-edge-to-text-50);
+    --spectrum-actionbutton-sized-edge-to-visual-only: var(--spectrum-component-edge-to-visual-only-50);
 }
 
 :host([size='s']) {
     --spectrum-actionbutton-sized-height: var(--spectrum-component-height-75);
-    --spectrum-actionbutton-sized-icon-size: var(
-        --spectrum-workflow-icon-size-75
-    );
+    --spectrum-actionbutton-sized-icon-size: var(--spectrum-workflow-icon-size-75);
     --spectrum-actionbutton-sized-font-size: var(--spectrum-font-size-75);
-    --spectrum-actionbutton-sized-text-to-visual: var(
-        --spectrum-text-to-visual-75
-    );
-    --spectrum-actionbutton-sized-edge-to-hold-icon: var(
-        --spectrum-action-button-edge-to-hold-icon-small
-    );
-    --spectrum-actionbutton-sized-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-75
-    );
-    --spectrum-actionbutton-sized-edge-to-text: var(
-        --spectrum-component-edge-to-text-75
-    );
-    --spectrum-actionbutton-sized-edge-to-visual-only: var(
-        --spectrum-component-edge-to-visual-only-75
-    );
+    --spectrum-actionbutton-sized-text-to-visual: var(--spectrum-text-to-visual-75);
+    --spectrum-actionbutton-sized-edge-to-hold-icon: var(--spectrum-action-button-edge-to-hold-icon-small);
+    --spectrum-actionbutton-sized-edge-to-visual: var(--spectrum-component-edge-to-visual-75);
+    --spectrum-actionbutton-sized-edge-to-text: var(--spectrum-component-edge-to-text-75);
+    --spectrum-actionbutton-sized-edge-to-visual-only: var(--spectrum-component-edge-to-visual-only-75);
 }
 
 :host([size='l']) {
     --spectrum-actionbutton-sized-height: var(--spectrum-component-height-200);
-    --spectrum-actionbutton-sized-icon-size: var(
-        --spectrum-workflow-icon-size-200
-    );
+    --spectrum-actionbutton-sized-icon-size: var(--spectrum-workflow-icon-size-200);
     --spectrum-actionbutton-sized-font-size: var(--spectrum-font-size-200);
-    --spectrum-actionbutton-sized-text-to-visual: var(
-        --spectrum-text-to-visual-200
-    );
-    --spectrum-actionbutton-sized-edge-to-hold-icon: var(
-        --spectrum-action-button-edge-to-hold-icon-large
-    );
-    --spectrum-actionbutton-sized-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-200
-    );
-    --spectrum-actionbutton-sized-edge-to-text: var(
-        --spectrum-component-edge-to-text-200
-    );
-    --spectrum-actionbutton-sized-edge-to-visual-only: var(
-        --spectrum-component-edge-to-visual-only-200
-    );
+    --spectrum-actionbutton-sized-text-to-visual: var(--spectrum-text-to-visual-200);
+    --spectrum-actionbutton-sized-edge-to-hold-icon: var(--spectrum-action-button-edge-to-hold-icon-large);
+    --spectrum-actionbutton-sized-edge-to-visual: var(--spectrum-component-edge-to-visual-200);
+    --spectrum-actionbutton-sized-edge-to-text: var(--spectrum-component-edge-to-text-200);
+    --spectrum-actionbutton-sized-edge-to-visual-only: var(--spectrum-component-edge-to-visual-only-200);
 }
 
 :host([size='xl']) {
     --spectrum-actionbutton-sized-height: var(--spectrum-component-height-300);
-    --spectrum-actionbutton-sized-icon-size: var(
-        --spectrum-workflow-icon-size-300
-    );
+    --spectrum-actionbutton-sized-icon-size: var(--spectrum-workflow-icon-size-300);
     --spectrum-actionbutton-sized-font-size: var(--spectrum-font-size-300);
-    --spectrum-actionbutton-sized-text-to-visual: var(
-        --spectrum-text-to-visual-300
-    );
-    --spectrum-actionbutton-sized-edge-to-hold-icon: var(
-        --spectrum-action-button-edge-to-hold-icon-extra-large
-    );
-    --spectrum-actionbutton-sized-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-300
-    );
-    --spectrum-actionbutton-sized-edge-to-text: var(
-        --spectrum-component-edge-to-text-300
-    );
-    --spectrum-actionbutton-sized-edge-to-visual-only: var(
-        --spectrum-component-edge-to-visual-only-300
-    );
+    --spectrum-actionbutton-sized-text-to-visual: var(--spectrum-text-to-visual-300);
+    --spectrum-actionbutton-sized-edge-to-hold-icon: var(--spectrum-action-button-edge-to-hold-icon-extra-large);
+    --spectrum-actionbutton-sized-edge-to-visual: var(--spectrum-component-edge-to-visual-300);
+    --spectrum-actionbutton-sized-edge-to-text: var(--spectrum-component-edge-to-text-300);
+    --spectrum-actionbutton-sized-edge-to-visual-only: var(--spectrum-component-edge-to-visual-only-300);
 }
 
 :host {
-    --spectrum-actionbutton-height: var(
-        --mod-actionbutton-height,
-        var(--spectrum-actionbutton-sized-height)
-    );
-    --spectrum-actionbutton-icon-size: var(
-        --mod-actionbutton-icon-size,
-        var(--spectrum-actionbutton-sized-icon-size)
-    );
-    --spectrum-actionbutton-font-size: var(
-        --mod-actionbutton-font-size,
-        var(--spectrum-actionbutton-sized-font-size)
-    );
-    --spectrum-actionbutton-text-to-visual: var(
-        --mod-actionbutton-text-to-visual,
-        var(--spectrum-actionbutton-sized-text-to-visual)
-    );
-    --spectrum-actionbutton-edge-to-hold-icon: var(
-        --mod-actionbutton-edge-to-hold-icon,
-        var(--spectrum-actionbutton-sized-edge-to-hold-icon)
-    );
-    --spectrum-actionbutton-edge-to-visual: var(
-        --mod-actionbutton-edge-to-visual,
-        calc(
-            var(--spectrum-actionbutton-sized-edge-to-visual) -
-                var(--spectrum-actionbutton-border-width)
-        )
-    );
-    --spectrum-actionbutton-edge-to-text: var(
-        --mod-actionbutton-edge-to-text,
-        calc(
-            var(--spectrum-actionbutton-sized-edge-to-text) -
-                var(--spectrum-actionbutton-border-width)
-        )
-    );
-    --spectrum-actionbutton-edge-to-visual-only: var(
-        --mod-actionbutton-edge-to-visual-only,
-        calc(
-            var(--spectrum-actionbutton-sized-edge-to-visual-only) -
-                var(--spectrum-actionbutton-border-width)
-        )
-    );
-    min-inline-size: var(
-        --mod-actionbutton-min-width,
-        calc(
-            var(
-                    --mod-actionbutton-edge-to-visual-only,
-                    var(--spectrum-actionbutton-sized-edge-to-visual-only)
-                ) * 2 + var(--spectrum-actionbutton-icon-size)
-        )
-    );
+    --spectrum-actionbutton-height: var(--mod-actionbutton-height, var(--spectrum-actionbutton-sized-height));
+    --spectrum-actionbutton-icon-size: var(--mod-actionbutton-icon-size, var(--spectrum-actionbutton-sized-icon-size));
+    --spectrum-actionbutton-font-size: var(--mod-actionbutton-font-size, var(--spectrum-actionbutton-sized-font-size));
+    --spectrum-actionbutton-text-to-visual: var(--mod-actionbutton-text-to-visual, var(--spectrum-actionbutton-sized-text-to-visual));
+    --spectrum-actionbutton-edge-to-hold-icon: var(--mod-actionbutton-edge-to-hold-icon, var(--spectrum-actionbutton-sized-edge-to-hold-icon));
+    --spectrum-actionbutton-edge-to-visual: var(--mod-actionbutton-edge-to-visual, calc(var(--spectrum-actionbutton-sized-edge-to-visual) - var(--spectrum-actionbutton-border-width)));
+    --spectrum-actionbutton-edge-to-text: var(--mod-actionbutton-edge-to-text, calc(var(--spectrum-actionbutton-sized-edge-to-text) - var(--spectrum-actionbutton-border-width)));
+    --spectrum-actionbutton-edge-to-visual-only: var(--mod-actionbutton-edge-to-visual-only, calc(var(--spectrum-actionbutton-sized-edge-to-visual-only) - var(--spectrum-actionbutton-border-width)));
+    min-inline-size: var(--mod-actionbutton-min-width, calc(var(--mod-actionbutton-edge-to-visual-only, var(--spectrum-actionbutton-sized-edge-to-visual-only)) * 2 + var(--spectrum-actionbutton-icon-size)));
     block-size: var(--spectrum-actionbutton-height);
     border-radius: var(--spectrum-actionbutton-border-radius);
     border-width: var(--spectrum-actionbutton-border-width);
-    gap: calc(
-        var(--spectrum-actionbutton-text-to-visual) +
-            var(--spectrum-actionbutton-edge-to-text) -
-            var(--spectrum-actionbutton-edge-to-visual-only)
-    );
+    gap: calc(var(--spectrum-actionbutton-text-to-visual) + var(--spectrum-actionbutton-edge-to-text) - var(--spectrum-actionbutton-edge-to-visual-only));
     padding-inline: var(--spectrum-actionbutton-edge-to-text);
     background-color: var(--spectrum-actionbutton-background-color);
     border-color: var(--spectrum-actionbutton-border-color);
     color: var(--spectrum-actionbutton-content-color);
-    transition: border-color
-        var(
-            --mod-actionbutton-animation-duration,
-            var(--spectrum-animation-duration-100)
-        )
-        ease-in-out;
+    transition: border-color var(--mod-actionbutton-animation-duration, var(--spectrum-animation-duration-100)) ease-in-out;
     position: relative;
 }
 
 :host:after {
-    margin: calc(
-        (
-                var(--spectrum-actionbutton-focus-indicator-gap) +
-                    var(--spectrum-actionbutton-border-width)
-            ) * -1
-    );
-    border-radius: var(
-        --mod-actionbutton-focus-indicator-border-radius,
-        calc(
-            var(--spectrum-actionbutton-border-radius) +
-                var(--spectrum-actionbutton-focus-indicator-gap)
-        )
-    );
-    transition: box-shadow
-        var(
-            --mod-actionbutton-animation-duration,
-            var(--spectrum-animation-duration-100)
-        )
-        ease-in-out;
+    margin: calc((var(--spectrum-actionbutton-focus-indicator-gap) + var(--spectrum-actionbutton-border-width)) * -1);
+    border-radius: var(--mod-actionbutton-focus-indicator-border-radius, calc(var(--spectrum-actionbutton-border-radius) + var(--spectrum-actionbutton-focus-indicator-gap)));
+    transition: box-shadow var(--mod-actionbutton-animation-duration, var(--spectrum-animation-duration-100)) ease-in-out;
     pointer-events: none;
     content: '';
     position: absolute;
@@ -631,30 +294,20 @@ governing permissions and limitations under the License.
 }
 
 :host(:focus-visible):after {
-    box-shadow: 0 0 0 var(--spectrum-actionbutton-focus-indicator-thickness)
-        var(--spectrum-actionbutton-focus-indicator-color);
+    box-shadow: 0 0 0 var(--spectrum-actionbutton-focus-indicator-thickness) var(--spectrum-actionbutton-focus-indicator-color);
 }
 
 ::slotted([slot='icon']) {
     inline-size: var(--spectrum-actionbutton-icon-size);
     block-size: var(--spectrum-actionbutton-icon-size);
     color: inherit;
-    margin-inline-start: calc(
-        var(--spectrum-actionbutton-edge-to-visual) -
-            var(--spectrum-actionbutton-edge-to-text)
-    );
-    margin-inline-end: calc(
-        var(--spectrum-actionbutton-edge-to-visual-only) -
-            var(--spectrum-actionbutton-edge-to-text)
-    );
+    margin-inline-start: calc(var(--spectrum-actionbutton-edge-to-visual) - var(--spectrum-actionbutton-edge-to-text));
+    margin-inline-end: calc(var(--spectrum-actionbutton-edge-to-visual-only) - var(--spectrum-actionbutton-edge-to-text));
 }
 
 .hold-affordance + ::slotted([slot='icon']),
 [icon-only]::slotted([slot='icon']) {
-    margin-inline-start: calc(
-        var(--spectrum-actionbutton-edge-to-visual-only) -
-            var(--spectrum-actionbutton-edge-to-text)
-    );
+    margin-inline-start: calc(var(--spectrum-actionbutton-edge-to-visual-only) - var(--spectrum-actionbutton-edge-to-text));
 }
 
 #label {
@@ -672,12 +325,6 @@ governing permissions and limitations under the License.
     color: inherit;
     transform: var(--spectrum-logical-rotation,);
     position: absolute;
-    inset-block-end: calc(
-        var(--spectrum-actionbutton-edge-to-hold-icon) -
-            var(--spectrum-actionbutton-border-width)
-    );
-    inset-inline-end: calc(
-        var(--spectrum-actionbutton-edge-to-hold-icon) -
-            var(--spectrum-actionbutton-border-width)
-    );
+    inset-block-end: calc(var(--spectrum-actionbutton-edge-to-hold-icon) - var(--spectrum-actionbutton-border-width));
+    inset-inline-end: calc(var(--spectrum-actionbutton-edge-to-hold-icon) - var(--spectrum-actionbutton-border-width));
 }

--- a/packages/action-group/src/spectrum-action-group.css
+++ b/packages/action-group/src/spectrum-action-group.css
@@ -19,28 +19,19 @@ governing permissions and limitations under the License.
 
 :host([size='s']),
 :host([size='xs']) {
-    --spectrum-actiongroup-horizontal-spacing-regular: var(
-        --spectrum-spacing-75
-    );
+    --spectrum-actiongroup-horizontal-spacing-regular: var(--spectrum-spacing-75);
     --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-75);
 }
 
 :host([size='l']),
 :host,
 :host([size='xl']) {
-    --spectrum-actiongroup-horizontal-spacing-regular: var(
-        --spectrum-spacing-100
-    );
-    --spectrum-actiongroup-vertical-spacing-regular: var(
-        --spectrum-spacing-100
-    );
+    --spectrum-actiongroup-horizontal-spacing-regular: var(--spectrum-spacing-100);
+    --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-100);
 }
 
 :host {
-    gap: var(
-        --mod-actiongroup-horizontal-spacing-regular,
-        var(--spectrum-actiongroup-horizontal-spacing-regular)
-    );
+    gap: var(--mod-actiongroup-horizontal-spacing-regular, var(--spectrum-actiongroup-horizontal-spacing-regular));
     flex-wrap: wrap;
     display: flex;
 }
@@ -58,19 +49,13 @@ governing permissions and limitations under the License.
 }
 
 :host([vertical]) {
-    gap: var(
-        --mod-actiongroup-vertical-spacing-regular,
-        var(--spectrum-actiongroup-vertical-spacing-regular)
-    );
+    gap: var(--mod-actiongroup-vertical-spacing-regular, var(--spectrum-actiongroup-vertical-spacing-regular));
     flex-direction: column;
     display: inline-flex;
 }
 
 :host([compact]) {
-    gap: var(
-        --mod-actiongroup-gap-size-compact,
-        var(--spectrum-actiongroup-gap-size-compact)
-    );
+    gap: var(--mod-actiongroup-gap-size-compact, var(--spectrum-actiongroup-gap-size-compact));
 }
 
 :host([compact]:not([quiet])) {
@@ -78,77 +63,30 @@ governing permissions and limitations under the License.
 }
 
 :host([compact]:not([quiet])) ::slotted(*) {
-    border-radius: var(
-        --mod-actiongroup-border-radius-reset,
-        var(--spectrum-actiongroup-border-radius-reset)
-    );
+    border-radius: var(--mod-actiongroup-border-radius-reset, var(--spectrum-actiongroup-border-radius-reset));
     z-index: 0;
     position: relative;
 }
 
 :host([compact]:not([quiet])) ::slotted(:first-child) {
-    --mod-actionbutton-focus-indicator-border-radius: var(
-            --mod-actiongroup-border-radius,
-            var(--spectrum-actiongroup-border-radius)
-        )
-        0px 0px
-        var(
-            --mod-actiongroup-border-radius,
-            var(--spectrum-actiongroup-border-radius)
-        );
-    border-start-start-radius: var(
-        --mod-actiongroup-border-radius,
-        var(--spectrum-actiongroup-border-radius)
-    );
-    border-end-start-radius: var(
-        --mod-actiongroup-border-radius,
-        var(--spectrum-actiongroup-border-radius)
-    );
-    margin-inline-start: var(
-        --mod-actiongroup-button-spacing-reset,
-        var(--spectrum-actiongroup-button-spacing-reset)
-    );
+    --mod-actionbutton-focus-indicator-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    border-start-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    border-end-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    margin-inline-start: var(--mod-actiongroup-button-spacing-reset, var(--spectrum-actiongroup-button-spacing-reset));
 }
 
 :host([compact]:not([quiet])) ::slotted(:not(:first-child)) {
     --mod-actionbutton-focus-indicator-border-radius: 0px;
-    margin-inline-start: var(
-        --mod-actiongroup-horizontal-spacing-compact,
-        var(--spectrum-actiongroup-horizontal-spacing-compact)
-    );
-    margin-inline-end: var(
-        --mod-actiongroup-horizontal-spacing-compact,
-        var(--spectrum-actiongroup-horizontal-spacing-compact)
-    );
+    margin-inline-start: var(--mod-actiongroup-horizontal-spacing-compact, var(--spectrum-actiongroup-horizontal-spacing-compact));
+    margin-inline-end: var(--mod-actiongroup-horizontal-spacing-compact, var(--spectrum-actiongroup-horizontal-spacing-compact));
 }
 
 :host([compact]:not([quiet])) ::slotted(:last-child) {
-    --mod-actionbutton-focus-indicator-border-radius: 0px
-        var(
-            --mod-actiongroup-border-radius,
-            var(--spectrum-actiongroup-border-radius)
-        )
-        var(
-            --mod-actiongroup-border-radius,
-            var(--spectrum-actiongroup-border-radius)
-        )
-        0px;
-    border-start-end-radius: var(
-        --mod-actiongroup-border-radius,
-        var(--spectrum-actiongroup-border-radius)
-    );
-    border-end-end-radius: var(
-        --mod-actiongroup-border-radius,
-        var(--spectrum-actiongroup-border-radius)
-    );
-    margin-inline-start: var(
-        --mod-actiongroup-horizontal-spacing-compact,
-        var(--spectrum-actiongroup-horizontal-spacing-compact)
-    );
-    margin-inline-end: var(
-        --mod-actiongroup-border-radius-reset,
-        var(--spectrum-actiongroup-border-radius-reset)
-    );
+    --mod-actionbutton-focus-indicator-border-radius: 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px;
+    border-start-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    border-end-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    margin-inline-start: var(--mod-actiongroup-horizontal-spacing-compact, var(--spectrum-actiongroup-horizontal-spacing-compact));
+    margin-inline-end: var(--mod-actiongroup-border-radius-reset, var(--spectrum-actiongroup-border-radius-reset));
 }
 
 :host([compact]:not([quiet])) ::slotted([selected]) {
@@ -166,96 +104,35 @@ governing permissions and limitations under the License.
 }
 
 :host([compact][vertical]:not([quiet])) {
-    gap: var(
-        --mod-actiongroup-gap-size-compact,
-        var(--spectrum-actiongroup-gap-size-compact)
-    );
+    gap: var(--mod-actiongroup-gap-size-compact, var(--spectrum-actiongroup-gap-size-compact));
 }
 
 :host([compact][vertical]:not([quiet])) ::slotted(*) {
-    border-radius: var(
-        --mod-actiongroup-border-radius-reset,
-        var(--spectrum-actiongroup-border-radius-reset)
-    );
+    border-radius: var(--mod-actiongroup-border-radius-reset, var(--spectrum-actiongroup-border-radius-reset));
 }
 
 :host([compact][vertical]:not([quiet])) ::slotted(:first-child) {
-    --mod-actionbutton-focus-indicator-border-radius: var(
-            --mod-actiongroup-border-radius,
-            var(--spectrum-actiongroup-border-radius)
-        )
-        var(
-            --mod-actiongroup-border-radius,
-            var(--spectrum-actiongroup-border-radius)
-        )
-        0px 0px;
-    border-start-start-radius: var(
-        --mod-actiongroup-border-radius,
-        var(--spectrum-actiongroup-border-radius)
-    );
-    border-start-end-radius: var(
-        --mod-actiongroup-border-radius,
-        var(--spectrum-actiongroup-border-radius)
-    );
-    margin-block-start: var(
-        --mod-actiongroup-vertical-spacing-compact,
-        var(--spectrum-actiongroup-vertical-spacing-compact)
-    );
-    margin-block-end: var(
-        --mod-actiongroup-vertical-spacing-compact,
-        var(--spectrum-actiongroup-vertical-spacing-compact)
-    );
-    margin-inline-end: var(
-        --mod-actiongroup-button-spacing-reset,
-        var(--spectrum-actiongroup-button-spacing-reset)
-    );
+    --mod-actionbutton-focus-indicator-border-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) 0px 0px;
+    border-start-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    border-start-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    margin-block-start: var(--mod-actiongroup-vertical-spacing-compact, var(--spectrum-actiongroup-vertical-spacing-compact));
+    margin-block-end: var(--mod-actiongroup-vertical-spacing-compact, var(--spectrum-actiongroup-vertical-spacing-compact));
+    margin-inline-end: var(--mod-actiongroup-button-spacing-reset, var(--spectrum-actiongroup-button-spacing-reset));
 }
 
 :host([compact][vertical]:not([quiet])) ::slotted(:not(:first-child)) {
-    margin-block-start: var(
-        --mod-actiongroup-button-spacing-reset,
-        var(--spectrum-actiongroup-button-spacing-reset)
-    );
-    margin-block-end: var(
-        --mod-actiongroup-vertical-spacing-compact,
-        var(--spectrum-actiongroup-vertical-spacing-compact)
-    );
-    margin-inline-start: var(
-        --mod-actiongroup-button-spacing-reset,
-        var(--spectrum-actiongroup-button-spacing-reset)
-    );
-    margin-inline-end: var(
-        --mod-actiongroup-button-spacing-reset,
-        var(--spectrum-actiongroup-button-spacing-reset)
-    );
+    margin-block-start: var(--mod-actiongroup-button-spacing-reset, var(--spectrum-actiongroup-button-spacing-reset));
+    margin-block-end: var(--mod-actiongroup-vertical-spacing-compact, var(--spectrum-actiongroup-vertical-spacing-compact));
+    margin-inline-start: var(--mod-actiongroup-button-spacing-reset, var(--spectrum-actiongroup-button-spacing-reset));
+    margin-inline-end: var(--mod-actiongroup-button-spacing-reset, var(--spectrum-actiongroup-button-spacing-reset));
 }
 
 :host([compact][vertical]:not([quiet])) ::slotted(:last-child) {
-    --mod-actionbutton-focus-indicator-border-radius: 0px 0px
-        var(
-            --mod-actiongroup-border-radius,
-            var(--spectrum-actiongroup-border-radius)
-        )
-        var(
-            --mod-actiongroup-border-radius,
-            var(--spectrum-actiongroup-border-radius)
-        );
-    border-end-end-radius: var(
-        --mod-actiongroup-border-radius,
-        var(--spectrum-actiongroup-border-radius)
-    );
-    border-end-start-radius: var(
-        --mod-actiongroup-border-radius,
-        var(--spectrum-actiongroup-border-radius)
-    );
-    margin-block-start: var(
-        --mod-actiongroup-vertical-spacing-compact,
-        var(--spectrum-actiongroup-vertical-spacing-compact)
-    );
-    margin-block-end: var(
-        --mod-actiongroup-button-spacing-reset,
-        var(--spectrum-actiongroup-button-spacing-reset)
-    );
+    --mod-actionbutton-focus-indicator-border-radius: 0px 0px var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius)) var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    border-end-end-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    border-end-start-radius: var(--mod-actiongroup-border-radius, var(--spectrum-actiongroup-border-radius));
+    margin-block-start: var(--mod-actiongroup-vertical-spacing-compact, var(--spectrum-actiongroup-vertical-spacing-compact));
+    margin-block-end: var(--mod-actiongroup-button-spacing-reset, var(--spectrum-actiongroup-button-spacing-reset));
 }
 
 :host([justified]) ::slotted(*) {

--- a/packages/alert-banner/src/spectrum-alert-banner.css
+++ b/packages/alert-banner/src/spectrum-alert-banner.css
@@ -12,60 +12,23 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --mod-divider-vertical-margin: var(
-        --mod-alert-banner-edge-to-divider,
-        var(--spectrum-alert-banner-edge-to-divider)
-    );
+    --mod-divider-vertical-margin: var(--mod-alert-banner-edge-to-divider, var(--spectrum-alert-banner-edge-to-divider));
     --mod-divider-vertical-height: auto;
     --mod-divider-vertical-align: stretch;
-    --mod-button-margin-block: var(
-        --mod-alert-banner-edge-to-button,
-        var(--spectrum-alert-banner-edge-to-button)
-    );
-    --mod-button-margin-right: var(
-        --mod-alert-banner-text-to-divider,
-        var(--spectrum-alert-banner-text-to-divider)
-    );
+    --mod-button-margin-block: var(--mod-alert-banner-edge-to-button, var(--spectrum-alert-banner-edge-to-button));
+    --mod-button-margin-right: var(--mod-alert-banner-text-to-divider, var(--spectrum-alert-banner-text-to-divider));
     --mod-button-margin-left: auto;
-    --mod-closebutton-margin-inline: var(
-        --mod-alert-banner-close-button-spacing,
-        var(--spectrum-alert-banner-close-button-spacing)
-    );
-    --mod-closebutton-margin-top: var(
-        --mod-alert-banner-close-button-spacing,
-        var(--spectrum-alert-banner-close-button-spacing)
-    );
+    --mod-closebutton-margin-inline: var(--mod-alert-banner-close-button-spacing, var(--spectrum-alert-banner-close-button-spacing));
+    --mod-closebutton-margin-top: var(--mod-alert-banner-close-button-spacing, var(--spectrum-alert-banner-close-button-spacing));
     --mod-closebutton-align-self: flex-start;
-    inline-size: var(
-        --mod-alert-banner-size,
-        var(--spectrum-alert-banner-size)
-    );
-    max-inline-size: var(
-        --mod-alert-banner-max-inline-size,
-        var(--spectrum-alert-banner-max-inline-size)
-    );
-    min-block-size: var(
-        --mod-alert-banner-min-height,
-        var(--spectrum-alert-banner-min-height)
-    );
-    font-size: var(
-        --mod-alert-banner-font-size,
-        var(--spectrum-alert-banner-font-size)
-    );
-    color: var(
-        --mod-alert-banner-font-color,
-        var(--spectrum-alert-banner-font-color)
-    );
-    background-color: var(
-        --mod-alert-banner-neutral-background,
-        var(
-            --mod-alert-banner-neutral-background,
-            var(--spectrum-alert-banner-neutral-background)
-        )
-    );
+    inline-size: var(--mod-alert-banner-size, var(--spectrum-alert-banner-size));
+    max-inline-size: var(--mod-alert-banner-max-inline-size, var(--spectrum-alert-banner-max-inline-size));
+    min-block-size: var(--mod-alert-banner-min-height, var(--spectrum-alert-banner-min-height));
+    font-size: var(--mod-alert-banner-font-size, var(--spectrum-alert-banner-font-size));
+    color: var(--mod-alert-banner-font-color, var(--spectrum-alert-banner-font-color));
+    background-color: var(--mod-alert-banner-neutral-background, var(--mod-alert-banner-neutral-background, var(--spectrum-alert-banner-neutral-background)));
     border: 0 solid #0000;
-    border: var(--highcontrast-alert-banner-border-width, 0) solid
-        var(--highcontrast-alert-banner-border-color, transparent);
+    border: var(--highcontrast-alert-banner-border-width, 0) solid var(--highcontrast-alert-banner-border-color, transparent);
     justify-content: space-between;
     display: none;
 }
@@ -75,40 +38,19 @@ governing permissions and limitations under the License.
 }
 
 :host([variant='info']) {
-    background-color: var(
-        --mod-alert-banner-informative-background,
-        var(--spectrum-alert-banner-informative-background)
-    );
+    background-color: var(--mod-alert-banner-informative-background, var(--spectrum-alert-banner-informative-background));
 }
 
 :host([variant='negative']) {
-    background-color: var(
-        --mod-alert-banner-negative-background,
-        var(--spectrum-alert-banner-negative-background)
-    );
+    background-color: var(--mod-alert-banner-negative-background, var(--spectrum-alert-banner-negative-background));
 }
 
 .body {
     inline-size: 100%;
-    gap: max(
-        calc(
-            var(
-                    --mod-alert-banner-text-to-button-vertical,
-                    var(--spectrum-alert-banner-text-to-button-vertical)
-                ) -
-                var(
-                    --mod-alert-banner-edge-to-button,
-                    var(--spectrum-alert-banner-edge-to-button)
-                )
-        ),
-        0px
-    );
+    gap: max(calc(var(--mod-alert-banner-text-to-button-vertical, var(--spectrum-alert-banner-text-to-button-vertical)) - var(--mod-alert-banner-edge-to-button, var(--spectrum-alert-banner-edge-to-button))), 0px);
     flex-wrap: wrap;
     align-items: center;
-    margin-inline-start: var(
-        --mod-alert-banner-start-edge,
-        var(--spectrum-alert-banner-start-edge)
-    );
+    margin-inline-start: var(--mod-alert-banner-start-edge, var(--spectrum-alert-banner-start-edge));
     display: flex;
 }
 
@@ -122,45 +64,22 @@ governing permissions and limitations under the License.
 }
 
 .type {
-    inline-size: var(
-        --mod-alert-banner-icon-size,
-        var(--spectrum-alert-banner-icon-size)
-    );
-    block-size: var(
-        --mod-alert-banner-icon-size,
-        var(--spectrum-alert-banner-icon-size)
-    );
+    inline-size: var(--mod-alert-banner-icon-size, var(--spectrum-alert-banner-icon-size));
+    block-size: var(--mod-alert-banner-icon-size, var(--spectrum-alert-banner-icon-size));
     flex-shrink: 0;
-    margin-block-start: var(
-        --mod-alert-banner-top-icon,
-        var(--spectrum-alert-banner-top-icon)
-    );
-    margin-inline-end: var(
-        --mod-alert-banner-icon-to-text,
-        var(--spectrum-alert-banner-icon-to-text)
-    );
+    margin-block-start: var(--mod-alert-banner-top-icon, var(--spectrum-alert-banner-top-icon));
+    margin-inline-end: var(--mod-alert-banner-icon-to-text, var(--spectrum-alert-banner-icon-to-text));
 }
 
 .text {
-    margin-block-start: var(
-        --mod-alert-banner-top-text,
-        var(--spectrum-alert-banner-top-text)
-    );
-    margin-block-end: var(
-        --mod-alert-banner-bottom-text,
-        var(--spectrum-alert-banner-bottom-text)
-    );
-    margin-inline-end: var(
-        --mod-alert-banner-text-to-button-horizontal,
-        var(--spectrum-alert-banner-text-to-button-horizontal)
-    );
+    margin-block-start: var(--mod-alert-banner-top-text, var(--spectrum-alert-banner-top-text));
+    margin-block-end: var(--mod-alert-banner-bottom-text, var(--spectrum-alert-banner-bottom-text));
+    margin-inline-end: var(--mod-alert-banner-text-to-button-horizontal, var(--spectrum-alert-banner-text-to-button-horizontal));
 }
 
 @media (forced-colors: active) {
     :host {
         --highcontrast-alert-banner-border-color: CanvasText;
-        --highcontrast-alert-banner-border-width: var(
-            --spectrum-border-width-100
-        );
+        --highcontrast-alert-banner-border-width: var(--spectrum-border-width-100);
     }
 }

--- a/packages/alert-dialog/src/spectrum-alert-dialog.css
+++ b/packages/alert-dialog/src/spectrum-alert-dialog.css
@@ -15,51 +15,27 @@ governing permissions and limitations under the License.
     --mod-buttongroup-justify-content: flex-end;
     box-sizing: border-box;
     inline-size: fit-content;
-    min-inline-size: var(
-        --mod-alert-dialog-min-width,
-        var(--spectrum-alert-dialog-min-width)
-    );
-    max-inline-size: var(
-        --mod-alert-dialog-max-width,
-        var(--spectrum-alert-dialog-max-width)
-    );
+    min-inline-size: var(--mod-alert-dialog-min-width, var(--spectrum-alert-dialog-min-width));
+    max-inline-size: var(--mod-alert-dialog-max-width, var(--spectrum-alert-dialog-max-width));
     max-block-size: inherit;
-    padding: var(
-        --mod-alert-dialog-padding,
-        var(--spectrum-alert-dialog-padding)
-    );
+    padding: var(--mod-alert-dialog-padding, var(--spectrum-alert-dialog-padding));
     outline: none;
     display: flex;
 }
 
 .icon {
-    inline-size: var(
-        --mod-alert-dialog-icon-size,
-        var(--spectrum-alert-dialog-icon-size)
-    );
-    block-size: var(
-        --mod-alert-dialog-icon-size,
-        var(--spectrum-alert-dialog-icon-size)
-    );
+    inline-size: var(--mod-alert-dialog-icon-size, var(--spectrum-alert-dialog-icon-size));
+    block-size: var(--mod-alert-dialog-icon-size, var(--spectrum-alert-dialog-icon-size));
     flex-shrink: 0;
-    margin-inline-start: var(
-        --mod-alert-dialog-title-to-icon,
-        var(--spectrum-alert-dialog-title-to-icon)
-    );
+    margin-inline-start: var(--mod-alert-dialog-title-to-icon, var(--spectrum-alert-dialog-title-to-icon));
 }
 
 :host([variant='warning']) {
-    --mod-icon-color: var(
-        --mod-alert-dialog-warning-icon-color,
-        var(--spectrum-alert-dialog-warning-icon-color)
-    );
+    --mod-icon-color: var(--mod-alert-dialog-warning-icon-color, var(--spectrum-alert-dialog-warning-icon-color));
 }
 
 :host([variant='error']) {
-    --mod-icon-color: var(
-        --mod-alert-dialog-error-icon-color,
-        var(--spectrum-alert-dialog-error-icon-color)
-    );
+    --mod-icon-color: var(--mod-alert-dialog-error-icon-color, var(--spectrum-alert-dialog-error-icon-color));
 }
 
 .grid {
@@ -73,72 +49,27 @@ governing permissions and limitations under the License.
 }
 
 ::slotted([slot='heading']) {
-    font-family: var(
-        --mod-alert-dialog-title-font-family,
-        var(--spectrum-alert-dialog-title-font-family)
-    );
-    font-weight: var(
-        --mod-alert-dialog-title-font-weight,
-        var(--spectrum-alert-dialog-title-font-weight)
-    );
-    font-style: var(
-        --mod-alert-dialog-title-font-style,
-        var(--spectrum-alert-dialog-title-font-style)
-    );
-    font-size: var(
-        --mod-alert-dialog-title-font-size,
-        var(--spectrum-alert-dialog-title-font-size)
-    );
-    line-height: var(
-        --mod-alert-dialog-title-line-height,
-        var(--spectrum-alert-dialog-title-line-height)
-    );
-    color: var(
-        --mod-alert-dialog-title-color,
-        var(--spectrum-alert-dialog-title-color)
-    );
+    font-family: var(--mod-alert-dialog-title-font-family, var(--spectrum-alert-dialog-title-font-family));
+    font-weight: var(--mod-alert-dialog-title-font-weight, var(--spectrum-alert-dialog-title-font-weight));
+    font-style: var(--mod-alert-dialog-title-font-style, var(--spectrum-alert-dialog-title-font-style));
+    font-size: var(--mod-alert-dialog-title-font-size, var(--spectrum-alert-dialog-title-font-size));
+    line-height: var(--mod-alert-dialog-title-line-height, var(--spectrum-alert-dialog-title-line-height));
+    color: var(--mod-alert-dialog-title-color, var(--spectrum-alert-dialog-title-color));
     margin: 0;
-    margin-block-end: var(
-        --mod-alert-dialog-title-to-divider,
-        var(--spectrum-alert-dialog-title-to-divider)
-    );
+    margin-block-end: var(--mod-alert-dialog-title-to-divider, var(--spectrum-alert-dialog-title-to-divider));
 }
 
 .content {
-    font-family: var(
-        --mod-alert-dialog-body-font-family,
-        var(--spectrum-alert-dialog-body-font-family)
-    );
-    font-weight: var(
-        --mod-alert-dialog-body-font-weight,
-        var(--spectrum-alert-dialog-body-font-weight)
-    );
-    font-style: var(
-        --mod-alert-dialog-body-font-style,
-        var(--spectrum-alert-dialog-body-font-style)
-    );
-    font-size: var(
-        --mod-alert-dialog-body-font-size,
-        var(--spectrum-alert-dialog-body-font-size)
-    );
-    line-height: var(
-        --mod-alert-dialog-body-line-height,
-        var(--spectrum-alert-dialog-body-line-height)
-    );
-    color: var(
-        --mod-alert-dialog-body-color,
-        var(--spectrum-alert-dialog-body-color)
-    );
+    font-family: var(--mod-alert-dialog-body-font-family, var(--spectrum-alert-dialog-body-font-family));
+    font-weight: var(--mod-alert-dialog-body-font-weight, var(--spectrum-alert-dialog-body-font-weight));
+    font-style: var(--mod-alert-dialog-body-font-style, var(--spectrum-alert-dialog-body-font-style));
+    font-size: var(--mod-alert-dialog-body-font-size, var(--spectrum-alert-dialog-body-font-size));
+    line-height: var(--mod-alert-dialog-body-line-height, var(--spectrum-alert-dialog-body-line-height));
+    color: var(--mod-alert-dialog-body-color, var(--spectrum-alert-dialog-body-color));
     -webkit-overflow-scrolling: touch;
     margin: 0;
-    margin-block-start: var(
-        --mod-alert-dialog-divider-to-description,
-        var(--spectrum-alert-dialog-divider-to-description)
-    );
-    margin-block-end: var(
-        --mod-alert-dialog-description-to-buttons,
-        var(--spectrum-alert-dialog-description-to-buttons)
-    );
+    margin-block-start: var(--mod-alert-dialog-divider-to-description, var(--spectrum-alert-dialog-divider-to-description));
+    margin-block-end: var(--mod-alert-dialog-description-to-buttons, var(--spectrum-alert-dialog-description-to-buttons));
     overflow-y: auto;
 }
 

--- a/packages/asset/src/spectrum-asset.css
+++ b/packages/asset/src/spectrum-asset.css
@@ -29,41 +29,23 @@ governing permissions and limitations under the License.
 .file,
 .folder {
     inline-size: max(48px, min(100%, 80px));
-    inline-size: max(
-        var(--mod-asset-icon-min-width, 48px),
-        min(100%, var(--mod-asset-icon-max-width, 80px))
-    );
+    inline-size: max(var(--mod-asset-icon-min-width, 48px), min(100%, var(--mod-asset-icon-max-width, 80px)));
     block-size: 100%;
     margin: 20px;
     margin: var(--mod-asset-icon-margin, 20px);
 }
 
 .folderBackground {
-    fill: var(
-        --highcontrast-asset-folder-background-color,
-        var(
-            --mod-asset-folder-background-color,
-            var(--spectrum-asset-folder-background-color)
-        )
-    );
+    fill: var(--highcontrast-asset-folder-background-color, var(--mod-asset-folder-background-color, var(--spectrum-asset-folder-background-color)));
 }
 
 .fileBackground {
-    fill: var(
-        --highcontrast-asset-file-background-color,
-        var(
-            --mod-asset-file-background-color,
-            var(--spectrum-asset-file-background-color)
-        )
-    );
+    fill: var(--highcontrast-asset-file-background-color, var(--mod-asset-file-background-color, var(--spectrum-asset-file-background-color)));
 }
 
 .fileOutline,
 .folderOutline {
-    fill: var(
-        --mod-asset-icon-outline-color,
-        var(--spectrum-asset-icon-outline-color)
-    );
+    fill: var(--mod-asset-icon-outline-color, var(--spectrum-asset-icon-outline-color));
 }
 
 @media (forced-colors: active) {

--- a/packages/avatar/src/spectrum-avatar.css
+++ b/packages/avatar/src/spectrum-avatar.css
@@ -19,22 +19,13 @@ governing permissions and limitations under the License.
 
 :host {
     --spectrum-avatar-border-radius: var(--spectrum-avatar-block-size);
-    inline-size: var(
-        --mod-avatar-inline-size,
-        var(--spectrum-avatar-inline-size)
-    );
+    inline-size: var(--mod-avatar-inline-size, var(--spectrum-avatar-inline-size));
     block-size: var(--mod-avatar-block-size, var(--spectrum-avatar-block-size));
-    border-radius: var(
-        --mod-avatar-border-radius,
-        var(--spectrum-avatar-border-radius)
-    );
+    border-radius: var(--mod-avatar-border-radius, var(--spectrum-avatar-border-radius));
     -webkit-user-drag: none;
     -webkit-user-select: none;
     user-select: none;
-    opacity: var(
-        --mod-avatar-color-opacity,
-        var(--spectrum-avatar-color-opacity)
-    );
+    opacity: var(--mod-avatar-color-opacity, var(--spectrum-avatar-color-opacity));
     border-width: 0;
     outline: none;
     display: inline-block;
@@ -43,74 +34,22 @@ governing permissions and limitations under the License.
 }
 
 :host([disabled]) {
-    opacity: var(
-        --highcontrast-avatar-color-opacity-disabled,
-        var(
-            --mod-avatar-color-opacity-disabled,
-            var(--spectrum-avatar-color-opacity-disabled)
-        )
-    );
+    opacity: var(--highcontrast-avatar-color-opacity-disabled, var(--mod-avatar-color-opacity-disabled, var(--spectrum-avatar-color-opacity-disabled)));
 }
 
 :host(:not([disabled])) .is-focused:after,
 :host(:not([disabled])) .link:focus-visible:after {
     pointer-events: none;
     content: '';
-    inline-size: calc(
-        var(--mod-avatar-inline-size, var(--spectrum-avatar-inline-size)) +
-            var(
-                --mod-avatar-focus-indicator-gap,
-                var(--spectrum-avatar-focus-indicator-gap)
-            ) * 2
-    );
-    block-size: calc(
-        var(--mod-avatar-inline-size, var(--spectrum-avatar-inline-size)) +
-            var(
-                --mod-avatar-focus-indicator-gap,
-                var(--spectrum-avatar-focus-indicator-gap)
-            ) * 2
-    );
+    inline-size: calc(var(--mod-avatar-inline-size, var(--spectrum-avatar-inline-size)) + var(--mod-avatar-focus-indicator-gap, var(--spectrum-avatar-focus-indicator-gap)) * 2);
+    block-size: calc(var(--mod-avatar-inline-size, var(--spectrum-avatar-inline-size)) + var(--mod-avatar-focus-indicator-gap, var(--spectrum-avatar-focus-indicator-gap)) * 2);
     border-style: solid;
-    border-width: var(
-        --mod-avatar-focus-indicator-thickness,
-        var(--spectrum-avatar-focus-indicator-thickness)
-    );
-    border-color: var(
-        --highcontrast-avatar-focus-indicator-color,
-        var(
-            --mod-avatar-focus-indicator-color,
-            var(--spectrum-avatar-focus-indicator-color)
-        )
-    );
-    border-radius: var(
-        --mod-avatar-border-radius,
-        var(--spectrum-avatar-border-radius)
-    );
+    border-width: var(--mod-avatar-focus-indicator-thickness, var(--spectrum-avatar-focus-indicator-thickness));
+    border-color: var(--highcontrast-avatar-focus-indicator-color, var(--mod-avatar-focus-indicator-color, var(--spectrum-avatar-focus-indicator-color)));
+    border-radius: var(--mod-avatar-border-radius, var(--spectrum-avatar-border-radius));
     position: absolute;
-    inset-block-start: calc(
-        (
-                var(
-                        --mod-avatar-focus-indicator-gap,
-                        var(--spectrum-avatar-focus-indicator-gap)
-                    ) +
-                    var(
-                        --mod-avatar-focus-indicator-thickness,
-                        var(--spectrum-avatar-focus-indicator-thickness)
-                    )
-            ) * -1
-    );
-    inset-inline-start: calc(
-        (
-                var(
-                        --mod-avatar-focus-indicator-gap,
-                        var(--spectrum-avatar-focus-indicator-gap)
-                    ) +
-                    var(
-                        --mod-avatar-focus-indicator-thickness,
-                        var(--spectrum-avatar-focus-indicator-thickness)
-                    )
-            ) * -1
-    );
+    inset-block-start: calc((var(--mod-avatar-focus-indicator-gap, var(--spectrum-avatar-focus-indicator-gap)) + var(--mod-avatar-focus-indicator-thickness, var(--spectrum-avatar-focus-indicator-thickness))) * -1);
+    inset-inline-start: calc((var(--mod-avatar-focus-indicator-gap, var(--spectrum-avatar-focus-indicator-gap)) + var(--mod-avatar-focus-indicator-thickness, var(--spectrum-avatar-focus-indicator-thickness))) * -1);
 }
 
 .link {
@@ -118,13 +57,7 @@ governing permissions and limitations under the License.
 }
 
 .image {
-    inline-size: var(
-        --mod-avatar-inline-size,
-        var(--spectrum-avatar-inline-size)
-    );
+    inline-size: var(--mod-avatar-inline-size, var(--spectrum-avatar-inline-size));
     block-size: var(--mod-avatar-block-size, var(--spectrum-avatar-block-size));
-    border-radius: var(
-        --mod-avatar-border-radius,
-        var(--spectrum-avatar-border-radius)
-    );
+    border-radius: var(--mod-avatar-border-radius, var(--spectrum-avatar-border-radius));
 }

--- a/packages/badge/src/spectrum-badge.css
+++ b/packages/badge/src/spectrum-badge.css
@@ -24,14 +24,8 @@ governing permissions and limitations under the License.
     cursor: default;
     -webkit-font-smoothing: subpixel-antialiased;
     -moz-osx-font-smoothing: auto;
-    border-radius: var(
-        --mod-badge-corner-radius,
-        var(--spectrum-badge-corner-radius)
-    );
-    color: var(
-        --mod-badge-label-icon-color,
-        var(--spectrum-badge-label-icon-color)
-    );
+    border-radius: var(--mod-badge-corner-radius, var(--spectrum-badge-corner-radius));
+    color: var(--mod-badge-label-icon-color, var(--spectrum-badge-label-icon-color));
     border: 1px solid #0000;
     display: inline-flex;
     position: relative;
@@ -39,143 +33,83 @@ governing permissions and limitations under the License.
 
 :host,
 :host([variant='neutral']) {
-    background: var(
-        --mod-badge-background-color-default,
-        var(--spectrum-badge-background-color-default)
-    );
+    background: var(--mod-badge-background-color-default, var(--spectrum-badge-background-color-default));
 }
 
 :host([variant='accent']) {
-    background: var(
-        --mod-badge-background-color-accent,
-        var(--spectrum-badge-background-color-accent)
-    );
+    background: var(--mod-badge-background-color-accent, var(--spectrum-badge-background-color-accent));
 }
 
 :host([variant='informative']) {
-    background: var(
-        --mod-badge-background-color-informative,
-        var(--spectrum-badge-background-color-informative)
-    );
+    background: var(--mod-badge-background-color-informative, var(--spectrum-badge-background-color-informative));
 }
 
 :host([variant='negative']) {
-    background: var(
-        --mod-badge-background-color-negative,
-        var(--spectrum-badge-background-color-negative)
-    );
+    background: var(--mod-badge-background-color-negative, var(--spectrum-badge-background-color-negative));
 }
 
 :host([variant='positive']) {
-    background: var(
-        --mod-badge-background-color-positive,
-        var(--spectrum-badge-background-color-positive)
-    );
+    background: var(--mod-badge-background-color-positive, var(--spectrum-badge-background-color-positive));
 }
 
 :host([variant='notice']) {
-    background: var(
-        --mod-badge-background-color-notice,
-        var(--spectrum-badge-background-color-notice)
-    );
+    background: var(--mod-badge-background-color-notice, var(--spectrum-badge-background-color-notice));
 }
 
 :host([variant='gray']) {
-    background: var(
-        --mod-badge-background-color-gray,
-        var(--spectrum-badge-background-color-gray)
-    );
+    background: var(--mod-badge-background-color-gray, var(--spectrum-badge-background-color-gray));
 }
 
 :host([variant='red']) {
-    background: var(
-        --mod-badge-background-color-red,
-        var(--spectrum-badge-background-color-red)
-    );
+    background: var(--mod-badge-background-color-red, var(--spectrum-badge-background-color-red));
 }
 
 :host([variant='orange']) {
-    background: var(
-        --mod-badge-background-color-orange,
-        var(--spectrum-badge-background-color-orange)
-    );
+    background: var(--mod-badge-background-color-orange, var(--spectrum-badge-background-color-orange));
 }
 
 :host([variant='yellow']) {
-    background: var(
-        --mod-badge-background-color-yellow,
-        var(--spectrum-badge-background-color-yellow)
-    );
+    background: var(--mod-badge-background-color-yellow, var(--spectrum-badge-background-color-yellow));
 }
 
 :host([variant='chartreuse']) {
-    background: var(
-        --mod-badge-background-color-chartreuse,
-        var(--spectrum-badge-background-color-chartreuse)
-    );
+    background: var(--mod-badge-background-color-chartreuse, var(--spectrum-badge-background-color-chartreuse));
 }
 
 :host([variant='celery']) {
-    background: var(
-        --mod-badge-background-color-celery,
-        var(--spectrum-badge-background-color-celery)
-    );
+    background: var(--mod-badge-background-color-celery, var(--spectrum-badge-background-color-celery));
 }
 
 :host([variant='green']) {
-    background: var(
-        --mod-badge-background-color-green,
-        var(--spectrum-badge-background-color-green)
-    );
+    background: var(--mod-badge-background-color-green, var(--spectrum-badge-background-color-green));
 }
 
 :host([variant='seafoam']) {
-    background: var(
-        --mod-badge-background-color-seafoam,
-        var(--spectrum-badge-background-color-seafoam)
-    );
+    background: var(--mod-badge-background-color-seafoam, var(--spectrum-badge-background-color-seafoam));
 }
 
 :host([variant='cyan']) {
-    background: var(
-        --mod-badge-background-color-cyan,
-        var(--spectrum-badge-background-color-cyan)
-    );
+    background: var(--mod-badge-background-color-cyan, var(--spectrum-badge-background-color-cyan));
 }
 
 :host([variant='blue']) {
-    background: var(
-        --mod-badge-background-color-blue,
-        var(--spectrum-badge-background-color-blue)
-    );
+    background: var(--mod-badge-background-color-blue, var(--spectrum-badge-background-color-blue));
 }
 
 :host([variant='indigo']) {
-    background: var(
-        --mod-badge-background-color-indigo,
-        var(--spectrum-badge-background-color-indigo)
-    );
+    background: var(--mod-badge-background-color-indigo, var(--spectrum-badge-background-color-indigo));
 }
 
 :host([variant='purple']) {
-    background: var(
-        --mod-badge-background-color-purple,
-        var(--spectrum-badge-background-color-purple)
-    );
+    background: var(--mod-badge-background-color-purple, var(--spectrum-badge-background-color-purple));
 }
 
 :host([variant='fuchsia']) {
-    background: var(
-        --mod-badge-background-color-fuchsia,
-        var(--spectrum-badge-background-color-fuchsia)
-    );
+    background: var(--mod-badge-background-color-fuchsia, var(--spectrum-badge-background-color-fuchsia));
 }
 
 :host([variant='magenta']) {
-    background: var(
-        --mod-badge-background-color-magenta,
-        var(--spectrum-badge-background-color-magenta)
-    );
+    background: var(--mod-badge-background-color-magenta, var(--spectrum-badge-background-color-magenta));
 }
 
 :host([fixed='inline-start']) {
@@ -200,39 +134,18 @@ governing permissions and limitations under the License.
 
 .label {
     font-size: var(--mod-badge-font-size, var(--spectrum-badge-font-size));
-    line-height: var(
-        --mod-badge-line-height,
-        var(--spectrum-badge-line-height)
-    );
-    color: var(
-        --mod-badge-label-icon-color,
-        var(--spectrum-badge-label-icon-color)
-    );
-    padding-block-start: var(
-        --mod-badge-label-spacing-vertical-top,
-        var(--spectrum-badge-label-spacing-vertical-top)
-    );
-    padding-block-end: var(
-        --mod-badge-label-spacing-vertical-bottom,
-        var(--spectrum-badge-label-spacing-vertical-bottom)
-    );
-    padding-inline-start: var(
-        --mod-badge-label-spacing-horizontal,
-        var(--spectrum-badge-label-spacing-horizontal)
-    );
-    padding-inline-end: var(
-        --mod-badge-label-spacing-horizontal,
-        var(--spectrum-badge-label-spacing-horizontal)
-    );
+    line-height: var(--mod-badge-line-height, var(--spectrum-badge-line-height));
+    color: var(--mod-badge-label-icon-color, var(--spectrum-badge-label-icon-color));
+    padding-block-start: var(--mod-badge-label-spacing-vertical-top, var(--spectrum-badge-label-spacing-vertical-top));
+    padding-block-end: var(--mod-badge-label-spacing-vertical-bottom, var(--spectrum-badge-label-spacing-vertical-bottom));
+    padding-inline-start: var(--mod-badge-label-spacing-horizontal, var(--spectrum-badge-label-spacing-horizontal));
+    padding-inline-end: var(--mod-badge-label-spacing-horizontal, var(--spectrum-badge-label-spacing-horizontal));
 }
 
 .label:lang(ja),
 .label:lang(ko),
 .label:lang(zh) {
-    line-height: var(
-        --mod-badge-line-height-cjk,
-        var(--spectrum-badge-line-height-cjk)
-    );
+    line-height: var(--mod-badge-line-height-cjk, var(--spectrum-badge-line-height-cjk));
 }
 
 [name='icon'] + .label {
@@ -240,48 +153,17 @@ governing permissions and limitations under the License.
 }
 
 ::slotted([slot='icon']) {
-    block-size: var(
-        --mod-badge-workflow-icon-size,
-        var(--spectrum-badge-workflow-icon-size)
-    );
-    inline-size: var(
-        --mod-badge-workflow-icon-size,
-        var(--spectrum-badge-workflow-icon-size)
-    );
-    flex: 0 0
-        var(
-            --mod-badge-workflow-icon-size,
-            var(--spectrum-badge-workflow-icon-size)
-        );
-    color: var(
-        --mod-badge-label-icon-color,
-        var(--spectrum-badge-label-icon-color)
-    );
-    padding-block-start: var(
-        --mod-badge-icon-spacing-vertical-top,
-        var(--spectrum-badge-icon-spacing-vertical-top)
-    );
-    padding-block-end: var(
-        --mod-badge-icon-spacing-vertical-top,
-        var(--spectrum-badge-icon-spacing-vertical-top)
-    );
-    padding-inline-start: var(
-        --mod-badge-icon-spacing-horizontal,
-        var(--spectrum-badge-icon-spacing-horizontal)
-    );
-    padding-inline-end: var(
-        --mod-badge-icon-text-spacing,
-        var(--spectrum-badge-icon-text-spacing)
-    );
+    block-size: var(--mod-badge-workflow-icon-size, var(--spectrum-badge-workflow-icon-size));
+    inline-size: var(--mod-badge-workflow-icon-size, var(--spectrum-badge-workflow-icon-size));
+    flex: 0 0 var(--mod-badge-workflow-icon-size, var(--spectrum-badge-workflow-icon-size));
+    color: var(--mod-badge-label-icon-color, var(--spectrum-badge-label-icon-color));
+    padding-block-start: var(--mod-badge-icon-spacing-vertical-top, var(--spectrum-badge-icon-spacing-vertical-top));
+    padding-block-end: var(--mod-badge-icon-spacing-vertical-top, var(--spectrum-badge-icon-spacing-vertical-top));
+    padding-inline-start: var(--mod-badge-icon-spacing-horizontal, var(--spectrum-badge-icon-spacing-horizontal));
+    padding-inline-end: var(--mod-badge-icon-text-spacing, var(--spectrum-badge-icon-text-spacing));
 }
 
 [icon-only]::slotted(*) {
-    padding-inline-start: var(
-        --mod-badge-icon-only-spacing-horizontal,
-        var(--spectrum-badge-icon-only-spacing-horizontal)
-    );
-    padding-inline-end: var(
-        --mod-badge-icon-only-spacing-horizontal,
-        var(--spectrum-badge-icon-only-spacing-horizontal)
-    );
+    padding-inline-start: var(--mod-badge-icon-only-spacing-horizontal, var(--spectrum-badge-icon-only-spacing-horizontal));
+    padding-inline-end: var(--mod-badge-icon-only-spacing-horizontal, var(--spectrum-badge-icon-only-spacing-horizontal));
 }

--- a/packages/breadcrumbs/src/spectrum-breadcrumbs-item.css
+++ b/packages/breadcrumbs/src/spectrum-breadcrumbs-item.css
@@ -12,22 +12,10 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #separator {
-    margin-block: var(
-        --mod-breadcrumbs-icon-spacing-block,
-        var(--spectrum-breadcrumbs-icon-spacing-block)
-    );
-    margin-inline: var(
-        --mod-breadcrumbs-separator-spacing-inline,
-        var(--spectrum-breadcrumbs-separator-spacing-inline)
-    );
+    margin-block: var(--mod-breadcrumbs-icon-spacing-block, var(--spectrum-breadcrumbs-icon-spacing-block));
+    margin-inline: var(--mod-breadcrumbs-separator-spacing-inline, var(--spectrum-breadcrumbs-separator-spacing-inline));
     opacity: 1;
-    color: var(
-        --highcontrast-breadcrumbs-separator-color,
-        var(
-            --mod-breadcrumbs-separator-color,
-            var(--spectrum-breadcrumbs-separator-color)
-        )
-    );
+    color: var(--highcontrast-breadcrumbs-separator-color, var(--mod-breadcrumbs-separator-color, var(--spectrum-breadcrumbs-separator-color)));
     position: relative;
 }
 
@@ -39,40 +27,19 @@ governing permissions and limitations under the License.
 :host {
     box-sizing: border-box;
     white-space: nowrap;
-    font-family: var(
-        --mod-breadcrumbs-font-family,
-        var(--spectrum-breadcrumbs-font-family)
-    );
-    font-size: var(
-        --mod-breadcrumbs-font-size,
-        var(--spectrum-breadcrumbs-font-size)
-    );
-    font-weight: var(
-        --mod-breadcrumbs-font-weight,
-        var(--spectrum-breadcrumbs-font-weight)
-    );
-    line-height: var(
-        --mod-breadcrumbs-line-height,
-        var(--spectrum-breadcrumbs-line-height)
-    );
+    font-family: var(--mod-breadcrumbs-font-family, var(--spectrum-breadcrumbs-font-family));
+    font-size: var(--mod-breadcrumbs-font-size, var(--spectrum-breadcrumbs-font-size));
+    font-weight: var(--mod-breadcrumbs-font-weight, var(--spectrum-breadcrumbs-font-weight));
+    line-height: var(--mod-breadcrumbs-line-height, var(--spectrum-breadcrumbs-line-height));
     align-items: center;
     display: inline-flex;
     position: relative;
 }
 
 :host(:not(.is-menu):last-of-type) {
-    font-family: var(
-        --mod-breadcrumbs-font-family-current,
-        var(--spectrum-breadcrumbs-font-family-current)
-    );
-    font-size: var(
-        --mod-breadcrumbs-font-size-current,
-        var(--spectrum-breadcrumbs-font-size-current)
-    );
-    font-weight: var(
-        --mod-breadcrumbs-font-weight-current,
-        var(--spectrum-breadcrumbs-font-weight-current)
-    );
+    font-family: var(--mod-breadcrumbs-font-family-current, var(--spectrum-breadcrumbs-font-family-current));
+    font-size: var(--mod-breadcrumbs-font-size-current, var(--spectrum-breadcrumbs-font-size-current));
+    font-weight: var(--mod-breadcrumbs-font-weight-current, var(--spectrum-breadcrumbs-font-weight-current));
 }
 
 :host(:not(.is-menu):last-of-type) #separator {
@@ -80,63 +47,27 @@ governing permissions and limitations under the License.
 }
 
 ::slotted(sp-action-menu) {
-    margin-inline: var(
-        --mod-breadcrumbs-action-button-spacing-inline,
-        var(--spectrum-breadcrumbs-action-button-spacing-inline)
-    );
-    margin-block: var(
-        --mod-breadcrumbs-action-button-spacing-block,
-        var(--spectrum-breadcrumbs-action-button-spacing-block)
-    );
-    color: var(
-        --highcontrast-breadcrumbs-action-button-color,
-        var(
-            --mod-breadcrumbs-action-button-color,
-            var(--spectrum-breadcrumbs-action-button-color)
-        )
-    );
+    margin-inline: var(--mod-breadcrumbs-action-button-spacing-inline, var(--spectrum-breadcrumbs-action-button-spacing-inline));
+    margin-block: var(--mod-breadcrumbs-action-button-spacing-block, var(--spectrum-breadcrumbs-action-button-spacing-block));
+    color: var(--highcontrast-breadcrumbs-action-button-color, var(--mod-breadcrumbs-action-button-color, var(--spectrum-breadcrumbs-action-button-color)));
 }
 
 ::slotted(sp-action-menu[disabled]) {
-    color: var(
-        --highcontrast-breadcrumbs-action-button-color-disabled,
-        var(
-            --mod-breadcrumbs-action-button-color-disabled,
-            var(--spectrum-breadcrumbs-action-button-color-disabled)
-        )
-    );
+    color: var(--highcontrast-breadcrumbs-action-button-color-disabled, var(--mod-breadcrumbs-action-button-color-disabled, var(--spectrum-breadcrumbs-action-button-color-disabled)));
 }
 
 :host(:first-of-type) > ::slotted(sp-action-menu) {
-    margin-inline-start: var(
-        --mod-breadcrumbs-action-button-spacing-inline-start,
-        var(--spectrum-breadcrumbs-action-button-spacing-inline-start)
-    );
+    margin-inline-start: var(--mod-breadcrumbs-action-button-spacing-inline-start, var(--spectrum-breadcrumbs-action-button-spacing-inline-start));
 }
 
 #item-link {
     cursor: default;
     box-sizing: border-box;
-    border-radius: var(
-        --mod-breadcrumbs-item-link-border-radius,
-        var(--spectrum-breadcrumbs-item-link-border-radius)
-    );
-    color: var(
-        --highcontrast-breadcrumbs-text-color,
-        var(
-            --mod-breadcrumbs-text-color,
-            var(--spectrum-breadcrumbs-text-color)
-        )
-    );
+    border-radius: var(--mod-breadcrumbs-item-link-border-radius, var(--spectrum-breadcrumbs-item-link-border-radius));
+    color: var(--highcontrast-breadcrumbs-text-color, var(--mod-breadcrumbs-text-color, var(--spectrum-breadcrumbs-text-color)));
     outline: none;
-    margin-block-start: var(
-        --mod-breadcrumbs-text-spacing-block-start,
-        var(--spectrum-breadcrumbs-text-spacing-block-start)
-    );
-    margin-block-end: var(
-        --mod-breadcrumbs-text-spacing-block-end,
-        var(--spectrum-breadcrumbs-text-spacing-block-end)
-    );
+    margin-block-start: var(--mod-breadcrumbs-text-spacing-block-start, var(--spectrum-breadcrumbs-text-spacing-block-start));
+    margin-block-end: var(--mod-breadcrumbs-text-spacing-block-end, var(--spectrum-breadcrumbs-text-spacing-block-end));
     -webkit-text-decoration: none;
     text-decoration: none;
     display: block;
@@ -145,23 +76,11 @@ governing permissions and limitations under the License.
 
 #item-link.is-disabled,
 :host([aria-disabled='true']) #item-link {
-    color: var(
-        --highcontrast-breadcrumbs-text-color-disabled,
-        var(
-            --mod-breadcrumbs-text-color-disabled,
-            var(--spectrum-breadcrumbs-text-color-disabled)
-        )
-    );
+    color: var(--highcontrast-breadcrumbs-text-color-disabled, var(--mod-breadcrumbs-text-color-disabled, var(--spectrum-breadcrumbs-text-color-disabled)));
 }
 
 :host(:not(.is-menu):last-of-type) #item-link {
-    color: var(
-        --highcontrast-breadcrumbs-text-color-current,
-        var(
-            --mod-breadcrumbs-text-color-current,
-            var(--spectrum-breadcrumbs-text-color-current)
-        )
-    );
+    color: var(--highcontrast-breadcrumbs-text-color-current, var(--mod-breadcrumbs-text-color-current, var(--spectrum-breadcrumbs-text-color-current)));
 }
 
 #item-link[href],
@@ -173,14 +92,8 @@ governing permissions and limitations under the License.
 #item-link[tabindex]:focus-visible {
     -webkit-text-decoration: underline;
     text-decoration: underline;
-    text-decoration-thickness: var(
-        --mod-breadcrumbs-text-decoration-thickness,
-        var(--spectrum-breadcrumbs-text-decoration-thickness)
-    );
-    text-underline-offset: var(
-        --mod-breadcrumbs-text-decoration-gap,
-        var(--spectrum-breadcrumbs-text-decoration-gap)
-    );
+    text-decoration-thickness: var(--mod-breadcrumbs-text-decoration-thickness, var(--spectrum-breadcrumbs-text-decoration-thickness));
+    text-underline-offset: var(--mod-breadcrumbs-text-decoration-gap, var(--spectrum-breadcrumbs-text-decoration-gap));
 }
 
 @media (hover: hover) {
@@ -188,84 +101,24 @@ governing permissions and limitations under the License.
     #item-link[tabindex]:hover {
         -webkit-text-decoration: underline;
         text-decoration: underline;
-        text-decoration-thickness: var(
-            --mod-breadcrumbs-text-decoration-thickness,
-            var(--spectrum-breadcrumbs-text-decoration-thickness)
-        );
-        text-underline-offset: var(
-            --mod-breadcrumbs-text-decoration-gap,
-            var(--spectrum-breadcrumbs-text-decoration-gap)
-        );
+        text-decoration-thickness: var(--mod-breadcrumbs-text-decoration-thickness, var(--spectrum-breadcrumbs-text-decoration-thickness));
+        text-underline-offset: var(--mod-breadcrumbs-text-decoration-gap, var(--spectrum-breadcrumbs-text-decoration-gap));
     }
 }
 
 :host .is-dragged #item-link:before,
 #item-link:focus-visible:before {
     box-sizing: border-box;
-    inline-size: calc(
-        100% +
-            var(
-                --mod-breadcrumbs-focus-indicator-gap,
-                var(--spectrum-breadcrumbs-focus-indicator-gap)
-            ) * 2 +
-            var(
-                --mod-breadcrumbs-focus-indicator-thickness,
-                var(--spectrum-breadcrumbs-focus-indicator-thickness)
-            ) * 2
-    );
-    block-size: calc(
-        100% +
-            var(
-                --mod-breadcrumbs-focus-indicator-gap,
-                var(--spectrum-breadcrumbs-focus-indicator-gap)
-            ) * 2 +
-            var(
-                --mod-breadcrumbs-focus-indicator-thickness,
-                var(--spectrum-breadcrumbs-focus-indicator-thickness)
-            ) * 2
-    );
-    border-width: var(
-        --mod-breadcrumbs-focus-indicator-thickness,
-        var(--spectrum-breadcrumbs-focus-indicator-thickness)
-    );
-    border-radius: var(
-        --mod-breadcrumbs-item-link-border-radius,
-        var(--spectrum-breadcrumbs-item-link-border-radius)
-    );
+    inline-size: calc(100% + var(--mod-breadcrumbs-focus-indicator-gap, var(--spectrum-breadcrumbs-focus-indicator-gap)) * 2 + var(--mod-breadcrumbs-focus-indicator-thickness, var(--spectrum-breadcrumbs-focus-indicator-thickness)) * 2);
+    block-size: calc(100% + var(--mod-breadcrumbs-focus-indicator-gap, var(--spectrum-breadcrumbs-focus-indicator-gap)) * 2 + var(--mod-breadcrumbs-focus-indicator-thickness, var(--spectrum-breadcrumbs-focus-indicator-thickness)) * 2);
+    border-width: var(--mod-breadcrumbs-focus-indicator-thickness, var(--spectrum-breadcrumbs-focus-indicator-thickness));
+    border-radius: var(--mod-breadcrumbs-item-link-border-radius, var(--spectrum-breadcrumbs-item-link-border-radius));
     content: '';
     pointer-events: none;
     border-style: solid;
-    border-color: var(
-        --highcontrast-breadcrumbs-focus-indicator-color,
-        var(
-            --mod-breadcrumbs-focus-indicator-color,
-            var(--spectrum-breadcrumbs-focus-indicator-color)
-        )
-    );
-    margin-block-start: calc(
-        (
-                var(
-                        --mod-breadcrumbs-focus-indicator-gap,
-                        var(--spectrum-breadcrumbs-focus-indicator-gap)
-                    ) +
-                    var(
-                        --mod-breadcrumbs-focus-indicator-thickness,
-                        var(--spectrum-breadcrumbs-focus-indicator-thickness)
-                    )
-            ) * -1
-    );
-    margin-inline-start: calc(
-        (
-                var(
-                        --mod-breadcrumbs-focus-indicator-gap,
-                        var(--spectrum-breadcrumbs-focus-indicator-gap)
-                    ) +
-                    var(
-                        --mod-breadcrumbs-focus-indicator-thickness,
-                        var(--spectrum-breadcrumbs-focus-indicator-thickness)
-                    )
-            ) * -1
-    );
+    border-color: var(--highcontrast-breadcrumbs-focus-indicator-color, var(--mod-breadcrumbs-focus-indicator-color, var(--spectrum-breadcrumbs-focus-indicator-color)));
+    margin-block-start: calc((var(--mod-breadcrumbs-focus-indicator-gap, var(--spectrum-breadcrumbs-focus-indicator-gap)) + var(--mod-breadcrumbs-focus-indicator-thickness, var(--spectrum-breadcrumbs-focus-indicator-thickness))) * -1);
+    margin-inline-start: calc((var(--mod-breadcrumbs-focus-indicator-gap, var(--spectrum-breadcrumbs-focus-indicator-gap)) + var(--mod-breadcrumbs-focus-indicator-thickness, var(--spectrum-breadcrumbs-focus-indicator-thickness))) * -1);
     display: block;
     position: absolute;
 }

--- a/packages/breadcrumbs/src/spectrum-breadcrumbs.css
+++ b/packages/breadcrumbs/src/spectrum-breadcrumbs.css
@@ -24,69 +24,36 @@ governing permissions and limitations under the License.
 }
 
 #list {
-    block-size: var(
-        --mod-breadcrumbs-block-size,
-        var(--spectrum-breadcrumbs-block-size)
-    );
+    block-size: var(--mod-breadcrumbs-block-size, var(--spectrum-breadcrumbs-block-size));
     flex-flow: row;
     flex: 1 0;
     justify-content: flex-start;
     align-items: center;
     margin: 0;
-    padding-inline-start: var(
-        --mod-breadcrumbs-inline-start,
-        var(--spectrum-breadcrumbs-inline-start)
-    );
-    padding-inline-end: var(
-        --mod-breadcrumbs-inline-end,
-        var(--spectrum-breadcrumbs-inline-end)
-    );
+    padding-inline-start: var(--mod-breadcrumbs-inline-start, var(--spectrum-breadcrumbs-inline-start));
+    padding-inline-end: var(--mod-breadcrumbs-inline-end, var(--spectrum-breadcrumbs-inline-end));
     list-style-type: none;
     display: flex;
 }
 
 :host([compact]) #list {
-    block-size: var(
-        --mod-breadcrumbs-block-size-compact,
-        var(--spectrum-breadcrumbs-block-size-compact)
-    );
+    block-size: var(--mod-breadcrumbs-block-size-compact, var(--spectrum-breadcrumbs-block-size-compact));
 }
 
 .spectrum-Breadcrumbs--multiline {
-    block-size: var(
-        --mod-breadcrumbs-block-size-multiline,
-        var(--spectrum-breadcrumbs-block-size-multiline)
-    );
+    block-size: var(--mod-breadcrumbs-block-size-multiline, var(--spectrum-breadcrumbs-block-size-multiline));
     flex-wrap: wrap;
     align-content: center;
 }
 
 :host([compact]) ::slotted(sp-breadcrumb-item) {
-    font-family: var(
-        --mod-breadcrumbs-font-family-compact,
-        var(--spectrum-breadcrumbs-font-family-compact)
-    );
-    font-size: var(
-        --mod-breadcrumbs-font-size-compact,
-        var(--spectrum-breadcrumbs-font-size-compact)
-    );
-    font-weight: var(
-        --mod-breadcrumbs-font-weight-compact,
-        var(--spectrum-breadcrumbs-font-weight-compact)
-    );
+    font-family: var(--mod-breadcrumbs-font-family-compact, var(--spectrum-breadcrumbs-font-family-compact));
+    font-size: var(--mod-breadcrumbs-font-size-compact, var(--spectrum-breadcrumbs-font-size-compact));
+    font-weight: var(--mod-breadcrumbs-font-weight-compact, var(--spectrum-breadcrumbs-font-weight-compact));
 }
 
 :host([compact]) ::slotted(:last-of-type) {
-    font-family: var(
-        --mod-breadcrumbs-font-family-compact-current,
-        var(--spectrum-breadcrumbs-font-family-compact-current)
-    );
-    font-size: var(
-        --mod-breadcrumbs-font-size-compact-current,
-        var(--spectrum-breadcrumbs-font-size-compact-current)
-    );
-    font-weight: var(
-        --mod-breadcrumbs-font-weight-compact-current,
-        var(--spectrum-breadcrumbs-font-weight-compact-current)
-    );
+    font-family: var(--mod-breadcrumbs-font-family-compact-current, var(--spectrum-breadcrumbs-font-family-compact-current));
+    font-size: var(--mod-breadcrumbs-font-size-compact-current, var(--spectrum-breadcrumbs-font-size-compact-current));
+    font-weight: var(--mod-breadcrumbs-font-weight-compact-current, var(--spectrum-breadcrumbs-font-weight-compact-current));
 }

--- a/packages/button-group/src/spectrum-button-group.css
+++ b/packages/button-group/src/spectrum-button-group.css
@@ -12,10 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    gap: var(
-        --mod-buttongroup-spacing-horizontal,
-        var(--spectrum-buttongroup-spacing-horizontal)
-    );
+    gap: var(--mod-buttongroup-spacing-horizontal, var(--spectrum-buttongroup-spacing-horizontal));
     justify-content: normal;
     justify-content: var(--mod-buttongroup-justify-content, normal);
     flex-wrap: wrap;
@@ -27,10 +24,7 @@ governing permissions and limitations under the License.
 }
 
 :host([vertical]) {
-    gap: var(
-        --mod-buttongroup-spacing-vertical,
-        var(--spectrum-buttongroup-spacing-vertical)
-    );
+    gap: var(--mod-buttongroup-spacing-vertical, var(--spectrum-buttongroup-spacing-vertical));
     flex-direction: column;
     display: inline-flex;
 }

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -16,59 +16,18 @@ governing permissions and limitations under the License.
     -webkit-user-select: none;
     user-select: none;
     box-sizing: border-box;
-    font-family: var(
-        --mod-button-font-family,
-        var(
-            --mod-sans-font-family-stack,
-            var(--spectrum-sans-font-family-stack)
-        )
-    );
+    font-family: var(--mod-button-font-family, var(--mod-sans-font-family-stack, var(--spectrum-sans-font-family-stack)));
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    line-height: var(
-        --mod-button-line-height,
-        var(--mod-line-height-100, var(--spectrum-line-height-100))
-    );
+    line-height: var(--mod-button-line-height, var(--mod-line-height-100, var(--spectrum-line-height-100)));
     text-transform: none;
     vertical-align: top;
     -webkit-appearance: button;
     transition:
-        background
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        border-color
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        color
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        box-shadow
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out;
+        background var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        border-color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        box-shadow var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out;
     justify-content: center;
     align-items: center;
     margin: 0;
@@ -88,40 +47,17 @@ governing permissions and limitations under the License.
 }
 
 :host:after {
-    margin: calc(
-        var(
-                --mod-button-focus-indicator-gap,
-                var(--spectrum-focus-indicator-gap)
-            ) * -1
-    );
+    margin: calc(var(--mod-button-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -1);
     transition:
-        opacity
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-button-animation-duration,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        margin
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-button-animation-duration,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out;
+        opacity var(--mod-button-animation-duration, var(--mod-button-animation-duration, var(--spectrum-animation-duration-100))) ease-out,
+        margin var(--mod-button-animation-duration, var(--mod-button-animation-duration, var(--spectrum-animation-duration-100))) ease-out;
     display: block;
     inset-block: 0;
     inset-inline: 0;
 }
 
 :host(:focus-visible):after {
-    margin: calc(
-        var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -2
-    );
+    margin: calc(var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -2);
 }
 
 #label {
@@ -136,123 +72,53 @@ governing permissions and limitations under the License.
 :host {
     --spectrum-button-sized-height: var(--spectrum-component-height-100);
     --spectrum-button-sized-font-size: var(--spectrum-font-size-100);
-    --spectrum-button-sized-edge-to-visual: calc(
-        var(--spectrum-component-pill-edge-to-visual-100) -
-            var(--spectrum-button-border-width)
-    );
-    --spectrum-button-sized-edge-to-visual-only: var(
-        --spectrum-component-pill-edge-to-visual-only-100
-    );
-    --spectrum-button-sized-edge-to-text: calc(
-        var(--spectrum-component-pill-edge-to-text-100) -
-            var(--spectrum-button-border-width)
-    );
-    --spectrum-button-sized-padding-label-to-icon: var(
-        --spectrum-text-to-visual-100
-    );
-    --spectrum-button-sized-top-to-text: var(
-        --spectrum-button-top-to-text-medium
-    );
-    --spectrum-button-sized-bottom-to-text: var(
-        --spectrum-button-bottom-to-text-medium
-    );
-    --spectrum-button-sized-top-to-icon: var(
-        --spectrum-component-top-to-workflow-icon-100
-    );
-    --spectrum-button-intended-icon-size: var(
-        --spectrum-workflow-icon-size-100
-    );
+    --spectrum-button-sized-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-100) - var(--spectrum-button-border-width));
+    --spectrum-button-sized-edge-to-visual-only: var(--spectrum-component-pill-edge-to-visual-only-100);
+    --spectrum-button-sized-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-100) - var(--spectrum-button-border-width));
+    --spectrum-button-sized-padding-label-to-icon: var(--spectrum-text-to-visual-100);
+    --spectrum-button-sized-top-to-text: var(--spectrum-button-top-to-text-medium);
+    --spectrum-button-sized-bottom-to-text: var(--spectrum-button-bottom-to-text-medium);
+    --spectrum-button-sized-top-to-icon: var(--spectrum-component-top-to-workflow-icon-100);
+    --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-100);
 }
 
 :host([size='s']) {
     --spectrum-button-sized-height: var(--spectrum-component-height-75);
     --spectrum-button-sized-font-size: var(--spectrum-font-size-75);
-    --spectrum-button-sized-edge-to-visual: calc(
-        var(--spectrum-component-pill-edge-to-visual-75) -
-            var(--spectrum-button-border-width)
-    );
-    --spectrum-button-sized-edge-to-visual-only: var(
-        --spectrum-component-pill-edge-to-visual-only-75
-    );
-    --spectrum-button-sized-edge-to-text: calc(
-        var(--spectrum-component-pill-edge-to-text-75) -
-            var(--spectrum-button-border-width)
-    );
-    --spectrum-button-sized-padding-label-to-icon: var(
-        --spectrum-text-to-visual-75
-    );
-    --spectrum-button-sized-top-to-text: var(
-        --spectrum-button-top-to-text-small
-    );
-    --spectrum-button-sized-bottom-to-text: var(
-        --spectrum-button-bottom-to-text-small
-    );
-    --spectrum-button-sized-top-to-icon: var(
-        --spectrum-component-top-to-workflow-icon-75
-    );
+    --spectrum-button-sized-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-75) - var(--spectrum-button-border-width));
+    --spectrum-button-sized-edge-to-visual-only: var(--spectrum-component-pill-edge-to-visual-only-75);
+    --spectrum-button-sized-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-75) - var(--spectrum-button-border-width));
+    --spectrum-button-sized-padding-label-to-icon: var(--spectrum-text-to-visual-75);
+    --spectrum-button-sized-top-to-text: var(--spectrum-button-top-to-text-small);
+    --spectrum-button-sized-bottom-to-text: var(--spectrum-button-bottom-to-text-small);
+    --spectrum-button-sized-top-to-icon: var(--spectrum-component-top-to-workflow-icon-75);
     --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-75);
 }
 
 :host([size='l']) {
     --spectrum-button-sized-height: var(--spectrum-component-height-200);
     --spectrum-button-sized-font-size: var(--spectrum-font-size-200);
-    --spectrum-button-sized-edge-to-visual: calc(
-        var(--spectrum-component-pill-edge-to-visual-200) -
-            var(--spectrum-button-border-width)
-    );
-    --spectrum-button-sized-edge-to-visual-only: var(
-        --spectrum-component-pill-edge-to-visual-only-200
-    );
-    --spectrum-button-sized-edge-to-text: calc(
-        var(--spectrum-component-pill-edge-to-text-200) -
-            var(--spectrum-button-border-width)
-    );
-    --spectrum-button-sized-padding-label-to-icon: var(
-        --spectrum-text-to-visual-200
-    );
-    --spectrum-button-sized-top-to-text: var(
-        --spectrum-button-top-to-text-large
-    );
-    --spectrum-button-sized-bottom-to-text: var(
-        --spectrum-button-bottom-to-text-large
-    );
-    --spectrum-button-sized-top-to-icon: var(
-        --spectrum-component-top-to-workflow-icon-200
-    );
-    --spectrum-button-intended-icon-size: var(
-        --spectrum-workflow-icon-size-200
-    );
+    --spectrum-button-sized-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-200) - var(--spectrum-button-border-width));
+    --spectrum-button-sized-edge-to-visual-only: var(--spectrum-component-pill-edge-to-visual-only-200);
+    --spectrum-button-sized-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-200) - var(--spectrum-button-border-width));
+    --spectrum-button-sized-padding-label-to-icon: var(--spectrum-text-to-visual-200);
+    --spectrum-button-sized-top-to-text: var(--spectrum-button-top-to-text-large);
+    --spectrum-button-sized-bottom-to-text: var(--spectrum-button-bottom-to-text-large);
+    --spectrum-button-sized-top-to-icon: var(--spectrum-component-top-to-workflow-icon-200);
+    --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-200);
 }
 
 :host([size='xl']) {
     --spectrum-button-sized-height: var(--spectrum-component-height-300);
     --spectrum-button-sized-font-size: var(--spectrum-font-size-300);
-    --spectrum-button-sized-edge-to-visual: calc(
-        var(--spectrum-component-pill-edge-to-visual-300) -
-            var(--spectrum-button-border-width)
-    );
-    --spectrum-button-sized-edge-to-visual-only: var(
-        --spectrum-component-pill-edge-to-visual-only-300
-    );
-    --spectrum-button-sized-edge-to-text: calc(
-        var(--spectrum-component-pill-edge-to-text-300) -
-            var(--spectrum-button-border-width)
-    );
-    --spectrum-button-sized-padding-label-to-icon: var(
-        --spectrum-text-to-visual-300
-    );
-    --spectrum-button-sized-top-to-text: var(
-        --spectrum-button-top-to-text-extra-large
-    );
-    --spectrum-button-sized-bottom-to-text: var(
-        --spectrum-button-bottom-to-text-extra-large
-    );
-    --spectrum-button-sized-top-to-icon: var(
-        --spectrum-component-top-to-workflow-icon-300
-    );
-    --spectrum-button-intended-icon-size: var(
-        --spectrum-workflow-icon-size-300
-    );
+    --spectrum-button-sized-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-300) - var(--spectrum-button-border-width));
+    --spectrum-button-sized-edge-to-visual-only: var(--spectrum-component-pill-edge-to-visual-only-300);
+    --spectrum-button-sized-edge-to-text: calc(var(--spectrum-component-pill-edge-to-text-300) - var(--spectrum-button-border-width));
+    --spectrum-button-sized-padding-label-to-icon: var(--spectrum-text-to-visual-300);
+    --spectrum-button-sized-top-to-text: var(--spectrum-button-top-to-text-extra-large);
+    --spectrum-button-sized-bottom-to-text: var(--spectrum-button-bottom-to-text-extra-large);
+    --spectrum-button-sized-top-to-icon: var(--spectrum-component-top-to-workflow-icon-300);
+    --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-300);
 }
 
 :host([selected]) {
@@ -264,32 +130,20 @@ governing permissions and limitations under the License.
     --mod-button-content-color-hover: var(--spectrum-white);
     --mod-button-content-color-down: var(--spectrum-white);
     --mod-button-content-color-focus: var(--spectrum-white);
-    --mod-button-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
     --mod-button-border-color-disabled: transparent;
 }
 
 :host([selected][emphasized]),
 :host([variant='accent']) {
-    --mod-button-background-color-default: var(
-        --spectrum-accent-background-color-default
-    );
-    --mod-button-background-color-hover: var(
-        --spectrum-accent-background-color-hover
-    );
-    --mod-button-background-color-down: var(
-        --spectrum-accent-background-color-down
-    );
-    --mod-button-background-color-focus: var(
-        --spectrum-accent-background-color-key-focus
-    );
+    --mod-button-background-color-default: var(--spectrum-accent-background-color-default);
+    --mod-button-background-color-hover: var(--spectrum-accent-background-color-hover);
+    --mod-button-background-color-down: var(--spectrum-accent-background-color-down);
+    --mod-button-background-color-focus: var(--spectrum-accent-background-color-key-focus);
 }
 
 :host([variant='accent']) {
-    --mod-button-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
     --mod-button-border-color-default: transparent;
     --mod-button-border-color-hover: transparent;
     --mod-button-border-color-down: transparent;
@@ -310,32 +164,18 @@ governing permissions and limitations under the License.
     --mod-button-border-color-down: var(--spectrum-accent-color-1100);
     --mod-button-border-color-focus: var(--spectrum-accent-color-1000);
     --mod-button-border-color-disabled: var(--spectrum-disabled-border-color);
-    --mod-button-content-color-default: var(
-        --spectrum-accent-content-color-default
-    );
-    --mod-button-content-color-hover: var(
-        --spectrum-accent-content-color-hover
-    );
+    --mod-button-content-color-default: var(--spectrum-accent-content-color-default);
+    --mod-button-content-color-hover: var(--spectrum-accent-content-color-hover);
     --mod-button-content-color-down: var(--spectrum-accent-content-color-down);
-    --mod-button-content-color-focus: var(
-        --spectrum-accent-content-color-key-focus
-    );
+    --mod-button-content-color-focus: var(--spectrum-accent-content-color-key-focus);
     --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 :host([variant='negative']) {
-    --mod-button-background-color-default: var(
-        --spectrum-negative-background-color-default
-    );
-    --mod-button-background-color-hover: var(
-        --spectrum-negative-background-color-hover
-    );
-    --mod-button-background-color-down: var(
-        --spectrum-negative-background-color-down
-    );
-    --mod-button-background-color-focus: var(
-        --spectrum-negative-background-color-key-focus
-    );
+    --mod-button-background-color-default: var(--spectrum-negative-background-color-default);
+    --mod-button-background-color-hover: var(--spectrum-negative-background-color-hover);
+    --mod-button-background-color-down: var(--spectrum-negative-background-color-down);
+    --mod-button-background-color-focus: var(--spectrum-negative-background-color-key-focus);
     --mod-button-border-color-default: transparent;
     --mod-button-border-color-hover: transparent;
     --mod-button-border-color-down: transparent;
@@ -344,9 +184,7 @@ governing permissions and limitations under the License.
     --mod-button-content-color-hover: var(--spectrum-white);
     --mod-button-content-color-down: var(--spectrum-white);
     --mod-button-content-color-focus: var(--spectrum-white);
-    --mod-button-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
     --mod-button-border-color-disabled: transparent;
     --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
@@ -360,37 +198,19 @@ governing permissions and limitations under the License.
     --mod-button-border-color-down: var(--spectrum-negative-color-1100);
     --mod-button-border-color-focus: var(--spectrum-negative-color-1000);
     --mod-button-border-color-disabled: var(--spectrum-disabled-border-color);
-    --mod-button-content-color-default: var(
-        --spectrum-negative-content-color-default
-    );
-    --mod-button-content-color-hover: var(
-        --spectrum-negative-content-color-hover
-    );
-    --mod-button-content-color-down: var(
-        --spectrum-negative-content-color-down
-    );
-    --mod-button-content-color-focus: var(
-        --spectrum-negative-content-color-key-focus
-    );
+    --mod-button-content-color-default: var(--spectrum-negative-content-color-default);
+    --mod-button-content-color-hover: var(--spectrum-negative-content-color-hover);
+    --mod-button-content-color-down: var(--spectrum-negative-content-color-down);
+    --mod-button-content-color-focus: var(--spectrum-negative-content-color-key-focus);
     --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 :host([variant='primary']) {
-    --mod-button-background-color-default: var(
-        --spectrum-neutral-background-color-default
-    );
-    --mod-button-background-color-hover: var(
-        --spectrum-neutral-background-color-hover
-    );
-    --mod-button-background-color-down: var(
-        --spectrum-neutral-background-color-down
-    );
-    --mod-button-background-color-focus: var(
-        --spectrum-neutral-background-color-key-focus
-    );
-    --mod-button-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --mod-button-background-color-default: var(--spectrum-neutral-background-color-default);
+    --mod-button-background-color-hover: var(--spectrum-neutral-background-color-hover);
+    --mod-button-background-color-down: var(--spectrum-neutral-background-color-down);
+    --mod-button-background-color-focus: var(--spectrum-neutral-background-color-key-focus);
+    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
     --mod-button-border-color-default: transparent;
     --mod-button-border-color-hover: transparent;
     --mod-button-border-color-down: transparent;
@@ -403,39 +223,25 @@ governing permissions and limitations under the License.
     --mod-button-border-color-hover: var(--spectrum-gray-900);
     --mod-button-border-color-down: var(--spectrum-gray-900);
     --mod-button-border-color-focus: var(--spectrum-gray-900);
-    --mod-button-content-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --mod-button-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
+    --mod-button-content-color-default: var(--spectrum-neutral-content-color-default);
+    --mod-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
     --mod-button-content-color-down: var(--spectrum-neutral-content-color-down);
-    --mod-button-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
+    --mod-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
     --mod-button-border-color-disabled: var(--spectrum-disabled-border-color);
     --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 :host([variant='secondary']) {
-    --mod-button-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
     --mod-button-border-color-default: transparent;
     --mod-button-border-color-hover: transparent;
     --mod-button-border-color-down: transparent;
     --mod-button-border-color-focus: transparent;
     --mod-button-border-color-disabled: transparent;
-    --mod-button-content-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --mod-button-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
+    --mod-button-content-color-default: var(--spectrum-neutral-content-color-default);
+    --mod-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
     --mod-button-content-color-down: var(--spectrum-neutral-content-color-down);
-    --mod-button-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
+    --mod-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
     --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
@@ -446,16 +252,10 @@ governing permissions and limitations under the License.
     --mod-button-border-color-down: var(--spectrum-gray-500);
     --mod-button-border-color-focus: var(--spectrum-gray-400);
     --mod-button-border-color-disabled: var(--spectrum-disabled-border-color);
-    --mod-button-content-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --mod-button-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
+    --mod-button-content-color-default: var(--spectrum-neutral-content-color-default);
+    --mod-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
     --mod-button-content-color-down: var(--spectrum-neutral-content-color-down);
-    --mod-button-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
+    --mod-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
     --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
@@ -496,58 +296,33 @@ governing permissions and limitations under the License.
 }
 
 :host([static-color='white']) {
-    --mod-button-content-color-disabled: var(
-        --spectrum-disabled-static-white-content-color
-    );
-    --mod-button-background-color-disabled: var(
-        --spectrum-disabled-static-white-background-color
-    );
-    --mod-button-focus-ring-color: var(
-        --spectrum-static-white-focus-indicator-color
-    );
+    --mod-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
+    --mod-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
+    --mod-button-focus-ring-color: var(--spectrum-static-white-focus-indicator-color);
 }
 
 :host([static-color='white'][variant='secondary']:not([treatment='outline'])) {
-    --mod-button-background-color-disabled: var(
-        --spectrum-disabled-static-white-background-color
-    );
+    --mod-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
 }
 
 :host([static-color='white'][treatment='outline']) {
-    --mod-button-content-color-disabled: var(
-        --spectrum-disabled-static-white-content-color
-    );
-    --mod-button-border-color-disabled: var(
-        --spectrum-disabled-static-white-border-color
-    );
+    --mod-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
+    --mod-button-border-color-disabled: var(--spectrum-disabled-static-white-border-color);
 }
 
 :host([static-color='black']) {
-    --mod-button-content-color-disabled: var(
-        --spectrum-disabled-static-black-content-color
-    );
-    --mod-button-background-color-disabled: var(
-        --spectrum-disabled-static-black-background-color
-    );
-    --mod-button-focus-ring-color: var(
-        --mod-static-black-focus-indicator-color,
-        var(--spectrum-static-black-focus-indicator-color)
-    );
+    --mod-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
+    --mod-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
+    --mod-button-focus-ring-color: var(--mod-static-black-focus-indicator-color, var(--spectrum-static-black-focus-indicator-color));
 }
 
 :host([static-color='black'][variant='secondary']:not([treatment='outline'])) {
-    --mod-button-background-color-disabled: var(
-        --spectrum-disabled-static-black-background-color
-    );
+    --mod-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
 }
 
 :host([static-color='black'][treatment='outline']) {
-    --mod-button-content-color-disabled: var(
-        --spectrum-disabled-static-black-content-color
-    );
-    --mod-button-border-color-disabled: var(
-        --spectrum-disabled-static-black-border-color
-    );
+    --mod-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
+    --mod-button-border-color-disabled: var(--spectrum-disabled-static-black-border-color);
 }
 
 :host([treatment='outline']),
@@ -557,109 +332,28 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    --spectrum-button-height: var(
-        --mod-button-height,
-        var(--spectrum-button-sized-height)
-    );
-    --spectrum-button-min-width: var(
-        --mod-button-min-width,
-        calc(
-            var(--spectrum-button-height) *
-                var(--spectrum-button-minimum-width-multiplier)
-        )
-    );
+    --spectrum-button-height: var(--mod-button-height, var(--spectrum-button-sized-height));
+    --spectrum-button-min-width: var(--mod-button-min-width, calc(var(--spectrum-button-height) * var(--spectrum-button-minimum-width-multiplier)));
     --spectrum-button-line-height: var(--mod-button-line-height, 1.2);
-    --spectrum-button-font-size: var(
-        --mod-button-font-size,
-        var(--spectrum-button-sized-font-size)
-    );
-    --spectrum-button-padding-label-to-icon: var(
-        --mod-button-padding-label-to-icon,
-        var(--spectrum-button-sized-padding-label-to-icon)
-    );
-    --spectrum-button-edge-to-visual: var(
-        --mod-button-edge-to-visual,
-        var(--spectrum-button-sized-edge-to-visual)
-    );
-    --spectrum-button-edge-to-visual-only: var(
-        --mod-button-edge-to-visual-only,
-        var(--spectrum-button-sized-edge-to-visual-only)
-    );
-    --spectrum-button-edge-to-text: var(
-        --mod-button-edge-to-text,
-        var(--spectrum-button-sized-edge-to-text)
-    );
-    --spectrum-button-top-to-text: var(
-        --mod-button-top-to-text,
-        var(--spectrum-button-sized-top-to-text)
-    );
-    --spectrum-button-bottom-to-text: var(
-        --mod-button-bottom-to-text,
-        var(--spectrum-button-sized-bottom-to-text)
-    );
-    --spectrum-button-top-to-icon: var(
-        --mod-button-top-to-icon,
-        var(--spectrum-button-sized-top-to-icon)
-    );
-    --spectrum-button-focus-ring-thickness: var(
-        --mod-button-focus-ring-thickness,
-        var(--spectrum-focus-indicator-thickness)
-    );
-    --spectrum-button-focus-indicator-color: var(
-        --mod-button-focus-ring-color,
-        var(--spectrum-focus-indicator-color)
-    );
-    --spectrum-button-animation-duration: var(
-        --mod-button-animation-duration,
-        var(--spectrum-animation-duration-100)
-    );
-    --spectrum-button-border-width: var(
-        --mod-button-border-width,
-        var(--spectrum-border-width-200)
-    );
-    --spectrum-button-focus-ring-gap: var(
-        --mod-focus-indicator-gap,
-        var(--mod-button-focus-ring-gap, var(--spectrum-focus-indicator-gap))
-    );
-    --spectrum-button-border-radius: var(
-        --mod-button-border-radius,
-        calc(var(--spectrum-button-height) / 2)
-    );
-    --spectrum-button-content-color-default: var(
-        --highcontrast-button-content-color-default,
-        var(
-            --mod-button-content-color-default,
-            var(--spectrum-neutral-content-color-default)
-        )
-    );
-    --spectrum-button-content-color-hover: var(
-        --highcontrast-button-content-color-hover,
-        var(
-            --mod-button-content-color-hover,
-            var(--spectrum-neutral-content-color-hover)
-        )
-    );
-    --spectrum-button-content-color-down: var(
-        --highcontrast-button-content-color-down,
-        var(
-            --mod-button-content-color-down,
-            var(--spectrum-neutral-content-color-down)
-        )
-    );
-    --spectrum-button-content-color-focus: var(
-        --highcontrast-button-content-color-focus,
-        var(
-            --mod-button-content-color-focus,
-            var(--spectrum-neutral-content-color-key-focus)
-        )
-    );
-    --spectrum-button-content-color-disabled: var(
-        --highcontrast-button-content-color-disabled,
-        var(
-            --mod-button-content-color-disabled,
-            var(--spectrum-disabled-content-color)
-        )
-    );
+    --spectrum-button-font-size: var(--mod-button-font-size, var(--spectrum-button-sized-font-size));
+    --spectrum-button-padding-label-to-icon: var(--mod-button-padding-label-to-icon, var(--spectrum-button-sized-padding-label-to-icon));
+    --spectrum-button-edge-to-visual: var(--mod-button-edge-to-visual, var(--spectrum-button-sized-edge-to-visual));
+    --spectrum-button-edge-to-visual-only: var(--mod-button-edge-to-visual-only, var(--spectrum-button-sized-edge-to-visual-only));
+    --spectrum-button-edge-to-text: var(--mod-button-edge-to-text, var(--spectrum-button-sized-edge-to-text));
+    --spectrum-button-top-to-text: var(--mod-button-top-to-text, var(--spectrum-button-sized-top-to-text));
+    --spectrum-button-bottom-to-text: var(--mod-button-bottom-to-text, var(--spectrum-button-sized-bottom-to-text));
+    --spectrum-button-top-to-icon: var(--mod-button-top-to-icon, var(--spectrum-button-sized-top-to-icon));
+    --spectrum-button-focus-ring-thickness: var(--mod-button-focus-ring-thickness, var(--spectrum-focus-indicator-thickness));
+    --spectrum-button-focus-indicator-color: var(--mod-button-focus-ring-color, var(--spectrum-focus-indicator-color));
+    --spectrum-button-animation-duration: var(--mod-button-animation-duration, var(--spectrum-animation-duration-100));
+    --spectrum-button-border-width: var(--mod-button-border-width, var(--spectrum-border-width-200));
+    --spectrum-button-focus-ring-gap: var(--mod-focus-indicator-gap, var(--mod-button-focus-ring-gap, var(--spectrum-focus-indicator-gap)));
+    --spectrum-button-border-radius: var(--mod-button-border-radius, calc(var(--spectrum-button-height) / 2));
+    --spectrum-button-content-color-default: var(--highcontrast-button-content-color-default, var(--mod-button-content-color-default, var(--spectrum-neutral-content-color-default)));
+    --spectrum-button-content-color-hover: var(--highcontrast-button-content-color-hover, var(--mod-button-content-color-hover, var(--spectrum-neutral-content-color-hover)));
+    --spectrum-button-content-color-down: var(--highcontrast-button-content-color-down, var(--mod-button-content-color-down, var(--spectrum-neutral-content-color-down)));
+    --spectrum-button-content-color-focus: var(--highcontrast-button-content-color-focus, var(--mod-button-content-color-focus, var(--spectrum-neutral-content-color-key-focus)));
+    --spectrum-button-content-color-disabled: var(--highcontrast-button-content-color-disabled, var(--mod-button-content-color-disabled, var(--spectrum-disabled-content-color)));
     --mod-progress-circle-position: absolute;
     border-radius: var(--spectrum-button-border-radius);
     border-width: var(--spectrum-button-border-width);
@@ -673,21 +367,9 @@ governing permissions and limitations under the License.
     padding-block: 0;
     padding-inline: var(--spectrum-button-edge-to-text);
     margin-block: var(--mod-button-margin-block);
-    background-color: var(
-        --highcontrast-button-background-color-default,
-        var(
-            --mod-button-background-color-default,
-            var(--spectrum-button-background-color-default)
-        )
-    );
+    background-color: var(--highcontrast-button-background-color-default, var(--mod-button-background-color-default, var(--spectrum-button-background-color-default)));
     border-style: solid;
-    border-color: var(
-        --highcontrast-button-border-color-default,
-        var(
-            --mod-button-border-color-default,
-            var(--spectrum-button-border-color-default)
-        )
-    );
+    border-color: var(--highcontrast-button-border-color-default, var(--mod-button-border-color-default, var(--spectrum-button-border-color-default)));
     color: inherit;
     color: var(--spectrum-button-content-color-default, inherit);
     transition:
@@ -708,41 +390,18 @@ governing permissions and limitations under the License.
 }
 
 :host:after {
-    margin: var(
-        --mod-button-focus-ring-border-radius,
-        calc(
-            (
-                    var(--spectrum-button-focus-ring-gap) +
-                        var(--spectrum-button-border-width)
-                ) * -1
-        )
-    );
+    margin: var(--mod-button-focus-ring-border-radius, calc((var(--spectrum-button-focus-ring-gap) + var(--spectrum-button-border-width)) * -1));
     transition: box-shadow var(--spectrum-button-animation-duration) ease-in-out;
     pointer-events: none;
     content: '';
-    border-radius: calc(
-        var(--spectrum-button-border-radius) +
-            var(--spectrum-focus-indicator-gap)
-    );
+    border-radius: calc(var(--spectrum-button-border-radius) + var(--spectrum-focus-indicator-gap));
     position: absolute;
     inset: 0;
 }
 
 :host(:focus-visible) {
-    background-color: var(
-        --highcontrast-button-background-color-focus,
-        var(
-            --mod-button-background-color-focus,
-            var(--spectrum-button-background-color-focus)
-        )
-    );
-    border-color: var(
-        --highcontrast-button-border-color-focus,
-        var(
-            --mod-button-border-color-focus,
-            var(--spectrum-button-border-color-focus)
-        )
-    );
+    background-color: var(--highcontrast-button-background-color-focus, var(--mod-button-background-color-focus, var(--spectrum-button-background-color-focus)));
+    border-color: var(--highcontrast-button-border-color-focus, var(--mod-button-border-color-focus, var(--spectrum-button-border-color-focus)));
     color: var(--spectrum-button-content-color-focus);
     box-shadow: none;
     outline: none;
@@ -750,45 +409,20 @@ governing permissions and limitations under the License.
 
 :host([focused]):after,
 :host(:focus-visible):after {
-    box-shadow: 0 0 0 var(--spectrum-button-focus-ring-thickness)
-        var(--spectrum-button-focus-indicator-color);
+    box-shadow: 0 0 0 var(--spectrum-button-focus-ring-thickness) var(--spectrum-button-focus-indicator-color);
 }
 
 :host(:is(:active, [active])) {
-    background-color: var(
-        --highcontrast-button-background-color-down,
-        var(
-            --mod-button-background-color-down,
-            var(--spectrum-button-background-color-down)
-        )
-    );
-    border-color: var(
-        --highcontrast-button-border-color-down,
-        var(
-            --mod-button-border-color-down,
-            var(--spectrum-button-border-color-down)
-        )
-    );
+    background-color: var(--highcontrast-button-background-color-down, var(--mod-button-background-color-down, var(--spectrum-button-background-color-down)));
+    border-color: var(--highcontrast-button-border-color-down, var(--mod-button-border-color-down, var(--spectrum-button-border-color-down)));
     color: var(--spectrum-button-content-color-down);
     box-shadow: none;
 }
 
 @media (hover: hover) {
     :host(:hover) {
-        background-color: var(
-            --highcontrast-button-background-color-hover,
-            var(
-                --mod-button-background-color-hover,
-                var(--spectrum-button-background-color-hover)
-            )
-        );
-        border-color: var(
-            --highcontrast-button-border-color-hover,
-            var(
-                --mod-button-border-color-hover,
-                var(--spectrum-button-border-color-hover)
-            )
-        );
+        background-color: var(--highcontrast-button-background-color-hover, var(--mod-button-background-color-hover, var(--spectrum-button-background-color-hover)));
+        border-color: var(--highcontrast-button-border-color-hover, var(--mod-button-border-color-hover, var(--spectrum-button-border-color-hover)));
         color: var(--spectrum-button-content-color-hover);
         box-shadow: none;
     }
@@ -798,57 +432,19 @@ governing permissions and limitations under the License.
 :host([pending]),
 :host([disabled]),
 :host([pending]) {
-    background-color: var(
-        --highcontrast-button-background-color-disabled,
-        var(
-            --mod-button-background-color-disabled,
-            var(--spectrum-button-background-color-disabled)
-        )
-    );
-    border-color: var(
-        --highcontrast-button-border-color-disabled,
-        var(
-            --mod-button-border-color-disabled,
-            var(--spectrum-button-border-color-disabled)
-        )
-    );
+    background-color: var(--highcontrast-button-background-color-disabled, var(--mod-button-background-color-disabled, var(--spectrum-button-background-color-disabled)));
+    border-color: var(--highcontrast-button-border-color-disabled, var(--mod-button-border-color-disabled, var(--spectrum-button-border-color-disabled)));
     color: var(--spectrum-button-content-color-disabled);
 }
 
 ::slotted([slot='icon']) {
-    --_icon-size-difference: max(
-        0px,
-        var(--spectrum-button-intended-icon-size) -
-            var(
-                --spectrum-icon-block-size,
-                var(--spectrum-button-intended-icon-size)
-            )
-    );
-    margin-block-start: var(
-        --mod-button-icon-margin-block-start,
-        max(
-            0px,
-            var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) -
-                var(
-                    --mod-button-border-width,
-                    var(--spectrum-button-border-width)
-                ) + (var(--_icon-size-difference, 0px) / 2)
-        )
-    );
-    margin-inline-start: calc(
-        var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) -
-            var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text))
-    );
+    --_icon-size-difference: max(0px, var(--spectrum-button-intended-icon-size) - var(--spectrum-icon-block-size, var(--spectrum-button-intended-icon-size)));
+    margin-block-start: var(--mod-button-icon-margin-block-start, max(0px, var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) - var(--mod-button-border-width, var(--spectrum-button-border-width)) + (var(--_icon-size-difference, 0px) / 2)));
+    margin-inline-start: calc(var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) - var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text)));
 }
 
 :host([icon-only]) {
-    padding: calc(
-        var(
-                --mod-button-edge-to-visual-only,
-                var(--spectrum-button-edge-to-visual-only)
-            ) -
-            var(--mod-button-border-width, var(--spectrum-button-border-width))
-    );
+    padding: calc(var(--mod-button-edge-to-visual-only, var(--spectrum-button-edge-to-visual-only)) - var(--mod-button-border-width, var(--spectrum-button-border-width)));
 }
 
 #label,
@@ -856,8 +452,7 @@ governing permissions and limitations under the License.
     visibility: visible;
     opacity: 1;
     transition: opacity 0.13s ease-in-out;
-    transition: opacity var(--spectrum-button-animation-duration, 0.13s)
-        ease-in-out;
+    transition: opacity var(--spectrum-button-animation-duration, 0.13s) ease-in-out;
 }
 
 .spectrum-ProgressCircle {
@@ -881,47 +476,21 @@ governing permissions and limitations under the License.
     visibility: visible;
     opacity: 1;
     transition: opacity 0.13s ease-in-out;
-    transition: opacity var(--spectrum-button-animation-duration, 0.13s)
-        ease-in-out;
+    transition: opacity var(--spectrum-button-animation-duration, 0.13s) ease-in-out;
 }
 
 ::slotted([slot='icon']) {
-    --_icon-size-difference: max(
-        0px,
-        calc(
-            var(--spectrum-button-intended-icon-size) -
-                var(
-                    --spectrum-icon-block-size,
-                    var(--spectrum-button-intended-icon-size)
-                )
-        )
-    );
+    --_icon-size-difference: max(0px, calc(var(--spectrum-button-intended-icon-size) - var(--spectrum-icon-block-size, var(--spectrum-button-intended-icon-size))));
     color: inherit;
     flex-shrink: 0;
     align-self: flex-start;
-    margin-block-start: var(
-        --mod-button-icon-margin-block-start,
-        max(
-            0px,
-            calc(
-                var(--spectrum-button-top-to-icon) -
-                    var(--spectrum-button-border-width) +
-                    var(--_icon-size-difference, 0px) / 2
-            )
-        )
-    );
-    margin-inline-start: calc(
-        var(--spectrum-button-edge-to-visual) -
-            var(--spectrum-button-edge-to-text)
-    );
+    margin-block-start: var(--mod-button-icon-margin-block-start, max(0px, calc(var(--spectrum-button-top-to-icon) - var(--spectrum-button-border-width) + var(--_icon-size-difference, 0px) / 2)));
+    margin-inline-start: calc(var(--spectrum-button-edge-to-visual) - var(--spectrum-button-edge-to-text));
 }
 
 :host([icon-only]) {
     min-inline-size: unset;
-    padding: calc(
-        var(--spectrum-button-edge-to-visual-only) -
-            var(--spectrum-button-border-width)
-    );
+    padding: calc(var(--spectrum-button-edge-to-visual-only) - var(--spectrum-button-border-width));
     border-radius: 50%;
 }
 
@@ -945,13 +514,8 @@ governing permissions and limitations under the License.
     text-align: center;
     text-align: var(--mod-button-text-align, center);
     align-self: start;
-    padding-block-start: calc(
-        var(--spectrum-button-top-to-text) - var(--spectrum-button-border-width)
-    );
-    padding-block-end: calc(
-        var(--spectrum-button-bottom-to-text) -
-            var(--spectrum-button-border-width)
-    );
+    padding-block-start: calc(var(--spectrum-button-top-to-text) - var(--spectrum-button-border-width));
+    padding-block-end: calc(var(--spectrum-button-bottom-to-text) - var(--spectrum-button-border-width));
 }
 
 :host([no-wrap]) #label {
@@ -979,9 +543,7 @@ governing permissions and limitations under the License.
         --highcontrast-button-background-color-disabled: ButtonFace;
         --mod-progress-circle-track-border-color: ButtonText;
         --mod-progress-circle-track-border-color-over-background: ButtonText;
-        --mod-progress-circle-thickness: var(
-            --spectrum-progress-circle-thickness-medium
-        );
+        --mod-progress-circle-thickness: var(--spectrum-progress-circle-thickness-medium);
         --mod-button-animation-duration: 0s;
     }
 

--- a/packages/card/src/spectrum-card.css
+++ b/packages/card/src/spectrum-card.css
@@ -13,24 +13,11 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     box-sizing: border-box;
-    min-inline-size: var(
-        --mod-card-minimum-width,
-        var(--spectrum-card-minimum-width)
-    );
-    border: var(--mod-card-border-width, var(--spectrum-card-border-width))
-        solid transparent;
-    border-radius: var(
-        --mod-card-corner-radius,
-        var(--spectrum-card-corner-radius)
-    );
-    border-color: var(
-        --highcontrast-card-border-color,
-        var(--mod-card-border-color, var(--spectrum-card-border-color))
-    );
-    background-color: var(
-        --highcontrast-card-background-color,
-        var(--mod-card-background-color, var(--spectrum-card-background-color))
-    );
+    min-inline-size: var(--mod-card-minimum-width, var(--spectrum-card-minimum-width));
+    border: var(--mod-card-border-width, var(--spectrum-card-border-width)) solid transparent;
+    border-radius: var(--mod-card-corner-radius, var(--spectrum-card-corner-radius));
+    border-color: var(--highcontrast-card-border-color, var(--mod-card-border-color, var(--spectrum-card-border-color)));
+    background-color: var(--highcontrast-card-background-color, var(--mod-card-background-color, var(--spectrum-card-background-color)));
     flex-direction: column;
     -webkit-text-decoration: none;
     text-decoration: none;
@@ -49,23 +36,10 @@ governing permissions and limitations under the License.
 }
 
 :host:after {
-    border-radius: var(
-        --mod-card-corner-radius,
-        var(--spectrum-card-corner-radius)
-    );
+    border-radius: var(--mod-card-corner-radius, var(--spectrum-card-corner-radius));
     border: 0 solid #0000;
-    margin-block-start: calc(
-        var(
-                --mod-card-focus-indicator-width,
-                var(--spectrum-card-focus-indicator-width)
-            ) * -1
-    );
-    margin-inline-start: calc(
-        var(
-                --mod-card-focus-indicator-width,
-                var(--spectrum-card-focus-indicator-width)
-            ) * -1
-    );
+    margin-block-start: calc(var(--mod-card-focus-indicator-width, var(--spectrum-card-focus-indicator-width)) * -1);
+    margin-inline-start: calc(var(--mod-card-focus-indicator-width, var(--spectrum-card-focus-indicator-width)) * -1);
     inset-inline-end: 0;
 }
 
@@ -74,77 +48,28 @@ governing permissions and limitations under the License.
 }
 
 :host(:focus-visible):after {
-    border-width: var(
-        --mod-card-focus-indicator-width,
-        var(--spectrum-card-focus-indicator-width)
-    );
-    border-color: var(
-        --mod-card-focus-indicator-color,
-        var(--spectrum-card-focus-indicator-color)
-    );
+    border-width: var(--mod-card-focus-indicator-width, var(--spectrum-card-focus-indicator-width));
+    border-color: var(--mod-card-focus-indicator-color, var(--spectrum-card-focus-indicator-color));
 }
 
 :host(:focus-visible) #cover-photo,
 :host(:focus-visible) #preview {
-    border-start-start-radius: calc(
-        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
-            var(
-                --mod-card-focus-indicator-width,
-                var(--spectrum-card-focus-indicator-width)
-            )
-    );
-    border-start-end-radius: calc(
-        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
-            var(
-                --mod-card-focus-indicator-width,
-                var(--spectrum-card-focus-indicator-width)
-            )
-    );
+    border-start-start-radius: calc(var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) - var(--mod-card-focus-indicator-width, var(--spectrum-card-focus-indicator-width)));
+    border-start-end-radius: calc(var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) - var(--mod-card-focus-indicator-width, var(--spectrum-card-focus-indicator-width)));
 }
 
 :host([selected]) {
-    border-color: var(
-        --highcontrast-card-border-color-selected,
-        var(
-            --mod-card-border-color-selected,
-            var(--spectrum-card-border-color-selected)
-        )
-    );
+    border-color: var(--highcontrast-card-border-color-selected, var(--mod-card-border-color-selected, var(--spectrum-card-border-color-selected)));
 }
 
 :host([selected]):before {
-    background-color: rgba(
-        var(
-            --mod-card-selected-background-color-rgb,
-            var(--spectrum-card-selected-background-color-rgb)
-        ),
-        var(
-            --mod-card-selected-background-opacity,
-            var(--spectrum-card-selected-background-opacity)
-        )
-    );
+    background-color: rgba(var(--mod-card-selected-background-color-rgb, var(--spectrum-card-selected-background-color-rgb)), var(--mod-card-selected-background-opacity, var(--spectrum-card-selected-background-opacity)));
 }
 
 :host([drop-target]) {
-    border-color: var(
-        --highcontrast-card-border-color-selected,
-        var(
-            --mod-card-border-color-selected,
-            var(--spectrum-card-border-color-selected)
-        )
-    );
-    box-shadow: 0 0 0 1px
-        var(
-            --highcontrast-card-border-color-selected,
-            var(
-                --mod-card-border-color-selected,
-                var(--spectrum-card-border-color-selected)
-            )
-        );
-    background-color: var(
-        --mod-card-background-color,
-        var(--spectrum-card-background-color-quiet)
-    );
+    border-color: var(--highcontrast-card-border-color-selected, var(--mod-card-border-color-selected, var(--spectrum-card-border-color-selected)));
+    box-shadow: 0 0 0 1px var(--highcontrast-card-border-color-selected, var(--mod-card-border-color-selected, var(--spectrum-card-border-color-selected)));
+    background-color: var(--mod-card-background-color, var(--spectrum-card-background-color-quiet));
 }
 
 :host([focused]) .actions,
@@ -160,41 +85,11 @@ governing permissions and limitations under the License.
 
 .checkbox-toggle {
     visibility: hidden;
-    box-shadow: var(
-            --mod-card-actions-drop-shadow-x,
-            var(--spectrum-card-actions-drop-shadow-x)
-        )
-        var(
-            --mod-card-actions-drop-shadow-y,
-            var(--spectrum-card-actions-drop-shadow-y)
-        )
-        var(
-            --mod-card-actions-drop-shadow-blur,
-            var(--spectrum-card-actions-drop-shadow-blur)
-        )
-        var(
-            --mod-card-actions-drop-shadow-color,
-            var(--spectrum-card-actions-drop-shadow-color)
-        );
-    inline-size: var(
-        --mod-card-actions-size,
-        var(--spectrum-card-actions-size)
-    );
+    box-shadow: var(--mod-card-actions-drop-shadow-x, var(--spectrum-card-actions-drop-shadow-x)) var(--mod-card-actions-drop-shadow-y, var(--spectrum-card-actions-drop-shadow-y)) var(--mod-card-actions-drop-shadow-blur, var(--spectrum-card-actions-drop-shadow-blur)) var(--mod-card-actions-drop-shadow-color, var(--spectrum-card-actions-drop-shadow-color));
+    inline-size: var(--mod-card-actions-size, var(--spectrum-card-actions-size));
     block-size: var(--mod-card-actions-size, var(--spectrum-card-actions-size));
-    border-radius: var(
-        --mod-card-actions-border-radius,
-        var(--spectrum-card-actions-border-radius)
-    );
-    background-color: rgba(
-        var(
-            --mod-card-actions-background-color-rgb,
-            var(--spectrum-card-actions-background-color-rgb)
-        ),
-        var(
-            --mod-card-actions-background-color-opacity,
-            var(--spectrum-card-actions-background-color-opacity)
-        )
-    );
+    border-radius: var(--mod-card-actions-border-radius, var(--spectrum-card-actions-border-radius));
+    background-color: rgba(var(--mod-card-actions-background-color-rgb, var(--spectrum-card-actions-background-color-rgb)), var(--mod-card-actions-background-color-opacity, var(--spectrum-card-actions-background-color-opacity)));
     pointer-events: auto;
     box-sizing: border-box;
     transition:
@@ -202,72 +97,31 @@ governing permissions and limitations under the License.
         opacity 0.13s ease-in-out,
         visibility 0s linear 0.13s;
     transition:
-        transform
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        opacity
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        visibility 0s linear
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            );
+        transform var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        opacity var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        visibility 0s linear var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s));
     justify-content: center;
     align-items: center;
     display: inline-flex;
     position: absolute;
-    inset-block-start: calc(
-        var(--mod-card-actions-spacing, var(--spectrum-card-actions-spacing)) -
-            var(--mod-card-border-width, var(--spectrum-card-border-width))
-    );
-    inset-inline-start: calc(
-        var(--mod-card-actions-spacing, var(--spectrum-card-actions-spacing)) -
-            var(--mod-card-border-width, var(--spectrum-card-border-width))
-    );
+    inset-block-start: calc(var(--mod-card-actions-spacing, var(--spectrum-card-actions-spacing)) - var(--mod-card-border-width, var(--spectrum-card-border-width)));
+    inset-inline-start: calc(var(--mod-card-actions-spacing, var(--spectrum-card-actions-spacing)) - var(--mod-card-border-width, var(--spectrum-card-border-width)));
 }
 
 .actions {
-    inset-block-start: var(
-        --mod-card-actions-spacing,
-        var(--spectrum-card-actions-spacing)
-    );
-    inset-inline-end: var(
-        --mod-card-actions-spacing,
-        var(--spectrum-card-actions-spacing)
-    );
+    inset-block-start: var(--mod-card-actions-spacing, var(--spectrum-card-actions-spacing));
+    inset-inline-end: var(--mod-card-actions-spacing, var(--spectrum-card-actions-spacing));
 }
 
 #cover-photo {
-    block-size: var(
-        --mod-card-preview-minimum-height,
-        var(--spectrum-card-preview-minimum-height)
-    );
+    block-size: var(--mod-card-preview-minimum-height, var(--spectrum-card-preview-minimum-height));
     box-sizing: border-box;
     background-position: 50%;
     background-size: cover;
-    background-color: var(
-        --mod-card-preview-background-color,
-        var(--spectrum-card-preview-background-color)
-    );
-    border-block-end-color: var(
-        --mod-card-border-color,
-        var(--spectrum-card-border-color)
-    );
-    border-start-start-radius: calc(
-        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
-            var(--mod-card-border-width, var(--spectrum-card-border-width))
-    );
-    border-start-end-radius: calc(
-        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
-            var(--mod-card-border-width, var(--spectrum-card-border-width))
-    );
+    background-color: var(--mod-card-preview-background-color, var(--spectrum-card-preview-background-color));
+    border-block-end-color: var(--mod-card-border-color, var(--spectrum-card-border-color));
+    border-start-start-radius: calc(var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) - var(--mod-card-border-width, var(--spectrum-card-border-width)));
+    border-start-end-radius: calc(var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) - var(--mod-card-border-width, var(--spectrum-card-border-width)));
     border-end-end-radius: 0;
     border-end-start-radius: 0;
     justify-content: center;
@@ -283,57 +137,21 @@ governing permissions and limitations under the License.
 
 .content {
     align-items: center;
-    margin-block-start: var(
-        --mod-card-content-margin-top,
-        var(--spectrum-card-content-margin-top)
-    );
+    margin-block-start: var(--mod-card-content-margin-top, var(--spectrum-card-content-margin-top));
     display: flex;
 }
 
 .body {
-    padding-block-start: var(
-        --mod-card-body-padding-block-start,
-        var(
-            --mod-card-title-padding-top,
-            var(--spectrum-card-title-padding-top)
-        )
-    );
-    padding-block-end: var(
-        --mod-card-body-padding-block-end,
-        calc(
-            var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) -
-                var(--mod-card-border-width, var(--spectrum-card-border-width))
-        )
-    );
-    padding-inline-start: var(
-        --mod-card-body-padding-inline-start,
-        calc(
-            var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) -
-                var(--mod-card-border-width, var(--spectrum-card-border-width))
-        )
-    );
-    padding-inline-end: var(
-        --mod-card-body-padding-inline-end,
-        calc(
-            var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) -
-                var(--mod-card-border-width, var(--spectrum-card-border-width))
-        )
-    );
+    padding-block-start: var(--mod-card-body-padding-block-start, var(--mod-card-title-padding-top, var(--spectrum-card-title-padding-top)));
+    padding-block-end: var(--mod-card-body-padding-block-end, calc(var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) - var(--mod-card-border-width, var(--spectrum-card-border-width))));
+    padding-inline-start: var(--mod-card-body-padding-inline-start, calc(var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) - var(--mod-card-border-width, var(--spectrum-card-border-width))));
+    padding-inline-end: var(--mod-card-body-padding-inline-end, calc(var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) - var(--mod-card-border-width, var(--spectrum-card-border-width))));
 }
 
 #preview {
-    color: var(
-        --highcontrast-card-body-font-color,
-        var(--mod-card-body-font-color, var(--spectrum-card-body-font-color))
-    );
-    border-start-start-radius: var(
-        --mod-card-corner-radius,
-        var(--spectrum-card-corner-radius)
-    );
-    border-start-end-radius: var(
-        --mod-card-corner-radius,
-        var(--spectrum-card-corner-radius)
-    );
+    color: var(--highcontrast-card-body-font-color, var(--mod-card-body-font-color, var(--spectrum-card-body-font-color)));
+    border-start-start-radius: var(--mod-card-corner-radius, var(--spectrum-card-corner-radius));
+    border-start-end-radius: var(--mod-card-corner-radius, var(--spectrum-card-corner-radius));
     border-end-end-radius: 0;
     border-end-start-radius: 0;
     align-items: center;
@@ -342,38 +160,17 @@ governing permissions and limitations under the License.
 }
 
 .title {
-    font-family: var(
-        --mod-card-title-font-family,
-        var(--spectrum-card-title-font-family)
-    );
-    font-size: var(
-        --mod-card-title-font-size,
-        var(--spectrum-card-title-font-size)
-    );
-    font-weight: var(
-        --mod-card-title-font-weight,
-        var(--spectrum-card-title-font-weight)
-    );
-    font-style: var(
-        --mod-card-title-font-style,
-        var(--spectrum-card-title-font-style)
-    );
-    line-height: var(
-        --mod-card-title-line-height,
-        var(--spectrum-card-title-line-height)
-    );
-    padding-inline-end: var(
-        --mod-card-title-padding-right,
-        var(--spectrum-card-title-padding-right)
-    );
+    font-family: var(--mod-card-title-font-family, var(--spectrum-card-title-font-family));
+    font-size: var(--mod-card-title-font-size, var(--spectrum-card-title-font-size));
+    font-weight: var(--mod-card-title-font-weight, var(--spectrum-card-title-font-weight));
+    font-style: var(--mod-card-title-font-style, var(--spectrum-card-title-font-style));
+    line-height: var(--mod-card-title-line-height, var(--spectrum-card-title-line-height));
+    padding-inline-end: var(--mod-card-title-padding-right, var(--spectrum-card-title-padding-right));
 }
 
 .subtitle,
 .title {
-    color: var(
-        --highcontrast-card-title-font-color,
-        var(--mod-card-title-font-color, var(--spectrum-card-title-font-color))
-    );
+    color: var(--highcontrast-card-title-font-color, var(--mod-card-title-font-color, var(--spectrum-card-title-font-color)));
 }
 
 .subtitle {
@@ -382,10 +179,7 @@ governing permissions and limitations under the License.
 
 .subtitle,
 .subtitle + ::slotted([slot='description']):before {
-    padding-inline-end: var(
-        --mod-card-subtitle-padding-right,
-        var(--spectrum-card-subtitle-padding-right)
-    );
+    padding-inline-end: var(--mod-card-subtitle-padding-right, var(--spectrum-card-subtitle-padding-right));
 }
 
 .subtitle + ::slotted([slot='description']):before {
@@ -393,79 +187,25 @@ governing permissions and limitations under the License.
 }
 
 ::slotted([slot='description']) {
-    font-family: var(
-        --mod-card-body-font-family,
-        var(--spectrum-card-body-font-family)
-    );
-    font-size: var(
-        --mod-card-body-font-size,
-        var(--spectrum-card-body-font-size)
-    );
-    font-weight: var(
-        --mod-card-body-font-weight,
-        var(--spectrum-card-body-font-weight)
-    );
-    font-style: var(
-        --mod-card-body-font-style,
-        var(--spectrum-card-body-font-style)
-    );
+    font-family: var(--mod-card-body-font-family, var(--spectrum-card-body-font-family));
+    font-size: var(--mod-card-body-font-size, var(--spectrum-card-body-font-size));
+    font-weight: var(--mod-card-body-font-weight, var(--spectrum-card-body-font-weight));
+    font-style: var(--mod-card-body-font-style, var(--spectrum-card-body-font-style));
 }
 
 ::slotted([slot='description']),
 ::slotted([slot='footer']) {
-    line-height: var(
-        --mod-card-body-line-height,
-        var(--spectrum-card-body-line-height)
-    );
-    color: var(
-        --highcontrast-card-body-font-color,
-        var(--mod-card-body-font-color, var(--spectrum-card-body-font-color))
-    );
+    line-height: var(--mod-card-body-line-height, var(--spectrum-card-body-line-height));
+    color: var(--highcontrast-card-body-font-color, var(--mod-card-body-font-color, var(--spectrum-card-body-font-color)));
 }
 
 ::slotted([slot='footer']) {
-    border-block-start: var(
-            --mod-card-border-width,
-            var(--spectrum-card-border-width)
-        )
-        solid var(--mod-card-divider-color, var(--spectrum-card-divider-color));
-    margin-block-start: var(
-        --mod-card-footer-margin-block-start,
-        calc(
-            (
-                    var(
-                            --mod-card-body-spacing,
-                            var(--spectrum-card-body-spacing)
-                        ) -
-                        var(
-                            --mod-card-content-margin-bottom,
-                            var(--spectrum-card-content-margin-bottom)
-                        )
-                ) * -1
-        )
-    );
-    margin-inline-start: var(
-        --mod-card-footer-margin-inline-start,
-        var(--mod-card-body-spacing, var(--spectrum-card-body-spacing))
-    );
-    margin-inline-end: var(
-        --mod-card-footer-margin-inline-end,
-        var(--mod-card-body-spacing, var(--spectrum-card-body-spacing))
-    );
-    padding-block-start: var(
-        --mod-card-footer-padding-block-start,
-        var(
-            --mod-card-footer-margin-top,
-            var(--spectrum-card-footer-padding-top)
-        )
-    );
-    padding-block-end: var(
-        --mod-card-footer-padding-block-end,
-        calc(
-            var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) -
-                var(--mod-card-border-width, var(--spectrum-card-border-width))
-        )
-    );
+    border-block-start: var(--mod-card-border-width, var(--spectrum-card-border-width)) solid var(--mod-card-divider-color, var(--spectrum-card-divider-color));
+    margin-block-start: var(--mod-card-footer-margin-block-start, calc((var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) - var(--mod-card-content-margin-bottom, var(--spectrum-card-content-margin-bottom))) * -1));
+    margin-inline-start: var(--mod-card-footer-margin-inline-start, var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)));
+    margin-inline-end: var(--mod-card-footer-margin-inline-end, var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)));
+    padding-block-start: var(--mod-card-footer-padding-block-start, var(--mod-card-footer-margin-top, var(--spectrum-card-footer-padding-top)));
+    padding-block-end: var(--mod-card-footer-padding-block-end, calc(var(--mod-card-body-spacing, var(--spectrum-card-body-spacing)) - var(--mod-card-border-width, var(--spectrum-card-border-width))));
 }
 
 .header {
@@ -482,11 +222,7 @@ governing permissions and limitations under the License.
 }
 
 :host([variant='quiet']) #preview {
-    border: var(
-            --mod-card-focus-indicator-width,
-            var(--spectrum-card-focus-indicator-width)
-        )
-        solid transparent;
+    border: var(--mod-card-focus-indicator-width, var(--spectrum-card-focus-indicator-width)) solid transparent;
 }
 
 :host([variant='quiet'][focused]):after,
@@ -496,45 +232,20 @@ governing permissions and limitations under the License.
 
 :host([variant='quiet'][focused]) #preview:after,
 :host([variant='quiet']:focus) #preview:after {
-    border-color: var(
-        --mod-card-focus-indicator-color,
-        var(--spectrum-card-focus-indicator-color)
-    );
+    border-color: var(--mod-card-focus-indicator-color, var(--spectrum-card-focus-indicator-color));
 }
 
 :host([variant='quiet'][selected]) #preview {
-    border: var(
-            --mod-card-preview-border-width-selected,
-            var(
-                --mod-card-preview-border-width,
-                var(--spectrum-card-preview-border-width-selected)
-            )
-        )
-        solid;
-    border-color: var(
-        --highcontrast-card-border-color-selected,
-        var(
-            --mod-card-border-color-selected,
-            var(--spectrum-card-border-color-selected)
-        )
-    );
+    border: var(--mod-card-preview-border-width-selected, var(--mod-card-preview-border-width, var(--spectrum-card-preview-border-width-selected))) solid;
+    border-color: var(--highcontrast-card-border-color-selected, var(--mod-card-border-color-selected, var(--spectrum-card-border-color-selected)));
 }
 
 :host([variant='gallery']),
 :host([variant='quiet']) {
-    --spectrum-card-content-margin-top: var(
-        --mod-card-content-margin-top-quiet,
-        var(--spectrum-card-content-margin-top-quiet)
-    );
-    --spectrum-card-minimum-width: var(
-        --mod-card-minimum-width-quiet,
-        var(--spectrum-card-minimum-width-quiet)
-    );
+    --spectrum-card-content-margin-top: var(--mod-card-content-margin-top-quiet, var(--spectrum-card-content-margin-top-quiet));
+    --spectrum-card-minimum-width: var(--mod-card-minimum-width-quiet, var(--spectrum-card-minimum-width-quiet));
     block-size: 100%;
-    min-inline-size: var(
-        --mod-card-minimum-width,
-        var(--spectrum-card-minimum-width)
-    );
+    min-inline-size: var(--mod-card-minimum-width, var(--spectrum-card-minimum-width));
     background-color: initial;
     border-width: 0;
     border-color: #0000;
@@ -549,31 +260,12 @@ governing permissions and limitations under the License.
 
 :host([variant='gallery']) #preview,
 :host([variant='quiet']) #preview {
-    border-radius: var(
-        --mod-card-corner-radius,
-        var(--spectrum-card-corner-radius)
-    );
-    background-color: var(
-        --mod-card-preview-background-color,
-        var(
-            --mod-card-background-color,
-            var(--spectrum-card-preview-background-color)
-        )
-    );
-    min-block-size: var(
-        --mod-card-preview-minimum-height,
-        var(--spectrum-card-preview-minimum-height)
-    );
+    border-radius: var(--mod-card-corner-radius, var(--spectrum-card-corner-radius));
+    background-color: var(--mod-card-preview-background-color, var(--mod-card-background-color, var(--spectrum-card-preview-background-color)));
+    min-block-size: var(--mod-card-preview-minimum-height, var(--spectrum-card-preview-minimum-height));
     inline-size: 100%;
     box-sizing: border-box;
-    transition: background-color
-        var(
-            --mod-card-animation-duration,
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-        );
+    transition: background-color var(--mod-card-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)));
     flex: 1;
     margin: 0 auto;
     position: relative;
@@ -594,26 +286,10 @@ governing permissions and limitations under the License.
 
 :host([variant='gallery']) #preview:after,
 :host([variant='quiet']) #preview:after {
-    border-radius: calc(
-        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) +
-            var(
-                --mod-card-focus-indicator-width,
-                var(--spectrum-card-focus-indicator-width)
-            )
-    );
+    border-radius: calc(var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) + var(--mod-card-focus-indicator-width, var(--spectrum-card-focus-indicator-width)));
     border: 0 solid #0000;
-    margin-block-start: calc(
-        var(
-                --mod-card-focus-indicator-width,
-                var(--spectrum-card-focus-indicator-width)
-            ) * -1
-    );
-    margin-inline-start: calc(
-        var(
-                --mod-card-focus-indicator-width,
-                var(--spectrum-card-focus-indicator-width)
-            ) * -1
-    );
+    margin-block-start: calc(var(--mod-card-focus-indicator-width, var(--spectrum-card-focus-indicator-width)) * -1);
+    margin-inline-start: calc(var(--mod-card-focus-indicator-width, var(--spectrum-card-focus-indicator-width)) * -1);
     inset-inline-end: 0;
 }
 
@@ -626,49 +302,24 @@ governing permissions and limitations under the License.
 
 :host([variant='gallery'][drop-target]) #preview,
 :host([variant='quiet'][drop-target]) #preview {
-    background-color: var(
-        --mod-card-preview-background-color,
-        var(
-            --mod-card-background-color,
-            var(--spectrum-card-preview-background-color)
-        )
-    );
+    background-color: var(--mod-card-preview-background-color, var(--mod-card-background-color, var(--spectrum-card-preview-background-color)));
     transition: none;
 }
 
 :host([variant='gallery'][drop-target]) #preview:before,
 :host([variant='quiet'][drop-target]) #preview:before {
-    border-color: var(
-        --mod-card-focus-indicator-color,
-        var(--spectrum-card-focus-indicator-color)
-    );
-    box-shadow: 0 0 0 1px
-        var(
-            --mod-card-focus-indicator-color,
-            var(--spectrum-card-focus-indicator-color)
-        );
+    border-color: var(--mod-card-focus-indicator-color, var(--spectrum-card-focus-indicator-color));
+    box-shadow: 0 0 0 1px var(--mod-card-focus-indicator-color, var(--spectrum-card-focus-indicator-color));
 }
 
 :host([variant='gallery'][selected]) #preview:before,
 :host([variant='quiet'][selected]) #preview:before {
-    background-color: rgba(
-        var(
-            --mod-card-selected-background-color-rgb,
-            var(--spectrum-card-selected-background-color-rgb)
-        ),
-        var(
-            --mod-card-selected-background-opacity,
-            var(--spectrum-card-selected-background-opacity)
-        )
-    );
+    background-color: rgba(var(--mod-card-selected-background-color-rgb, var(--spectrum-card-selected-background-color-rgb)), var(--mod-card-selected-background-opacity, var(--spectrum-card-selected-background-opacity)));
 }
 
 :host([variant='gallery']) .body,
 :host([variant='quiet']) .body {
-    margin-block-start: var(
-        --mod-card-content-margin-top,
-        var(--spectrum-card-content-margin-top)
-    );
+    margin-block-start: var(--mod-card-content-margin-top, var(--spectrum-card-content-margin-top));
     padding: 0;
 }
 
@@ -683,13 +334,7 @@ governing permissions and limitations under the License.
 
 @media (hover: hover) {
     :host(:hover) {
-        border-color: var(
-            --highcontrast-card-border-color-hover,
-            var(
-                --mod-card-border-color-hover,
-                var(--spectrum-card-border-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-card-border-color-hover, var(--mod-card-border-color-hover, var(--spectrum-card-border-color-hover)));
     }
 
     :host(:hover) .actions,
@@ -706,47 +351,23 @@ governing permissions and limitations under the License.
 
     :host([variant='gallery']:hover) #preview,
     :host([variant='quiet']:hover) #preview {
-        background-color: var(
-            --mod-card-preview-background-color-hover,
-            var(
-                --mod-card-background-color-hover,
-                var(--spectrum-card-preview-background-color-hover)
-            )
-        );
+        background-color: var(--mod-card-preview-background-color-hover, var(--mod-card-background-color-hover, var(--spectrum-card-preview-background-color-hover)));
     }
 
     :host([horizontal]:hover) #preview {
-        border-color: var(
-            --mod-card-border-color-hover,
-            var(--spectrum-card-border-color-hover)
-        );
+        border-color: var(--mod-card-border-color-hover, var(--spectrum-card-border-color-hover));
     }
 }
 
 :host([horizontal]) #preview {
     min-block-size: 0;
-    padding: var(
-        --mod-card-horizontal-preview-padding,
-        var(--spectrum-card-horizontal-preview-padding)
-    );
-    background-color: var(
-        --mod-card-preview-background-color,
-        var(--spectrum-card-preview-background-color)
-    );
-    border-color: var(
-        --mod-card-border-color,
-        var(--spectrum-card-border-color)
-    );
-    border-start-start-radius: calc(
-        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
-            var(--mod-card-border-width, var(--spectrum-card-border-width))
-    );
+    padding: var(--mod-card-horizontal-preview-padding, var(--spectrum-card-horizontal-preview-padding));
+    background-color: var(--mod-card-preview-background-color, var(--spectrum-card-preview-background-color));
+    border-color: var(--mod-card-border-color, var(--spectrum-card-border-color));
+    border-start-start-radius: calc(var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) - var(--mod-card-border-width, var(--spectrum-card-border-width)));
     border-start-end-radius: 0;
     border-end-end-radius: 0;
-    border-end-start-radius: calc(
-        var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) -
-            var(--mod-card-border-width, var(--spectrum-card-border-width))
-    );
+    border-end-start-radius: calc(var(--mod-card-corner-radius, var(--spectrum-card-corner-radius)) - var(--mod-card-border-width, var(--spectrum-card-border-width)));
     flex-shrink: 0;
     justify-content: center;
     align-items: center;
@@ -769,10 +390,7 @@ governing permissions and limitations under the License.
 
 :host([horizontal]) .body {
     padding-block: 0;
-    padding-inline: var(
-        --mod-card-horizontal-body-padding,
-        var(--spectrum-card-horizontal-body-padding)
-    );
+    padding-inline: var(--mod-card-horizontal-body-padding, var(--spectrum-card-horizontal-body-padding));
     flex-direction: column;
     flex-shrink: 0;
     justify-content: center;

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -12,85 +12,39 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-checkbox-content-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-checkbox-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --spectrum-checkbox-content-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --spectrum-checkbox-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
-    --spectrum-checkbox-focus-indicator-color: var(
-        --spectrum-focus-indicator-color
-    );
-    --spectrum-checkbox-content-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
-    --spectrum-checkbox-control-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
-    --spectrum-checkbox-invalid-color-default: var(
-        --spectrum-negative-color-900
-    );
-    --spectrum-checkbox-invalid-color-hover: var(
-        --spectrum-negative-color-1000
-    );
+    --spectrum-checkbox-content-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-checkbox-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-checkbox-content-color-down: var(--spectrum-neutral-content-color-down);
+    --spectrum-checkbox-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-checkbox-focus-indicator-color: var(--spectrum-focus-indicator-color);
+    --spectrum-checkbox-content-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-checkbox-control-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-checkbox-invalid-color-default: var(--spectrum-negative-color-900);
+    --spectrum-checkbox-invalid-color-hover: var(--spectrum-negative-color-1000);
     --spectrum-checkbox-invalid-color-down: var(--spectrum-negative-color-1100);
-    --spectrum-checkbox-invalid-color-focus: var(
-        --spectrum-negative-color-1000
-    );
-    --spectrum-checkbox-emphasized-color-default: var(
-        --spectrum-accent-color-900
-    );
-    --spectrum-checkbox-emphasized-color-hover: var(
-        --spectrum-accent-color-1000
-    );
-    --spectrum-checkbox-emphasized-color-down: var(
-        --spectrum-accent-color-1100
-    );
-    --spectrum-checkbox-emphasized-color-focus: var(
-        --spectrum-accent-color-1000
-    );
-    --spectrum-checkbox-control-selected-color-default: var(
-        --spectrum-neutral-background-color-selected-default
-    );
-    --spectrum-checkbox-control-selected-color-hover: var(
-        --spectrum-neutral-background-color-selected-hover
-    );
-    --spectrum-checkbox-control-selected-color-down: var(
-        --spectrum-neutral-background-color-selected-down
-    );
-    --spectrum-checkbox-control-selected-color-focus: var(
-        --spectrum-neutral-background-color-selected-key-focus
-    );
+    --spectrum-checkbox-invalid-color-focus: var(--spectrum-negative-color-1000);
+    --spectrum-checkbox-emphasized-color-default: var(--spectrum-accent-color-900);
+    --spectrum-checkbox-emphasized-color-hover: var(--spectrum-accent-color-1000);
+    --spectrum-checkbox-emphasized-color-down: var(--spectrum-accent-color-1100);
+    --spectrum-checkbox-emphasized-color-focus: var(--spectrum-accent-color-1000);
+    --spectrum-checkbox-control-selected-color-default: var(--spectrum-neutral-background-color-selected-default);
+    --spectrum-checkbox-control-selected-color-hover: var(--spectrum-neutral-background-color-selected-hover);
+    --spectrum-checkbox-control-selected-color-down: var(--spectrum-neutral-background-color-selected-down);
+    --spectrum-checkbox-control-selected-color-focus: var(--spectrum-neutral-background-color-selected-key-focus);
     --spectrum-checkbox-line-height: var(--spectrum-line-height-100);
     --spectrum-checkbox-line-height-cjk: var(--spectrum-cjk-line-height-100);
-    --spectrum-checkbox-focus-indicator-gap: var(
-        --spectrum-focus-indicator-gap
-    );
-    --spectrum-checkbox-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
+    --spectrum-checkbox-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
+    --spectrum-checkbox-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
     --spectrum-checkbox-border-width: var(--spectrum-border-width-200);
-    --spectrum-checkbox-selected-border-width: calc(
-        var(--spectrum-checkbox-control-size) / 2
-    );
-    --spectrum-checkbox-animation-duration: var(
-        --spectrum-animation-duration-100
-    );
+    --spectrum-checkbox-selected-border-width: calc(var(--spectrum-checkbox-control-size) / 2);
+    --spectrum-checkbox-animation-duration: var(--spectrum-animation-duration-100);
 }
 
 :host,
 :host {
     --spectrum-checkbox-font-size: var(--spectrum-font-size-100);
     --spectrum-checkbox-height: var(--spectrum-component-height-100);
-    --spectrum-checkbox-control-size: var(
-        --spectrum-checkbox-control-size-medium
-    );
+    --spectrum-checkbox-control-size: var(--spectrum-checkbox-control-size-medium);
     --spectrum-checkbox-top-to-text: var(--spectrum-component-top-to-text-100);
     --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-100);
 }
@@ -98,9 +52,7 @@ governing permissions and limitations under the License.
 :host([size='s']) {
     --spectrum-checkbox-font-size: var(--spectrum-font-size-75);
     --spectrum-checkbox-height: var(--spectrum-component-height-75);
-    --spectrum-checkbox-control-size: var(
-        --spectrum-checkbox-control-size-small
-    );
+    --spectrum-checkbox-control-size: var(--spectrum-checkbox-control-size-small);
     --spectrum-checkbox-top-to-text: var(--spectrum-component-top-to-text-75);
     --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-75);
 }
@@ -108,9 +60,7 @@ governing permissions and limitations under the License.
 :host([size='l']) {
     --spectrum-checkbox-font-size: var(--spectrum-font-size-200);
     --spectrum-checkbox-height: var(--spectrum-component-height-200);
-    --spectrum-checkbox-control-size: var(
-        --spectrum-checkbox-control-size-large
-    );
+    --spectrum-checkbox-control-size: var(--spectrum-checkbox-control-size-large);
     --spectrum-checkbox-top-to-text: var(--spectrum-component-top-to-text-200);
     --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-200);
 }
@@ -118,21 +68,13 @@ governing permissions and limitations under the License.
 :host([size='xl']) {
     --spectrum-checkbox-font-size: var(--spectrum-font-size-300);
     --spectrum-checkbox-height: var(--spectrum-component-height-300);
-    --spectrum-checkbox-control-size: var(
-        --spectrum-checkbox-control-size-extra-large
-    );
+    --spectrum-checkbox-control-size: var(--spectrum-checkbox-control-size-extra-large);
     --spectrum-checkbox-top-to-text: var(--spectrum-component-top-to-text-300);
     --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-300);
 }
 
 :host {
-    color: var(
-        --highcontrast-checkbox-content-color-default,
-        var(
-            --mod-checkbox-content-color-default,
-            var(--spectrum-checkbox-content-color-default)
-        )
-    );
+    color: var(--highcontrast-checkbox-content-color-default, var(--mod-checkbox-content-color-default, var(--spectrum-checkbox-content-color-default)));
     min-block-size: var(--mod-checkbox-height, var(--spectrum-checkbox-height));
     max-inline-size: 100%;
     vertical-align: top;
@@ -142,55 +84,25 @@ governing permissions and limitations under the License.
 }
 
 :host(:is(:active, [active])) #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-down,
-        var(
-            --mod-checkbox-control-color-down,
-            var(--spectrum-checkbox-control-color-down)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-highlight-color-down, var(--mod-checkbox-control-color-down, var(--spectrum-checkbox-control-color-down)));
 }
 
 :host(:is(:active, [active])) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-down,
-        var(
-            --mod-checkbox-control-selected-color-down,
-            var(--spectrum-checkbox-control-selected-color-down)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-highlight-color-down, var(--mod-checkbox-control-selected-color-down, var(--spectrum-checkbox-control-selected-color-down)));
 }
 
 :host(:is(:active, [active])) #label {
-    color: var(
-        --highcontrast-checkbox-content-color-down,
-        var(
-            --mod-checkbox-content-color-down,
-            var(--spectrum-checkbox-content-color-down)
-        )
-    );
+    color: var(--highcontrast-checkbox-content-color-down, var(--mod-checkbox-content-color-down, var(--spectrum-checkbox-content-color-down)));
 }
 
 :host([invalid][invalid]) #box:before,
 :host([invalid][invalid]) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-invalid-color-default,
-            var(--spectrum-checkbox-invalid-color-default)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-invalid-color-default, var(--spectrum-checkbox-invalid-color-default)));
 }
 
 :host([invalid][invalid]) #input:focus-visible + #box:before,
 :host([invalid][invalid][indeterminate]) #input:focus-visible + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-hover,
-        var(
-            --mod-checkbox-invalid-color-hover,
-            var(--spectrum-checkbox-invalid-color-hover)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-color-hover, var(--mod-checkbox-invalid-color-hover, var(--spectrum-checkbox-invalid-color-hover)));
 }
 
 :host([readonly]) #input {
@@ -199,46 +111,19 @@ governing permissions and limitations under the License.
 
 :host([readonly]) #input:checked:disabled + #box:before,
 :host([readonly]) #input:disabled + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-control-selected-color-default,
-            var(--spectrum-checkbox-control-selected-color-default)
-        )
-    );
-    background-color: var(
-        --highcontrast-checkbox-background-color-default,
-        var(
-            --mod-checkbox-checkmark-color,
-            var(--spectrum-checkbox-checkmark-color)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
+    background-color: var(--highcontrast-checkbox-background-color-default, var(--mod-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color)));
 }
 
 :host([readonly]) #input:checked:disabled ~ #label,
 :host([readonly]) #input:disabled ~ #label {
-    color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-content-color-default,
-            var(--spectrum-checkbox-content-color-default)
-        )
-    );
+    color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-content-color-default, var(--spectrum-checkbox-content-color-default)));
 }
 
 :host([indeterminate]) #box:before,
 :host([indeterminate]) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-default,
-        var(
-            --mod-checkbox-control-selected-color-default,
-            var(--spectrum-checkbox-control-selected-color-default)
-        )
-    );
-    border-width: var(
-        --mod-checkbox-selected-border-width,
-        var(--spectrum-checkbox-selected-border-width)
-    );
+    border-color: var(--highcontrast-checkbox-highlight-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
+    border-width: var(--mod-checkbox-selected-border-width, var(--spectrum-checkbox-selected-border-width));
 }
 
 :host([indeterminate]) #box #checkmark,
@@ -254,258 +139,114 @@ governing permissions and limitations under the License.
 }
 
 :host([indeterminate]) #input:focus-visible + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-focus,
-        var(
-            --mod-checkbox-control-selected-color-focus,
-            var(--spectrum-checkbox-control-selected-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-highlight-color-focus, var(--mod-checkbox-control-selected-color-focus, var(--spectrum-checkbox-control-selected-color-focus)));
 }
 
 :host([invalid][invalid][indeterminate]) #box:before,
 :host([invalid][invalid][indeterminate]) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-invalid-color-default,
-            var(--spectrum-checkbox-invalid-color-default)
-        )
-    );
-    border-width: var(
-        --mod-checkbox-selected-border-width,
-        var(--spectrum-checkbox-selected-border-width)
-    );
+    border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-invalid-color-default, var(--spectrum-checkbox-invalid-color-default)));
+    border-width: var(--mod-checkbox-selected-border-width, var(--spectrum-checkbox-selected-border-width));
 }
 
 :host([emphasized]) #input:checked + #box:before,
 :host([emphasized][indeterminate]) #box:before,
 :host([emphasized][indeterminate]) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-default,
-        var(
-            --mod-checkbox-emphasized-color-default,
-            var(--spectrum-checkbox-emphasized-color-default)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-highlight-color-default, var(--mod-checkbox-emphasized-color-default, var(--spectrum-checkbox-emphasized-color-default)));
 }
 
 :host([emphasized]) #input:focus-visible:checked + #box:before,
 :host([emphasized][indeterminate]) #input:focus-visible + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-focus,
-        var(
-            --mod-checkbox-emphasized-color-focus,
-            var(--spectrum-checkbox-emphasized-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-highlight-color-focus, var(--mod-checkbox-emphasized-color-focus, var(--spectrum-checkbox-emphasized-color-focus)));
 }
 
-:host([emphasized][invalid][invalid])
-    #input:focus-visible:checked
-    + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-invalid-color-focus,
-            var(--spectrum-checkbox-invalid-color-focus)
-        )
-    );
+:host([emphasized][invalid][invalid]) #input:focus-visible:checked + #box:before {
+    border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-invalid-color-focus, var(--spectrum-checkbox-invalid-color-focus)));
 }
 
 @media (hover: hover) {
     :host(:hover) #box:before {
-        border-color: var(
-            --highcontrast-checkbox-highlight-color-hover,
-            var(
-                --mod-checkbox-control-color-hover,
-                var(--spectrum-checkbox-control-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-checkbox-highlight-color-hover, var(--mod-checkbox-control-color-hover, var(--spectrum-checkbox-control-color-hover)));
     }
 
     :host(:hover) #input:checked + #box:before {
-        border-color: var(
-            --highcontrast-checkbox-highlight-color-hover,
-            var(
-                --mod-checkbox-control-selected-color-hover,
-                var(--spectrum-checkbox-control-selected-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-checkbox-highlight-color-hover, var(--mod-checkbox-control-selected-color-hover, var(--spectrum-checkbox-control-selected-color-hover)));
     }
 
     :host(:hover) #label {
-        color: var(
-            --highcontrast-checkbox-content-color-hover,
-            var(
-                --mod-checkbox-content-color-hover,
-                var(--spectrum-checkbox-content-color-hover)
-            )
-        );
+        color: var(--highcontrast-checkbox-content-color-hover, var(--mod-checkbox-content-color-hover, var(--spectrum-checkbox-content-color-hover)));
     }
 
     :host([invalid][invalid]:hover) #box:before,
     :host([invalid][invalid]:hover) #input:checked + #box {
-        border-color: var(
-            --highcontrast-checkbox-color-hover,
-            var(
-                --mod-checkbox-invalid-color-hover,
-                var(--spectrum-checkbox-invalid-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-checkbox-color-hover, var(--mod-checkbox-invalid-color-hover, var(--spectrum-checkbox-invalid-color-hover)));
     }
 
     :host([indeterminate]:hover) #box:before,
     :host([indeterminate]:hover) #input:checked + #box:before {
-        border-color: var(
-            --highcontrast-checkbox-highlight-color-hover,
-            var(
-                --mod-checkbox-control-selected-color-hover,
-                var(--spectrum-checkbox-control-selected-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-checkbox-highlight-color-hover, var(--mod-checkbox-control-selected-color-hover, var(--spectrum-checkbox-control-selected-color-hover)));
     }
 
     :host([invalid][invalid][indeterminate]:hover) #box:before,
-    :host([invalid][invalid][indeterminate]:hover)
-        #input:checked
-        + #box:before {
-        border-color: var(
-            --highcontrast-checkbox-color-default,
-            var(
-                --mod-checkbox-invalid-color-hover,
-                var(--spectrum-checkbox-invalid-color-hover)
-            )
-        );
+    :host([invalid][invalid][indeterminate]:hover) #input:checked + #box:before {
+        border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-invalid-color-hover, var(--spectrum-checkbox-invalid-color-hover)));
     }
 
     :host([invalid][invalid][indeterminate]:hover) #label {
-        color: var(
-            --highcontrast-checkbox-content-color-hover,
-            var(
-                --mod-checkbox-content-color-hover,
-                var(--spectrum-checkbox-content-color-hover)
-            )
-        );
+        color: var(--highcontrast-checkbox-content-color-hover, var(--mod-checkbox-content-color-hover, var(--spectrum-checkbox-content-color-hover)));
     }
 
     :host([emphasized][indeterminate]:hover) #box:before,
     :host([emphasized][indeterminate]:hover) #input:checked + #box:before,
     :host([emphasized]:hover) #input:checked + #box:before {
-        border-color: var(
-            --highcontrast-checkbox-color-hover,
-            var(
-                --mod-checkbox-emphasized-color-hover,
-                var(--spectrum-checkbox-emphasized-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-checkbox-color-hover, var(--mod-checkbox-emphasized-color-hover, var(--spectrum-checkbox-emphasized-color-hover)));
     }
 
     :host([emphasized][invalid][invalid][indeterminate]:hover) #box:before,
-    :host([emphasized][invalid][invalid][indeterminate]:hover)
-        #input:checked
-        + #box:before,
+    :host([emphasized][invalid][invalid][indeterminate]:hover) #input:checked + #box:before,
     :host([emphasized][invalid][invalid]:hover) #input:checked + #box:before {
-        border-color: var(
-            --highcontrast-checkbox-color-hover,
-            var(
-                --mod-checkbox-invalid-color-hover,
-                var(--spectrum-checkbox-invalid-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-checkbox-color-hover, var(--mod-checkbox-invalid-color-hover, var(--spectrum-checkbox-invalid-color-hover)));
     }
 
     :host([emphasized][indeterminate]:hover) #box:before,
     :host([emphasized][indeterminate]:hover) #input:checked + #box:before,
     :host([emphasized]:hover) #input:checked + #box:before {
-        border-color: var(
-            --highcontrast-checkbox-highlight-color-hover,
-            var(
-                --mod-checkbox-emphasized-color-hover,
-                var(--spectrum-checkbox-emphasized-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-checkbox-highlight-color-hover, var(--mod-checkbox-emphasized-color-hover, var(--spectrum-checkbox-emphasized-color-hover)));
     }
 }
 
 :host([emphasized][indeterminate]:is(:active, [active])) #box:before,
-:host([emphasized][indeterminate]:is(:active, [active]))
-    #input:checked
-    + #box:before,
+:host([emphasized][indeterminate]:is(:active, [active])) #input:checked + #box:before,
 :host([emphasized]:is(:active, [active])) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-default,
-        var(
-            --mod-checkbox-emphasized-color-down,
-            var(--spectrum-checkbox-emphasized-color-down)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-highlight-color-default, var(--mod-checkbox-emphasized-color-down, var(--spectrum-checkbox-emphasized-color-down)));
 }
 
 :host([emphasized][invalid][invalid]:is(:active, [active])) #box:before,
-:host([emphasized][invalid][invalid]:is(:active, [active]))
-    #input:checked
-    + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-default,
-        var(
-            --mod-checkbox-control-invalid-color-down,
-            var(--spectrum-checkbox-invalid-color-down)
-        )
-    );
+:host([emphasized][invalid][invalid]:is(:active, [active])) #input:checked + #box:before {
+    border-color: var(--highcontrast-checkbox-highlight-color-default, var(--mod-checkbox-control-invalid-color-down, var(--spectrum-checkbox-invalid-color-down)));
 }
 
 :host([emphasized]:focus-visible) #box:before,
 :host([emphasized]:focus-visible) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-focus,
-        var(
-            --mod-checkbox-control-color-focus,
-            var(--spectrum-checkbox-control-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-color-focus, var(--mod-checkbox-control-color-focus, var(--spectrum-checkbox-control-color-focus)));
 }
 
 #label {
     text-align: start;
-    font-size: var(
-        --mod-checkbox-font-size,
-        var(--spectrum-checkbox-font-size)
-    );
-    transition: color
-        var(
-            --mod-checkbox-animation-duration,
-            var(--spectrum-checkbox-animation-duration)
-        )
-        ease-in-out;
-    line-height: var(
-        --mod-checkbox-line-height,
-        var(--spectrum-checkbox-line-height)
-    );
-    margin-block-start: var(
-        --mod-checkbox-top-to-text,
-        var(--spectrum-checkbox-top-to-text)
-    );
-    margin-inline-start: var(
-        --mod-checkbox-text-to-control,
-        var(--spectrum-checkbox-text-to-control)
-    );
+    font-size: var(--mod-checkbox-font-size, var(--spectrum-checkbox-font-size));
+    transition: color var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-in-out;
+    line-height: var(--mod-checkbox-line-height, var(--spectrum-checkbox-line-height));
+    margin-block-start: var(--mod-checkbox-top-to-text, var(--spectrum-checkbox-top-to-text));
+    margin-inline-start: var(--mod-checkbox-text-to-control, var(--spectrum-checkbox-text-to-control));
 }
 
 #label:lang(ja),
 #label:lang(ko),
 #label:lang(zh) {
-    line-height: var(
-        --mod-checkbox-line-height-cjk,
-        var(--spectrum-checkbox-line-height-cjk)
-    );
+    line-height: var(--mod-checkbox-line-height-cjk, var(--spectrum-checkbox-line-height-cjk));
 }
 
 #input {
-    color: var(
-        --mod-checkbox-control-color-default,
-        var(--spectrum-checkbox-control-color-default)
-    );
+    color: var(--mod-checkbox-control-color-default, var(--spectrum-checkbox-control-color-default));
     box-sizing: border-box;
     inline-size: 100%;
     block-size: 100%;
@@ -526,21 +267,9 @@ governing permissions and limitations under the License.
 }
 
 #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-default,
-        var(
-            --mod-checkbox-control-selected-color-default,
-            var(--spectrum-checkbox-control-selected-color-default)
-        )
-    );
-    background-color: var(
-        --mod-checkbox-checkmark-color,
-        var(--spectrum-checkbox-checkmark-color)
-    );
-    border-width: var(
-        --mod-checkbox-selected-border-width,
-        var(--spectrum-checkbox-selected-border-width)
-    );
+    border-color: var(--highcontrast-checkbox-highlight-color-default, var(--mod-checkbox-control-selected-color-default, var(--spectrum-checkbox-control-selected-color-default)));
+    background-color: var(--mod-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color));
+    border-width: var(--mod-checkbox-selected-border-width, var(--spectrum-checkbox-selected-border-width));
 }
 
 #input:checked + #box #checkmark {
@@ -549,69 +278,26 @@ governing permissions and limitations under the License.
 }
 
 #input:focus-visible + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-focus,
-        var(
-            --mod-checkbox-control-color-focus,
-            var(--spectrum-checkbox-control-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-color-focus, var(--mod-checkbox-control-color-focus, var(--spectrum-checkbox-control-color-focus)));
 }
 
 #input:focus-visible + #box:after {
     forced-color-adjust: none;
-    box-shadow: 0 0 0
-        var(
-            --mod-checkbox-focus-indicator-thinkness,
-            var(--spectrum-checkbox-focus-indicator-thickness)
-        )
-        var(
-            --highcontrast-checkbox-focus-indicator-color,
-            var(
-                --mod-checkbox-focus-indicator-color,
-                var(--spectrum-checkbox-focus-indicator-color)
-            )
-        );
-    margin: calc(
-        var(
-                --mod-checkbox-focus-indicator-gap,
-                var(--spectrum-checkbox-focus-indicator-gap)
-            ) * -1
-    );
+    box-shadow: 0 0 0 var(--mod-checkbox-focus-indicator-thinkness, var(--spectrum-checkbox-focus-indicator-thickness)) var(--highcontrast-checkbox-focus-indicator-color, var(--mod-checkbox-focus-indicator-color, var(--spectrum-checkbox-focus-indicator-color)));
+    margin: calc(var(--mod-checkbox-focus-indicator-gap, var(--spectrum-checkbox-focus-indicator-gap)) * -1);
 }
 
 #input:focus-visible + #label {
-    color: var(
-        --highcontrast-checkbox-content-color-focus,
-        var(
-            --mod-checkbox-content-color-focus,
-            var(--spectrum-checkbox-content-color-focus)
-        )
-    );
+    color: var(--highcontrast-checkbox-content-color-focus, var(--mod-checkbox-content-color-focus, var(--spectrum-checkbox-content-color-focus)));
 }
 
 #input:focus-visible:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-focus,
-        var(
-            --mod-checkbox-control-selected-color-focus,
-            var(--spectrum-checkbox-control-selected-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-highlight-color-focus, var(--mod-checkbox-control-selected-color-focus, var(--spectrum-checkbox-control-selected-color-focus)));
 }
 
 #box {
-    --spectrum-checkbox-spacing: calc(
-        var(--mod-checkbox-height, var(--spectrum-checkbox-height)) -
-            var(
-                --mod-checkbox-control-size,
-                var(--spectrum-checkbox-control-size)
-            )
-    );
-    margin: calc(
-            var(--mod-checkbox-spacing, var(--spectrum-checkbox-spacing)) / 2
-        )
-        0;
+    --spectrum-checkbox-spacing: calc(var(--mod-checkbox-height, var(--spectrum-checkbox-height)) - var(--mod-checkbox-control-size, var(--spectrum-checkbox-control-size)));
+    margin: calc(var(--mod-checkbox-spacing, var(--spectrum-checkbox-spacing)) / 2) 0;
     flex-grow: 0;
     flex-shrink: 0;
     justify-content: center;
@@ -623,82 +309,32 @@ governing permissions and limitations under the License.
 #box,
 #box:before {
     box-sizing: border-box;
-    inline-size: var(
-        --mod-checkbox-control-size,
-        var(--spectrum-checkbox-control-size)
-    );
-    block-size: var(
-        --mod-checkbox-control-size,
-        var(--spectrum-checkbox-control-size)
-    );
+    inline-size: var(--mod-checkbox-control-size, var(--spectrum-checkbox-control-size));
+    block-size: var(--mod-checkbox-control-size, var(--spectrum-checkbox-control-size));
 }
 
 #box:before {
     forced-color-adjust: none;
-    border-color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-control-color-default,
-            var(--spectrum-checkbox-control-color-default)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-control-color-default, var(--spectrum-checkbox-control-color-default)));
     z-index: 0;
     content: '';
-    border-radius: var(
-        --mod-checkbox-control-corner-radius,
-        var(--spectrum-checkbox-control-corner-radius)
-    );
-    border-width: var(
-        --mod-checkbox-border-width,
-        var(--spectrum-checkbox-border-width)
-    );
+    border-radius: var(--mod-checkbox-control-corner-radius, var(--spectrum-checkbox-control-corner-radius));
+    border-width: var(--mod-checkbox-border-width, var(--spectrum-checkbox-border-width));
     transition:
-        border
-            var(
-                --mod-checkbox-animation-duration,
-                var(--spectrum-checkbox-animation-duration)
-            )
-            ease-in-out,
-        box-shadow
-            var(
-                --mod-checkbox-animation-duration,
-                var(--spectrum-checkbox-animation-duration)
-            )
-            ease-in-out;
+        border var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-in-out,
+        box-shadow var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-in-out;
     border-style: solid;
     display: block;
     position: absolute;
 }
 
 #box:after {
-    border-radius: calc(
-        var(
-                --mod-checkbox-control-corner-radius,
-                var(--spectrum-checkbox-control-corner-radius)
-            ) +
-            var(
-                --mod-checkbox-focus-indicator-gap,
-                var(--spectrum-checkbox-focus-indicator-gap)
-            )
-    );
+    border-radius: calc(var(--mod-checkbox-control-corner-radius, var(--spectrum-checkbox-control-corner-radius)) + var(--mod-checkbox-focus-indicator-gap, var(--spectrum-checkbox-focus-indicator-gap)));
     content: '';
-    margin: var(
-        --mod-checkbox-focus-indicator-gap,
-        var(--spectrum-checkbox-focus-indicator-gap)
-    );
+    margin: var(--mod-checkbox-focus-indicator-gap, var(--spectrum-checkbox-focus-indicator-gap));
     transition:
-        box-shadow
-            var(
-                --mod-checkbox-animation-duration,
-                var(--spectrum-checkbox-animation-duration)
-            )
-            ease-out,
-        margin
-            var(
-                --mod-checkbox-animation-duration,
-                var(--spectrum-checkbox-animation-duration)
-            )
-            ease-out;
+        box-shadow var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-out,
+        margin var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-out;
     display: block;
     position: absolute;
     inset-block: 0;
@@ -708,27 +344,11 @@ governing permissions and limitations under the License.
 
 #checkmark,
 #partialCheckmark {
-    color: var(
-        --highcontrast-checkbox-background-color-default,
-        var(
-            --mod-checkbox-checkmark-color,
-            var(--spectrum-checkbox-checkmark-color)
-        )
-    );
+    color: var(--highcontrast-checkbox-background-color-default, var(--mod-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color)));
     opacity: 0;
     transition:
-        opacity
-            var(
-                --mod-checkbox-animation-duration,
-                var(--spectrum-checkbox-animation-duration)
-            )
-            ease-in-out,
-        transform
-            var(
-                --mod-checkbox-animation-duration,
-                var(--spectrum-checkbox-animation-duration)
-            )
-            ease-in-out;
+        opacity var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-in-out,
+        transform var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-in-out;
     transform: scale(0);
 }
 
@@ -738,64 +358,27 @@ governing permissions and limitations under the License.
 
 #input:checked:disabled + #box:before,
 #input:disabled + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-disabled-color-default,
-        var(
-            --mod-checkbox-control-color-disabled,
-            var(--spectrum-checkbox-control-color-disabled)
-        )
-    );
-    background-color: var(
-        --highcontrast-checkbox-background-color-default,
-        var(
-            --mod-checkbox-checkmark-color,
-            var(--spectrum-checkbox-checkmark-color)
-        )
-    );
+    border-color: var(--highcontrast-checkbox-disabled-color-default, var(--mod-checkbox-control-color-disabled, var(--spectrum-checkbox-control-color-disabled)));
+    background-color: var(--highcontrast-checkbox-background-color-default, var(--mod-checkbox-checkmark-color, var(--spectrum-checkbox-checkmark-color)));
 }
 
 #input:checked:disabled ~ #label,
 #input:disabled ~ #label {
     forced-color-adjust: none;
-    color: var(
-        --highcontrast-checkbox-disabled-color-default,
-        var(
-            --mod-checkbox-content-color-disabled,
-            var(--spectrum-checkbox-content-color-disabled)
-        )
-    );
+    color: var(--highcontrast-checkbox-disabled-color-default, var(--mod-checkbox-content-color-disabled, var(--spectrum-checkbox-content-color-disabled)));
 }
 
 @media (forced-colors: active) {
     #input:focus-visible + #box {
         forced-color-adjust: none;
-        outline-color: var(
-            --highcontrast-checkbox-focus-indicator-color,
-            var(
-                --mod-checkbox-focus-indicator-color,
-                var(--spectrum-checkbox-focus-indicator-color)
-            )
-        );
-        outline-offset: var(
-            --mod-checkbox-focus-indicator-gap,
-            var(--spectrum-checkbox-focus-indicator-gap)
-        );
+        outline-color: var(--highcontrast-checkbox-focus-indicator-color, var(--mod-checkbox-focus-indicator-color, var(--spectrum-checkbox-focus-indicator-color)));
+        outline-offset: var(--mod-checkbox-focus-indicator-gap, var(--spectrum-checkbox-focus-indicator-gap));
         outline-style: auto;
-        outline-width: var(
-            --mod-focus-indicator-thickness,
-            var(--spectrum-focus-indicator-thickness)
-        );
+        outline-width: var(--mod-focus-indicator-thickness, var(--spectrum-focus-indicator-thickness));
     }
 
     #input:focus-visible + #box:after {
-        box-shadow: 0 0 0 0
-            var(
-                --highcontrast-checkbox-focus-indicator-color,
-                var(
-                    --mod-checkbox-focus-indicator-color,
-                    var(--spectrum-checkbox-focus-indicator-color)
-                )
-            );
+        box-shadow: 0 0 0 0 var(--highcontrast-checkbox-focus-indicator-color, var(--mod-checkbox-focus-indicator-color, var(--spectrum-checkbox-focus-indicator-color)));
     }
 
     :host {

--- a/packages/clear-button/src/spectrum-clear-button.css
+++ b/packages/clear-button/src/spectrum-clear-button.css
@@ -12,25 +12,13 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    block-size: var(
-        --mod-clear-button-height,
-        var(--spectrum-clear-button-height)
-    );
-    inline-size: var(
-        --mod-clear-button-width,
-        var(--spectrum-clear-button-width)
-    );
+    block-size: var(--mod-clear-button-height, var(--spectrum-clear-button-height));
+    inline-size: var(--mod-clear-button-width, var(--spectrum-clear-button-width));
     cursor: pointer;
     background-color: initial;
     background-color: var(--mod-clear-button-background-color, transparent);
-    padding: var(
-        --mod-clear-button-padding,
-        var(--spectrum-clear-button-padding)
-    );
-    color: var(
-        --mod-clear-button-icon-color,
-        var(--spectrum-clear-button-icon-color)
-    );
+    padding: var(--mod-clear-button-padding, var(--spectrum-clear-button-padding));
+    color: var(--mod-clear-button-icon-color, var(--spectrum-clear-button-icon-color));
     border: none;
     border-radius: 100%;
     margin: 0;
@@ -43,74 +31,44 @@ governing permissions and limitations under the License.
 
 @media (hover: hover) {
     :host(:hover) {
-        color: var(
-            --highcontrast-clear-button-icon-color-hover,
-            var(
-                --mod-clear-button-icon-color-hover,
-                var(--spectrum-clear-button-icon-color-hover)
-            )
-        );
+        color: var(--highcontrast-clear-button-icon-color-hover, var(--mod-clear-button-icon-color-hover, var(--spectrum-clear-button-icon-color-hover)));
     }
 
     :host(:hover) .fill {
-        background-color: var(
-            --mod-clear-button-background-color-hover,
-            var(--spectrum-clear-button-background-color-hover)
-        );
+        background-color: var(--mod-clear-button-background-color-hover, var(--spectrum-clear-button-background-color-hover));
     }
 }
 
 :host(:is(:active, [active])) {
-    color: var(
-        --mod-clear-button-icon-color-down,
-        var(--spectrum-clear-button-icon-color-down)
-    );
+    color: var(--mod-clear-button-icon-color-down, var(--spectrum-clear-button-icon-color-down));
 }
 
 :host(:is(:active, [active])) .fill {
-    background-color: var(
-        --mod-clear-button-background-color-down,
-        var(--spectrum-clear-button-background-color-down)
-    );
+    background-color: var(--mod-clear-button-background-color-down, var(--spectrum-clear-button-background-color-down));
 }
 
 :host([focus-within]) .js-focus-within,
 :host(:focus-visible),
 :host:focus-within,
 :host([focus-within]) .js-focus-within {
-    color: var(
-        --mod-clear-button-icon-color-key-focus,
-        var(--spectrum-clear-button-icon-color-key-focus)
-    );
+    color: var(--mod-clear-button-icon-color-key-focus, var(--spectrum-clear-button-icon-color-key-focus));
 }
 
 :host([focus-within]) .js-focus-within .fill,
 :host(:focus-visible) .fill,
 :host:focus-within .fill,
 :host([focus-within]) .js-focus-within .fill {
-    background-color: var(
-        --mod-clear-button-background-color-key-focus,
-        var(--spectrum-clear-button-background-color-key-focus)
-    );
+    background-color: var(--mod-clear-button-background-color-key-focus, var(--spectrum-clear-button-background-color-key-focus));
 }
 
 :host([disabled]),
 :host([disabled]) {
-    --spectrum-clear-button-icon-color: var(
-        --mod-clear-button-icon-color-disabled,
-        var(--spectrum-disabled-content-color)
-    );
-    --spectrum-clear-button-background-color: var(
-        --mod-clear-button-background-color-disabled,
-        transparent
-    );
+    --spectrum-clear-button-icon-color: var(--mod-clear-button-icon-color-disabled, var(--spectrum-disabled-content-color));
+    --spectrum-clear-button-background-color: var(--mod-clear-button-background-color-disabled, transparent);
 }
 
 .fill {
-    background-color: var(
-        --mod-clear-button-background-color,
-        var(--spectrum-clear-button-background-color)
-    );
+    background-color: var(--mod-clear-button-background-color, var(--spectrum-clear-button-background-color));
     inline-size: 100%;
     block-size: 100%;
     border-radius: 100%;

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -16,59 +16,18 @@ governing permissions and limitations under the License.
     -webkit-user-select: none;
     user-select: none;
     box-sizing: border-box;
-    font-family: var(
-        --mod-button-font-family,
-        var(
-            --mod-sans-font-family-stack,
-            var(--spectrum-sans-font-family-stack)
-        )
-    );
+    font-family: var(--mod-button-font-family, var(--mod-sans-font-family-stack, var(--spectrum-sans-font-family-stack)));
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    line-height: var(
-        --mod-button-line-height,
-        var(--mod-line-height-100, var(--spectrum-line-height-100))
-    );
+    line-height: var(--mod-button-line-height, var(--mod-line-height-100, var(--spectrum-line-height-100)));
     text-transform: none;
     vertical-align: top;
     -webkit-appearance: button;
     transition:
-        background
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        border-color
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        color
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        box-shadow
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out;
+        background var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        border-color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        box-shadow var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out;
     border-style: solid;
     margin: 0;
     -webkit-text-decoration: none;
@@ -103,23 +62,10 @@ governing permissions and limitations under the License.
 
     :host(:focus-visible):after {
         forced-color-adjust: none;
-        margin: var(
-            --mod-closebutton-focus-indicator-gap,
-            var(--spectrum-closebutton-focus-indicator-gap)
-        );
+        margin: var(--mod-closebutton-focus-indicator-gap, var(--spectrum-closebutton-focus-indicator-gap));
         transition:
-            opacity
-                var(
-                    --mod-closebutton-animation-duration,
-                    var(--spectrum-closebutton-animation-duration)
-                )
-                ease-out,
-            margin
-                var(
-                    --mod-closebutton-animation-duraction,
-                    var(--spectrum-closebutton-animation-duration)
-                )
-                ease-out;
+            opacity var(--mod-closebutton-animation-duration, var(--spectrum-closebutton-animation-duration)) ease-out,
+            margin var(--mod-closebutton-animation-duraction, var(--spectrum-closebutton-animation-duration)) ease-out;
     }
 
     :host([static-color='black']) {
@@ -139,16 +85,8 @@ governing permissions and limitations under the License.
     block-size: var(--mod-closebutton-height, var(--spectrum-closebutton-size));
     inline-size: var(--mod-closebutton-width, var(--spectrum-closebutton-size));
     color: inherit;
-    border-radius: var(
-        --mod-closebutton-border-radius,
-        var(--spectrum-closebutton-size)
-    );
-    transition: border-color
-        var(
-            --mod-closebutton-animation-duration,
-            var(--spectrum-closebutton-animation-duration)
-        )
-        ease-in-out;
+    border-radius: var(--mod-closebutton-border-radius, var(--spectrum-closebutton-size));
+    transition: border-color var(--mod-closebutton-animation-duration, var(--spectrum-closebutton-animation-duration)) ease-in-out;
     margin-inline: var(--mod-closebutton-margin-inline);
     justify-content: center;
     align-items: center;
@@ -165,25 +103,9 @@ governing permissions and limitations under the License.
 :host:after {
     pointer-events: none;
     content: '';
-    margin: calc(
-        var(
-                --mod-closebutton-focus-indicator-gap,
-                var(--spectrum-closebutton-focus-indicator-gap)
-            ) * -1
-    );
-    border-radius: calc(
-        var(--mod-closebutton-size, var(--spectrum-closebutton-size)) +
-            var(
-                --mod-closebutton-focus-indicator-gap,
-                var(--spectrum-closebutton-focus-indicator-gap)
-            )
-    );
-    transition: box-shadow
-        var(
-            --mod-closebutton-animation-duration,
-            var(--spectrum-closebutton-animation-duration)
-        )
-        ease-in-out;
+    margin: calc(var(--mod-closebutton-focus-indicator-gap, var(--spectrum-closebutton-focus-indicator-gap)) * -1);
+    border-radius: calc(var(--mod-closebutton-size, var(--spectrum-closebutton-size)) + var(--mod-closebutton-focus-indicator-gap, var(--spectrum-closebutton-focus-indicator-gap)));
+    transition: box-shadow var(--mod-closebutton-animation-duration, var(--spectrum-closebutton-animation-duration)) ease-in-out;
     position: absolute;
     inset-block: 0;
     inset-inline: 0;
@@ -195,186 +117,88 @@ governing permissions and limitations under the License.
 }
 
 :host(:focus-visible):after {
-    box-shadow: 0 0 0
-        var(
-            --mod-closebutton-focus-indicator-thickness,
-            var(--spectrum-closebutton-focus-indicator-thickness)
-        )
-        var(
-            --highcontrast-closebutton-focus-indicator-color,
-            var(
-                --mod-closebutton-focus-indicator-color,
-                var(--spectrum-closebutton-focus-indicator-color)
-            )
-        );
+    box-shadow: 0 0 0 var(--mod-closebutton-focus-indicator-thickness, var(--spectrum-closebutton-focus-indicator-thickness)) var(--highcontrast-closebutton-focus-indicator-color, var(--mod-closebutton-focus-indicator-color, var(--spectrum-closebutton-focus-indicator-color)));
 }
 
 :host(:not([disabled])) {
-    background-color: var(
-        --highcontrast-closebutton-background-color-default,
-        var(
-            --mod-closebutton-background-color-default,
-            var(--spectrum-closebutton-background-color-default)
-        )
-    );
+    background-color: var(--highcontrast-closebutton-background-color-default, var(--mod-closebutton-background-color-default, var(--spectrum-closebutton-background-color-default)));
 }
 
 :host(:not([disabled]):is(:active, [active])) {
-    background-color: var(
-        --mod-closebutton-background-color-down,
-        var(--spectrum-closebutton-background-color-down)
-    );
+    background-color: var(--mod-closebutton-background-color-down, var(--spectrum-closebutton-background-color-down));
 }
 
 :host(:not([disabled]):is(:active, [active])) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-down,
-        var(
-            --mod-closebutton-icon-color-down,
-            var(--spectrum-closebutton-icon-color-down)
-        )
-    );
+    color: var(--highcontrast-closebutton-icon-color-down, var(--mod-closebutton-icon-color-down, var(--spectrum-closebutton-icon-color-down)));
 }
 
 :host([focused]:not([disabled])),
 :host(:not([disabled]):focus-visible) {
-    background-color: var(
-        --mod-closebutton-background-color-focus,
-        var(--spectrum-closebutton-background-color-focus)
-    );
+    background-color: var(--mod-closebutton-background-color-focus, var(--spectrum-closebutton-background-color-focus));
 }
 
 :host([focused]:not([disabled])) .icon,
 :host(:not([disabled]):focus-visible) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-focus,
-        var(
-            --mod-closebutton-icon-color-focus,
-            var(--spectrum-closebutton-icon-color-focus)
-        )
-    );
+    color: var(--highcontrast-closebutton-icon-color-focus, var(--mod-closebutton-icon-color-focus, var(--spectrum-closebutton-icon-color-focus)));
 }
 
 :host(:not([disabled])) .icon {
-    color: var(
-        --mod-closebutton-icon-color-default,
-        var(--spectrum-closebutton-icon-color-default)
-    );
+    color: var(--mod-closebutton-icon-color-default, var(--spectrum-closebutton-icon-color-default));
 }
 
 :host([focused]:not([disabled])) .icon,
 :host(:not([disabled]):focus) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-focus,
-        var(
-            --mod-closebutton-icon-color-focus,
-            var(--spectrum-closebutton-icon-color-focus)
-        )
-    );
+    color: var(--highcontrast-closebutton-icon-color-focus, var(--mod-closebutton-icon-color-focus, var(--spectrum-closebutton-icon-color-focus)));
 }
 
 :host([disabled]) {
-    background-color: var(
-        --mod-closebutton-background-color-default,
-        var(--spectrum-closebutton-background-color-default)
-    );
+    background-color: var(--mod-closebutton-background-color-default, var(--spectrum-closebutton-background-color-default));
 }
 
 :host([disabled]) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-disabled,
-        var(
-            --mod-closebutton-icon-color-disabled,
-            var(--spectrum-closebutton-icon-color-disabled)
-        )
-    );
+    color: var(--highcontrast-closebutton-icon-color-disabled, var(--mod-closebutton-icon-color-disabled, var(--spectrum-closebutton-icon-color-disabled)));
 }
 
 :host([static-color='black']:not([disabled])),
 :host([static-color='white']:not([disabled])) {
-    background-color: var(
-        --highcontrast-closebutton-static-background-color-default,
-        var(
-            --mod-closebutton-static-background-color-default,
-            var(--spectrum-closebutton-static-background-color-default)
-        )
-    );
+    background-color: var(--highcontrast-closebutton-static-background-color-default, var(--mod-closebutton-static-background-color-default, var(--spectrum-closebutton-static-background-color-default)));
 }
 
 @media (hover: hover) {
     :host(:not([disabled]):hover) {
-        background-color: var(
-            --mod-closebutton-background-color-hover,
-            var(--spectrum-closebutton-background-color-hover)
-        );
+        background-color: var(--mod-closebutton-background-color-hover, var(--spectrum-closebutton-background-color-hover));
     }
 
     :host(:not([disabled]):hover) .icon {
-        color: var(
-            --highcontrast-closebutton-icon-color-hover,
-            var(
-                --mod-closebutton-icon-color-hover,
-                var(--spectrum-closebutton-icon-color-hover)
-            )
-        );
+        color: var(--highcontrast-closebutton-icon-color-hover, var(--mod-closebutton-icon-color-hover, var(--spectrum-closebutton-icon-color-hover)));
     }
 
     :host([static-color='black']:not([disabled]):hover),
     :host([static-color='white']:not([disabled]):hover) {
-        background-color: var(
-            --highcontrast-closebutton-static-background-color-hover,
-            var(
-                --mod-closebutton-static-background-color-hover,
-                var(--spectrum-closebutton-static-background-color-hover)
-            )
-        );
+        background-color: var(--highcontrast-closebutton-static-background-color-hover, var(--mod-closebutton-static-background-color-hover, var(--spectrum-closebutton-static-background-color-hover)));
     }
 
     :host([static-color='black']:not([disabled]):hover) .icon,
     :host([static-color='white']:not([disabled]):hover) .icon {
-        color: var(
-            --highcontrast-closebutton-icon-color-default,
-            var(
-                --mod-closebutton-icon-color-default,
-                var(--spectrum-closebutton-icon-color-default)
-            )
-        );
+        color: var(--highcontrast-closebutton-icon-color-default, var(--mod-closebutton-icon-color-default, var(--spectrum-closebutton-icon-color-default)));
     }
 }
 
 :host([static-color='black']:not([disabled]):is(:active, [active])),
 :host([static-color='white']:not([disabled]):is(:active, [active])) {
-    background-color: var(
-        --highcontrast-closebutton-static-background-color-down,
-        var(
-            --mod-closebutton-static-background-color-down,
-            var(--spectrum-closebutton-static-background-color-down)
-        )
-    );
+    background-color: var(--highcontrast-closebutton-static-background-color-down, var(--mod-closebutton-static-background-color-down, var(--spectrum-closebutton-static-background-color-down)));
 }
 
 :host([static-color='black']:not([disabled]):is(:active, [active])) .icon,
 :host([static-color='white']:not([disabled]):is(:active, [active])) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-default,
-        var(
-            --mod-closebutton-icon-color-default,
-            var(--spectrum-closebutton-icon-color-default)
-        )
-    );
+    color: var(--highcontrast-closebutton-icon-color-default, var(--mod-closebutton-icon-color-default, var(--spectrum-closebutton-icon-color-default)));
 }
 
 :host([static-color='black'][focused]:not([disabled])),
 :host([static-color='black']:not([disabled]):focus-visible),
 :host([static-color='white'][focused]:not([disabled])),
 :host([static-color='white']:not([disabled]):focus-visible) {
-    background-color: var(
-        --highcontrast-closebutton-static-background-color-focus,
-        var(
-            --mod-closebutton-static-background-color-focus,
-            var(--spectrum-closebutton-static-background-color-focus)
-        )
-    );
+    background-color: var(--highcontrast-closebutton-static-background-color-focus, var(--mod-closebutton-static-background-color-focus, var(--spectrum-closebutton-static-background-color-focus)));
 }
 
 :host([static-color='black'][focused]:not([disabled])) .icon,
@@ -385,32 +209,17 @@ governing permissions and limitations under the License.
 :host([static-color='white'][focused]:not([disabled])) .icon,
 :host([static-color='white']:not([disabled]):focus) .icon,
 :host([static-color='white']:not([disabled]):focus-visible) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-default,
-        var(
-            --mod-closebutton-icon-color-default,
-            var(--spectrum-closebutton-icon-color-default)
-        )
-    );
+    color: var(--highcontrast-closebutton-icon-color-default, var(--mod-closebutton-icon-color-default, var(--spectrum-closebutton-icon-color-default)));
 }
 
 :host([static-color='black']:not([disabled])) .icon,
 :host([static-color='white']:not([disabled])) .icon {
-    color: var(
-        --mod-closebutton-icon-color-default,
-        var(--spectrum-closebutton-icon-color-default)
-    );
+    color: var(--mod-closebutton-icon-color-default, var(--spectrum-closebutton-icon-color-default));
 }
 
 :host([static-color='black'][disabled]) .icon,
 :host([static-color='white'][disabled]) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-disabled,
-        var(
-            --mod-closebutton-icon-color-disabled,
-            var(--spectrum-closebutton-icon-color-disabled)
-        )
-    );
+    color: var(--highcontrast-closebutton-icon-disabled, var(--mod-closebutton-icon-color-disabled, var(--spectrum-closebutton-icon-color-disabled)));
 }
 
 .icon {

--- a/packages/coachmark/src/spectrum-coach-indicator.css
+++ b/packages/coachmark/src/spectrum-coach-indicator.css
@@ -13,169 +13,57 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     margin: var(--mod-coach-indicator-gap, var(--spectrum-coach-indicator-gap));
-    min-inline-size: var(
-        --mod-coach-indicator-min-inline-size,
-        var(--spectrum-coach-indicator-min-inline-size)
-    );
-    min-block-size: var(
-        --mod-coach-indicator-min-block-size,
-        var(--spectrum-coach-indicator-min-block-size)
-    );
-    inline-size: var(
-        --mod-coach-indicator-inline-size,
-        var(--spectrum-coach-indicator-inline-size)
-    );
-    block-size: var(
-        --mod-coach-indicator-block-size,
-        var(--spectrum-coach-indicator-block-size)
-    );
+    min-inline-size: var(--mod-coach-indicator-min-inline-size, var(--spectrum-coach-indicator-min-inline-size));
+    min-block-size: var(--mod-coach-indicator-min-block-size, var(--spectrum-coach-indicator-min-block-size));
+    inline-size: var(--mod-coach-indicator-inline-size, var(--spectrum-coach-indicator-inline-size));
+    block-size: var(--mod-coach-indicator-block-size, var(--spectrum-coach-indicator-block-size));
     position: relative;
 }
 
 :host([quiet]) {
-    --mod-coach-indicator-min-inline-size: calc(
-        var(
-                --mod-coach-indicator-quiet-ring-diameter,
-                var(--spectrum-coach-indicator-quiet-ring-diameter-size)
-            ) * 2.75
-    );
-    --mod-coach-indicator-min-block-size: calc(
-        var(
-                --mod-coach-indicator-quiet-ring-diameter,
-                var(--spectrum-coach-indicator-quiet-ring-diameter-size)
-            ) * 2.75
-    );
-    --mod-coach-indicator-inline-size: calc(
-        var(
-                --mod-coach-indicator-quiet-ring-diameter,
-                var(--spectrum-coach-indicator-quiet-ring-diameter-size)
-            ) * 2.75
-    );
-    --mod-coach-indicator-block-size: calc(
-        var(
-                --mod-coach-indicator-quiet-ring-diameter,
-                var(--spectrum-coach-indicator-quiet-ring-diameter-size)
-            ) * 2.75
-    );
-    --mod-coach-indicator-ring-inline-size: var(
-        --mod-coach-indicator-quiet-ring-diameter,
-        var(--spectrum-coach-indicator-quiet-ring-diameter-size)
-    );
-    --mod-coach-indicator-ring-block-size: var(
-        --mod-coach-indicator-quiet-ring-diameter,
-        var(--spectrum-coach-indicator-quiet-ring-diameter-size)
-    );
-    --mod-coach-indicator-top: calc(
-        var(--mod-coach-indicator-min-inline-size) / 3 -
-            var(--spectrum-coach-indicator-ring-border-size)
-    );
-    --mod-coach-indicator-left: calc(
-        var(--mod-coach-indicator-min-inline-size) / 3 -
-            var(--spectrum-coach-indicator-ring-border-size)
-    );
-    --mod-coach-indicator-inner-animation-delay-multiple: var(
-        --mod-coach-indicator-quiet-animation-ring-inner-delay-multiple,
-        var(
-            --spectrum-coach-indicator-quiet-animation-ring-inner-delay-multiple
-        )
-    );
+    --mod-coach-indicator-min-inline-size: calc(var(--mod-coach-indicator-quiet-ring-diameter, var(--spectrum-coach-indicator-quiet-ring-diameter-size)) * 2.75);
+    --mod-coach-indicator-min-block-size: calc(var(--mod-coach-indicator-quiet-ring-diameter, var(--spectrum-coach-indicator-quiet-ring-diameter-size)) * 2.75);
+    --mod-coach-indicator-inline-size: calc(var(--mod-coach-indicator-quiet-ring-diameter, var(--spectrum-coach-indicator-quiet-ring-diameter-size)) * 2.75);
+    --mod-coach-indicator-block-size: calc(var(--mod-coach-indicator-quiet-ring-diameter, var(--spectrum-coach-indicator-quiet-ring-diameter-size)) * 2.75);
+    --mod-coach-indicator-ring-inline-size: var(--mod-coach-indicator-quiet-ring-diameter, var(--spectrum-coach-indicator-quiet-ring-diameter-size));
+    --mod-coach-indicator-ring-block-size: var(--mod-coach-indicator-quiet-ring-diameter, var(--spectrum-coach-indicator-quiet-ring-diameter-size));
+    --mod-coach-indicator-top: calc(var(--mod-coach-indicator-min-inline-size) / 3 - var(--spectrum-coach-indicator-ring-border-size));
+    --mod-coach-indicator-left: calc(var(--mod-coach-indicator-min-inline-size) / 3 - var(--spectrum-coach-indicator-ring-border-size));
+    --mod-coach-indicator-inner-animation-delay-multiple: var(--mod-coach-indicator-quiet-animation-ring-inner-delay-multiple, var(--spectrum-coach-indicator-quiet-animation-ring-inner-delay-multiple));
 }
 
 .ring {
     border-style: solid;
-    border-width: var(
-        --mod-coach-indicator-ring-border-size,
-        var(--spectrum-coach-indicator-ring-border-size)
-    );
-    border-color: var(
-        --mod-coach-indicator-ring-default-color,
-        var(--spectrum-coach-indicator-ring-default-color)
-    );
-    inline-size: var(
-        --mod-coach-indicator-ring-inline-size,
-        var(--spectrum-coach-indicator-ring-inline-size)
-    );
-    block-size: var(
-        --mod-coach-indicator-ring-block-size,
-        var(--spectrum-coach-indicator-ring-block-size)
-    );
-    animation: var(
-            --mod-coach-indicator-animation-name,
-            var(--spectrum-coach-indicator-animation-name)
-        )
-        var(
-            --mod-coach-animation-indicator-ring-duration,
-            var(--spectrum-coach-animation-indicator-ring-duration)
-        )
-        linear infinite;
+    border-width: var(--mod-coach-indicator-ring-border-size, var(--spectrum-coach-indicator-ring-border-size));
+    border-color: var(--mod-coach-indicator-ring-default-color, var(--spectrum-coach-indicator-ring-default-color));
+    inline-size: var(--mod-coach-indicator-ring-inline-size, var(--spectrum-coach-indicator-ring-inline-size));
+    block-size: var(--mod-coach-indicator-ring-block-size, var(--spectrum-coach-indicator-ring-block-size));
+    animation: var(--mod-coach-indicator-animation-name, var(--spectrum-coach-indicator-animation-name)) var(--mod-coach-animation-indicator-ring-duration, var(--spectrum-coach-animation-indicator-ring-duration)) linear infinite;
     border-radius: 50%;
     display: block;
     position: absolute;
-    inset-block-start: var(
-        --mod-coach-indicator-top,
-        var(--spectrum-coach-indicator-top)
-    );
-    inset-inline-start: var(
-        --mod-coach-indicator-left,
-        var(--spectrum-coach-indicator-left)
-    );
+    inset-block-start: var(--mod-coach-indicator-top, var(--spectrum-coach-indicator-top));
+    inset-inline-start: var(--mod-coach-indicator-left, var(--spectrum-coach-indicator-left));
 }
 
 .ring:first-child {
-    animation-delay: calc(
-        var(
-                --mod-coach-animation-indicator-ring-duration,
-                var(--spectrum-coach-animation-indicator-ring-duration)
-            ) *
-            var(
-                --mod-coach-indicator-inner-animation-delay-multiple,
-                var(--spectrum-coach-indicator-inner-animation-delay-multiple)
-            )
-    );
+    animation-delay: calc(var(--mod-coach-animation-indicator-ring-duration, var(--spectrum-coach-animation-indicator-ring-duration)) * var(--mod-coach-indicator-inner-animation-delay-multiple, var(--spectrum-coach-indicator-inner-animation-delay-multiple)));
 }
 
 .ring:nth-child(2) {
-    animation-delay: calc(
-        var(
-                --mod-coach-animation-indicator-ring-duration,
-                var(--spectrum-coach-animation-indicator-ring-duration)
-            ) *
-            var(
-                --mod-coach-animation-indicator-ring-center-delay-multiple,
-                var(
-                    --spectrum-coach-animation-indicator-ring-center-delay-multiple
-                )
-            )
-    );
+    animation-delay: calc(var(--mod-coach-animation-indicator-ring-duration, var(--spectrum-coach-animation-indicator-ring-duration)) * var(--mod-coach-animation-indicator-ring-center-delay-multiple, var(--spectrum-coach-animation-indicator-ring-center-delay-multiple)));
 }
 
 .ring:nth-child(3) {
-    animation-delay: calc(
-        var(
-                --mod-coach-animation-indicator-ring-duration,
-                var(--spectrum-coach-animation-indicator-ring-duration)
-            ) *
-            var(
-                --mod-coach-animation-indicator-ring-outer-delay-multiple,
-                var(
-                    --spectrum-coach-animation-indicator-ring-outer-delay-multiple
-                )
-            )
-    );
+    animation-delay: calc(var(--mod-coach-animation-indicator-ring-duration, var(--spectrum-coach-animation-indicator-ring-duration)) * var(--mod-coach-animation-indicator-ring-outer-delay-multiple, var(--spectrum-coach-animation-indicator-ring-outer-delay-multiple)));
 }
 
 :host([static-color='white']) .ring {
-    border-color: var(
-        --mod-coach-indicator-ring-light-color,
-        var(--spectrum-coach-indicator-ring-light-color)
-    );
+    border-color: var(--mod-coach-indicator-ring-light-color, var(--spectrum-coach-indicator-ring-light-color));
 }
 
 :host([static-color='black']) .ring {
-    border-color: var(
-        --mod-coach-indicator-ring-dark-color,
-        var(--spectrum-coach-indicator-ring-dark-color)
-    );
+    border-color: var(--mod-coach-indicator-ring-dark-color, var(--spectrum-coach-indicator-ring-dark-color));
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -186,46 +74,34 @@ governing permissions and limitations under the License.
 
 @keyframes pulse {
     0% {
-        transform: scale(
-            var(--spectrum-coach-indicator-animation-keyframe-0-scale)
-        );
+        transform: scale(var(--spectrum-coach-indicator-animation-keyframe-0-scale));
         opacity: var(--spectrum-coach-indicator-animation-keyframe-0-opacity);
     }
 
     50% {
-        transform: scale(
-            var(--spectrum-coach-indicator-animation-keyframe-50-scale)
-        );
+        transform: scale(var(--spectrum-coach-indicator-animation-keyframe-50-scale));
         opacity: var(--spectrum-coach-indicator-animation-keyframe-50-opacity);
     }
 
     to {
-        transform: scale(
-            var(--spectrum-coach-indicator-animation-keyframe-100-scale)
-        );
+        transform: scale(var(--spectrum-coach-indicator-animation-keyframe-100-scale));
         opacity: var(--spectrum-coach-indicator-animation-keyframe-100-opacity);
     }
 }
 
 @keyframes pulse-quiet {
     0% {
-        transform: scale(
-            var(--spectrum-coach-indicator-quiet-animation-keyframe-0-scale)
-        );
+        transform: scale(var(--spectrum-coach-indicator-quiet-animation-keyframe-0-scale));
         opacity: var(--spectrum-coach-indicator-animation-keyframe-0-opacity);
     }
 
     50% {
-        transform: scale(
-            var(--spectrum-coach-indicator-animation-keyframe-50-scale)
-        );
+        transform: scale(var(--spectrum-coach-indicator-animation-keyframe-50-scale));
         opacity: var(--spectrum-coach-indicator-animation-keyframe-50-opacity);
     }
 
     to {
-        transform: scale(
-            var(--spectrum-coach-indicator-animation-keyframe-100-scale)
-        );
+        transform: scale(var(--spectrum-coach-indicator-animation-keyframe-100-scale));
         opacity: var(--spectrum-coach-indicator-animation-keyframe-100-opacity);
     }
 }

--- a/packages/coachmark/src/spectrum-coachmark.css
+++ b/packages/coachmark/src/spectrum-coachmark.css
@@ -14,21 +14,13 @@ governing permissions and limitations under the License.
 :host {
     --mod-buttongroup-justify-content: flex-end;
     --mod-popover-border-width: var(--spectrum-coachmark-popover-border-width);
-    --mod-popover-corner-radius: var(
-        --spectrum-coachmark-popover-corner-radius
-    );
+    --mod-popover-corner-radius: var(--spectrum-coachmark-popover-corner-radius);
     --mod-popover-content-area-spacing-vertical: 0;
     --mod-button-edge-to-visual-only: 9px;
     --spectrum-coachmark-border-size: var(--mod-popover-border-width);
     --spectrum-coachmark-border-radius: var(--mod-popover-corner-radius);
-    min-inline-size: var(
-        --mod-coachmark-min-width,
-        var(--spectrum-coachmark-min-width)
-    );
-    max-inline-size: var(
-        --mod-coachmark-max-width,
-        var(--spectrum-coachmark-max-width)
-    );
+    min-inline-size: var(--mod-coachmark-min-width, var(--spectrum-coachmark-min-width));
+    max-inline-size: var(--mod-coachmark-max-width, var(--spectrum-coachmark-max-width));
     inline-size: var(--mod-coachmark-width, var(--spectrum-coachmark-width));
     position: relative;
 }
@@ -38,9 +30,7 @@ governing permissions and limitations under the License.
 }
 
 .buttongroup-mobile {
-    --mod-buttongroup-spacing-horizontal: var(
-        --spectrum-coachmark-buttongroup-spacing-horizontal
-    );
+    --mod-buttongroup-spacing-horizontal: var(--spectrum-coachmark-buttongroup-spacing-horizontal);
     display: var(--spectrum-coachmark-buttongroup-mobile-display);
 }
 
@@ -53,21 +43,9 @@ governing permissions and limitations under the License.
 }
 
 .image-wrapper {
-    block-size: var(
-        --mod-coachmark-media-height,
-        var(--spectrum-coachmark-media-height)
-    );
-    min-block-size: var(
-        --mod-coachmark-media-min-height,
-        var(--spectrum-coachmark-media-min-height)
-    );
-    inline-size: calc(
-        var(--mod-coachmark-width, var(--spectrum-coachmark-width)) -
-            var(
-                --mod-coachmark-border-size,
-                var(--spectrum-coachmark-border-size)
-            ) * 2
-    );
+    block-size: var(--mod-coachmark-media-height, var(--spectrum-coachmark-media-height));
+    min-block-size: var(--mod-coachmark-media-min-height, var(--spectrum-coachmark-media-min-height));
+    inline-size: calc(var(--mod-coachmark-width, var(--spectrum-coachmark-width)) - var(--mod-coachmark-border-size, var(--spectrum-coachmark-border-size)) * 2);
     object-fit: cover;
     object-position: center;
     border-start-start-radius: inherit;
@@ -78,26 +56,8 @@ governing permissions and limitations under the License.
     inline-size: 100%;
     block-size: 100%;
     object-fit: cover;
-    border-start-start-radius: calc(
-        var(
-                --mod-coachmark-border-radius,
-                var(--spectrum-coachmark-border-radius)
-            ) -
-            var(
-                --mod-coachmark-border-size,
-                var(--spectrum-coachmark-border-size)
-            )
-    );
-    border-start-end-radius: calc(
-        var(
-                --mod-coachmark-border-radius,
-                var(--spectrum-coachmark-border-radius)
-            ) -
-            var(
-                --mod-coachmark-border-size,
-                var(--spectrum-coachmark-border-size)
-            )
-    );
+    border-start-start-radius: calc(var(--mod-coachmark-border-radius, var(--spectrum-coachmark-border-radius)) - var(--mod-coachmark-border-size, var(--spectrum-coachmark-border-size)));
+    border-start-end-radius: calc(var(--mod-coachmark-border-radius, var(--spectrum-coachmark-border-radius)) - var(--mod-coachmark-border-size, var(--spectrum-coachmark-border-size)));
     display: block;
 }
 
@@ -105,73 +65,37 @@ governing permissions and limitations under the License.
 .footer,
 .header {
     padding-block: 0;
-    padding-inline: var(
-        --mod-coachmark-padding,
-        var(--spectrum-coachmark-padding)
-    );
+    padding-inline: var(--mod-coachmark-padding, var(--spectrum-coachmark-padding));
 }
 
 .header {
     justify-content: space-between;
     align-items: center;
-    margin-block-end: var(
-        --mod-coachmark-header-to-body,
-        var(--spectrum-coachmark-header-to-body)
-    );
-    padding-block-start: var(
-        --mod-coachmark-padding,
-        var(--spectrum-coachmark-padding)
-    );
+    margin-block-end: var(--mod-coachmark-header-to-body, var(--spectrum-coachmark-header-to-body));
+    padding-block-start: var(--mod-coachmark-padding, var(--spectrum-coachmark-padding));
     display: flex;
 }
 
 .action-menu {
     white-space: nowrap;
     z-index: 1;
-    margin-inline-start: var(
-        --mod-coachmark-heading-to-action-button,
-        var(--spectrum-coachmark-heading-to-action-button)
-    );
+    margin-inline-start: var(--mod-coachmark-heading-to-action-button, var(--spectrum-coachmark-heading-to-action-button));
 }
 
 .content {
-    color: var(
-        --mod-coachmark-content-font-color,
-        var(--spectrum-coachmark-content-font-color)
-    );
-    font-size: var(
-        --mod-coachmark-content-font-size,
-        var(--spectrum-coachmark-content-font-size)
-    );
-    font-weight: var(
-        --mod-coachmark-content-font-weight,
-        var(--spectrum-coachmark-content-font-weight)
-    );
-    font-family: var(
-        --mod-coachmark-content-font-family,
-        var(--spectrum-coachmark-content-font-family)
-    );
-    font-style: var(
-        --mod-coachmark-content-font-style,
-        var(--spectrum-coachmark-content-font-style)
-    );
-    line-height: var(
-        --mod-coachmark-content-line-height,
-        var(--spectrum-coachmark-content-line-height)
-    );
-    margin-block-end: var(
-        --mod-coachmark-body-to-footer,
-        var(--spectrum-coachmark-body-to-footer)
-    );
+    color: var(--mod-coachmark-content-font-color, var(--spectrum-coachmark-content-font-color));
+    font-size: var(--mod-coachmark-content-font-size, var(--spectrum-coachmark-content-font-size));
+    font-weight: var(--mod-coachmark-content-font-weight, var(--spectrum-coachmark-content-font-weight));
+    font-family: var(--mod-coachmark-content-font-family, var(--spectrum-coachmark-content-font-family));
+    font-style: var(--mod-coachmark-content-font-style, var(--spectrum-coachmark-content-font-style));
+    line-height: var(--mod-coachmark-content-line-height, var(--spectrum-coachmark-content-line-height));
+    margin-block-end: var(--mod-coachmark-body-to-footer, var(--spectrum-coachmark-body-to-footer));
 }
 
 .footer {
     align-items: end;
     margin-block-start: 0;
-    padding-block-end: var(
-        --mod-coachmark-padding,
-        var(--spectrum-coachmark-padding)
-    );
+    padding-block-end: var(--mod-coachmark-padding, var(--spectrum-coachmark-padding));
     display: grid;
 }
 
@@ -180,60 +104,22 @@ governing permissions and limitations under the License.
 }
 
 .title {
-    color: var(
-        --mod-coachmark-title-color,
-        var(--spectrum-coachmark-title-color)
-    );
-    font-size: var(
-        --mod-coachmark-title-font-size,
-        var(--spectrum-coachmark-title-font-size)
-    );
-    font-weight: var(
-        --mod-coachmark-title-text-font-weight,
-        var(--spectrum-coachmark-title-text-font-weight)
-    );
-    font-family: var(
-        --mod-coachmark-title-font-family,
-        var(--spectrum-coachmark-title-font-family)
-    );
-    font-style: var(
-        --mod-coachmark-title-font-style,
-        var(--spectrum-coachmark-title-font-style)
-    );
-    line-height: var(
-        --mod-coachmark-title-text-line-height,
-        var(--spectrum-coachmark-title-text-line-height)
-    );
+    color: var(--mod-coachmark-title-color, var(--spectrum-coachmark-title-color));
+    font-size: var(--mod-coachmark-title-font-size, var(--spectrum-coachmark-title-font-size));
+    font-weight: var(--mod-coachmark-title-text-font-weight, var(--spectrum-coachmark-title-text-font-weight));
+    font-family: var(--mod-coachmark-title-font-family, var(--spectrum-coachmark-title-font-family));
+    font-style: var(--mod-coachmark-title-font-style, var(--spectrum-coachmark-title-font-style));
+    line-height: var(--mod-coachmark-title-text-line-height, var(--spectrum-coachmark-title-text-line-height));
     margin-block-end: 0;
 }
 
 .step {
-    color: var(
-        --mod-coachmark-step-color,
-        var(--spectrum-coachmark-step-color)
-    );
-    font-size: var(
-        --mod-coachmark-step-font-size,
-        var(--spectrum-coachmark-step-font-size)
-    );
-    font-weight: var(
-        --mod-coachmark-step-text-font-weight,
-        var(--spectrum-coachmark-step-text-font-weight)
-    );
-    font-style: var(
-        --mod-coachmark-step-font-style,
-        var(--spectrum-coachmark-step-font-style)
-    );
-    line-height: var(
-        --mod-coachmark-step-text-line-height,
-        var(--spectrum-coachmark-step-text-line-height)
-    );
+    color: var(--mod-coachmark-step-color, var(--spectrum-coachmark-step-color));
+    font-size: var(--mod-coachmark-step-font-size, var(--spectrum-coachmark-step-font-size));
+    font-weight: var(--mod-coachmark-step-text-font-weight, var(--spectrum-coachmark-step-text-font-weight));
+    font-style: var(--mod-coachmark-step-font-style, var(--spectrum-coachmark-step-font-style));
+    line-height: var(--mod-coachmark-step-text-line-height, var(--spectrum-coachmark-step-text-line-height));
     white-space: nowrap;
     justify-self: start;
-    margin-block-end: calc(
-        var(
-                --mod-coachmark-step-to-bottom,
-                var(--spectrum-coachmark-step-to-bottom)
-            ) - var(--mod-coachmark-padding, var(--spectrum-coachmark-padding))
-    );
+    margin-block-end: calc(var(--mod-coachmark-step-to-bottom, var(--spectrum-coachmark-step-to-bottom)) - var(--mod-coachmark-padding, var(--spectrum-coachmark-padding)));
 }

--- a/packages/color-area/src/spectrum-color-area.css
+++ b/packages/color-area/src/spectrum-color-area.css
@@ -28,33 +28,13 @@ governing permissions and limitations under the License.
     cursor: default;
     -webkit-user-select: none;
     user-select: none;
-    min-inline-size: var(
-        --mod-colorarea-min-width,
-        var(--spectrum-colorarea-min-width)
-    );
-    min-block-size: var(
-        --mod-colorarea-min-height,
-        var(--spectrum-colorarea-min-height)
-    );
+    min-inline-size: var(--mod-colorarea-min-width, var(--spectrum-colorarea-min-width));
+    min-block-size: var(--mod-colorarea-min-height, var(--spectrum-colorarea-min-height));
     inline-size: var(--mod-colorarea-width, var(--spectrum-colorarea-width));
     block-size: var(--mod-colorarea-height, var(--spectrum-colorarea-height));
     box-sizing: border-box;
-    border-radius: var(
-        --mod-colorarea-border-radius,
-        var(--spectrum-colorarea-border-radius)
-    );
-    border: var(
-            --mod-colorarea-border-width,
-            var(--spectrum-colorarea-border-width)
-        )
-        solid
-        var(
-            --highcontrast-colorarea-border-color,
-            var(
-                --mod-colorarea-border-color,
-                var(--spectrum-colorarea-border-color)
-            )
-        );
+    border-radius: var(--mod-colorarea-border-radius, var(--spectrum-colorarea-border-radius));
+    border: var(--mod-colorarea-border-width, var(--spectrum-colorarea-border-width)) solid var(--highcontrast-colorarea-border-color, var(--mod-colorarea-border-color, var(--spectrum-colorarea-border-color)));
     display: inline-block;
     position: relative;
 }
@@ -65,18 +45,8 @@ governing permissions and limitations under the License.
 
 :host([disabled]) {
     pointer-events: none;
-    background: var(
-        --highcontrast-colorarea-fill-color-disabled,
-        var(
-            --mod-colorarea-disabled-background-color,
-            var(--spectrum-colorarea-disabled-background-color)
-        )
-    );
-    border: var(
-            --mod-colorarea-border-width,
-            var(--spectrum-colorarea-border-width)
-        )
-        solid var(--highcontrast-colorarea-border-color-disabled);
+    background: var(--highcontrast-colorarea-fill-color-disabled, var(--mod-colorarea-disabled-background-color, var(--spectrum-colorarea-disabled-background-color)));
+    border: var(--mod-colorarea-border-width, var(--spectrum-colorarea-border-width)) solid var(--highcontrast-colorarea-border-color-disabled);
 }
 
 :host([disabled]) .gradient {
@@ -84,12 +54,7 @@ governing permissions and limitations under the License.
 }
 
 .handle {
-    transform: translate(
-        calc(
-            var(--mod-colorarea-width, var(--spectrum-colorarea-width)) -
-                var(--spectrum-colorarea-border-width)
-        )
-    );
+    transform: translate(calc(var(--mod-colorarea-width, var(--spectrum-colorarea-width)) - var(--spectrum-colorarea-border-width)));
     inset-block-start: 0;
 }
 
@@ -101,10 +66,7 @@ governing permissions and limitations under the License.
 .gradient {
     inline-size: 100%;
     block-size: 100%;
-    border-radius: var(
-        --mod-colorarea-border-radius,
-        var(--spectrum-colorarea-border-radius)
-    );
+    border-radius: var(--mod-colorarea-border-radius, var(--spectrum-colorarea-border-radius));
 }
 
 .slider {

--- a/packages/color-handle/src/spectrum-color-handle.css
+++ b/packages/color-handle/src/spectrum-color-handle.css
@@ -17,41 +17,12 @@ governing permissions and limitations under the License.
     box-sizing: border-box;
     inline-size: var(--mod-colorhandle-size, var(--spectrum-colorhandle-size));
     block-size: var(--mod-colorhandle-size, var(--spectrum-colorhandle-size));
-    margin-inline: calc(
-        var(--mod-colorhandle-size, var(--spectrum-colorhandle-size)) / 2 * -1
-    );
-    margin-block: calc(
-        var(--mod-colorhandle-size, var(--spectrum-colorhandle-size)) / 2 * -1
-    );
-    border-width: var(
-        --mod-colorhandle-border-width,
-        var(--spectrum-colorhandle-border-width)
-    );
-    border-color: var(
-        --highcontrast-colorhandle-border-color,
-        var(
-            --mod-colorhandle-border-color,
-            var(--spectrum-colorhandle-border-color)
-        )
-    );
-    box-shadow: 0 0 0
-        var(
-            --mod-colorhandle-outer-border-width,
-            var(--spectrum-colorhandle-outer-border-width)
-        )
-        var(
-            --mod-colorhandle-outer-border-color,
-            var(--spectrum-colorhandle-outer-border-color)
-        );
-    transition: all
-        var(
-            --mod-colorhandle-animation-duration,
-            var(--spectrum-colorhandle-animation-duration)
-        )
-        var(
-            --mod-colorhandle-animation-easing,
-            var(--spectrum-colorhandle-animation-easing)
-        );
+    margin-inline: calc(var(--mod-colorhandle-size, var(--spectrum-colorhandle-size)) / 2 * -1);
+    margin-block: calc(var(--mod-colorhandle-size, var(--spectrum-colorhandle-size)) / 2 * -1);
+    border-width: var(--mod-colorhandle-border-width, var(--spectrum-colorhandle-border-width));
+    border-color: var(--highcontrast-colorhandle-border-color, var(--mod-colorhandle-border-color, var(--spectrum-colorhandle-border-color)));
+    box-shadow: 0 0 0 var(--mod-colorhandle-outer-border-width, var(--spectrum-colorhandle-outer-border-width)) var(--mod-colorhandle-outer-border-color, var(--spectrum-colorhandle-outer-border-color));
+    transition: all var(--mod-colorhandle-animation-duration, var(--spectrum-colorhandle-animation-duration)) var(--mod-colorhandle-animation-easing, var(--spectrum-colorhandle-animation-easing));
     border-style: solid;
 }
 
@@ -64,66 +35,26 @@ governing permissions and limitations under the License.
 
 :host:after {
     content: '';
-    inset-inline: calc(
-        50% -
-            var(
-                --mod-colorhandle-hitarea-size,
-                var(--spectrum-colorhandle-hitarea-size)
-            ) / 2
-    );
-    inset-block: calc(
-        50% -
-            var(
-                --mod-colorhandle-hitarea-size,
-                var(--spectrum-colorhandle-hitarea-size)
-            ) / 2
-    );
-    inline-size: var(
-        --mod-colorhandle-hitarea-size,
-        var(--spectrum-colorhandle-hitarea-size)
-    );
-    block-size: var(
-        --mod-colorhandle-hitarea-size,
-        var(--spectrum-colorhandle-hitarea-size)
-    );
+    inset-inline: calc(50% - var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size)) / 2);
+    inset-block: calc(50% - var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size)) / 2);
+    inline-size: var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size));
+    block-size: var(--mod-colorhandle-hitarea-size, var(--spectrum-colorhandle-hitarea-size));
     border-radius: var(--mod-colorhandle-hitarea-border-radius, 100%);
 }
 
 :host([focused]),
 :host(:focus-visible) {
-    inline-size: var(
-        --mod-colorhandle-focused-size,
-        var(--spectrum-colorhandle-focused-size)
-    );
-    block-size: var(
-        --mod-colorhandle-focused-size,
-        var(--spectrum-colorhandle-focused-size)
-    );
-    margin-inline: calc(
-        var(--mod-colorhandle-size, var(--spectrum-colorhandle-size)) * -1
-    );
-    margin-block: calc(
-        var(--mod-colorhandle-size, var(--spectrum-colorhandle-size)) * -1
-    );
+    inline-size: var(--mod-colorhandle-focused-size, var(--spectrum-colorhandle-focused-size));
+    block-size: var(--mod-colorhandle-focused-size, var(--spectrum-colorhandle-focused-size));
+    margin-inline: calc(var(--mod-colorhandle-size, var(--spectrum-colorhandle-size)) * -1);
+    margin-block: calc(var(--mod-colorhandle-size, var(--spectrum-colorhandle-size)) * -1);
     outline: none;
 }
 
 :host([disabled]) {
     pointer-events: none;
-    border-color: var(
-        --highcontrast-colorhandle-border-color-disabled,
-        var(
-            --mod-colorhandle-border-color-disabled,
-            var(--spectrum-colorhandle-border-color-disabled)
-        )
-    );
-    background: var(
-        --highcontrast-colorhandle-fill-color-disabled,
-        var(
-            --mod-colorhandle-fill-color-disabled,
-            var(--spectrum-colorhandle-fill-color-disabled)
-        )
-    );
+    border-color: var(--highcontrast-colorhandle-border-color-disabled, var(--mod-colorhandle-border-color-disabled, var(--spectrum-colorhandle-border-color-disabled)));
+    background: var(--highcontrast-colorhandle-fill-color-disabled, var(--mod-colorhandle-fill-color-disabled, var(--spectrum-colorhandle-fill-color-disabled)));
     box-shadow: none;
 }
 
@@ -134,15 +65,7 @@ governing permissions and limitations under the License.
 .inner {
     inline-size: 100%;
     block-size: 100%;
-    box-shadow: inset 0 0 0
-        var(
-            --mod-colorhandle-inner-border-width,
-            var(--spectrum-colorhandle-inner-border-width)
-        )
-        var(
-            --mod-colorhandle-inner-border-color,
-            var(--spectrum-colorhandle-inner-border-color)
-        );
+    box-shadow: inset 0 0 0 var(--mod-colorhandle-inner-border-width, var(--spectrum-colorhandle-inner-border-width)) var(--mod-colorhandle-inner-border-color, var(--spectrum-colorhandle-inner-border-color));
     background-color: var(--spectrum-picked-color);
     border-radius: 100%;
 }

--- a/packages/color-loupe/src/spectrum-color-loupe.css
+++ b/packages/color-loupe/src/spectrum-color-loupe.css
@@ -14,42 +14,16 @@ governing permissions and limitations under the License.
 :host {
     inline-size: var(--spectrum-colorloupe-width);
     block-size: var(--spectrum-colorloupe-height);
-    transform: translateY(
-        var(
-            --mod-colorloupe-animation-distance,
-            var(--spectrum-colorloupe-animation-distance)
-        )
-    );
+    transform: translateY(var(--mod-colorloupe-animation-distance, var(--spectrum-colorloupe-animation-distance)));
     opacity: 0;
     transform-origin: bottom;
     pointer-events: none;
-    filter: drop-shadow(
-        var(
-                --mod-colorloupe-drop-shadow-x,
-                var(--spectrum-colorloupe-drop-shadow-x)
-            )
-            var(
-                --mod-colorloupe-drop-shadow-y,
-                var(--spectrum-colorloupe-drop-shadow-y)
-            )
-            var(
-                --mod-colorloupe-drop-shadow-blur,
-                var(--spectrum-colorloupe-drop-shadow-blur)
-            )
-            var(
-                --mod-colorloupe-drop-shadow-color,
-                var(--spectrum-colorloupe-drop-shadow-color)
-            )
-    );
+    filter: drop-shadow(var(--mod-colorloupe-drop-shadow-x, var(--spectrum-colorloupe-drop-shadow-x)) var(--mod-colorloupe-drop-shadow-y, var(--spectrum-colorloupe-drop-shadow-y)) var(--mod-colorloupe-drop-shadow-blur, var(--spectrum-colorloupe-drop-shadow-blur)) var(--mod-colorloupe-drop-shadow-color, var(--spectrum-colorloupe-drop-shadow-color)));
     transition:
         transform 0.1s ease-in-out,
         opacity 0.125s ease-in-out;
     position: absolute;
-    inset-block-end: calc(
-        var(--spectrum-color-handle-size) -
-            var(--spectrum-color-handle-outer-border-width) +
-            var(--mod-colorloupe-offset, var(--spectrum-colorloupe-offset))
-    );
+    inset-block-end: calc(var(--spectrum-color-handle-size) - var(--spectrum-color-handle-outer-border-width) + var(--mod-colorloupe-offset, var(--spectrum-colorloupe-offset)));
     inset-inline-end: calc(50% - var(--spectrum-colorloupe-width) / 2);
 }
 
@@ -65,31 +39,14 @@ governing permissions and limitations under the License.
 
 .spectrum-ColorLoupe-inner-border {
     fill: var(--spectrum-picked-color);
-    stroke: var(
-        --mod-colorloupe-inner-border-color,
-        var(--spectrum-colorloupe-inner-border-color)
-    );
-    stroke-width: var(
-        --mod-colorloupe-inner-border-width,
-        var(--spectrum-colorloupe-inner-border-width)
-    );
+    stroke: var(--mod-colorloupe-inner-border-color, var(--spectrum-colorloupe-inner-border-color));
+    stroke-width: var(--mod-colorloupe-inner-border-width, var(--spectrum-colorloupe-inner-border-width));
 }
 
 .spectrum-ColorLoupe-outer-border {
     fill: none;
-    stroke: var(
-        --highcontrast-colorloupe-outer-border-color,
-        var(
-            --mod-colorloupe-outer-border-color,
-            var(--spectrum-colorloupe-outer-border-color)
-        )
-    );
-    stroke-width: calc(
-        var(
-                --mod-colorloupe-outer-border-width,
-                var(--spectrum-colorloupe-outer-border-width)
-            ) + 2px
-    );
+    stroke: var(--highcontrast-colorloupe-outer-border-color, var(--mod-colorloupe-outer-border-color, var(--spectrum-colorloupe-outer-border-color)));
+    stroke-width: calc(var(--mod-colorloupe-outer-border-width, var(--spectrum-colorloupe-outer-border-width)) + 2px);
 }
 
 .spectrum-ColorLoupe-checkerboard-pattern {

--- a/packages/color-slider/src/spectrum-color-slider.css
+++ b/packages/color-slider/src/spectrum-color-slider.css
@@ -21,22 +21,10 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    --mod-colorhandle-hitarea-border-radius: var(
-        --mod-color-slider-handle-hitarea-border-radius,
-        0px
-    );
-    min-inline-size: var(
-        --mod-color-slider-minimum-length,
-        var(--spectrum-color-slider-minimum-length)
-    );
-    inline-size: var(
-        --mod-color-slider-length,
-        var(--spectrum-color-slider-length)
-    );
-    block-size: var(
-        --mod-color-slider-control-track-width,
-        var(--spectrum-color-control-track-width)
-    );
+    --mod-colorhandle-hitarea-border-radius: var(--mod-color-slider-handle-hitarea-border-radius, 0px);
+    min-inline-size: var(--mod-color-slider-minimum-length, var(--spectrum-color-slider-minimum-length));
+    inline-size: var(--mod-color-slider-length, var(--spectrum-color-slider-length));
+    block-size: var(--mod-color-slider-control-track-width, var(--spectrum-color-control-track-width));
     -webkit-user-select: none;
     user-select: none;
     cursor: default;
@@ -57,25 +45,10 @@ governing permissions and limitations under the License.
 }
 
 :host([vertical]) {
-    min-block-size: var(
-        --mod-color-slider-vertical-minimum-height,
-        var(
-            --mod-color-slider-minimum-length,
-            var(--spectrum-color-slider-minimum-length)
-        )
-    );
-    block-size: var(
-        --mod-color-slider-vertical-height,
-        var(--mod-color-slider-length, var(--spectrum-color-slider-length))
-    );
+    min-block-size: var(--mod-color-slider-vertical-minimum-height, var(--mod-color-slider-minimum-length, var(--spectrum-color-slider-minimum-length)));
+    block-size: var(--mod-color-slider-vertical-height, var(--mod-color-slider-length, var(--spectrum-color-slider-length)));
     min-inline-size: 0;
-    inline-size: var(
-        --mod-color-slider-vertical-control-track-width,
-        var(
-            --mod-color-slider-control-track-height,
-            var(--spectrum-color-control-track-width)
-        )
-    );
+    inline-size: var(--mod-color-slider-vertical-control-track-width, var(--mod-color-slider-control-track-height, var(--spectrum-color-control-track-width)));
     display: inline-block;
 }
 
@@ -90,57 +63,28 @@ governing permissions and limitations under the License.
 }
 
 .checkerboard {
-    --spectrum-color-slider-border-color-local: var(
-        --highcontrast-color-slider-border-color,
-        var(
-            --mod-color-slider-border-color,
-            var(--spectrum-color-slider-border-color-rgba)
-        )
-    );
+    --spectrum-color-slider-border-color-local: var(--highcontrast-color-slider-border-color, var(--mod-color-slider-border-color, var(--spectrum-color-slider-border-color-rgba)));
 }
 
 .checkerboard:before {
     content: '';
     z-index: 1;
-    box-shadow: inset 0 0 0
-        var(
-            --mod-color-slider-border-width,
-            var(--spectrum-color-slider-border-width)
-        )
-        var(--spectrum-color-slider-border-color-local);
-    border-radius: var(
-        --mod-color-slider-border-rounding,
-        var(--spectrum-color-slider-border-rounding)
-    );
+    box-shadow: inset 0 0 0 var(--mod-color-slider-border-width, var(--spectrum-color-slider-border-width)) var(--spectrum-color-slider-border-color-local);
+    border-radius: var(--mod-color-slider-border-rounding, var(--spectrum-color-slider-border-rounding));
     position: absolute;
     inset: 0;
 }
 
 :host([disabled]) .checkerboard {
-    --spectrum-color-slider-border-color-local: var(
-        --highcontrast-color-slider-border-color-disabled,
-        var(
-            --mod-color-slider-border-color-disabled,
-            var(--spectrum-disabled-background-color)
-        )
-    );
-    background: var(
-        --highcontrast-color-slider-background-color-disabled,
-        var(
-            --mod-color-slider-background-color-disabled,
-            var(--spectrum-disabled-background-color)
-        )
-    );
+    --spectrum-color-slider-border-color-local: var(--highcontrast-color-slider-border-color-disabled, var(--mod-color-slider-border-color-disabled, var(--spectrum-disabled-background-color)));
+    background: var(--highcontrast-color-slider-background-color-disabled, var(--mod-color-slider-background-color-disabled, var(--spectrum-disabled-background-color)));
 }
 
 .checkerboard,
 .gradient {
     inline-size: 100%;
     block-size: 100%;
-    border-radius: var(
-        --mod-color-slider-border-rounding,
-        var(--spectrum-color-slider-border-rounding)
-    );
+    border-radius: var(--mod-color-slider-border-rounding, var(--spectrum-color-slider-border-rounding));
 }
 
 .gradient:dir(rtl),

--- a/packages/color-wheel/src/spectrum-color-wheel.css
+++ b/packages/color-wheel/src/spectrum-color-wheel.css
@@ -20,18 +20,9 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    --_track-width: var(
-        --mod-colorwheel-track-width,
-        var(--spectrum-colorwheel-track-width)
-    );
-    --_border-width: var(
-        --mod-colorwheel-border-width,
-        var(--spectrum-colorwheel-border-width)
-    );
-    min-inline-size: var(
-        --mod-colorwheel-min-width,
-        var(--spectrum-colorwheel-min-width)
-    );
+    --_track-width: var(--mod-colorwheel-track-width, var(--spectrum-colorwheel-track-width));
+    --_border-width: var(--mod-colorwheel-border-width, var(--spectrum-colorwheel-border-width));
+    min-inline-size: var(--mod-colorwheel-min-width, var(--spectrum-colorwheel-min-width));
     inline-size: var(--mod-colorwheel-width, var(--spectrum-colorwheel-width));
     block-size: var(--mod-colorwheel-height, var(--spectrum-colorwheel-height));
     -webkit-user-select: none;
@@ -54,14 +45,8 @@ governing permissions and limitations under the License.
 }
 
 .inner {
-    inline-size: var(
-        --mod-colorwheel-colorarea-container-size,
-        var(--spectrum-colorwheel-colorarea-container-size)
-    );
-    block-size: var(
-        --mod-colorwheel-colorarea-container-size,
-        var(--spectrum-colorwheel-colorarea-container-size)
-    );
+    inline-size: var(--mod-colorwheel-colorarea-container-size, var(--spectrum-colorwheel-colorarea-container-size));
+    block-size: var(--mod-colorwheel-colorarea-container-size, var(--spectrum-colorwheel-colorarea-container-size));
     margin: auto;
     display: flex;
     position: absolute;
@@ -72,10 +57,7 @@ governing permissions and limitations under the License.
 .colorarea-container {
     block-size: auto;
     inline-size: 100%;
-    margin: var(
-        --mod-colorwheel-colorarea-margin,
-        var(--spectrum-colorwheel-colorarea-margin)
-    );
+    margin: var(--mod-colorwheel-colorarea-margin, var(--spectrum-colorwheel-colorarea-margin));
     justify-content: center;
     align-items: center;
     display: flex;
@@ -100,65 +82,26 @@ governing permissions and limitations under the License.
 }
 
 .border {
-    background-color: var(
-        --mod-colorwheel-border-color,
-        var(--spectrum-colorwheel-border-color)
-    );
+    background-color: var(--mod-colorwheel-border-color, var(--spectrum-colorwheel-border-color));
     inline-size: var(--mod-colorwheel-width, var(--spectrum-colorwheel-width));
     block-size: var(--mod-colorwheel-height, var(--spectrum-colorwheel-height));
-    clip-path: path(
-        evenodd,
-        var(
-            --mod-colorwheel-path-borders,
-            var(--spectrum-colorwheel-path-borders)
-        )
-    );
+    clip-path: path(evenodd, var(--mod-colorwheel-path-borders, var(--spectrum-colorwheel-path-borders)));
     position: relative;
 }
 
 :host([disabled]) .border {
-    background-color: var(
-        --highcontrast-colorwheel-border-color-disabled,
-        var(
-            --mod-colorwheel-fill-color-disabled,
-            var(--spectrum-colorwheel-fill-color-disabled)
-        )
-    );
+    background-color: var(--highcontrast-colorwheel-border-color-disabled, var(--mod-colorwheel-fill-color-disabled, var(--spectrum-colorwheel-fill-color-disabled)));
 }
 
 .wheel {
     inset-block: var(--spectrum-colorwheel-border-width);
     inset-inline: var(--spectrum-colorwheel-border-width);
-    clip-path: path(
-        evenodd,
-        var(--mod-colorwheel-path, var(--spectrum-colorwheel-path))
-    );
-    background: conic-gradient(
-        from 90deg,
-        red,
-        #ff8000,
-        #ff0,
-        #80ff00,
-        #0f0,
-        #00ff80,
-        #0ff,
-        #0080ff,
-        #00f,
-        #8000ff,
-        #f0f,
-        #ff0080,
-        red
-    );
+    clip-path: path(evenodd, var(--mod-colorwheel-path, var(--spectrum-colorwheel-path)));
+    background: conic-gradient(from 90deg, red, #ff8000, #ff0, #80ff00, #0f0, #00ff80, #0ff, #0080ff, #00f, #8000ff, #f0f, #ff0080, red);
     position: absolute;
 }
 
 :host([disabled]) .wheel {
     pointer-events: none;
-    background: var(
-        --highcontrast-colorwheel-fill-color-disabled,
-        var(
-            --mod-colorwheel-fill-color-disabled,
-            var(--spectrum-colorwheel-fill-color-disabled)
-        )
-    );
+    background: var(--highcontrast-colorwheel-fill-color-disabled, var(--mod-colorwheel-fill-color-disabled, var(--spectrum-colorwheel-fill-color-disabled)));
 }

--- a/packages/combobox/src/spectrum-combobox.css
+++ b/packages/combobox/src/spectrum-combobox.css
@@ -14,182 +14,68 @@ governing permissions and limitations under the License.
 :host {
     --spectrum-combobox-inline-size: var(--spectrum-field-width);
     --spectrum-combobox-block-size: var(--spectrum-component-height-100);
-    --spectrum-combobox-min-inline-size: calc(
-        var(--spectrum-combo-box-minimum-width-multiplier) *
-            var(--spectrum-combobox-block-size)
-    );
+    --spectrum-combobox-min-inline-size: calc(var(--spectrum-combo-box-minimum-width-multiplier) * var(--spectrum-combobox-block-size));
     --spectrum-combobox-button-width: var(--spectrum-combobox-block-size);
     --spectrum-combobox-icon-size: var(--spectrum-workflow-icon-size-100);
     --spectrum-combobox-font-size: var(--spectrum-font-size-100);
-    --spectrum-combobox-spacing-inline-icon-to-button: var(
-        --spectrum-combo-box-visual-to-field-button-medium
-    );
-    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(
-        --spectrum-field-top-to-progress-circle-medium
-    );
-    --spectrum-combobox-block-spacing-edge-to-alert: var(
-        --spectrum-field-top-to-alert-icon-medium
-    );
-    --spectrum-combobox-spacing-edge-to-menu: var(
-        --spectrum-component-to-menu-medium
-    );
-    --spectrum-combobox-spacing-block-start-edge-to-text: var(
-        --spectrum-component-top-to-text-100
-    );
-    --spectrum-combobox-spacing-block-end-edge-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --spectrum-combobox-spacing-inline-start-edge-to-text: var(
-        --spectrum-component-edge-to-text-100
-    );
-    --spectrum-combobox-spacing-inline-end-edge-to-text: var(
-        --spectrum-component-edge-to-text-100
-    );
-    --spectrum-combobox-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
-    --spectrum-combobox-focus-indicator-gap: var(
-        --spectrum-focus-indicator-gap
-    );
-    --spectrum-combobox-focus-indicator-color: var(
-        --spectrum-focus-indicator-color
-    );
+    --spectrum-combobox-spacing-inline-icon-to-button: var(--spectrum-combo-box-visual-to-field-button-medium);
+    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(--spectrum-field-top-to-progress-circle-medium);
+    --spectrum-combobox-block-spacing-edge-to-alert: var(--spectrum-field-top-to-alert-icon-medium);
+    --spectrum-combobox-spacing-edge-to-menu: var(--spectrum-component-to-menu-medium);
+    --spectrum-combobox-spacing-block-start-edge-to-text: var(--spectrum-component-top-to-text-100);
+    --spectrum-combobox-spacing-block-end-edge-to-text: var(--spectrum-component-bottom-to-text-100);
+    --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-component-edge-to-text-100);
+    --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-100);
+    --spectrum-combobox-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
+    --spectrum-combobox-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
+    --spectrum-combobox-focus-indicator-color: var(--spectrum-focus-indicator-color);
     --spectrum-combobox-border-radius: var(--spectrum-corner-radius-100);
     --spectrum-combobox-border-width: var(--spectrum-border-width-100);
-    --spectrum-combobox-spacing-label-to-combobox: var(
-        --spectrum-field-label-to-component
-    );
+    --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component);
     --spectrum-combobox-font-style: var(--spectrum-default-font-style);
     --spectrum-combobox-line-height: var(--spectrum-line-height-100);
-    --spectrum-combobox-border-color-invalid-default: var(
-        --spectrum-negative-border-color-default
-    );
-    --spectrum-combobox-border-color-invalid-hover: var(
-        --spectrum-negative-border-color-hover
-    );
-    --spectrum-combobox-border-color-invalid-focus: var(
-        --spectrum-negative-border-color-focus
-    );
-    --spectrum-combobox-border-color-invalid-focus-hover: var(
-        --spectrum-negative-border-color-focus-hover
-    );
-    --spectrum-combobox-border-color-invalid-key-focus: var(
-        --spectrum-negative-border-color-key-focus
-    );
-    --mod-textfield-focus-indicator-gap: var(
-        --mod-combobox-focus-indicator-gap,
-        var(--spectrum-combobox-focus-indicator-gap)
-    );
-    --mod-textfield-focus-indicator-width: var(
-        --mod-combobox-focus-indicator-thickness,
-        var(--spectrum-combobox-focus-indicator-thickness)
-    );
-    --mod-textfield-focus-indicator-color: var(
-        --mod-combobox-focus-indicator-color,
-        var(--spectrum-combobox-focus-indicator-color)
-    );
-    --mod-textfield-background-color: var(
-        --mod-combobox-background-color-default
-    );
-    --mod-textfield-background-color-disabled: var(
-        --mod-combobox-background-color-disabled,
-        var(--spectrum-combobox-background-color-disabled)
-    );
+    --spectrum-combobox-border-color-invalid-default: var(--spectrum-negative-border-color-default);
+    --spectrum-combobox-border-color-invalid-hover: var(--spectrum-negative-border-color-hover);
+    --spectrum-combobox-border-color-invalid-focus: var(--spectrum-negative-border-color-focus);
+    --spectrum-combobox-border-color-invalid-focus-hover: var(--spectrum-negative-border-color-focus-hover);
+    --spectrum-combobox-border-color-invalid-key-focus: var(--spectrum-negative-border-color-key-focus);
+    --mod-textfield-focus-indicator-gap: var(--mod-combobox-focus-indicator-gap, var(--spectrum-combobox-focus-indicator-gap));
+    --mod-textfield-focus-indicator-width: var(--mod-combobox-focus-indicator-thickness, var(--spectrum-combobox-focus-indicator-thickness));
+    --mod-textfield-focus-indicator-color: var(--mod-combobox-focus-indicator-color, var(--spectrum-combobox-focus-indicator-color));
+    --mod-textfield-background-color: var(--mod-combobox-background-color-default);
+    --mod-textfield-background-color-disabled: var(--mod-combobox-background-color-disabled, var(--spectrum-combobox-background-color-disabled));
     --mod-textfield-font-family: var(--mod-combobox-font-family);
     --mod-textfield-font-weight: var(--mod-combobox-font-weight);
     --mod-textfield-text-color-default: var(--mod-combobox-font-color-default);
     --mod-textfield-text-color-hover: var(--mod-combobox-font-color-hover);
     --mod-textfield-text-color-focus: var(--mod-combobox-font-color-focus);
-    --mod-textfield-text-color-focus-hover: var(
-        --mod-combobox-font-color-focus-hover
-    );
-    --mod-textfield-text-color-keyboard-focus: var(
-        --mod-combobox-font-color-key-focus
-    );
-    --mod-textfield-text-color-disabled: var(
-        --mod-combobox-font-color-disabled
-    );
-    --mod-textfield-border-width: var(
-        --mod-combobox-border-width,
-        var(--spectrum-combobox-border-width)
-    );
-    --mod-textfield-border-color: var(
-        --mod-combobox-border-color-default,
-        var(--spectrum-combobox-border-color-default)
-    );
-    --mod-textfield-border-color-disabled: var(
-        --mod-combobox-border-color-disabled
-    );
-    --mod-textfield-border-color-focus: var(
-        --mod-combobox-border-color-focus,
-        var(--spectrum-combobox-border-color-focus)
-    );
-    --mod-textfield-border-color-focus-hover: var(
-        --mod-combobox-border-color-focus-hover,
-        var(--spectrum-combobox-border-color-focus-hover)
-    );
-    --mod-textfield-border-color-hover: var(
-        --mod-combobox-border-color-hover,
-        var(--spectrum-combobox-border-color-hover)
-    );
-    --mod-textfield-border-color-keyboard-focus: var(
-        --mod-combobox-border-color-key-focus,
-        var(--spectrum-combobox-border-color-key-focus)
-    );
-    --mod-textfield-border-color-invalid-default: var(
-        --mod-combobox-border-color-invalid-default,
-        var(--spectrum-combobox-border-color-invalid-default)
-    );
-    --mod-textfield-border-color-invalid-hover: var(
-        --mod-combobox-border-color-invalid-hover,
-        var(--spectrum-combobox-border-color-invalid-hover)
-    );
-    --mod-textfield-border-color-invalid-focus: var(
-        --mod-combobox-border-color-invalid-focus,
-        var(--spectrum-combobox-border-color-invalid-focus)
-    );
-    --mod-textfield-border-color-invalid-focus-hover: var(
-        --mod-combobox-border-color-invalid-focus-hover,
-        var(--spectrum-combobox-border-color-invalid-focus-hover)
-    );
-    --mod-textfield-border-color-invalid-keyboard-focus: var(
-        --mod-combobox-border-color-invalid-key-focus,
-        var(--spectrum-combobox-border-color-invalid-key-focus)
-    );
+    --mod-textfield-text-color-focus-hover: var(--mod-combobox-font-color-focus-hover);
+    --mod-textfield-text-color-keyboard-focus: var(--mod-combobox-font-color-key-focus);
+    --mod-textfield-text-color-disabled: var(--mod-combobox-font-color-disabled);
+    --mod-textfield-border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
+    --mod-textfield-border-color: var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default));
+    --mod-textfield-border-color-disabled: var(--mod-combobox-border-color-disabled);
+    --mod-textfield-border-color-focus: var(--mod-combobox-border-color-focus, var(--spectrum-combobox-border-color-focus));
+    --mod-textfield-border-color-focus-hover: var(--mod-combobox-border-color-focus-hover, var(--spectrum-combobox-border-color-focus-hover));
+    --mod-textfield-border-color-hover: var(--mod-combobox-border-color-hover, var(--spectrum-combobox-border-color-hover));
+    --mod-textfield-border-color-keyboard-focus: var(--mod-combobox-border-color-key-focus, var(--spectrum-combobox-border-color-key-focus));
+    --mod-textfield-border-color-invalid-default: var(--mod-combobox-border-color-invalid-default, var(--spectrum-combobox-border-color-invalid-default));
+    --mod-textfield-border-color-invalid-hover: var(--mod-combobox-border-color-invalid-hover, var(--spectrum-combobox-border-color-invalid-hover));
+    --mod-textfield-border-color-invalid-focus: var(--mod-combobox-border-color-invalid-focus, var(--spectrum-combobox-border-color-invalid-focus));
+    --mod-textfield-border-color-invalid-focus-hover: var(--mod-combobox-border-color-invalid-focus-hover, var(--spectrum-combobox-border-color-invalid-focus-hover));
+    --mod-textfield-border-color-invalid-keyboard-focus: var(--mod-combobox-border-color-invalid-key-focus, var(--spectrum-combobox-border-color-invalid-key-focus));
     --mod-textfield-icon-color-invalid: var(--mod-combobox-alert-icon-color);
-    --mod-picker-button-border-width: var(
-        --mod-combobox-border-width,
-        var(--spectrum-combobox-border-width)
-    );
-    --mod-picker-button-border-color: var(
-        --mod-combobox-border-color-default,
-        var(--spectrum-combobox-border-color-default)
-    );
-    --mod-picker-button-background-color: var(
-        --mod-combobox-background-color-default
-    );
-    --mod-picker-button-background-color-disabled: var(
-        --mod-combobox-background-color-disabled
-    );
-    --mod-picker-button-font-color-disabled: var(
-        --mod-combobox-font-color-disabled
-    );
-    --spectrum-combobox-readonly-input-background-color: var(
-        --spectrum-gray-50
-    );
+    --mod-picker-button-border-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
+    --mod-picker-button-border-color: var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default));
+    --mod-picker-button-background-color: var(--mod-combobox-background-color-default);
+    --mod-picker-button-background-color-disabled: var(--mod-combobox-background-color-disabled);
+    --mod-picker-button-font-color-disabled: var(--mod-combobox-font-color-disabled);
+    --spectrum-combobox-readonly-input-background-color: var(--spectrum-gray-50);
     --spectrum-combobox-readonly-input-border-color: var(--spectrum-gray-500);
-    --spectrum-combobox-readonly-border-color-invalid-default: var(
-        --spectrum-negative-border-color-default
-    );
-    --spectrum-combobox-readonly-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --spectrum-combobox-readonly-text-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
-    --spectrum-combobox-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
+    --spectrum-combobox-readonly-border-color-invalid-default: var(--spectrum-negative-border-color-default);
+    --spectrum-combobox-readonly-background-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-combobox-readonly-text-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-combobox-border-color-disabled: var(--spectrum-disabled-border-color);
 }
 
 :host,
@@ -197,167 +83,82 @@ governing permissions and limitations under the License.
     --spectrum-combobox-block-size: var(--spectrum-component-height-100);
     --spectrum-combobox-icon-size: var(--spectrum-workflow-icon-size-100);
     --spectrum-combobox-font-size: var(--spectrum-font-size-100);
-    --spectrum-combobox-spacing-inline-icon-to-button: var(
-        --spectrum-combo-box-visual-to-field-button-medium
-    );
-    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(
-        --spectrum-field-top-to-progress-circle-medium
-    );
-    --spectrum-combobox-block-spacing-edge-to-alert: var(
-        --spectrum-field-top-to-alert-icon-medium
-    );
-    --spectrum-combobox-spacing-edge-to-menu: var(
-        --spectrum-component-to-menu-medium
-    );
-    --spectrum-combobox-spacing-block-start-edge-to-text: var(
-        --spectrum-component-top-to-text-100
-    );
-    --spectrum-combobox-spacing-block-end-edge-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --spectrum-combobox-spacing-inline-start-edge-to-text: var(
-        --spectrum-component-edge-to-text-100
-    );
-    --spectrum-combobox-spacing-inline-end-edge-to-text: var(
-        --spectrum-component-edge-to-text-100
-    );
+    --spectrum-combobox-spacing-inline-icon-to-button: var(--spectrum-combo-box-visual-to-field-button-medium);
+    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(--spectrum-field-top-to-progress-circle-medium);
+    --spectrum-combobox-block-spacing-edge-to-alert: var(--spectrum-field-top-to-alert-icon-medium);
+    --spectrum-combobox-spacing-edge-to-menu: var(--spectrum-component-to-menu-medium);
+    --spectrum-combobox-spacing-block-start-edge-to-text: var(--spectrum-component-top-to-text-100);
+    --spectrum-combobox-spacing-block-end-edge-to-text: var(--spectrum-component-bottom-to-text-100);
+    --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-component-edge-to-text-100);
+    --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-100);
 }
 
 :host([size='s']) {
     --spectrum-combobox-block-size: var(--spectrum-component-height-75);
     --spectrum-combobox-icon-size: var(--spectrum-workflow-icon-size-75);
     --spectrum-combobox-font-size: var(--spectrum-font-size-75);
-    --spectrum-combobox-spacing-inline-icon-to-button: var(
-        --spectrum-combo-box-visual-to-field-button-small
-    );
-    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(
-        --spectrum-field-top-to-progress-circle-small
-    );
-    --spectrum-combobox-block-spacing-edge-to-alert: var(
-        --spectrum-field-top-to-alert-icon-small
-    );
-    --spectrum-combobox-spacing-edge-to-menu: var(
-        --spectrum-component-to-menu-small
-    );
-    --spectrum-combobox-spacing-block-start-edge-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --spectrum-combobox-spacing-block-end-edge-to-text: var(
-        --spectrum-component-bottom-to-text-75
-    );
-    --spectrum-combobox-spacing-inline-start-edge-to-text: var(
-        --spectrum-component-edge-to-text-75
-    );
-    --spectrum-combobox-spacing-inline-end-edge-to-text: var(
-        --spectrum-component-edge-to-text-75
-    );
+    --spectrum-combobox-spacing-inline-icon-to-button: var(--spectrum-combo-box-visual-to-field-button-small);
+    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(--spectrum-field-top-to-progress-circle-small);
+    --spectrum-combobox-block-spacing-edge-to-alert: var(--spectrum-field-top-to-alert-icon-small);
+    --spectrum-combobox-spacing-edge-to-menu: var(--spectrum-component-to-menu-small);
+    --spectrum-combobox-spacing-block-start-edge-to-text: var(--spectrum-component-top-to-text-75);
+    --spectrum-combobox-spacing-block-end-edge-to-text: var(--spectrum-component-bottom-to-text-75);
+    --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-component-edge-to-text-75);
+    --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-75);
 }
 
 :host([size='l']) {
     --spectrum-combobox-block-size: var(--spectrum-component-height-200);
     --spectrum-combobox-icon-size: var(--spectrum-workflow-icon-size-200);
     --spectrum-combobox-font-size: var(--spectrum-font-size-200);
-    --spectrum-combobox-spacing-inline-icon-to-button: var(
-        --spectrum-combo-box-visual-to-field-button-large
-    );
-    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(
-        --spectrum-field-top-to-progress-circle-large
-    );
-    --spectrum-combobox-block-spacing-edge-to-alert: var(
-        --spectrum-field-top-to-alert-icon-large
-    );
-    --spectrum-combobox-spacing-edge-to-menu: var(
-        --spectrum-component-to-menu-large
-    );
-    --spectrum-combobox-spacing-block-start-edge-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --spectrum-combobox-spacing-block-end-edge-to-text: var(
-        --spectrum-component-bottom-to-text-200
-    );
-    --spectrum-combobox-spacing-inline-start-edge-to-text: var(
-        --spectrum-component-edge-to-text-200
-    );
-    --spectrum-combobox-spacing-inline-end-edge-to-text: var(
-        --spectrum-component-edge-to-text-200
-    );
+    --spectrum-combobox-spacing-inline-icon-to-button: var(--spectrum-combo-box-visual-to-field-button-large);
+    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(--spectrum-field-top-to-progress-circle-large);
+    --spectrum-combobox-block-spacing-edge-to-alert: var(--spectrum-field-top-to-alert-icon-large);
+    --spectrum-combobox-spacing-edge-to-menu: var(--spectrum-component-to-menu-large);
+    --spectrum-combobox-spacing-block-start-edge-to-text: var(--spectrum-component-top-to-text-200);
+    --spectrum-combobox-spacing-block-end-edge-to-text: var(--spectrum-component-bottom-to-text-200);
+    --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-component-edge-to-text-200);
+    --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-200);
 }
 
 :host([size='xl']) {
     --spectrum-combobox-block-size: var(--spectrum-component-height-300);
     --spectrum-combobox-icon-size: var(--spectrum-workflow-icon-size-300);
     --spectrum-combobox-font-size: var(--spectrum-font-size-300);
-    --spectrum-combobox-spacing-inline-icon-to-button: var(
-        --spectrum-combo-box-visual-to-field-button-extra-large
-    );
-    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(
-        --spectrum-field-top-to-progress-circle-extra-large
-    );
-    --spectrum-combobox-block-spacing-edge-to-alert: var(
-        --spectrum-field-top-to-alert-icon-extra-large
-    );
-    --spectrum-combobox-spacing-edge-to-menu: var(
-        --spectrum-component-to-menu-extra-large
-    );
-    --spectrum-combobox-spacing-block-start-edge-to-text: var(
-        --spectrum-component-top-to-text-300
-    );
-    --spectrum-combobox-spacing-block-end-edge-to-text: var(
-        --spectrum-component-bottom-to-text-300
-    );
-    --spectrum-combobox-spacing-inline-start-edge-to-text: var(
-        --spectrum-component-edge-to-text-300
-    );
-    --spectrum-combobox-spacing-inline-end-edge-to-text: var(
-        --spectrum-component-edge-to-text-300
-    );
+    --spectrum-combobox-spacing-inline-icon-to-button: var(--spectrum-combo-box-visual-to-field-button-extra-large);
+    --spectrum-combobox-block-spacing-edge-to-progress-circle: var(--spectrum-field-top-to-progress-circle-extra-large);
+    --spectrum-combobox-block-spacing-edge-to-alert: var(--spectrum-field-top-to-alert-icon-extra-large);
+    --spectrum-combobox-spacing-edge-to-menu: var(--spectrum-component-to-menu-extra-large);
+    --spectrum-combobox-spacing-block-start-edge-to-text: var(--spectrum-component-top-to-text-300);
+    --spectrum-combobox-spacing-block-end-edge-to-text: var(--spectrum-component-bottom-to-text-300);
+    --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-component-edge-to-text-300);
+    --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-300);
 }
 
 :host([quiet]) {
-    --spectrum-combobox-min-inline-size: calc(
-        var(--spectrum-combo-box-quiet-minimum-width-multiplier) *
-            var(--spectrum-combobox-block-size)
-    );
-    --spectrum-combobox-spacing-inline-icon-to-button: var(
-        --spectrum-combo-box-visual-to-field-button-quiet
-    );
-    --spectrum-combobox-spacing-inline-start-edge-to-text: var(
-        --spectrum-field-edge-to-text-quiet
-    );
-    --spectrum-combobox-spacing-label-to-combobox: var(
-        --spectrum-field-label-to-component-quiet-medium
-    );
-    --spectrum-combobox-button-inline-offset: calc(
-        var(--mod-combobox-block-size, var(--spectrum-combobox-block-size)) / 2 -
-            var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) /
-            2
-    );
+    --spectrum-combobox-min-inline-size: calc(var(--spectrum-combo-box-quiet-minimum-width-multiplier) * var(--spectrum-combobox-block-size));
+    --spectrum-combobox-spacing-inline-icon-to-button: var(--spectrum-combo-box-visual-to-field-button-quiet);
+    --spectrum-combobox-spacing-inline-start-edge-to-text: var(--spectrum-field-edge-to-text-quiet);
+    --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-medium);
+    --spectrum-combobox-button-inline-offset: calc(var(--mod-combobox-block-size, var(--spectrum-combobox-block-size)) / 2 - var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) / 2);
     --mod-picker-button-background-color-quiet: transparent;
     --mod-picker-button-border-color-quiet: transparent;
 }
 
 :host([quiet][size='s']) {
-    --spectrum-combobox-spacing-label-to-combobox: var(
-        --spectrum-field-label-to-component-quiet-small
-    );
+    --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-small);
 }
 
 :host([quiet]) {
-    --spectrum-combobox-spacing-label-to-combobox: var(
-        --spectrum-field-label-to-component-quiet-medium
-    );
+    --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-medium);
 }
 
 :host([quiet][size='l']) {
-    --spectrum-combobox-spacing-label-to-combobox: var(
-        --spectrum-field-label-to-component-quiet-large
-    );
+    --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-large);
 }
 
 :host([quiet][size='xl']) {
-    --spectrum-combobox-spacing-label-to-combobox: var(
-        --spectrum-field-label-to-component-quiet-extra-large
-    );
+    --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-extra-large);
 }
 
 @media (forced-colors: active) {
@@ -376,44 +177,21 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    inline-size: var(
-        --mod-combobox-inline-size,
-        var(--spectrum-combobox-inline-size)
-    );
-    min-inline-size: var(
-        --mod-combobox-min-inline-size,
-        var(--spectrum-combobox-min-inline-size)
-    );
-    block-size: var(
-        --mod-combobox-block-size,
-        var(--spectrum-combobox-block-size)
-    );
-    border-radius: var(
-        --mod-combobox-border-radius,
-        var(--spectrum-combobox-border-radius)
-    );
+    inline-size: var(--mod-combobox-inline-size, var(--spectrum-combobox-inline-size));
+    min-inline-size: var(--mod-combobox-min-inline-size, var(--spectrum-combobox-min-inline-size));
+    block-size: var(--mod-combobox-block-size, var(--spectrum-combobox-block-size));
+    border-radius: var(--mod-combobox-border-radius, var(--spectrum-combobox-border-radius));
     flex-flow: row;
-    margin-block-start: var(
-        --mod-combobox-spacing-label-to-combobox,
-        var(--spectrum-combobox-spacing-label-to-combobox)
-    );
+    margin-block-start: var(--mod-combobox-spacing-label-to-combobox, var(--spectrum-combobox-spacing-label-to-combobox));
     display: inline-flex;
     position: relative;
 }
 
 .spectrum-Popover.is-open {
-    transform: translateY(
-        var(
-            --mod-combobox-spacing-edge-to-menu,
-            var(--spectrum-combobox-spacing-edge-to-menu)
-        )
-    );
+    transform: translateY(var(--mod-combobox-spacing-edge-to-menu, var(--spectrum-combobox-spacing-edge-to-menu)));
 }
 
-:host([keyboard-focused])
-    .is-readOnly:not(.spectrum-Combobox--quiet)
-    #textfield
-    #input {
+:host([keyboard-focused]) .is-readOnly:not(.spectrum-Combobox--quiet) #textfield #input {
     outline-offset: var(--mod-textfield-focus-indicator-gap);
     outline: var(--mod-textfield-focus-indicator-width) solid;
     outline-color: var(--mod-textfield-focus-indicator-color);
@@ -425,168 +203,75 @@ governing permissions and limitations under the License.
 }
 
 :host([invalid]) .is-readOnly:not(.spectrum-Combobox--quiet) #input:read-only {
-    border-color: var(
-        --highcontrast-textfield-border-color-invalid-default,
-        var(
-            --mod-textfield-border-color-invalid-default,
-            var(--spectrum-combobox-readonly-border-color-invalid-default)
-        )
-    );
+    border-color: var(--highcontrast-textfield-border-color-invalid-default, var(--mod-textfield-border-color-invalid-default, var(--spectrum-combobox-readonly-border-color-invalid-default)));
 }
 
 :host([disabled]) .is-readOnly:not(.spectrum-Combobox--quiet) #input:read-only {
-    background-color: var(
-        --mod-textfield-background-color-disabled,
-        var(--spectrum-combobox-readonly-background-color-disabled)
-    );
-    color: var(
-        --highcontrast-textfield-text-color-disabled,
-        var(
-            --mod-textfield-text-color-disabled,
-            var(--spectrum-combobox-readonly-text-color-disabled)
-        )
-    );
+    background-color: var(--mod-textfield-background-color-disabled, var(--spectrum-combobox-readonly-background-color-disabled));
+    color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-combobox-readonly-text-color-disabled)));
     border-color: #0000;
 }
 
 .progress-circle {
     position: absolute;
-    inset-block-start: var(
-        --mod-combobox-block-spacing-edge-to-progress-circle,
-        var(--spectrum-combobox-block-spacing-edge-to-progress-circle)
-    );
-    inset-block-end: var(
-        --mod-combobox-block-spacing-edge-to-alert,
-        var(--spectrum-combobox-block-spacing-edge-to-alert)
-    );
-    inset-inline-end: calc(
-        var(
-                --mod-combobox-spacing-inline-icon-to-button,
-                var(--spectrum-combobox-spacing-inline-icon-to-button)
-            ) +
-            var(
-                --mod-combobox-button-width,
-                var(--spectrum-combobox-button-width)
-            )
-    );
+    inset-block-start: var(--mod-combobox-block-spacing-edge-to-progress-circle, var(--spectrum-combobox-block-spacing-edge-to-progress-circle));
+    inset-block-end: var(--mod-combobox-block-spacing-edge-to-alert, var(--spectrum-combobox-block-spacing-edge-to-alert));
+    inset-inline-end: calc(var(--mod-combobox-spacing-inline-icon-to-button, var(--spectrum-combobox-spacing-inline-icon-to-button)) + var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)));
 }
 
 .progress-circle:dir(rtl),
 :host([dir='rtl']) .progress-circle {
-    inset-inline-start: calc(
-        var(
-                --mod-combobox-spacing-inline-icon-to-button,
-                var(--spectrum-combobox-spacing-inline-icon-to-button)
-            ) +
-            var(
-                --mod-combobox-button-width,
-                var(--spectrum-combobox-button-width)
-            )
-    );
+    inset-inline-start: calc(var(--mod-combobox-spacing-inline-icon-to-button, var(--spectrum-combobox-spacing-inline-icon-to-button)) + var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)));
     inset-inline-end: inherit;
 }
 
 .button {
     position: absolute;
-    inset-inline-end: calc(
-        var(
-                --mod-combobox-button-inline-offset,
-                var(--spectrum-combobox-button-inline-offset, 0px)
-            ) * -1
-    );
+    inset-inline-end: calc(var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px)) * -1);
 }
 
 .button:not(:disabled, .is-invalid, [quiet]) {
-    --mod-picker-button-border-color: var(
-        --mod-combobox-border-color-default,
-        var(--spectrum-combobox-border-color-default)
-    );
+    --mod-picker-button-border-color: var(--mod-combobox-border-color-default, var(--spectrum-combobox-border-color-default));
 }
 
-:host([focused])
-    .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet),
+:host([focused]) .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet),
 .button:not(:disabled, .is-invalid, [quiet]):focus,
 :host([focused]) .button:not(:disabled, .is-invalid, [quiet]),
 :host:has(:focus) .button:not(:disabled, .is-invalid, [quiet]) {
-    --mod-picker-button-border-color: var(
-        --highcontrast-combobox-border-color-highlight,
-        var(
-            --mod-combobox-border-color-focus,
-            var(--spectrum-combobox-border-color-focus)
-        )
-    );
+    --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-highlight, var(--mod-combobox-border-color-focus, var(--spectrum-combobox-border-color-focus)));
 }
 
-:host([keyboard-focused])
-    .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet),
+:host([keyboard-focused]) .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet),
 .button:not(:disabled, .is-invalid, [quiet]):focus-visible,
 :host([keyboard-focused]) .button:not(:disabled, .is-invalid, [quiet]) {
-    --mod-picker-button-border-color: var(
-        --mod-combobox-border-color-key-focus,
-        var(--spectrum-combobox-border-color-key-focus)
-    );
+    --mod-picker-button-border-color: var(--mod-combobox-border-color-key-focus, var(--spectrum-combobox-border-color-key-focus));
 }
 
 .button:not(:disabled, .is-invalid, [quiet]):active,
 :host:has(:active) .button:not(:disabled, .is-invalid, [quiet]) {
-    --mod-picker-button-border-color: var(
-        --highcontrast-combobox-border-color-highlight,
-        var(
-            --mod-combobox-border-color-hover,
-            var(--spectrum-combobox-border-color-hover)
-        )
-    );
+    --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-highlight, var(--mod-combobox-border-color-hover, var(--spectrum-combobox-border-color-hover)));
 }
 
 :host([invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet) {
-    --mod-picker-button-border-color: var(
-        --highcontrast-combobox-border-color-invalid,
-        var(
-            --mod-combobox-border-color-invalid-default,
-            var(--spectrum-combobox-border-color-invalid-default)
-        )
-    );
+    --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-default, var(--spectrum-combobox-border-color-invalid-default)));
 }
 
 :host([invalid][focused]) .button:not(:disabled, .spectrum-PickerButton--quiet),
 :host([invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet):focus,
 :host([focused][invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet),
-:host([invalid]):has(:focus)
-    .button:not(:disabled, .spectrum-PickerButton--quiet) {
-    --mod-picker-button-border-color: var(
-        --highcontrast-combobox-border-color-invalid,
-        var(
-            --mod-combobox-border-color-invalid-focus,
-            var(--spectrum-combobox-border-color-invalid-focus)
-        )
-    );
+:host([invalid]):has(:focus) .button:not(:disabled, .spectrum-PickerButton--quiet) {
+    --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-focus, var(--spectrum-combobox-border-color-invalid-focus)));
 }
 
-:host([invalid][keyboard-focused])
-    .button:not(:disabled, .spectrum-PickerButton--quiet),
-:host([invalid])
-    .button:not(:disabled, .spectrum-PickerButton--quiet):focus-visible,
-:host([keyboard-focused][invalid])
-    .button:not(:disabled, .spectrum-PickerButton--quiet) {
-    --mod-picker-button-border-color: var(
-        --highcontrast-combobox-border-color-invalid,
-        var(
-            --mod-combobox-border-color-invalid-key-focus,
-            var(--spectrum-combobox-border-color-invalid-key-focus)
-        )
-    );
+:host([invalid][keyboard-focused]) .button:not(:disabled, .spectrum-PickerButton--quiet),
+:host([invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet):focus-visible,
+:host([keyboard-focused][invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet) {
+    --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-key-focus, var(--spectrum-combobox-border-color-invalid-key-focus)));
 }
 
 :host([invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet):active,
-:host([invalid]):has(:active)
-    .button:not(:disabled, .spectrum-PickerButton--quiet) {
-    --mod-picker-button-border-color: var(
-        --highcontrast-combobox-border-color-invalid,
-        var(
-            --mod-combobox-border-color-invalid-hover,
-            var(--spectrum-combobox-border-color-invalid-hover)
-        )
-    );
+:host([invalid]):has(:active) .button:not(:disabled, .spectrum-PickerButton--quiet) {
+    --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-hover, var(--spectrum-combobox-border-color-invalid-hover)));
 }
 
 #textfield {
@@ -595,81 +280,27 @@ governing permissions and limitations under the License.
 
 #input {
     backface-visibility: hidden;
-    line-height: var(
-        --mod-combobox-line-height,
-        var(--spectrum-combobox-line-height)
-    );
-    font-size: var(
-        --mod-combobox-font-size,
-        var(--spectrum-combobox-font-size)
-    );
-    font-style: var(
-        --mod-combobox-font-style,
-        var(--spectrum-combobox-font-style)
-    );
-    padding-block-start: calc(
-        var(
-                --mod-combobox-spacing-block-start-edge-to-text,
-                var(--spectrum-combobox-spacing-block-start-edge-to-text)
-            ) -
-            var(
-                --mod-combobox-border-width,
-                var(--spectrum-combobox-border-width)
-            )
-    );
-    padding-block-end: calc(
-        var(
-                --mod-combobox-spacing-block-end-edge-to-text,
-                var(--spectrum-combobox-spacing-block-end-edge-to-text)
-            ) -
-            var(
-                --mod-combobox-border-width,
-                var(--spectrum-combobox-border-width)
-            )
-    );
-    padding-inline-start: calc(
-        var(
-                --mod-combobox-spacing-inline-start-edge-to-text,
-                var(--spectrum-combobox-spacing-inline-start-edge-to-text)
-            ) -
-            var(
-                --mod-combobox-border-width,
-                var(--spectrum-combobox-border-width)
-            )
-    );
-    padding-inline-end: calc(
-        var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) +
-            var(
-                --mod-combobox-spacing-inline-end-edge-to-text,
-                var(--spectrum-combobox-spacing-inline-end-edge-to-text)
-            ) -
-            var(
-                --mod-combobox-border-width,
-                var(--spectrum-combobox-border-width)
-            ) * 2
-    );
+    line-height: var(--mod-combobox-line-height, var(--spectrum-combobox-line-height));
+    font-size: var(--mod-combobox-font-size, var(--spectrum-combobox-font-size));
+    font-style: var(--mod-combobox-font-style, var(--spectrum-combobox-font-style));
+    padding-block-start: calc(var(--mod-combobox-spacing-block-start-edge-to-text, var(--spectrum-combobox-spacing-block-start-edge-to-text)) - var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)));
+    padding-block-end: calc(var(--mod-combobox-spacing-block-end-edge-to-text, var(--spectrum-combobox-spacing-block-end-edge-to-text)) - var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)));
+    padding-inline-start: calc(var(--mod-combobox-spacing-inline-start-edge-to-text, var(--spectrum-combobox-spacing-inline-start-edge-to-text)) - var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)));
+    padding-inline-end: calc(var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) + var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) - var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)) * 2);
 }
 
 #input::placeholder {
-    --mod-textfield-text-color-default: var(
-        --mod-combobox-font-color-placeholder
-    );
+    --mod-textfield-text-color-default: var(--mod-combobox-font-color-placeholder);
 }
 
 #input:active {
-    --mod-textfield-background-color: var(
-        --mod-combobox-background-color-hover
-    );
+    --mod-textfield-background-color: var(--mod-combobox-background-color-hover);
 }
 
 #input:focus,
 :host([focused]) #textfield #input {
-    --mod-combobox-border-color-default: var(
-        --spectrum-combobox-border-color-focus
-    );
-    --mod-textfield-background-color: var(
-        --mod-combobox-background-color-focus
-    );
+    --mod-combobox-border-color-default: var(--spectrum-combobox-border-color-focus);
+    --mod-textfield-background-color: var(--mod-combobox-background-color-focus);
 }
 
 @media (hover: hover) {
@@ -677,152 +308,65 @@ governing permissions and limitations under the License.
         background-color: revert;
     }
 
-    :host([disabled])
-        .is-readOnly:not(.spectrum-Combobox--quiet)
-        #input:read-only:hover {
-        background-color: var(
-            --mod-textfield-background-color-disabled,
-            var(--spectrum-combobox-readonly-background-color-disabled)
-        );
+    :host([disabled]) .is-readOnly:not(.spectrum-Combobox--quiet) #input:read-only:hover {
+        background-color: var(--mod-textfield-background-color-disabled, var(--spectrum-combobox-readonly-background-color-disabled));
     }
 
     .button:not(:disabled, .is-invalid, [quiet]):hover,
     :host(:hover) .button:not(:disabled, .is-invalid, [quiet]) {
-        --mod-picker-button-border-color: var(
-            --highcontrast-combobox-border-color-highlight,
-            var(
-                --mod-combobox-border-color-hover,
-                var(--spectrum-combobox-border-color-hover)
-            )
-        );
+        --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-highlight, var(--mod-combobox-border-color-hover, var(--spectrum-combobox-border-color-hover)));
     }
 
-    :host([focused])
-        .button:not(
-            :disabled,
-            .is-invalid,
-            .spectrum-PickerButton--quiet
-        ):hover,
+    :host([focused]) .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet):hover,
     .button:not(:disabled, .is-invalid, [quiet]):focus:hover,
     :host([focused]:hover) .button:not(:disabled, .is-invalid, [quiet]),
     :host(:hover):has(:focus) .button:not(:disabled, .is-invalid, [quiet]) {
-        --mod-picker-button-border-color: var(
-            --highcontrast-combobox-border-color-highlight,
-            var(
-                --mod-combobox-border-color-focus-hover,
-                var(--spectrum-combobox-border-color-focus-hover)
-            )
-        );
+        --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-highlight, var(--mod-combobox-border-color-focus-hover, var(--spectrum-combobox-border-color-focus-hover)));
     }
 
-    :host([invalid])
-        .button:not(:disabled, .spectrum-PickerButton--quiet):hover,
-    :host([invalid]:hover)
-        .button:not(:disabled, .spectrum-PickerButton--quiet) {
-        --mod-picker-button-border-color: var(
-            --highcontrast-combobox-border-color-invalid,
-            var(
-                --mod-combobox-border-color-invalid-hover,
-                var(--spectrum-combobox-border-color-invalid-hover)
-            )
-        );
+    :host([invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet):hover,
+    :host([invalid]:hover) .button:not(:disabled, .spectrum-PickerButton--quiet) {
+        --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-hover, var(--spectrum-combobox-border-color-invalid-hover)));
     }
 
-    :host([invalid][focused])
-        .button:not(:disabled, .spectrum-PickerButton--quiet):hover,
-    :host([invalid])
-        .button:not(:disabled, .spectrum-PickerButton--quiet):focus:hover,
-    :host([focused][invalid]:hover)
-        .button:not(:disabled, .spectrum-PickerButton--quiet),
-    :host([invalid]:hover):has(:focus)
-        .button:not(:disabled, .spectrum-PickerButton--quiet) {
-        --mod-picker-button-border-color: var(
-            --highcontrast-combobox-border-color-invalid,
-            var(
-                --mod-combobox-border-color-invalid-focus-hover,
-                var(--spectrum-combobox-border-color-invalid-focus-hover)
-            )
-        );
+    :host([invalid][focused]) .button:not(:disabled, .spectrum-PickerButton--quiet):hover,
+    :host([invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet):focus:hover,
+    :host([focused][invalid]:hover) .button:not(:disabled, .spectrum-PickerButton--quiet),
+    :host([invalid]:hover):has(:focus) .button:not(:disabled, .spectrum-PickerButton--quiet) {
+        --mod-picker-button-border-color: var(--highcontrast-combobox-border-color-invalid, var(--mod-combobox-border-color-invalid-focus-hover, var(--spectrum-combobox-border-color-invalid-focus-hover)));
     }
 
     #input:hover,
     #textfield:hover #input {
-        --mod-textfield-background-color: var(
-            --mod-combobox-background-color-hover
-        );
+        --mod-textfield-background-color: var(--mod-combobox-background-color-hover);
     }
 
     #input:focus:hover,
     :host([focused]) #textfield #input:hover {
-        --mod-combobox-border-color-default: var(
-            --spectrum-combobox-border-color-focus-hover
-        );
-        --mod-textfield-background-color: var(
-            --mod-combobox-background-color-focus-hover
-        );
+        --mod-combobox-border-color-default: var(--spectrum-combobox-border-color-focus-hover);
+        --mod-textfield-background-color: var(--mod-combobox-background-color-focus-hover);
     }
 }
 
 :host([keyboard-focused]) #textfield #input {
-    --mod-combobox-border-color-default: var(
-        --spectrum-combobox-border-color-key-focus
-    );
-    --mod-textfield-background-color: var(
-        --mod-combobox-background-color-key-focus
-    );
+    --mod-combobox-border-color-default: var(--spectrum-combobox-border-color-key-focus);
+    --mod-textfield-background-color: var(--mod-combobox-background-color-key-focus);
 }
 
 :host([invalid]) #textfield #input,
 :host([pending]) #textfield #input {
     padding-inline-end: calc(
-        var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) +
-            var(
-                --mod-combobox-spacing-inline-icon-to-button,
-                var(--spectrum-combobox-spacing-inline-icon-to-button)
-            ) +
-            var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) +
-            var(
-                --mod-combobox-spacing-inline-end-edge-to-text,
-                var(--spectrum-combobox-spacing-inline-end-edge-to-text)
-            ) -
-            var(
-                --mod-combobox-button-inline-offset,
-                var(--spectrum-combobox-button-inline-offset, 0px)
-            ) -
-            var(
-                --mod-combobox-border-width,
-                var(--spectrum-combobox-border-width)
-            ) * 2
+        var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) + var(--mod-combobox-spacing-inline-icon-to-button, var(--spectrum-combobox-spacing-inline-icon-to-button)) + var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) + var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) - var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px)) -
+            var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)) * 2
     );
 }
 
 :host([invalid]) #textfield .icon {
-    inline-size: var(
-        --mod-combobox-icon-size,
-        var(--spectrum-combobox-icon-size)
-    );
-    block-size: var(
-        --mod-combobox-icon-size,
-        var(--spectrum-combobox-icon-size)
-    );
-    inset-block-start: var(
-        --mod-combobox-block-spacing-edge-to-alert,
-        var(--spectrum-combobox-block-spacing-edge-to-alert)
-    );
-    inset-block-end: var(
-        --mod-combobox-block-spacing-edge-to-alert,
-        var(--spectrum-combobox-block-spacing-edge-to-alert)
-    );
-    inset-inline-end: calc(
-        var(
-                --mod-combobox-spacing-inline-icon-to-button,
-                var(--spectrum-combobox-spacing-inline-icon-to-button)
-            ) +
-            var(
-                --mod-combobox-button-width,
-                var(--spectrum-combobox-button-width)
-            )
-    );
+    inline-size: var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size));
+    block-size: var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size));
+    inset-block-start: var(--mod-combobox-block-spacing-edge-to-alert, var(--spectrum-combobox-block-spacing-edge-to-alert));
+    inset-block-end: var(--mod-combobox-block-spacing-edge-to-alert, var(--spectrum-combobox-block-spacing-edge-to-alert));
+    inset-inline-end: calc(var(--mod-combobox-spacing-inline-icon-to-button, var(--spectrum-combobox-spacing-inline-icon-to-button)) + var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)));
 }
 
 :host([disabled]) #textfield .icon,
@@ -836,100 +380,31 @@ governing permissions and limitations under the License.
 }
 
 :host([quiet][invalid]) #textfield .icon {
-    inset-inline-end: var(
-        --mod-combobox-button-width,
-        var(--spectrum-combobox-button-width)
-    );
+    inset-inline-end: var(--mod-combobox-button-width, var(--spectrum-combobox-button-width));
 }
 
 :host([quiet]) #textfield.is-readOnly #input:read-only {
-    border-block-end: var(
-            --mod-combobox-border-width,
-            var(--spectrum-combobox-border-width)
-        )
-        solid
-        var(
-            --mod-combobox-readonly-input-border-color,
-            var(--spectrum-combobox-readonly-input-border-color)
-        );
+    border-block-end: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)) solid var(--mod-combobox-readonly-input-border-color, var(--spectrum-combobox-readonly-input-border-color));
 }
 
 :host([quiet][invalid]) #textfield.is-readOnly > #input:read-only {
-    border-color: var(
-        --highcontrast-textfield-border-color-invalid-default,
-        var(
-            --mod-textfield-border-color-invalid-default,
-            var(--spectrum-combobox-readonly-border-color-invalid-default)
-        )
-    );
+    border-color: var(--highcontrast-textfield-border-color-invalid-default, var(--mod-textfield-border-color-invalid-default, var(--spectrum-combobox-readonly-border-color-invalid-default)));
 }
 
 :host([quiet][disabled]) #textfield.is-readOnly #input:read-only {
-    color: var(
-        --highcontrast-textfield-text-color-disabled,
-        var(
-            --mod-textfield-text-color-disabled,
-            var(--spectrum-combobox-readonly-text-color-disabled)
-        )
-    );
-    border-color: var(
-        --mod-textfield-border-color-disabled,
-        var(--spectrum-combobox-border-color-disabled)
-    );
+    color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-combobox-readonly-text-color-disabled)));
+    border-color: var(--mod-textfield-border-color-disabled, var(--spectrum-combobox-border-color-disabled));
 }
 
 :host([quiet]) #input {
-    border-block-end-width: var(
-        --mod-combobox-border-width,
-        var(--spectrum-combobox-border-width)
-    );
-    padding-block-start: var(
-        --mod-combobox-spacing-block-start-edge-to-text,
-        var(--spectrum-combobox-spacing-block-start-edge-to-text)
-    );
-    padding-block-end: calc(
-        var(
-                --mod-combobox-spacing-block-end-edge-to-text,
-                var(--spectrum-combobox-spacing-block-end-edge-to-text)
-            ) -
-            var(
-                --mod-combobox-border-width,
-                var(--spectrum-combobox-border-width)
-            )
-    );
-    padding-inline-start: var(
-        --mod-combobox-spacing-inline-start-edge-to-text,
-        var(--spectrum-combobox-spacing-inline-start-edge-to-text)
-    );
-    padding-inline-end: calc(
-        var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) +
-            var(
-                --mod-combobox-spacing-inline-end-edge-to-text,
-                var(--spectrum-combobox-spacing-inline-end-edge-to-text)
-            ) -
-            var(
-                --mod-combobox-button-inline-offset,
-                var(--spectrum-combobox-button-inline-offset, 0px)
-            )
-    );
+    border-block-end-width: var(--mod-combobox-border-width, var(--spectrum-combobox-border-width));
+    padding-block-start: var(--mod-combobox-spacing-block-start-edge-to-text, var(--spectrum-combobox-spacing-block-start-edge-to-text));
+    padding-block-end: calc(var(--mod-combobox-spacing-block-end-edge-to-text, var(--spectrum-combobox-spacing-block-end-edge-to-text)) - var(--mod-combobox-border-width, var(--spectrum-combobox-border-width)));
+    padding-inline-start: var(--mod-combobox-spacing-inline-start-edge-to-text, var(--spectrum-combobox-spacing-inline-start-edge-to-text));
+    padding-inline-end: calc(var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) + var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) - var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px)));
 }
 
 :host([quiet][invalid]) #textfield #input,
 :host([quiet][pending]) #textfield #input {
-    padding-inline-end: calc(
-        var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) +
-            var(
-                --mod-combobox-spacing-inline-icon-to-button,
-                var(--spectrum-combobox-spacing-inline-icon-to-button)
-            ) +
-            var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) +
-            var(
-                --mod-combobox-spacing-inline-end-edge-to-text,
-                var(--spectrum-combobox-spacing-inline-end-edge-to-text)
-            ) -
-            var(
-                --mod-combobox-button-inline-offset,
-                var(--spectrum-combobox-button-inline-offset, 0px)
-            )
-    );
+    padding-inline-end: calc(var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) + var(--mod-combobox-spacing-inline-icon-to-button, var(--spectrum-combobox-spacing-inline-icon-to-button)) + var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) + var(--mod-combobox-spacing-inline-end-edge-to-text, var(--spectrum-combobox-spacing-inline-end-edge-to-text)) - var(--mod-combobox-button-inline-offset, var(--spectrum-combobox-button-inline-offset, 0px)));
 }

--- a/packages/contextual-help/src/spectrum-contextual-help.css
+++ b/packages/contextual-help/src/spectrum-contextual-help.css
@@ -12,26 +12,11 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .popover {
-    min-inline-size: var(
-        --mod-spectrum-contextual-help-minimum-width,
-        var(--spectrum-contextual-help-minimum-width)
-    );
-    padding-block: var(
-        --mod-spectrum-contextual-help-padding,
-        var(--spectrum-spacing-400)
-    );
-    padding-inline: var(
-        --mod-spectrum-contextual-help-padding,
-        var(--spectrum-spacing-400)
-    );
-    font-size: var(
-        --mod-spectrum-contextual-help-body-size,
-        var(--spectrum-contextual-help-body-size)
-    );
-    color: var(
-        --highcontrast-contextual-help-body-color,
-        var(--mod-contextual-help-body-color, var(--spectrum-body-color))
-    );
+    min-inline-size: var(--mod-spectrum-contextual-help-minimum-width, var(--spectrum-contextual-help-minimum-width));
+    padding-block: var(--mod-spectrum-contextual-help-padding, var(--spectrum-spacing-400));
+    padding-inline: var(--mod-spectrum-contextual-help-padding, var(--spectrum-spacing-400));
+    font-size: var(--mod-spectrum-contextual-help-body-size, var(--spectrum-contextual-help-body-size));
+    color: var(--highcontrast-contextual-help-body-color, var(--mod-contextual-help-body-color, var(--spectrum-body-color)));
     max-inline-size: var(--mod-spectrum-contextual-help-popover-maximum-width);
     position: relative;
 }
@@ -42,25 +27,13 @@ governing permissions and limitations under the License.
 }
 
 .popover ::slotted([slot='heading']) {
-    font-size: var(
-        --mod-spectrum-contextual-help-heading-size,
-        var(--spectrum-contextual-help-title-size)
-    );
-    color: var(
-        --highcontrast-contextual-help-heading-color,
-        var(--mod-contextual-help-heading-color, var(--spectrum-heading-color))
-    );
-    margin-block-end: var(
-        --mod-spectrum-contextual-help-content-spacing,
-        var(--spectrum-contextual-help-content-spacing)
-    );
+    font-size: var(--mod-spectrum-contextual-help-heading-size, var(--spectrum-contextual-help-title-size));
+    color: var(--highcontrast-contextual-help-heading-color, var(--mod-contextual-help-heading-color, var(--spectrum-heading-color)));
+    margin-block-end: var(--mod-spectrum-contextual-help-content-spacing, var(--spectrum-contextual-help-content-spacing));
 }
 
 ::slotted([slot='link']) {
-    margin-block-start: var(
-        --mod-spectrum-contextual-help-link-spacing,
-        var(--spectrum-spacing-300)
-    );
+    margin-block-start: var(--mod-spectrum-contextual-help-link-spacing, var(--spectrum-spacing-300));
 }
 
 @media (forced-colors: active) {

--- a/packages/dialog/src/spectrum-dialog.css
+++ b/packages/dialog/src/spectrum-dialog.css
@@ -14,10 +14,7 @@ governing permissions and limitations under the License.
 :host {
     box-sizing: border-box;
     inline-size: fit-content;
-    min-inline-size: var(
-        --mod-dialog-min-inline-size,
-        var(--spectrum-dialog-min-inline-size)
-    );
+    min-inline-size: var(--mod-dialog-min-inline-size, var(--spectrum-dialog-min-inline-size));
     max-inline-size: 100%;
     max-block-size: inherit;
     outline: none;
@@ -25,53 +22,29 @@ governing permissions and limitations under the License.
 }
 
 :host([size='s']) {
-    inline-size: var(
-        --mod-dialog-confirm-small-width,
-        var(--spectrum-dialog-confirm-small-width)
-    );
+    inline-size: var(--mod-dialog-confirm-small-width, var(--spectrum-dialog-confirm-small-width));
 }
 
 :host([size='m']) {
-    inline-size: var(
-        --mod-dialog-confirm-medium-width,
-        var(--spectrum-dialog-confirm-medium-width)
-    );
+    inline-size: var(--mod-dialog-confirm-medium-width, var(--spectrum-dialog-confirm-medium-width));
 }
 
 :host([size='l']) {
-    inline-size: var(
-        --mod-dialog-confirm-large-width,
-        var(--spectrum-dialog-confirm-large-width)
-    );
+    inline-size: var(--mod-dialog-confirm-large-width, var(--spectrum-dialog-confirm-large-width));
 }
 
 ::slotted([slot='hero']) {
-    block-size: var(
-        --mod-dialog-confirm-hero-height,
-        var(--spectrum-dialog-confirm-hero-height)
-    );
+    block-size: var(--mod-dialog-confirm-hero-height, var(--spectrum-dialog-confirm-hero-height));
     background-position: 50%;
     background-size: cover;
-    border-start-start-radius: var(
-        --mod-dialog-confirm-border-radius,
-        var(--spectrum-dialog-confirm-border-radius)
-    );
-    border-start-end-radius: var(
-        --mod-dialog-confirm-border-radius,
-        var(--spectrum-dialog-confirm-border-radius)
-    );
+    border-start-start-radius: var(--mod-dialog-confirm-border-radius, var(--spectrum-dialog-confirm-border-radius));
+    border-start-end-radius: var(--mod-dialog-confirm-border-radius, var(--spectrum-dialog-confirm-border-radius));
     grid-area: hero;
     overflow: hidden;
 }
 
 .grid {
-    grid-template-columns: var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        ) auto 1fr auto minmax(0, auto) var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        );
+    grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto 1fr auto minmax(0, auto) var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     grid-template-areas:
         'hero hero hero hero hero hero'
         '. . . . . .'
@@ -80,41 +53,20 @@ governing permissions and limitations under the License.
         '. content content content content .'
         '. footer footer buttonGroup buttonGroup .'
         '. . . . . .';
-    grid-template-rows: auto var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        ) auto auto 1fr auto var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        );
+    grid-template-rows: auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto auto 1fr auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     inline-size: 100%;
     display: grid;
 }
 
 ::slotted([slot='heading']) {
-    font-size: var(
-        --mod-dialog-confirm-title-text-size,
-        var(--spectrum-dialog-confirm-title-text-size)
-    );
-    font-weight: var(
-        --mod-dialog-heading-font-weight,
-        var(--spectrum-dialog-heading-font-weight)
-    );
-    line-height: var(
-        --mod-dialog-confirm-title-text-line-height,
-        var(--spectrum-dialog-confirm-title-text-line-height)
-    );
-    color: var(
-        --mod-dialog-confirm-title-text-color,
-        var(--spectrum-dialog-confirm-title-text-color)
-    );
+    font-size: var(--mod-dialog-confirm-title-text-size, var(--spectrum-dialog-confirm-title-text-size));
+    font-weight: var(--mod-dialog-heading-font-weight, var(--spectrum-dialog-heading-font-weight));
+    line-height: var(--mod-dialog-confirm-title-text-line-height, var(--spectrum-dialog-confirm-title-text-line-height));
+    color: var(--mod-dialog-confirm-title-text-color, var(--spectrum-dialog-confirm-title-text-color));
     outline: none;
     grid-area: heading;
     margin: 0;
-    padding-inline-end: var(
-        --mod-dialog-confirm-gap-size,
-        var(--spectrum-dialog-confirm-gap-size)
-    );
+    padding-inline-end: var(--mod-dialog-confirm-gap-size, var(--spectrum-dialog-confirm-gap-size));
 }
 
 .no-header::slotted([slot='heading']) {
@@ -134,27 +86,12 @@ governing permissions and limitations under the License.
 .divider {
     inline-size: 100%;
     grid-area: divider;
-    margin-block-start: var(
-        --mod-dialog-confirm-divider-block-spacing-end,
-        var(--spectrum-dialog-confirm-divider-block-spacing-end)
-    );
-    margin-block-end: var(
-        --mod-dialog-confirm-divider-block-spacing-start,
-        var(--spectrum-dialog-confirm-divider-block-spacing-start)
-    );
+    margin-block-start: var(--mod-dialog-confirm-divider-block-spacing-end, var(--spectrum-dialog-confirm-divider-block-spacing-end));
+    margin-block-end: var(--mod-dialog-confirm-divider-block-spacing-start, var(--spectrum-dialog-confirm-divider-block-spacing-start));
 }
 
 :host([mode='fullscreen']) [name='heading'] + .divider {
-    margin-block-end: calc(
-        var(
-                --mod-dialog-confirm-divider-block-spacing-start,
-                var(--spectrum-dialog-confirm-divider-block-spacing-start)
-            ) -
-            var(
-                --mod-dialog-confirm-description-padding,
-                var(--spectrum-dialog-confirm-description-padding)
-            ) * 2
-    );
+    margin-block-end: calc(var(--mod-dialog-confirm-divider-block-spacing-start, var(--spectrum-dialog-confirm-divider-block-spacing-start)) - var(--mod-dialog-confirm-description-padding, var(--spectrum-dialog-confirm-description-padding)) * 2);
 }
 
 :host([no-divider]) .divider {
@@ -162,52 +99,18 @@ governing permissions and limitations under the License.
 }
 
 :host([no-divider]) ::slotted([slot='heading']) {
-    padding-block-end: calc(
-        var(
-                --mod-dialog-confirm-divider-block-spacing-end,
-                var(--spectrum-dialog-confirm-divider-block-spacing-end)
-            ) +
-            var(
-                --mod-dialog-confirm-divider-block-spacing-start,
-                var(--spectrum-dialog-confirm-divider-block-spacing-start)
-            ) +
-            var(
-                --mod-dialog-confirm-divider-height,
-                var(--spectrum-dialog-confirm-divider-height)
-            )
-    );
+    padding-block-end: calc(var(--mod-dialog-confirm-divider-block-spacing-end, var(--spectrum-dialog-confirm-divider-block-spacing-end)) + var(--mod-dialog-confirm-divider-block-spacing-start, var(--spectrum-dialog-confirm-divider-block-spacing-start)) + var(--mod-dialog-confirm-divider-height, var(--spectrum-dialog-confirm-divider-height)));
 }
 
 .content {
     box-sizing: border-box;
     -webkit-overflow-scrolling: touch;
-    font-size: var(
-        --mod-dialog-confirm-description-text-size,
-        var(--spectrum-dialog-confirm-description-text-size)
-    );
-    font-weight: var(
-        --mod-dialog-confirm-description-font-weight,
-        var(--spectrum-regular-font-weight)
-    );
-    line-height: var(
-        --mod-dialog-confirm-description-text-line-height,
-        var(--spectrum-dialog-confirm-description-text-line-height)
-    );
-    color: var(
-        --mod-dialog-confirm-description-text-color,
-        var(--spectrum-dialog-confirm-description-text-color)
-    );
-    padding: calc(
-        var(
-                --mod-dialog-confirm-description-padding,
-                var(--spectrum-dialog-confirm-description-padding)
-            ) * 2
-    );
-    margin: 0
-        var(
-            --mod-dialog-confirm-description-margin,
-            var(--spectrum-dialog-confirm-description-margin)
-        );
+    font-size: var(--mod-dialog-confirm-description-text-size, var(--spectrum-dialog-confirm-description-text-size));
+    font-weight: var(--mod-dialog-confirm-description-font-weight, var(--spectrum-regular-font-weight));
+    line-height: var(--mod-dialog-confirm-description-text-line-height, var(--spectrum-dialog-confirm-description-text-line-height));
+    color: var(--mod-dialog-confirm-description-text-color, var(--spectrum-dialog-confirm-description-text-color));
+    padding: calc(var(--mod-dialog-confirm-description-padding, var(--spectrum-dialog-confirm-description-padding)) * 2);
+    margin: 0 var(--mod-dialog-confirm-description-margin, var(--spectrum-dialog-confirm-description-margin));
     outline: none;
     grid-area: content;
     overflow-y: auto;
@@ -217,10 +120,7 @@ governing permissions and limitations under the License.
     outline: none;
     flex-wrap: wrap;
     grid-area: footer;
-    padding-block-start: var(
-        --mod-dialog-confirm-footer-padding-top,
-        var(--spectrum-dialog-confirm-footer-padding-top)
-    );
+    padding-block-start: var(--mod-dialog-confirm-footer-padding-top, var(--spectrum-dialog-confirm-footer-padding-top));
     display: flex;
 }
 
@@ -232,14 +132,8 @@ governing permissions and limitations under the License.
 .button-group {
     grid-area: buttonGroup;
     justify-content: flex-end;
-    padding-block-start: var(
-        --mod-dialog-confirm-buttongroup-padding-top,
-        var(--spectrum-dialog-confirm-buttongroup-padding-top)
-    );
-    padding-inline-start: var(
-        --mod-dialog-confirm-gap-size,
-        var(--spectrum-dialog-confirm-gap-size)
-    );
+    padding-block-start: var(--mod-dialog-confirm-buttongroup-padding-top, var(--spectrum-dialog-confirm-buttongroup-padding-top));
+    padding-inline-start: var(--mod-dialog-confirm-gap-size, var(--spectrum-dialog-confirm-gap-size));
     display: flex;
 }
 
@@ -248,19 +142,7 @@ governing permissions and limitations under the License.
 }
 
 :host([dismissable]) .grid {
-    grid-template-columns: var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        ) auto 1fr auto minmax(0, auto) minmax(
-            0,
-            var(
-                --mod-dialog-confirm-close-button-size,
-                var(--spectrum-dialog-confirm-close-button-size)
-            )
-        ) var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        );
+    grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto 1fr auto minmax(0, auto) minmax(0, var(--mod-dialog-confirm-close-button-size, var(--spectrum-dialog-confirm-close-button-size))) var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     grid-template-areas:
         'hero hero hero hero hero hero hero'
         '. . . . . closeButton closeButton'
@@ -269,13 +151,7 @@ governing permissions and limitations under the License.
         '. content content content content content .'
         '. footer footer buttonGroup buttonGroup buttonGroup .'
         '. . . . . . .';
-    grid-template-rows: auto var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        ) auto auto 1fr auto var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        );
+    grid-template-rows: auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto auto 1fr auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
 }
 
 :host([dismissable]) .grid .button-group {
@@ -283,24 +159,15 @@ governing permissions and limitations under the License.
 }
 
 :host([dismissable]) .grid .footer {
-    color: var(
-        --mod-dialog-confirm-description-text-color,
-        var(--spectrum-dialog-confirm-description-text-color)
-    );
+    color: var(--mod-dialog-confirm-description-text-color, var(--spectrum-dialog-confirm-description-text-color));
     grid-area: footer / footer / buttonGroup / buttonGroup;
 }
 
 .close-button {
     grid-area: closeButton;
     place-self: start end;
-    margin-block-start: var(
-        --mod-dialog-confirm-close-button-padding,
-        var(--spectrum-dialog-confirm-close-button-padding)
-    );
-    margin-inline-end: var(
-        --mod-dialog-confirm-close-button-padding,
-        var(--spectrum-dialog-confirm-close-button-padding)
-    );
+    margin-block-start: var(--mod-dialog-confirm-close-button-padding, var(--spectrum-dialog-confirm-close-button-padding));
+    margin-inline-end: var(--mod-dialog-confirm-close-button-padding, var(--spectrum-dialog-confirm-close-button-padding));
 }
 
 :host([mode='fullscreen']) {
@@ -322,20 +189,8 @@ governing permissions and limitations under the License.
 
 :host([mode='fullscreen']) .grid,
 :host([mode='fullscreenTakeover']) .grid {
-    grid-template-columns: var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        ) 1fr auto auto var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        );
-    grid-template-rows: var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        ) auto auto 1fr var(
-            --mod-dialog-confirm-padding-grid,
-            var(--spectrum-dialog-confirm-padding-grid)
-        );
+    grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) 1fr auto auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
+    grid-template-rows: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto auto 1fr var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     grid-template-areas:
         '. . . . .'
         '. heading header buttonGroup .'
@@ -347,10 +202,7 @@ governing permissions and limitations under the License.
 
 :host([mode='fullscreen']) ::slotted([slot='heading']),
 :host([mode='fullscreenTakeover']) ::slotted([slot='heading']) {
-    font-size: var(
-        --mod-dialog-fullscreen-header-text-size,
-        var(--spectrum-dialog-fullscreen-header-text-size)
-    );
+    font-size: var(--mod-dialog-fullscreen-header-text-size, var(--spectrum-dialog-fullscreen-header-text-size));
 }
 
 :host([mode='fullscreen']) .content,
@@ -378,13 +230,7 @@ governing permissions and limitations under the License.
 
 @media screen and (width <= 700px) {
     .grid {
-        grid-template-columns: var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            ) auto 1fr auto minmax(0, auto) var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            );
+        grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto 1fr auto minmax(0, auto) var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
         grid-template-areas:
             'hero hero hero hero hero hero'
             '. . . . . .'
@@ -398,29 +244,11 @@ governing permissions and limitations under the License.
 
     .grid,
     :host([dismissable]) .grid {
-        grid-template-rows: auto var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            ) auto auto auto 1fr auto var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            );
+        grid-template-rows: auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto auto auto 1fr auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     }
 
     :host([dismissable]) .grid {
-        grid-template-columns: var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            ) auto 1fr auto minmax(0, auto) minmax(
-                0,
-                var(
-                    --mod-dialog-confirm-close-button-size,
-                    var(--spectrum-dialog-confirm-close-button-size)
-                )
-            ) var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            );
+        grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto 1fr auto minmax(0, auto) minmax(0, var(--mod-dialog-confirm-close-button-size, var(--spectrum-dialog-confirm-close-button-size))) var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
         grid-template-areas:
             'hero hero hero hero hero hero hero'
             '. . . . . closeButton closeButton'
@@ -438,20 +266,8 @@ governing permissions and limitations under the License.
 
     :host([mode='fullscreen']) .grid,
     :host([mode='fullscreenTakeover']) .grid {
-        grid-template-columns: var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            ) 1fr var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            );
-        grid-template-rows: var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            ) auto auto auto 1fr auto var(
-                --mod-dialog-confirm-padding-grid,
-                var(--spectrum-dialog-confirm-padding-grid)
-            );
+        grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) 1fr var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
+        grid-template-rows: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto auto auto 1fr auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
         grid-template-areas:
             '. . .'
             '. heading .'
@@ -465,18 +281,12 @@ governing permissions and limitations under the License.
 
     :host([mode='fullscreen']) .button-group,
     :host([mode='fullscreenTakeover']) .button-group {
-        padding-block-start: var(
-            --mod-dialog-confirm-buttongroup-padding-top,
-            var(--spectrum-dialog-confirm-buttongroup-padding-top)
-        );
+        padding-block-start: var(--mod-dialog-confirm-buttongroup-padding-top, var(--spectrum-dialog-confirm-buttongroup-padding-top));
     }
 
     :host([mode='fullscreen']) ::slotted([slot='heading']),
     :host([mode='fullscreenTakeover']) ::slotted([slot='heading']) {
-        font-size: var(
-            --mod-dialog-confirm-title-text-size,
-            var(--spectrum-dialog-confirm-title-text-size)
-        );
+        font-size: var(--mod-dialog-confirm-title-text-size, var(--spectrum-dialog-confirm-title-text-size));
     }
 }
 

--- a/packages/divider/src/spectrum-divider.css
+++ b/packages/divider/src/spectrum-divider.css
@@ -20,93 +20,57 @@ governing permissions and limitations under the License.
 :host,
 :host {
     --spectrum-divider-thickness: var(--spectrum-divider-thickness-medium);
-    --spectrum-divider-background-color: var(
-        --spectrum-divider-background-color-medium
-    );
+    --spectrum-divider-background-color: var(--spectrum-divider-background-color-medium);
 }
 
 :host([size='s']) {
     --spectrum-divider-thickness: var(--spectrum-divider-thickness-small);
-    --spectrum-divider-background-color: var(
-        --spectrum-divider-background-color-small
-    );
+    --spectrum-divider-background-color: var(--spectrum-divider-background-color-small);
 }
 
 :host([size='l']) {
     --spectrum-divider-thickness: var(--spectrum-divider-thickness-large);
-    --spectrum-divider-background-color: var(
-        --spectrum-divider-background-color-large
-    );
+    --spectrum-divider-background-color: var(--spectrum-divider-background-color-large);
 }
 
 :host {
     block-size: var(--mod-divider-thickness, var(--spectrum-divider-thickness));
     inline-size: 100%;
     border: none;
-    border-width: var(
-        --mod-divider-thickness,
-        var(--spectrum-divider-thickness)
-    );
-    border-radius: var(
-        --mod-divider-thickness,
-        var(--spectrum-divider-thickness)
-    );
-    background-color: var(
-        --mod-divider-background-color,
-        var(--spectrum-divider-background-color)
-    );
+    border-width: var(--mod-divider-thickness, var(--spectrum-divider-thickness));
+    border-radius: var(--mod-divider-thickness, var(--spectrum-divider-thickness));
+    background-color: var(--mod-divider-background-color, var(--spectrum-divider-background-color));
     overflow: visible;
 }
 
 :host([static-color='white']),
 :host([static-color='white']) {
-    --spectrum-divider-background-color: var(
-        --mod-divider-background-color-medium-static-white,
-        var(--spectrum-divider-background-color-medium-static-white)
-    );
+    --spectrum-divider-background-color: var(--mod-divider-background-color-medium-static-white, var(--spectrum-divider-background-color-medium-static-white));
 }
 
 :host([static-color='white'][size='s']) {
-    --spectrum-divider-background-color: var(
-        --mod-divider-background-color-small-static-white,
-        var(--spectrum-divider-background-color-small-static-white)
-    );
+    --spectrum-divider-background-color: var(--mod-divider-background-color-small-static-white, var(--spectrum-divider-background-color-small-static-white));
 }
 
 :host([static-color='white'][size='l']) {
-    --spectrum-divider-background-color: var(
-        --mod-divider-background-color-large-static-white,
-        var(--spectrum-divider-background-color-large-static-white)
-    );
+    --spectrum-divider-background-color: var(--mod-divider-background-color-large-static-white, var(--spectrum-divider-background-color-large-static-white));
 }
 
 :host([static-color='black']),
 :host([static-color='black']) {
-    --spectrum-divider-background-color: var(
-        --mod-divider-background-color-medium-static-black,
-        var(--spectrum-divider-background-color-medium-static-black)
-    );
+    --spectrum-divider-background-color: var(--mod-divider-background-color-medium-static-black, var(--spectrum-divider-background-color-medium-static-black));
 }
 
 :host([static-color='black'][size='s']) {
-    --spectrum-divider-background-color: var(
-        --mod-divider-background-color-small-static-black,
-        var(--spectrum-divider-background-color-small-static-black)
-    );
+    --spectrum-divider-background-color: var(--mod-divider-background-color-small-static-black, var(--spectrum-divider-background-color-small-static-black));
 }
 
 :host([static-color='black'][size='l']) {
-    --spectrum-divider-background-color: var(
-        --mod-divider-background-color-large-static-black,
-        var(--spectrum-divider-background-color-large-static-black)
-    );
+    --spectrum-divider-background-color: var(--mod-divider-background-color-large-static-black, var(--spectrum-divider-background-color-large-static-black));
 }
 
 :host([vertical]) {
-    inline-size: var(
-        --mod-divider-thickness,
-        var(--spectrum-divider-thickness)
-    );
+    inline-size: var(--mod-divider-thickness, var(--spectrum-divider-thickness));
     margin-block: var(--mod-divider-vertical-margin);
     block-size: 100%;
     block-size: var(--mod-divider-vertical-height, 100%);

--- a/packages/dropzone/src/spectrum-dropzone.css
+++ b/packages/dropzone/src/spectrum-dropzone.css
@@ -12,160 +12,56 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --mod-illustrated-message-content-maximum-width: var(
-        --mod-drop-zone-content-maximum-width,
-        var(--spectrum-drop-zone-content-maximum-width)
-    );
-    --mod-illustrated-message-illustration-color: var(
-        --mod-drop-zone-illustration-color,
-        var(--spectrum-drop-zone-illustration-color)
-    );
-    --mod-illustrated-message-title-to-heading: var(
-        --mod-drop-zone-illustration-to-heading,
-        var(--spectrum-drop-zone-illustration-to-heading)
-    );
-    --mod-illustrated-message-heading-to-body: var(
-        --mod-drop-zone-heading-to-body,
-        var(--spectrum-drop-zone-heading-to-body)
-    );
-    --mod-illustrated-message-title-font-family: var(
-        --mod-drop-zone-heading-font-family,
-        var(--spectrum-drop-zone-heading-font-family)
-    );
-    --mod-illustrated-message-title-font-weight: var(
-        --mod-drop-zone-heading-font-weight,
-        var(--spectrum-drop-zone-heading-font-weight)
-    );
-    --mod-illustrated-message-title-font-style: var(
-        --mod-drop-zone-heading-font-style,
-        var(--spectrum-drop-zone-heading-font-style)
-    );
-    --mod-illustrated-message-title-font-size: var(
-        --mod-drop-zone-heading-font-size,
-        var(--spectrum-drop-zone-heading-font-size)
-    );
-    --mod-illustrated-message-title-line-height: var(
-        --mod-drop-zone-heading-line-height,
-        var(--spectrum-drop-zone-heading-line-height)
-    );
-    --mod-illustrated-message-title-color: var(
-        --mod-drop-zone-heading-color,
-        var(--spectrum-drop-zone-heading-color)
-    );
+    --mod-illustrated-message-content-maximum-width: var(--mod-drop-zone-content-maximum-width, var(--spectrum-drop-zone-content-maximum-width));
+    --mod-illustrated-message-illustration-color: var(--mod-drop-zone-illustration-color, var(--spectrum-drop-zone-illustration-color));
+    --mod-illustrated-message-title-to-heading: var(--mod-drop-zone-illustration-to-heading, var(--spectrum-drop-zone-illustration-to-heading));
+    --mod-illustrated-message-heading-to-body: var(--mod-drop-zone-heading-to-body, var(--spectrum-drop-zone-heading-to-body));
+    --mod-illustrated-message-title-font-family: var(--mod-drop-zone-heading-font-family, var(--spectrum-drop-zone-heading-font-family));
+    --mod-illustrated-message-title-font-weight: var(--mod-drop-zone-heading-font-weight, var(--spectrum-drop-zone-heading-font-weight));
+    --mod-illustrated-message-title-font-style: var(--mod-drop-zone-heading-font-style, var(--spectrum-drop-zone-heading-font-style));
+    --mod-illustrated-message-title-font-size: var(--mod-drop-zone-heading-font-size, var(--spectrum-drop-zone-heading-font-size));
+    --mod-illustrated-message-title-line-height: var(--mod-drop-zone-heading-line-height, var(--spectrum-drop-zone-heading-line-height));
+    --mod-illustrated-message-title-color: var(--mod-drop-zone-heading-color, var(--spectrum-drop-zone-heading-color));
     --mod-illustrated-message-description-position: relative;
     --mod-illustrated-message-description-z-index: 1;
     --mod-illustrated-message-heading-to-description: 0;
-    --mod-illustrated-message-description-font-family: var(
-        --mod-drop-zone-body-font-family,
-        var(--spectrum-drop-zone-body-font-family)
-    );
-    --mod-illustrated-message-description-font-weight: var(
-        --mod-drop-zone-body-font-weight,
-        var(--spectrum-drop-zone-body-font-weight)
-    );
-    --mod-illustrated-message-description-font-style: var(
-        --mod-drop-zone-body-font-style,
-        var(--spectrum-drop-zone-body-font-style)
-    );
-    --mod-illustrated-message-description-font-size: var(
-        --mod-drop-zone-body-font-size,
-        var(--spectrum-drop-zone-body-font-size)
-    );
-    --mod-illustrated-message-description-line-height: var(
-        --mod-drop-zone-body-line-height,
-        var(--spectrum-drop-zone-body-line-height)
-    );
-    --mod-illustrated-message-description-color: var(
-        --mod-drop-zone-body-color,
-        var(--spectrum-drop-zone-body-color)
-    );
-    --mod-actionbutton-font-size: var(
-        --mod-drop-zone-content-font-size,
-        var(--spectrum-drop-zone-content-font-size)
-    );
-    --mod-actionbutton-label-color: var(
-        --mod-drop-zone-content-color,
-        var(--spectrum-drop-zone-content-color)
-    );
-    --mod-actionbutton-edge-to-text: var(
-        --mod-drop-zone-content-edge-to-text,
-        var(--spectrum-drop-zone-content-edge-to-text)
-    );
+    --mod-illustrated-message-description-font-family: var(--mod-drop-zone-body-font-family, var(--spectrum-drop-zone-body-font-family));
+    --mod-illustrated-message-description-font-weight: var(--mod-drop-zone-body-font-weight, var(--spectrum-drop-zone-body-font-weight));
+    --mod-illustrated-message-description-font-style: var(--mod-drop-zone-body-font-style, var(--spectrum-drop-zone-body-font-style));
+    --mod-illustrated-message-description-font-size: var(--mod-drop-zone-body-font-size, var(--spectrum-drop-zone-body-font-size));
+    --mod-illustrated-message-description-line-height: var(--mod-drop-zone-body-line-height, var(--spectrum-drop-zone-body-line-height));
+    --mod-illustrated-message-description-color: var(--mod-drop-zone-body-color, var(--spectrum-drop-zone-body-color));
+    --mod-actionbutton-font-size: var(--mod-drop-zone-content-font-size, var(--spectrum-drop-zone-content-font-size));
+    --mod-actionbutton-label-color: var(--mod-drop-zone-content-color, var(--spectrum-drop-zone-content-color));
+    --mod-actionbutton-edge-to-text: var(--mod-drop-zone-content-edge-to-text, var(--spectrum-drop-zone-content-edge-to-text));
     box-sizing: border-box;
     inline-size: var(--mod-drop-zone-width, var(--spectrum-drop-zone-width));
-    padding: calc(
-        var(--mod-drop-zone-padding, var(--spectrum-drop-zone-padding)) -
-            var(
-                --mod-drop-zone-border-width,
-                var(--spectrum-drop-zone-border-width)
-            )
-    );
+    padding: calc(var(--mod-drop-zone-padding, var(--spectrum-drop-zone-padding)) - var(--mod-drop-zone-border-width, var(--spectrum-drop-zone-border-width)));
     text-align: center;
-    border-color: var(
-        --mod-drop-zone-border-color,
-        var(--spectrum-drop-zone-border-color)
-    );
-    border-width: var(
-        --mod-drop-zone-border-width,
-        var(--spectrum-drop-zone-border-width)
-    );
-    border-radius: var(
-        --mod-drop-zone-corner-radius,
-        var(--spectrum-drop-zone-corner-radius)
-    );
+    border-color: var(--mod-drop-zone-border-color, var(--spectrum-drop-zone-border-color));
+    border-width: var(--mod-drop-zone-border-width, var(--spectrum-drop-zone-border-width));
+    border-radius: var(--mod-drop-zone-corner-radius, var(--spectrum-drop-zone-corner-radius));
     border-style: dashed;
-    border-style: var(
-        --mod-drop-zone-border-style,
-        var(--spectrum-drop-zone-border-style, dashed)
-    );
-    background-color: var(
-        --mod-drop-zone-background-color,
-        var(--spectrum-drop-zone-background-color)
-    );
+    border-style: var(--mod-drop-zone-border-style, var(--spectrum-drop-zone-border-style, dashed));
+    background-color: var(--mod-drop-zone-background-color, var(--spectrum-drop-zone-background-color));
     background-size: cover;
 }
 
 :host:lang(ja),
 :host:lang(ko),
 :host:lang(zh) {
-    --spectrum-drop-zone-heading-font-size: var(
-        --spectrum-drop-zone-heading-font-size-cjk
-    );
+    --spectrum-drop-zone-heading-font-size: var(--spectrum-drop-zone-heading-font-size-cjk);
 }
 
 :host([dragged]) {
-    --mod-drop-zone-border-style: var(
-        --mod-drop-zone-border-style-dragged,
-        solid
-    );
-    --mod-drop-zone-background-color: rgba(
-        var(--spectrum-drop-zone-background-color),
-        var(
-            --mod-drop-zone-background-color-opacity,
-            var(--spectrum-drop-zone-background-color-opacity)
-        )
-    );
-    --spectrum-drop-zone-border-color: var(
-        --highcontrast-drop-zone-border-color-hover,
-        var(
-            --mod-drop-zone-border-color-hover,
-            var(--spectrum-drop-zone-border-color-hover)
-        )
-    );
-    --mod-illustrated-message-illustration-color: var(
-        --mod-drop-zone-illustration-color-hover,
-        var(--spectrum-drop-zone-illustration-color-hover)
-    );
+    --mod-drop-zone-border-style: var(--mod-drop-zone-border-style-dragged, solid);
+    --mod-drop-zone-background-color: rgba(var(--spectrum-drop-zone-background-color), var(--mod-drop-zone-background-color-opacity, var(--spectrum-drop-zone-background-color-opacity)));
+    --spectrum-drop-zone-border-color: var(--highcontrast-drop-zone-border-color-hover, var(--mod-drop-zone-border-color-hover, var(--spectrum-drop-zone-border-color-hover)));
+    --mod-illustrated-message-illustration-color: var(--mod-drop-zone-illustration-color-hover, var(--spectrum-drop-zone-illustration-color-hover));
 }
 
 :host([filled]) {
-    --mod-drop-zone-background-color: rgba(
-        var(--spectrum-drop-zone-background-color),
-        var(
-            --mod-drop-zone-background-color-opacity-filled,
-            var(--spectrum-drop-zone-background-color-opacity-filled)
-        )
-    );
+    --mod-drop-zone-background-color: rgba(var(--spectrum-drop-zone-background-color), var(--mod-drop-zone-background-color-opacity-filled, var(--spectrum-drop-zone-background-color-opacity-filled)));
     --mod-illustrated-message-display: none;
 }
 
@@ -175,22 +71,13 @@ governing permissions and limitations under the License.
 
 :host(:focus-visible) {
     --mod-drop-zone-border-style: solid;
-    --spectrum-drop-zone-border-color: var(
-        --highcontrast-drop-zone-border-color-hover,
-        var(
-            --mod-drop-zone-border-color-hover,
-            var(--spectrum-drop-zone-border-color-hover)
-        )
-    );
+    --spectrum-drop-zone-border-color: var(--highcontrast-drop-zone-border-color-hover, var(--mod-drop-zone-border-color-hover, var(--spectrum-drop-zone-border-color-hover)));
     outline: 0;
 }
 
 .spectrum-DropZone-content {
     display: none;
-    display: var(
-        --mod-drop-zone-content-display,
-        var(--spectrum-drop-zone-content-display, none)
-    );
+    display: var(--mod-drop-zone-content-display, var(--spectrum-drop-zone-content-display, none));
     block-size: 100%;
     z-index: 1;
     justify-content: center;
@@ -200,55 +87,25 @@ governing permissions and limitations under the License.
 
 .spectrum-DropZone-button {
     box-sizing: border-box;
-    block-size: var(
-        --mod-drop-zone-content-height,
-        var(--spectrum-drop-zone-content-height)
-    );
-    max-inline-size: var(
-        --mod-drop-zone-content-max-width,
-        var(--spectrum-drop-zone-content-max-width)
-    );
-    font-family: var(
-        --mod-drop-zone-content-font-family,
-        var(--spectrum-drop-zone-content-font-family)
-    );
-    font-weight: var(
-        --mod-drop-zone-content-font-weight,
-        var(--spectrum-drop-zone-content-font-weight)
-    );
-    font-style: var(
-        --mod-drop-zone-content-font-style,
-        var(--spectrum-drop-zone-content-font-style)
-    );
-    line-height: var(
-        --mod-drop-zone-content-line-height,
-        var(--spectrum-drop-zone-content-line-height)
-    );
+    block-size: var(--mod-drop-zone-content-height, var(--spectrum-drop-zone-content-height));
+    max-inline-size: var(--mod-drop-zone-content-max-width, var(--spectrum-drop-zone-content-max-width));
+    font-family: var(--mod-drop-zone-content-font-family, var(--spectrum-drop-zone-content-font-family));
+    font-weight: var(--mod-drop-zone-content-font-weight, var(--spectrum-drop-zone-content-font-weight));
+    font-style: var(--mod-drop-zone-content-font-style, var(--spectrum-drop-zone-content-font-style));
+    line-height: var(--mod-drop-zone-content-line-height, var(--spectrum-drop-zone-content-line-height));
     border: none;
-    padding-block-start: var(
-        --mod-drop-zone-content-top-to-text,
-        var(--spectrum-drop-zone-content-top-to-text)
-    );
-    padding-block-end: var(
-        --mod-drop-zone-content-bottom-to-text,
-        var(--spectrum-drop-zone-content-bottom-to-text)
-    );
+    padding-block-start: var(--mod-drop-zone-content-top-to-text, var(--spectrum-drop-zone-content-top-to-text));
+    padding-block-end: var(--mod-drop-zone-content-bottom-to-text, var(--spectrum-drop-zone-content-bottom-to-text));
 }
 
 .spectrum-DropZone-button,
 .spectrum-DropZone-button:focus {
-    background-color: var(
-        --mod-drop-zone-content-background-color,
-        var(--spectrum-drop-zone-content-background-color)
-    );
+    background-color: var(--mod-drop-zone-content-background-color, var(--spectrum-drop-zone-content-background-color));
 }
 
 @media (hover: hover) {
     .spectrum-DropZone-button:hover {
-        background-color: var(
-            --mod-drop-zone-content-background-color,
-            var(--spectrum-drop-zone-content-background-color)
-        );
+        background-color: var(--mod-drop-zone-content-background-color, var(--spectrum-drop-zone-content-background-color));
     }
 }
 
@@ -256,8 +113,6 @@ governing permissions and limitations under the License.
     :host {
         --highcontrast-drop-zone-illustration-color: CanvasText;
         --highcontrast-drop-zone-border-color-hover: Highlight;
-        --highcontrast-illustrated-message-illustration-color: var(
-            --highcontrast-drop-zone-illustration-color
-        );
+        --highcontrast-illustrated-message-illustration-color: var(--highcontrast-drop-zone-illustration-color);
     }
 }

--- a/packages/field-label/src/spectrum-field-label.css
+++ b/packages/field-label/src/spectrum-field-label.css
@@ -13,47 +13,17 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     box-sizing: border-box;
-    min-block-size: var(
-        --mod-fieldlabel-min-height,
-        var(--spectrum-field-label-min-height)
-    );
-    padding-block: var(
-        --mod-fieldlabel-padding-block,
-        var(
-                --mod-field-label-top-to-text,
-                var(--spectrum-field-label-top-to-text)
-            )
-            var(
-                --mod-field-label-bottom-to-text,
-                var(--spectrum-field-label-bottom-to-text)
-            )
-    );
+    min-block-size: var(--mod-fieldlabel-min-height, var(--spectrum-field-label-min-height));
+    padding-block: var(--mod-fieldlabel-padding-block, var(--mod-field-label-top-to-text, var(--spectrum-field-label-top-to-text)) var(--mod-field-label-bottom-to-text, var(--spectrum-field-label-bottom-to-text)));
     padding-inline: 0;
     padding-inline: var(--mod-fieldlabel-padding-inline, 0);
     margin-block: 0;
-    margin-block: var(
-        --mod-fieldlabel-margin-block,
-        var(--mod-fieldlabel-margin-block-start, 0)
-            var(--mod-fieldlabel-margin-block-end, 0)
-    );
+    margin-block: var(--mod-fieldlabel-margin-block, var(--mod-fieldlabel-margin-block-start, 0) var(--mod-fieldlabel-margin-block-end, 0));
     margin-inline: 0;
-    margin-inline: var(
-        --mod-fieldlabel-margin-inline,
-        var(--mod-fieldlabel-margin-inline-start, 0)
-            var(--mod-fieldlabel-margin-inline-end, 0)
-    );
-    font-size: var(
-        --mod-fieldlabel-font-size,
-        var(--spectrum-field-label-font-size)
-    );
-    font-weight: var(
-        --mod-fieldlabel-font-weight,
-        var(--spectrum-field-label-font-weight)
-    );
-    line-height: var(
-        --mod-fieldlabel-line-height,
-        var(--spectrum-field-label-line-height)
-    );
+    margin-inline: var(--mod-fieldlabel-margin-inline, var(--mod-fieldlabel-margin-inline-start, 0) var(--mod-fieldlabel-margin-inline-end, 0));
+    font-size: var(--mod-fieldlabel-font-size, var(--spectrum-field-label-font-size));
+    font-weight: var(--mod-fieldlabel-font-weight, var(--spectrum-field-label-font-weight));
+    line-height: var(--mod-fieldlabel-line-height, var(--spectrum-field-label-line-height));
     -webkit-font-smoothing: subpixel-antialiased;
     -moz-osx-font-smoothing: auto;
     color: var(--mod-fieldlabel-color, var(--spectrum-field-label-color));
@@ -63,30 +33,17 @@ governing permissions and limitations under the License.
 :host(:lang(ja)),
 :host(:lang(ko)),
 :host(:lang(zh)) {
-    --mod-fieldlabel-line-height: var(
-        --mod-fieldlabel-line-height-cjk,
-        var(--spectrum-field-label-line-height-cjk)
-    );
+    --mod-fieldlabel-line-height: var(--mod-fieldlabel-line-height-cjk, var(--spectrum-field-label-line-height-cjk));
 }
 
 :host([disabled]),
 :host([disabled]) .required-icon {
-    --mod-fieldlabel-color: var(
-        --highcontrast-field-label-disabled-content-color,
-        var(
-            --mod-disabled-content-color,
-            var(--spectrum-field-label-disabled-content-color)
-        )
-    );
+    --mod-fieldlabel-color: var(--highcontrast-field-label-disabled-content-color, var(--mod-disabled-content-color, var(--spectrum-field-label-disabled-content-color)));
 }
 
 .required-icon {
     margin-block: 0;
-    margin-inline: var(
-            --mod-field-label-text-to-asterisk,
-            var(--spectrum-field-label-text-to-asterisk)
-        )
-        0;
+    margin-inline: var(--mod-field-label-text-to-asterisk, var(--spectrum-field-label-text-to-asterisk)) 0;
     vertical-align: initial;
     vertical-align: var(--mod-field-label-asterisk-vertical-align, baseline);
 }
@@ -94,15 +51,9 @@ governing permissions and limitations under the License.
 :host([side-aligned='start']),
 :host([side-aligned='end']) {
     vertical-align: top;
-    margin-block-start: var(
-        --mod-fieldlabel-side-margin-block-start,
-        var(--spectrum-field-label-side-margin-block-start)
-    );
+    margin-block-start: var(--mod-fieldlabel-side-margin-block-start, var(--spectrum-field-label-side-margin-block-start));
     margin-block-end: 0;
-    margin-inline-end: var(
-        --mod-fieldlabel-side-padding-right,
-        var(--spectrum-field-label-side-padding-right)
-    );
+    margin-inline-end: var(--mod-fieldlabel-side-padding-right, var(--spectrum-field-label-side-padding-right));
     display: inline-block;
 }
 

--- a/packages/help-text/src/spectrum-help-text.css
+++ b/packages/help-text/src/spectrum-help-text.css
@@ -25,131 +25,54 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    --spectrum-helptext-bottom-to-workflow-icon: var(
-        --spectrum-helptext-top-to-workflow-icon
-    );
-    color: var(
-        --highcontrast-helptext-content-color-default,
-        var(
-            --mod-helptext-content-color-default,
-            var(--spectrum-helptext-content-color-default)
-        )
-    );
-    font-size: var(
-        --mod-helptext-font-size,
-        var(--spectrum-helptext-font-size)
-    );
-    min-block-size: var(
-        --mod-helptext-min-height,
-        var(--spectrum-helptext-min-height)
-    );
+    --spectrum-helptext-bottom-to-workflow-icon: var(--spectrum-helptext-top-to-workflow-icon);
+    color: var(--highcontrast-helptext-content-color-default, var(--mod-helptext-content-color-default, var(--spectrum-helptext-content-color-default)));
+    font-size: var(--mod-helptext-font-size, var(--spectrum-helptext-font-size));
+    min-block-size: var(--mod-helptext-min-height, var(--spectrum-helptext-min-height));
     display: flex;
 }
 
 .icon {
-    block-size: var(
-        --mod-helptext-icon-size,
-        var(--spectrum-helptext-icon-size)
-    );
-    inline-size: var(
-        --mod-helptext-icon-size,
-        var(--spectrum-helptext-icon-size)
-    );
+    block-size: var(--mod-helptext-icon-size, var(--spectrum-helptext-icon-size));
+    inline-size: var(--mod-helptext-icon-size, var(--spectrum-helptext-icon-size));
     flex-shrink: 0;
-    margin-inline-end: var(
-        --mod-helptext-text-to-visual,
-        var(--spectrum-helptext-text-to-visual)
-    );
-    padding-block-start: var(
-        --mod-helptext-top-to-workflow-icon,
-        var(--spectrum-helptext-top-to-workflow-icon)
-    );
-    padding-block-end: var(
-        --mod-helptext-bottom-to-workflow-icon,
-        var(--spectrum-helptext-bottom-to-workflow-icon)
-    );
+    margin-inline-end: var(--mod-helptext-text-to-visual, var(--spectrum-helptext-text-to-visual));
+    padding-block-start: var(--mod-helptext-top-to-workflow-icon, var(--spectrum-helptext-top-to-workflow-icon));
+    padding-block-end: var(--mod-helptext-bottom-to-workflow-icon, var(--spectrum-helptext-bottom-to-workflow-icon));
 }
 
 .text {
-    line-height: var(
-        --mod-helptext-line-height,
-        var(--spectrum-helptext-line-height)
-    );
-    padding-block-start: var(
-        --mod-helptext-top-to-text,
-        var(--spectrum-helptext-top-to-text)
-    );
-    padding-block-end: var(
-        --mod-helptext-bottom-to-text,
-        var(--spectrum-helptext-bottom-to-text)
-    );
+    line-height: var(--mod-helptext-line-height, var(--spectrum-helptext-line-height));
+    padding-block-start: var(--mod-helptext-top-to-text, var(--spectrum-helptext-top-to-text));
+    padding-block-end: var(--mod-helptext-bottom-to-text, var(--spectrum-helptext-bottom-to-text));
 }
 
 :host(:lang(ja)) .text,
 :host(:lang(ko)) .text,
 :host(:lang(zh)) .text {
-    line-height: var(
-        --mod-helptext-line-height-cjk,
-        var(--spectrum-helptext-line-height-cjk)
-    );
+    line-height: var(--mod-helptext-line-height-cjk, var(--spectrum-helptext-line-height-cjk));
 }
 
 :host([variant='neutral']) .text {
-    color: var(
-        --highcontrast-helptext-content-color-default,
-        var(
-            --mod-helptext-content-color-default,
-            var(--spectrum-helptext-content-color-default)
-        )
-    );
+    color: var(--highcontrast-helptext-content-color-default, var(--mod-helptext-content-color-default, var(--spectrum-helptext-content-color-default)));
 }
 
 :host([variant='neutral']) .icon {
-    color: var(
-        --highcontrast-helptext-icon-color-default,
-        var(
-            --mod-helptext-icon-color-default,
-            var(--spectrum-helptext-icon-color-default)
-        )
-    );
+    color: var(--highcontrast-helptext-icon-color-default, var(--mod-helptext-icon-color-default, var(--spectrum-helptext-icon-color-default)));
 }
 
 :host([variant='negative']) .text {
-    color: var(
-        --highcontrast-helptext-content-color-default,
-        var(
-            --mod-helptext-content-color-default,
-            var(--spectrum-helptext-content-color-default)
-        )
-    );
+    color: var(--highcontrast-helptext-content-color-default, var(--mod-helptext-content-color-default, var(--spectrum-helptext-content-color-default)));
 }
 
 :host([variant='negative']) .icon {
-    color: var(
-        --highcontrast-helptext-icon-color-default,
-        var(
-            --mod-helptext-icon-color-default,
-            var(--spectrum-helptext-icon-color-default)
-        )
-    );
+    color: var(--highcontrast-helptext-icon-color-default, var(--mod-helptext-icon-color-default, var(--spectrum-helptext-icon-color-default)));
 }
 
 :host([disabled]) .text {
-    color: var(
-        --highcontrast-helptext-content-color-default,
-        var(
-            --mod-helptext-content-color-default,
-            var(--spectrum-helptext-content-color-default)
-        )
-    );
+    color: var(--highcontrast-helptext-content-color-default, var(--mod-helptext-content-color-default, var(--spectrum-helptext-content-color-default)));
 }
 
 :host([disabled]) .icon {
-    color: var(
-        --highcontrast-helptext-icon-color-default,
-        var(
-            --mod-helptext-icon-color-default,
-            var(--spectrum-helptext-icon-color-default)
-        )
-    );
+    color: var(--highcontrast-helptext-icon-color-default, var(--mod-helptext-icon-color-default, var(--spectrum-helptext-icon-color-default)));
 }

--- a/packages/icon/src/spectrum-icon.css
+++ b/packages/icon/src/spectrum-icon.css
@@ -12,14 +12,8 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-icon-inline-size: var(
-        --mod-icon-inline-size,
-        var(--mod-icon-size, var(--spectrum-icon-size))
-    );
-    --spectrum-icon-block-size: var(
-        --mod-icon-block-size,
-        var(--mod-icon-size, var(--spectrum-icon-size))
-    );
+    --spectrum-icon-inline-size: var(--mod-icon-inline-size, var(--mod-icon-size, var(--spectrum-icon-size)));
+    --spectrum-icon-block-size: var(--mod-icon-block-size, var(--mod-icon-size, var(--spectrum-icon-size)));
     inline-size: var(--spectrum-icon-inline-size);
     block-size: var(--spectrum-icon-block-size);
     color: inherit;

--- a/packages/illustrated-message/src/spectrum-illustratedmessage.css
+++ b/packages/illustrated-message/src/spectrum-illustratedmessage.css
@@ -95,62 +95,26 @@ governing permissions and limitations under the License.
 }
 
 #illustration {
-    color: var(
-        --highcontrast-illustrated-message-illustration-color,
-        var(
-            --mod-illustrated-message-illustration-color,
-            var(--spectrum-illustrated-message-illustration-color)
-        )
-    );
+    color: var(--highcontrast-illustrated-message-illustration-color, var(--mod-illustrated-message-illustration-color, var(--spectrum-illustrated-message-illustration-color)));
     fill: currentColor;
     stroke: currentColor;
-    margin-block-end: var(
-        --mod-illustrated-message-title-to-heading,
-        var(--spectrum-illustrated-message-title-to-heading)
-    );
+    margin-block-end: var(--mod-illustrated-message-title-to-heading, var(--spectrum-illustrated-message-title-to-heading));
 }
 
 .spectrum-IllustratedMessage-accent {
-    color: var(
-        --highcontrast-illustrated-message-illustration-accent-color,
-        var(
-            --mod-illustrated-message-illustration-accent-color,
-            var(--spectrum-illustrated-message-illustration-accent-color)
-        )
-    );
+    color: var(--highcontrast-illustrated-message-illustration-accent-color, var(--mod-illustrated-message-illustration-accent-color, var(--spectrum-illustrated-message-illustration-accent-color)));
     fill: currentColor;
     stroke: currentColor;
 }
 
 #heading {
-    font-family: var(
-        --mod-illustrated-message-title-font-family,
-        var(--spectrum-illustrated-message-title-font-family)
-    );
-    font-weight: var(
-        --mod-illustrated-message-title-font-weight,
-        var(--spectrum-illustrated-message-title-font-weight)
-    );
-    font-style: var(
-        --mod-illustrated-message-title-font-style,
-        var(--spectrum-illustrated-message-title-font-style)
-    );
-    font-size: var(
-        --mod-illustrated-message-title-font-size,
-        var(--spectrum-illustrated-message-title-font-size)
-    );
-    line-height: var(
-        --mod-illustrated-message-title-line-height,
-        var(--spectrum-illustrated-message-title-line-height)
-    );
-    color: var(
-        --mod-illustrated-message-title-color,
-        var(--spectrum-illustrated-message-title-color)
-    );
-    max-inline-size: var(
-        --mod-illustrated-message-heading-max-inline-size,
-        var(--spectrum-illustrated-message-heading-max-inline-size)
-    );
+    font-family: var(--mod-illustrated-message-title-font-family, var(--spectrum-illustrated-message-title-font-family));
+    font-weight: var(--mod-illustrated-message-title-font-weight, var(--spectrum-illustrated-message-title-font-weight));
+    font-style: var(--mod-illustrated-message-title-font-style, var(--spectrum-illustrated-message-title-font-style));
+    font-size: var(--mod-illustrated-message-title-font-size, var(--spectrum-illustrated-message-title-font-size));
+    line-height: var(--mod-illustrated-message-title-line-height, var(--spectrum-illustrated-message-title-line-height));
+    color: var(--mod-illustrated-message-title-color, var(--spectrum-illustrated-message-title-color));
+    max-inline-size: var(--mod-illustrated-message-heading-max-inline-size, var(--spectrum-illustrated-message-heading-max-inline-size));
     margin-block-start: 0;
     margin-block-end: var(--mod-illustrated-message-heading-to-body, 0);
 }
@@ -159,41 +123,14 @@ governing permissions and limitations under the License.
     position: var(--mod-illustrated-message-description-position);
     z-index: var(--mod-illustrated-message-description-z-index);
     pointer-events: auto;
-    pointer-events: var(
-        --mod-illustrated-message-description-pointer-events,
-        auto
-    );
-    font-family: var(
-        --mod-illustrated-message-description-font-family,
-        var(--spectrum-illustrated-message-description-font-family)
-    );
-    font-weight: var(
-        --mod-illustrated-message-description-font-weight,
-        var(--spectrum-illustrated-message-description-font-weight)
-    );
-    font-style: var(
-        --mod-illustrated-message-description-font-style,
-        var(--spectrum-illustrated-message-description-font-style)
-    );
-    font-size: var(
-        --mod-illustrated-message-description-font-size,
-        var(--spectrum-illustrated-message-description-font-size)
-    );
-    line-height: var(
-        --mod-illustrated-message-description-line-height,
-        var(--spectrum-illustrated-message-description-line-height)
-    );
-    color: var(
-        --mod-illustrated-message-description-color,
-        var(--spectrum-illustrated-message-description-color)
-    );
-    max-inline-size: var(
-        --mod-illustrated-message-description-max-inline-size,
-        var(--spectrum-illustrated-message-description-max-inline-size)
-    );
-    margin-block-start: var(
-        --mod-illustrated-message-heading-to-description,
-        var(--spectrum-illustrated-message-heading-to-description)
-    );
+    pointer-events: var(--mod-illustrated-message-description-pointer-events, auto);
+    font-family: var(--mod-illustrated-message-description-font-family, var(--spectrum-illustrated-message-description-font-family));
+    font-weight: var(--mod-illustrated-message-description-font-weight, var(--spectrum-illustrated-message-description-font-weight));
+    font-style: var(--mod-illustrated-message-description-font-style, var(--spectrum-illustrated-message-description-font-style));
+    font-size: var(--mod-illustrated-message-description-font-size, var(--spectrum-illustrated-message-description-font-size));
+    line-height: var(--mod-illustrated-message-description-line-height, var(--spectrum-illustrated-message-description-line-height));
+    color: var(--mod-illustrated-message-description-color, var(--spectrum-illustrated-message-description-color));
+    max-inline-size: var(--mod-illustrated-message-description-max-inline-size, var(--spectrum-illustrated-message-description-max-inline-size));
+    margin-block-start: var(--mod-illustrated-message-heading-to-description, var(--spectrum-illustrated-message-heading-to-description));
     margin-block-end: 0;
 }

--- a/packages/illustrated-message/src/spectrum-illustratedmessage.css
+++ b/packages/illustrated-message/src/spectrum-illustratedmessage.css
@@ -12,66 +12,30 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-illustrated-message-description-max-inline-size: var(
-        --spectrum-illustrated-message-maximum-width
-    );
-    --spectrum-illustrated-message-heading-max-inline-size: var(
-        --spectrum-illustrated-message-maximum-width
-    );
-    --spectrum-illustrated-message-title-to-heading: var(
-        --spectrum-spacing-400
-    );
-    --spectrum-illustrated-message-heading-to-description: var(
-        --spectrum-spacing-75
-    );
-    --spectrum-illustrated-message-illustration-color: var(
-        --spectrum-neutral-visual-color
-    );
-    --spectrum-illustrated-message-illustration-accent-color: var(
-        --spectrum-accent-visual-color
-    );
-    --spectrum-illustrated-message-title-font-family: var(
-        --spectrum-sans-font-family-stack
-    );
-    --spectrum-illustrated-message-title-font-weight: var(
-        --spectrum-heading-sans-serif-font-weight
-    );
-    --spectrum-illustrated-message-title-font-style: var(
-        --spectrum-heading-sans-serif-font-style
-    );
-    --spectrum-illustrated-message-title-font-size: var(
-        --spectrum-illustrated-message-title-size
-    );
-    --spectrum-illustrated-message-title-line-height: var(
-        --spectrum-heading-line-height
-    );
+    --spectrum-illustrated-message-description-max-inline-size: var(--spectrum-illustrated-message-maximum-width);
+    --spectrum-illustrated-message-heading-max-inline-size: var(--spectrum-illustrated-message-maximum-width);
+    --spectrum-illustrated-message-title-to-heading: var(--spectrum-spacing-400);
+    --spectrum-illustrated-message-heading-to-description: var(--spectrum-spacing-75);
+    --spectrum-illustrated-message-illustration-color: var(--spectrum-neutral-visual-color);
+    --spectrum-illustrated-message-illustration-accent-color: var(--spectrum-accent-visual-color);
+    --spectrum-illustrated-message-title-font-family: var(--spectrum-sans-font-family-stack);
+    --spectrum-illustrated-message-title-font-weight: var(--spectrum-heading-sans-serif-font-weight);
+    --spectrum-illustrated-message-title-font-style: var(--spectrum-heading-sans-serif-font-style);
+    --spectrum-illustrated-message-title-font-size: var(--spectrum-illustrated-message-title-size);
+    --spectrum-illustrated-message-title-line-height: var(--spectrum-heading-line-height);
     --spectrum-illustrated-message-title-color: var(--spectrum-heading-color);
-    --spectrum-illustrated-message-description-font-family: var(
-        --spectrum-sans-font-family-stack
-    );
-    --spectrum-illustrated-message-description-font-weight: var(
-        --spectrum-body-sans-serif-font-weight
-    );
-    --spectrum-illustrated-message-description-font-style: var(
-        --spectrum-body-sans-serif-font-style
-    );
-    --spectrum-illustrated-message-description-font-size: var(
-        --spectrum-illustrated-message-body-size
-    );
-    --spectrum-illustrated-message-description-line-height: var(
-        --spectrum-body-line-height
-    );
-    --spectrum-illustrated-message-description-color: var(
-        --spectrum-body-color
-    );
+    --spectrum-illustrated-message-description-font-family: var(--spectrum-sans-font-family-stack);
+    --spectrum-illustrated-message-description-font-weight: var(--spectrum-body-sans-serif-font-weight);
+    --spectrum-illustrated-message-description-font-style: var(--spectrum-body-sans-serif-font-style);
+    --spectrum-illustrated-message-description-font-size: var(--spectrum-illustrated-message-body-size);
+    --spectrum-illustrated-message-description-line-height: var(--spectrum-body-line-height);
+    --spectrum-illustrated-message-description-color: var(--spectrum-body-color);
 }
 
 :host:lang(ja),
 :host:lang(ko),
 :host:lang(zh) {
-    --spectrum-illustrated-message-title-font-size: var(
-        --spectrum-illustrated-message-cjk-title-size
-    );
+    --spectrum-illustrated-message-title-font-size: var(--spectrum-illustrated-message-cjk-title-size);
 }
 
 @media (forced-colors: active) {

--- a/packages/infield-button/src/spectrum-infield-button.css
+++ b/packages/infield-button/src/spectrum-infield-button.css
@@ -27,18 +27,9 @@ governing permissions and limitations under the License.
 :host {
     background-color: initial;
     cursor: pointer;
-    block-size: var(
-        --mod-infield-button-height,
-        var(--spectrum-infield-button-height)
-    );
-    inline-size: var(
-        --mod-infield-button-width,
-        var(--spectrum-infield-button-width)
-    );
-    padding: var(
-        --mod-infield-button-edge-to-fill,
-        var(--spectrum-infield-button-edge-to-fill)
-    );
+    block-size: var(--mod-infield-button-height, var(--spectrum-infield-button-height));
+    inline-size: var(--mod-infield-button-width, var(--spectrum-infield-button-width));
+    padding: var(--mod-infield-button-edge-to-fill, var(--spectrum-infield-button-edge-to-fill));
     border-style: none;
     justify-content: center;
     align-items: center;
@@ -48,207 +39,93 @@ governing permissions and limitations under the License.
 .fill {
     block-size: 100%;
     inline-size: 100%;
-    background-color: var(
-        --mod-infield-button-background-color,
-        var(--spectrum-infield-button-background-color)
-    );
-    border-width: var(
-        --mod-infield-button-border-width,
-        var(--spectrum-infield-button-border-width)
-    );
+    background-color: var(--mod-infield-button-background-color, var(--spectrum-infield-button-background-color));
+    border-width: var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width));
     border-style: solid;
-    border-color: var(
-        --highcontrast-infield-button-border-color,
-        var(
-            --mod-infield-button-border-color,
-            var(--spectrum-infield-button-border-color)
-        )
-    );
-    padding: var(
-        --mod-infield-button-fill-padding,
-        var(--spectrum-infield-button-fill-padding)
-    );
-    border-start-start-radius: var(
-        --mod-infield-button-border-radius,
-        var(--spectrum-infield-button-border-radius)
-    );
-    border-start-end-radius: var(
-        --mod-infield-button-border-radius,
-        var(--spectrum-infield-button-border-radius)
-    );
-    border-end-end-radius: var(
-        --mod-infield-button-border-radius,
-        var(--spectrum-infield-button-border-radius)
-    );
-    border-end-start-radius: var(
-        --mod-infield-button-border-radius,
-        var(--spectrum-infield-button-border-radius)
-    );
+    border-color: var(--highcontrast-infield-button-border-color, var(--mod-infield-button-border-color, var(--spectrum-infield-button-border-color)));
+    padding: var(--mod-infield-button-fill-padding, var(--spectrum-infield-button-fill-padding));
+    border-start-start-radius: var(--mod-infield-button-border-radius, var(--spectrum-infield-button-border-radius));
+    border-start-end-radius: var(--mod-infield-button-border-radius, var(--spectrum-infield-button-border-radius));
+    border-end-end-radius: var(--mod-infield-button-border-radius, var(--spectrum-infield-button-border-radius));
+    border-end-start-radius: var(--mod-infield-button-border-radius, var(--spectrum-infield-button-border-radius));
 }
 
 ::slotted(*) {
-    color: var(
-        --mod-infield-button-icon-color,
-        var(--spectrum-infield-button-icon-color)
-    );
+    color: var(--mod-infield-button-icon-color, var(--spectrum-infield-button-icon-color));
 }
 
 :host([inline='end']) .fill {
-    border-start-start-radius: var(
-        --mod-infield-button-border-radius-reset,
-        var(--spectrum-infield-button-border-radius-reset)
-    );
-    border-end-start-radius: var(
-        --mod-infield-button-border-radius-reset,
-        var(--spectrum-infield-button-border-radius-reset)
-    );
+    border-start-start-radius: var(--mod-infield-button-border-radius-reset, var(--spectrum-infield-button-border-radius-reset));
+    border-end-start-radius: var(--mod-infield-button-border-radius-reset, var(--spectrum-infield-button-border-radius-reset));
 }
 
 :host([inline='start']) .fill {
-    border-start-end-radius: var(
-        --mod-infield-button-border-radius-reset,
-        var(--spectrum-infield-button-border-radius-reset)
-    );
-    border-end-end-radius: var(
-        --mod-infield-button-border-radius-reset,
-        var(--spectrum-infield-button-border-radius-reset)
-    );
+    border-start-end-radius: var(--mod-infield-button-border-radius-reset, var(--spectrum-infield-button-border-radius-reset));
+    border-end-end-radius: var(--mod-infield-button-border-radius-reset, var(--spectrum-infield-button-border-radius-reset));
 }
 
 :host([block='end']),
 :host([block='start']) {
-    --spectrum-infield-button-width: var(
-        --mod-infield-button-width-stacked,
-        var(--spectrum-in-field-button-width-stacked-medium)
-    );
+    --spectrum-infield-button-width: var(--mod-infield-button-width-stacked, var(--spectrum-in-field-button-width-stacked-medium));
 }
 
 :host([block='end'][size='s']),
 :host([block='start'][size='s']) {
-    --spectrum-infield-button-width: var(
-        --mod-infield-button-width-stacked,
-        var(--spectrum-in-field-button-width-stacked-small)
-    );
+    --spectrum-infield-button-width: var(--mod-infield-button-width-stacked, var(--spectrum-in-field-button-width-stacked-small));
 }
 
 :host([block='end'][size='l']),
 :host([block='start'][size='l']) {
-    --spectrum-infield-button-width: var(
-        --mod-infield-button-width-stacked,
-        var(--spectrum-in-field-button-width-stacked-large)
-    );
+    --spectrum-infield-button-width: var(--mod-infield-button-width-stacked, var(--spectrum-in-field-button-width-stacked-large));
 }
 
 :host([block='end'][size='xl']),
 :host([block='start'][size='xl']) {
-    --spectrum-infield-button-width: var(
-        --mod-infield-button-width-stacked,
-        var(--spectrum-in-field-button-width-stacked-extra-large)
-    );
+    --spectrum-infield-button-width: var(--mod-infield-button-width-stacked, var(--spectrum-in-field-button-width-stacked-extra-large));
 }
 
 :host([quiet]) {
-    --spectrum-infield-button-background-color: var(
-        --mod-infield-button-background-color-quiet,
-        transparent
-    );
-    --spectrum-infield-button-background-color-hover: var(
-        --mod-infield-button-background-color-hover-quiet,
-        transparent
-    );
-    --spectrum-infield-button-background-color-down: var(
-        --mod-infield-button-background-color-down-quiet,
-        transparent
-    );
-    --spectrum-infield-button-background-color-key-focus: var(
-        --mod-infield-button-background-color-key-focus-quiet,
-        transparent
-    );
-    --spectrum-infield-border-color: var(
-        --mod-infield-border-color-quiet,
-        transparent
-    );
-    --spectrum-infield-button-border-width: var(
-        --mod-infield-button-border-width-quiet,
-        0
-    );
+    --spectrum-infield-button-background-color: var(--mod-infield-button-background-color-quiet, transparent);
+    --spectrum-infield-button-background-color-hover: var(--mod-infield-button-background-color-hover-quiet, transparent);
+    --spectrum-infield-button-background-color-down: var(--mod-infield-button-background-color-down-quiet, transparent);
+    --spectrum-infield-button-background-color-key-focus: var(--mod-infield-button-background-color-key-focus-quiet, transparent);
+    --spectrum-infield-border-color: var(--mod-infield-border-color-quiet, transparent);
+    --spectrum-infield-button-border-width: var(--mod-infield-button-border-width-quiet, 0);
 }
 
 :host([quiet][disabled]) {
-    --spectrum-infield-button-background-color: var(
-        --mod-infield-button-background-color-quiet-disabled,
-        transparent
-    );
-    --spectrum-infield-button-border-color: var(
-        --mod-infield-button-border-color-quiet-disabled,
-        transparent
-    );
+    --spectrum-infield-button-background-color: var(--mod-infield-button-background-color-quiet-disabled, transparent);
+    --spectrum-infield-button-border-color: var(--mod-infield-button-border-color-quiet-disabled, transparent);
 }
 
 :host([disabled]) {
-    --spectrum-infield-button-background-color: var(
-        --mod-infield-button-background-color-disabled,
-        var(--spectrum-disabled-background-color)
-    );
-    --spectrum-infield-button-background-color-hover: var(
-        --mod-infield-button-background-color-hover-disabled,
-        var(--spectrum-disabled-background-color)
-    );
-    --spectrum-infield-button-background-color-down: var(
-        --mod-infield-button-background-color-down-disabled,
-        var(--spectrum-disabled-background-color)
-    );
-    --spectrum-infield-button-border-color: var(
-        --mod-infield-button-border-color-disabled,
-        var(--spectrum-disabled-background-color)
-    );
-    --spectrum-infield-button-icon-color: var(
-        --mod-infield-button-icon-color-disabled,
-        var(--spectrum-disabled-content-color)
-    );
-    --spectrum-infield-button-icon-color-hover: var(
-        --mod-infield-button-icon-color-hover-disabled,
-        var(--spectrum-disabled-content-color)
-    );
-    --spectrum-infield-button-icon-color-down: var(
-        --mod-infield-button-icon-color-down-disabled,
-        var(--spectrum-disabled-content-color)
-    );
-    --spectrum-infield-button-icon-color-key-focus: var(
-        --mod-infield-button-icon-color-key-focus-disabled,
-        var(--spectrum-disabled-content-color)
-    );
+    --spectrum-infield-button-background-color: var(--mod-infield-button-background-color-disabled, var(--spectrum-disabled-background-color));
+    --spectrum-infield-button-background-color-hover: var(--mod-infield-button-background-color-hover-disabled, var(--spectrum-disabled-background-color));
+    --spectrum-infield-button-background-color-down: var(--mod-infield-button-background-color-down-disabled, var(--spectrum-disabled-background-color));
+    --spectrum-infield-button-border-color: var(--mod-infield-button-border-color-disabled, var(--spectrum-disabled-background-color));
+    --spectrum-infield-button-icon-color: var(--mod-infield-button-icon-color-disabled, var(--spectrum-disabled-content-color));
+    --spectrum-infield-button-icon-color-hover: var(--mod-infield-button-icon-color-hover-disabled, var(--spectrum-disabled-content-color));
+    --spectrum-infield-button-icon-color-down: var(--mod-infield-button-icon-color-down-disabled, var(--spectrum-disabled-content-color));
+    --spectrum-infield-button-icon-color-key-focus: var(--mod-infield-button-icon-color-key-focus-disabled, var(--spectrum-disabled-content-color));
     cursor: auto;
 }
 
 @media (hover: hover) {
     :host(:hover) .fill {
-        background-color: var(
-            --mod-infield-button-background-color-hover,
-            var(--spectrum-infield-button-background-color-hover)
-        );
+        background-color: var(--mod-infield-button-background-color-hover, var(--spectrum-infield-button-background-color-hover));
     }
 
     :host(:hover) ::slotted(*) {
-        color: var(
-            --mod-infield-button-icon-color-hover,
-            var(--spectrum-infield-button-icon-color-hover)
-        );
+        color: var(--mod-infield-button-icon-color-hover, var(--spectrum-infield-button-icon-color-hover));
     }
 }
 
 :host(:is(:active, [active])) .fill {
-    background-color: var(
-        --mod-infield-button-background-color-down,
-        var(--spectrum-infield-button-background-color-down)
-    );
+    background-color: var(--mod-infield-button-background-color-down, var(--spectrum-infield-button-background-color-down));
 }
 
 :host(:is(:active, [active])) ::slotted(*) {
-    color: var(
-        --mod-infield-button-icon-color-down,
-        var(--spectrum-infield-button-icon-color-down)
-    );
+    color: var(--mod-infield-button-icon-color-down, var(--spectrum-infield-button-icon-color-down));
 }
 
 :host(:focus-visible) {
@@ -256,178 +133,56 @@ governing permissions and limitations under the License.
 }
 
 :host(:focus-visible) .fill {
-    background-color: var(
-        --mod-infield-button-background-color-key-focus,
-        var(--spectrum-infield-button-background-color-key-focus)
-    );
+    background-color: var(--mod-infield-button-background-color-key-focus, var(--spectrum-infield-button-background-color-key-focus));
 }
 
 :host(:focus-visible) ::slotted(*) {
-    color: var(
-        --mod-infield-button-icon-color-key-focus,
-        var(--spectrum-infield-button-icon-color-key-focus)
-    );
+    color: var(--mod-infield-button-icon-color-key-focus, var(--spectrum-infield-button-icon-color-key-focus));
 }
 
 .fill {
     align-items: center;
-    justify-content: var(
-        --mod-infield-button-fill-justify-content,
-        var(--spectrum-infield-button-fill-justify-content)
-    );
+    justify-content: var(--mod-infield-button-fill-justify-content, var(--spectrum-infield-button-fill-justify-content));
     display: flex;
 }
 
 :host([block='end']),
 :host([block='start']) {
-    block-size: calc(
-        var(--mod-infield-button-height, var(--spectrum-infield-button-height)) /
-            2
-    );
+    block-size: calc(var(--mod-infield-button-height, var(--spectrum-infield-button-height)) / 2);
 }
 
 :host([block='end']) .fill,
 :host([block='start']) .fill {
     box-sizing: border-box;
-    padding-inline-start: calc(
-        var(
-                --mod-infield-button-stacked-fill-padding-inline,
-                var(--spectrum-infield-button-stacked-fill-padding-inline)
-            ) -
-            var(
-                --mod-infield-button-edge-to-fill,
-                var(--spectrum-infield-button-edge-to-fill)
-            ) -
-            var(
-                --mod-infield-button-border-width,
-                var(--spectrum-infield-button-border-width)
-            )
-    );
-    padding-inline-end: calc(
-        var(
-                --mod-infield-button-stacked-fill-padding-inline,
-                var(--spectrum-infield-button-stacked-fill-padding-inline)
-            ) -
-            var(
-                --mod-infield-button-edge-to-fill,
-                var(--spectrum-infield-button-edge-to-fill)
-            ) -
-            var(
-                --mod-infield-button-border-width,
-                var(--spectrum-infield-button-border-width)
-            )
-    );
+    padding-inline-start: calc(var(--mod-infield-button-stacked-fill-padding-inline, var(--spectrum-infield-button-stacked-fill-padding-inline)) - var(--mod-infield-button-edge-to-fill, var(--spectrum-infield-button-edge-to-fill)) - var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));
+    padding-inline-end: calc(var(--mod-infield-button-stacked-fill-padding-inline, var(--spectrum-infield-button-stacked-fill-padding-inline)) - var(--mod-infield-button-edge-to-fill, var(--spectrum-infield-button-edge-to-fill)) - var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));
 }
 
 :host([block='start']) {
-    padding-block-end: var(
-        --mod-infield-button-inner-edge-to-fill,
-        var(--spectrum-infield-button-inner-edge-to-fill)
-    );
+    padding-block-end: var(--mod-infield-button-inner-edge-to-fill, var(--spectrum-infield-button-inner-edge-to-fill));
 }
 
 :host([block='start']) .fill {
     border-block-end: none;
-    border-start-start-radius: var(
-        --mod-infield-button-stacked-top-border-radius-start-start,
-        var(--spectrum-infield-button-stacked-top-border-radius-start-start)
-    );
-    border-end-end-radius: var(
-        --mod-infield-button-stacked-border-radius-reset,
-        var(--spectrum-infield-button-stacked-border-radius-reset)
-    );
-    border-end-start-radius: var(
-        --mod-infield-button-stacked-border-radius-reset,
-        var(--spectrum-infield-button-stacked-border-radius-reset)
-    );
-    padding-block-start: calc(
-        var(
-                --mod-infield-button-stacked-fill-padding-outer,
-                var(--spectrum-infield-button-stacked-fill-padding-outer)
-            ) -
-            var(
-                --mod-infield-button-edge-to-fill,
-                var(--spectrum-infield-button-edge-to-fill)
-            ) -
-            var(
-                --mod-infield-button-border-width,
-                var(--spectrum-infield-button-border-width)
-            )
-    );
-    padding-block-end: calc(
-        var(
-                --mod-infield-button-stacked-fill-padding-inner,
-                var(--spectrum-infield-button-stacked-fill-padding-inner)
-            ) -
-            var(
-                --mod-infield-button-inner-edge-to-fill,
-                var(--spectrum-infield-button-inner-edge-to-fill)
-            )
-    );
+    border-start-start-radius: var(--mod-infield-button-stacked-top-border-radius-start-start, var(--spectrum-infield-button-stacked-top-border-radius-start-start));
+    border-end-end-radius: var(--mod-infield-button-stacked-border-radius-reset, var(--spectrum-infield-button-stacked-border-radius-reset));
+    border-end-start-radius: var(--mod-infield-button-stacked-border-radius-reset, var(--spectrum-infield-button-stacked-border-radius-reset));
+    padding-block-start: calc(var(--mod-infield-button-stacked-fill-padding-outer, var(--spectrum-infield-button-stacked-fill-padding-outer)) - var(--mod-infield-button-edge-to-fill, var(--spectrum-infield-button-edge-to-fill)) - var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));
+    padding-block-end: calc(var(--mod-infield-button-stacked-fill-padding-inner, var(--spectrum-infield-button-stacked-fill-padding-inner)) - var(--mod-infield-button-inner-edge-to-fill, var(--spectrum-infield-button-inner-edge-to-fill)));
 }
 
 :host([block='end']) {
-    padding-block-start: var(
-        --mod-infield-button-inner-edge-to-fill,
-        var(--spectrum-infield-button-inner-edge-to-fill)
-    );
+    padding-block-start: var(--mod-infield-button-inner-edge-to-fill, var(--spectrum-infield-button-inner-edge-to-fill));
 }
 
 :host([block='end']) .fill {
-    border-block-end-width: var(
-        --mod-infield-button-stacked-bottom-border-block-end-width,
-        var(
-            --mod-infield-button-border-width,
-            var(--spectrum-infield-button-border-width)
-        )
-    );
-    border-start-start-radius: var(
-        --mod-infield-button-stacked-border-radius-reset,
-        var(--spectrum-infield-button-stacked-border-radius-reset)
-    );
-    border-start-end-radius: var(
-        --mod-infield-button-stacked-border-radius-reset,
-        var(--spectrum-infield-button-stacked-border-radius-reset)
-    );
-    border-end-end-radius: var(
-        --mod-infield-button-stacked-bottom-border-radius-end-end,
-        var(
-            --mod-infield-button-border-radius,
-            var(--spectrum-infield-button-border-radius)
-        )
-    );
-    border-end-start-radius: var(
-        --mod-infield-button-stacked-bottom-border-radius-end-start,
-        var(--spectrum-infield-button-stacked-bottom-border-radius-end-start)
-    );
-    padding-block-start: calc(
-        var(
-                --mod-infield-button-stacked-fill-padding-inner,
-                var(--spectrum-infield-button-stacked-fill-padding-inner)
-            ) -
-            var(
-                --mod-infield-button-edge-to-fill,
-                var(--spectrum-infield-button-edge-to-fill)
-            ) -
-            var(
-                --mod-infield-button-border-width,
-                var(--spectrum-infield-button-border-width)
-            )
-    );
-    padding-block-end: calc(
-        var(
-                --mod-infield-button-stacked-fill-padding-outer,
-                var(--spectrum-infield-button-stacked-fill-padding-outer)
-            ) -
-            var(
-                --mod-infield-button-inner-edge-to-fill,
-                var(--spectrum-infield-button-inner-edge-to-fill)
-            ) -
-            var(
-                --mod-infield-button-border-width,
-                var(--spectrum-infield-button-border-width)
-            )
-    );
+    border-block-end-width: var(--mod-infield-button-stacked-bottom-border-block-end-width, var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));
+    border-start-start-radius: var(--mod-infield-button-stacked-border-radius-reset, var(--spectrum-infield-button-stacked-border-radius-reset));
+    border-start-end-radius: var(--mod-infield-button-stacked-border-radius-reset, var(--spectrum-infield-button-stacked-border-radius-reset));
+    border-end-end-radius: var(--mod-infield-button-stacked-bottom-border-radius-end-end, var(--mod-infield-button-border-radius, var(--spectrum-infield-button-border-radius)));
+    border-end-start-radius: var(--mod-infield-button-stacked-bottom-border-radius-end-start, var(--spectrum-infield-button-stacked-bottom-border-radius-end-start));
+    padding-block-start: calc(var(--mod-infield-button-stacked-fill-padding-inner, var(--spectrum-infield-button-stacked-fill-padding-inner)) - var(--mod-infield-button-edge-to-fill, var(--spectrum-infield-button-edge-to-fill)) - var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));
+    padding-block-end: calc(var(--mod-infield-button-stacked-fill-padding-outer, var(--spectrum-infield-button-stacked-fill-padding-outer)) - var(--mod-infield-button-inner-edge-to-fill, var(--spectrum-infield-button-inner-edge-to-fill)) - var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));
 }
 
 ::slotted(*) {

--- a/packages/link/src/spectrum-link.css
+++ b/packages/link/src/spectrum-link.css
@@ -30,43 +30,20 @@ a {
     background-color: initial;
     -webkit-text-decoration-skip: objects;
     text-decoration-skip: objects;
-    transition: color
-        var(
-            --mod-link-animation-duration,
-            var(--spectrum-link-animation-duration)
-        )
-        ease-in-out;
+    transition: color var(--mod-link-animation-duration, var(--spectrum-link-animation-duration)) ease-in-out;
     cursor: pointer;
-    color: var(
-        --highcontrast-link-text-color-primary-default,
-        var(
-            --mod-link-text-color-primary-default,
-            var(--spectrum-link-text-color-primary-default)
-        )
-    );
+    color: var(--highcontrast-link-text-color-primary-default, var(--mod-link-text-color-primary-default, var(--spectrum-link-text-color-primary-default)));
     outline: none;
     -webkit-text-decoration: underline;
     text-decoration: underline;
 }
 
 a:active {
-    color: var(
-        --highcontrast-link-text-color-primary-active,
-        var(
-            --mod-link-text-color-primary-active,
-            var(--spectrum-link-text-color-primary-active)
-        )
-    );
+    color: var(--highcontrast-link-text-color-primary-active, var(--mod-link-text-color-primary-active, var(--spectrum-link-text-color-primary-active)));
 }
 
 a:focus-visible {
-    color: var(
-        --highcontrast-link-text-color-primary-focus,
-        var(
-            --mod-link-text-color-primary-focus,
-            var(--spectrum-link-text-color-primary-focus)
-        )
-    );
+    color: var(--highcontrast-link-text-color-primary-focus, var(--mod-link-text-color-primary-focus, var(--spectrum-link-text-color-primary-focus)));
     -webkit-text-decoration: underline double;
     text-decoration: underline double;
     text-decoration-color: inherit;
@@ -74,33 +51,15 @@ a:focus-visible {
 }
 
 :host([variant='secondary']) a {
-    color: var(
-        --highcontrast-link-text-color-secondary-default,
-        var(
-            --mod-link-text-color-secondary-default,
-            var(--spectrum-link-text-color-secondary-default)
-        )
-    );
+    color: var(--highcontrast-link-text-color-secondary-default, var(--mod-link-text-color-secondary-default, var(--spectrum-link-text-color-secondary-default)));
 }
 
 :host([variant='secondary']) a:active {
-    color: var(
-        --highcontrast-link-text-color-secondary-active,
-        var(
-            --mod-link-text-color-secondary-active,
-            var(--spectrum-link-text-color-secondary-active)
-        )
-    );
+    color: var(--highcontrast-link-text-color-secondary-active, var(--mod-link-text-color-secondary-active, var(--spectrum-link-text-color-secondary-active)));
 }
 
 :host([variant='secondary']) a:focus {
-    color: var(
-        --highcontrast-link-text-color-secondary-focus,
-        var(
-            --mod-link-text-color-secondary-focus,
-            var(--spectrum-link-text-color-secondary-focus)
-        )
-    );
+    color: var(--highcontrast-link-text-color-secondary-focus, var(--mod-link-text-color-secondary-focus, var(--spectrum-link-text-color-secondary-focus)));
 }
 
 :host([quiet]) a {
@@ -111,40 +70,22 @@ a:focus-visible {
 :host([static-color='white']) a,
 :host([static-color='white']) a:active,
 :host([static-color='white']) a:focus {
-    color: var(
-        --highcontrast-link-text-color-white,
-        var(--mod-link-text-color-white, var(--spectrum-link-text-color-white))
-    );
+    color: var(--highcontrast-link-text-color-white, var(--mod-link-text-color-white, var(--spectrum-link-text-color-white)));
 }
 
 :host([static-color='black']) a,
 :host([static-color='black']) a:active,
 :host([static-color='black']) a:focus {
-    color: var(
-        --highcontrast-link-text-color-black,
-        var(--mod-link-text-color-black, var(--spectrum-link-text-color-black))
-    );
+    color: var(--highcontrast-link-text-color-black, var(--mod-link-text-color-black, var(--spectrum-link-text-color-black)));
 }
 
 @media (hover: hover) {
     a:hover {
-        color: var(
-            --highcontrast-link-text-color-primary-hover,
-            var(
-                --mod-link-text-color-primary-hover,
-                var(--spectrum-link-text-color-primary-hover)
-            )
-        );
+        color: var(--highcontrast-link-text-color-primary-hover, var(--mod-link-text-color-primary-hover, var(--spectrum-link-text-color-primary-hover)));
     }
 
     :host([variant='secondary']) a:hover {
-        color: var(
-            --highcontrast-link-text-color-secondary-hover,
-            var(
-                --mod-link-text-color-secondary-hover,
-                var(--spectrum-link-text-color-secondary-hover)
-            )
-        );
+        color: var(--highcontrast-link-text-color-secondary-hover, var(--mod-link-text-color-secondary-hover, var(--spectrum-link-text-color-secondary-hover)));
     }
 
     :host([quiet]) a:hover {
@@ -153,22 +94,10 @@ a:focus-visible {
     }
 
     :host([static-color='white']) a:hover {
-        color: var(
-            --highcontrast-link-text-color-white,
-            var(
-                --mod-link-text-color-white,
-                var(--spectrum-link-text-color-white)
-            )
-        );
+        color: var(--highcontrast-link-text-color-white, var(--mod-link-text-color-white, var(--spectrum-link-text-color-white)));
     }
 
     :host([static-color='black']) a:hover {
-        color: var(
-            --highcontrast-link-text-color-black,
-            var(
-                --mod-link-text-color-black,
-                var(--spectrum-link-text-color-black)
-            )
-        );
+        color: var(--highcontrast-link-text-color-black, var(--mod-link-text-color-black, var(--spectrum-link-text-color-black)));
     }
 }

--- a/packages/menu/src/spectrum-checkmark.css
+++ b/packages/menu/src/spectrum-checkmark.css
@@ -12,76 +12,30 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .checkmark {
-    display: var(
-        --mod-menu-checkmark-display,
-        var(--spectrum-menu-checkmark-display)
-    );
-    block-size: var(
-        --mod-menu-item-checkmark-height,
-        var(--spectrum-menu-item-checkmark-height)
-    );
-    inline-size: var(
-        --mod-menu-item-checkmark-width,
-        var(--spectrum-menu-item-checkmark-width)
-    );
-    fill: var(
-        --highcontrast-menu-checkmark-icon-color-default,
-        var(
-            --mod-menu-checkmark-icon-color-default,
-            var(--spectrum-menu-checkmark-icon-color-default)
-        )
-    );
-    color: var(
-        --highcontrast-menu-checkmark-icon-color-default,
-        var(
-            --mod-menu-checkmark-icon-color-default,
-            var(--spectrum-menu-checkmark-icon-color-default)
-        )
-    );
+    display: var(--mod-menu-checkmark-display, var(--spectrum-menu-checkmark-display));
+    block-size: var(--mod-menu-item-checkmark-height, var(--spectrum-menu-item-checkmark-height));
+    inline-size: var(--mod-menu-item-checkmark-width, var(--spectrum-menu-item-checkmark-width));
+    fill: var(--highcontrast-menu-checkmark-icon-color-default, var(--mod-menu-checkmark-icon-color-default, var(--spectrum-menu-checkmark-icon-color-default)));
+    color: var(--highcontrast-menu-checkmark-icon-color-default, var(--mod-menu-checkmark-icon-color-default, var(--spectrum-menu-checkmark-icon-color-default)));
     opacity: 1;
     grid-area: checkmarkArea;
     align-self: start;
-    margin-block-start: calc(
-        var(
-                --mod-menu-item-top-to-checkmark,
-                var(--spectrum-menu-item-top-to-checkmark)
-            ) -
-            var(
-                --mod-menu-item-top-edge-to-text,
-                var(--spectrum-menu-item-top-edge-to-text)
-            )
-    );
-    margin-inline-end: var(
-        --mod-menu-item-text-to-control,
-        var(--spectrum-menu-item-text-to-control)
-    );
+    margin-block-start: calc(var(--mod-menu-item-top-to-checkmark, var(--spectrum-menu-item-top-to-checkmark)) - var(--mod-menu-item-top-edge-to-text, var(--spectrum-menu-item-top-edge-to-text)));
+    margin-inline-end: var(--mod-menu-item-text-to-control, var(--spectrum-menu-item-text-to-control));
 }
 
 .spectrum-Menu-back:focus-visible {
-    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow)
-        var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0
-        var(--spectrum-menu-item-focus-indicator-color-default);
-    outline: var(--spectrum-menu-item-focus-indicator-width)
-        var(--spectrum-menu-item-focus-indicator-outline-style)
-        var(--spectrum-menu-item-focus-indicator-color-default);
+    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow) var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0 var(--spectrum-menu-item-focus-indicator-color-default);
+    outline: var(--spectrum-menu-item-focus-indicator-width) var(--spectrum-menu-item-focus-indicator-outline-style) var(--spectrum-menu-item-focus-indicator-color-default);
     outline-offset: var(--spectrum-menu-item-focus-indicator-offset);
     border-radius: var(--spectrum-menu-item-corner-radius);
 }
 
 .spectrum-Menu-back {
-    padding-inline: 0
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
-    padding-inline: var(--mod-menu-back-padding-inline-start, 0)
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
+    padding-inline: 0 var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
+    padding-inline: var(--mod-menu-back-padding-inline-start, 0) var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
     padding-block: 0;
-    padding-block: var(--mod-menu-back-padding-block-start, 0)
-        var(--mod-menu-back-padding-block-end, 0);
+    padding-block: var(--mod-menu-back-padding-block-start, 0) var(--mod-menu-back-padding-block-end, 0);
     flex-flow: wrap;
     align-items: center;
     display: flex;
@@ -97,32 +51,14 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-backButton:focus-visible {
-    outline: var(--spectrum-focus-indicator-thickness) solid
-        var(--spectrum-focus-indicator-color);
-    outline-offset: calc(
-        (var(--spectrum-focus-indicator-thickness) + 1px) * -1
-    );
+    outline: var(--spectrum-focus-indicator-thickness) solid var(--spectrum-focus-indicator-color);
+    outline-offset: calc((var(--spectrum-focus-indicator-thickness) + 1px) * -1);
 }
 
 .spectrum-Menu-backHeading {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-back-heading-color,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
-    font-size: var(
-        --mod-menu-section-header-font-size,
-        var(--spectrum-menu-section-header-font-size)
-    );
-    font-weight: var(
-        --mod-menu-section-header-font-weight,
-        var(--spectrum-menu-section-header-font-weight)
-    );
-    line-height: var(
-        --mod-menu-section-header-line-height,
-        var(--spectrum-menu-section-header-line-height)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-heading-color, var(--spectrum-menu-section-header-color)));
+    font-size: var(--mod-menu-section-header-font-size, var(--spectrum-menu-section-header-font-size));
+    font-weight: var(--mod-menu-section-header-font-weight, var(--spectrum-menu-section-header-font-weight));
+    line-height: var(--mod-menu-section-header-line-height, var(--spectrum-menu-section-header-line-height));
     display: block;
 }

--- a/packages/menu/src/spectrum-chevron.css
+++ b/packages/menu/src/spectrum-chevron.css
@@ -16,37 +16,21 @@ governing permissions and limitations under the License.
     inline-size: var(--spectrum-menu-item-checkmark-width);
     grid-area: chevronArea;
     align-self: center;
-    margin-inline-end: var(
-        --mod-menu-item-text-to-control,
-        var(--spectrum-menu-item-text-to-control)
-    );
+    margin-inline-end: var(--mod-menu-item-text-to-control, var(--spectrum-menu-item-text-to-control));
 }
 
 .spectrum-Menu-back:focus-visible {
-    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow)
-        var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0
-        var(--spectrum-menu-item-focus-indicator-color-default);
-    outline: var(--spectrum-menu-item-focus-indicator-width)
-        var(--spectrum-menu-item-focus-indicator-outline-style)
-        var(--spectrum-menu-item-focus-indicator-color-default);
+    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow) var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0 var(--spectrum-menu-item-focus-indicator-color-default);
+    outline: var(--spectrum-menu-item-focus-indicator-width) var(--spectrum-menu-item-focus-indicator-outline-style) var(--spectrum-menu-item-focus-indicator-color-default);
     outline-offset: var(--spectrum-menu-item-focus-indicator-offset);
     border-radius: var(--spectrum-menu-item-corner-radius);
 }
 
 .spectrum-Menu-back {
-    padding-inline: 0
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
-    padding-inline: var(--mod-menu-back-padding-inline-start, 0)
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
+    padding-inline: 0 var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
+    padding-inline: var(--mod-menu-back-padding-inline-start, 0) var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
     padding-block: 0;
-    padding-block: var(--mod-menu-back-padding-block-start, 0)
-        var(--mod-menu-back-padding-block-end, 0);
+    padding-block: var(--mod-menu-back-padding-block-start, 0) var(--mod-menu-back-padding-block-end, 0);
     flex-flow: wrap;
     align-items: center;
     display: flex;
@@ -62,32 +46,14 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-backButton:focus-visible {
-    outline: var(--spectrum-focus-indicator-thickness) solid
-        var(--spectrum-focus-indicator-color);
-    outline-offset: calc(
-        (var(--spectrum-focus-indicator-thickness) + 1px) * -1
-    );
+    outline: var(--spectrum-focus-indicator-thickness) solid var(--spectrum-focus-indicator-color);
+    outline-offset: calc((var(--spectrum-focus-indicator-thickness) + 1px) * -1);
 }
 
 .spectrum-Menu-backHeading {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-back-heading-color,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
-    font-size: var(
-        --mod-menu-section-header-font-size,
-        var(--spectrum-menu-section-header-font-size)
-    );
-    font-weight: var(
-        --mod-menu-section-header-font-weight,
-        var(--spectrum-menu-section-header-font-weight)
-    );
-    line-height: var(
-        --mod-menu-section-header-line-height,
-        var(--spectrum-menu-section-header-line-height)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-heading-color, var(--spectrum-menu-section-header-color)));
+    font-size: var(--mod-menu-section-header-font-size, var(--spectrum-menu-section-header-font-size));
+    font-weight: var(--mod-menu-section-header-font-weight, var(--spectrum-menu-section-header-font-weight));
+    line-height: var(--mod-menu-section-header-line-height, var(--spectrum-menu-section-header-line-height));
     display: block;
 }

--- a/packages/menu/src/spectrum-menu-divider.css
+++ b/packages/menu/src/spectrum-menu-divider.css
@@ -14,48 +14,23 @@ governing permissions and limitations under the License.
 :host {
     --spectrum-menu-divider-thickness: var(--spectrum-divider-thickness-medium);
     inline-size: auto;
-    margin-block: var(
-        --mod-menu-section-divider-margin-block,
-        max(
-            0px,
-            (
-                    var(--spectrum-menu-item-section-divider-height) -
-                        var(--spectrum-menu-divider-thickness)
-                ) / 2
-        )
-    );
-    margin-inline: var(
-        --mod-menu-item-label-inline-edge-to-content,
-        var(--spectrum-menu-item-label-inline-edge-to-content)
-    );
+    margin-block: var(--mod-menu-section-divider-margin-block, max(0px, (var(--spectrum-menu-item-section-divider-height) - var(--spectrum-menu-divider-thickness)) / 2));
+    margin-inline: var(--mod-menu-item-label-inline-edge-to-content, var(--spectrum-menu-item-label-inline-edge-to-content));
     overflow: visible;
 }
 
 .spectrum-Menu-back:focus-visible {
-    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow)
-        var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0
-        var(--spectrum-menu-item-focus-indicator-color-default);
-    outline: var(--spectrum-menu-item-focus-indicator-width)
-        var(--spectrum-menu-item-focus-indicator-outline-style)
-        var(--spectrum-menu-item-focus-indicator-color-default);
+    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow) var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0 var(--spectrum-menu-item-focus-indicator-color-default);
+    outline: var(--spectrum-menu-item-focus-indicator-width) var(--spectrum-menu-item-focus-indicator-outline-style) var(--spectrum-menu-item-focus-indicator-color-default);
     outline-offset: var(--spectrum-menu-item-focus-indicator-offset);
     border-radius: var(--spectrum-menu-item-corner-radius);
 }
 
 .spectrum-Menu-back {
-    padding-inline: 0
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
-    padding-inline: var(--mod-menu-back-padding-inline-start, 0)
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
+    padding-inline: 0 var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
+    padding-inline: var(--mod-menu-back-padding-inline-start, 0) var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
     padding-block: 0;
-    padding-block: var(--mod-menu-back-padding-block-start, 0)
-        var(--mod-menu-back-padding-block-end, 0);
+    padding-block: var(--mod-menu-back-padding-block-start, 0) var(--mod-menu-back-padding-block-end, 0);
     flex-flow: wrap;
     align-items: center;
     display: flex;
@@ -71,32 +46,14 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-backButton:focus-visible {
-    outline: var(--spectrum-focus-indicator-thickness) solid
-        var(--spectrum-focus-indicator-color);
-    outline-offset: calc(
-        (var(--spectrum-focus-indicator-thickness) + 1px) * -1
-    );
+    outline: var(--spectrum-focus-indicator-thickness) solid var(--spectrum-focus-indicator-color);
+    outline-offset: calc((var(--spectrum-focus-indicator-thickness) + 1px) * -1);
 }
 
 .spectrum-Menu-backHeading {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-back-heading-color,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
-    font-size: var(
-        --mod-menu-section-header-font-size,
-        var(--spectrum-menu-section-header-font-size)
-    );
-    font-weight: var(
-        --mod-menu-section-header-font-weight,
-        var(--spectrum-menu-section-header-font-weight)
-    );
-    line-height: var(
-        --mod-menu-section-header-line-height,
-        var(--spectrum-menu-section-header-line-height)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-heading-color, var(--spectrum-menu-section-header-color)));
+    font-size: var(--mod-menu-section-header-font-size, var(--spectrum-menu-section-header-font-size));
+    font-weight: var(--mod-menu-section-header-font-weight, var(--spectrum-menu-section-header-font-weight));
+    line-height: var(--mod-menu-section-header-line-height, var(--spectrum-menu-section-header-line-height));
     display: block;
 }

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -12,68 +12,27 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 ::slotted([slot='icon']) {
-    fill: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-item-label-icon-color-default,
-            var(--spectrum-menu-item-label-icon-color-default)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-item-label-icon-color-default,
-            var(--spectrum-menu-item-label-icon-color-default)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-label-icon-color-default, var(--spectrum-menu-item-label-icon-color-default)));
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-label-icon-color-default, var(--spectrum-menu-item-label-icon-color-default)));
     grid-area: iconArea;
     align-self: start;
 }
 
 ::slotted([slot='icon']) {
-    margin-inline-end: var(
-        --mod-menu-item-label-text-to-visual,
-        var(--spectrum-menu-item-label-text-to-visual)
-    );
+    margin-inline-end: var(--mod-menu-item-label-text-to-visual, var(--spectrum-menu-item-label-text-to-visual));
 }
 
 :host {
     cursor: pointer;
     border-radius: var(--spectrum-menu-item-corner-radius);
     box-sizing: border-box;
-    background-color: var(
-        --highcontrast-menu-item-background-color-default,
-        var(
-            --mod-menu-item-background-color-default,
-            var(--spectrum-menu-item-background-color-default)
-        )
-    );
-    line-height: var(
-        --mod-menu-item-label-line-height,
-        var(--spectrum-menu-item-label-line-height)
-    );
-    min-block-size: var(
-        --mod-menu-item-min-height,
-        var(--spectrum-menu-item-min-height)
-    );
-    padding-block-start: var(
-        --mod-menu-item-top-edge-to-text,
-        var(--spectrum-menu-item-top-edge-to-text)
-    );
-    padding-block-end: var(
-        --mod-menu-item-bottom-edge-to-text,
-        var(--spectrum-menu-item-bottom-edge-to-text)
-    );
-    padding-inline: var(
-        --mod-menu-item-label-inline-edge-to-content,
-        var(--spectrum-menu-item-label-inline-edge-to-content)
-    );
-    margin: calc(
-        (
-                var(--spectrum-menu-item-focus-indicator-offset) +
-                    var(--spectrum-menu-item-focus-indicator-width)
-            ) * var(--spectrum-menu-item-spacing-multiplier)
-    );
+    background-color: var(--highcontrast-menu-item-background-color-default, var(--mod-menu-item-background-color-default, var(--spectrum-menu-item-background-color-default)));
+    line-height: var(--mod-menu-item-label-line-height, var(--spectrum-menu-item-label-line-height));
+    min-block-size: var(--mod-menu-item-min-height, var(--spectrum-menu-item-min-height));
+    padding-block-start: var(--mod-menu-item-top-edge-to-text, var(--spectrum-menu-item-top-edge-to-text));
+    padding-block-end: var(--mod-menu-item-bottom-edge-to-text, var(--spectrum-menu-item-bottom-edge-to-text));
+    padding-inline: var(--mod-menu-item-label-inline-edge-to-content, var(--spectrum-menu-item-label-inline-edge-to-content));
+    margin: calc((var(--spectrum-menu-item-focus-indicator-offset) + var(--spectrum-menu-item-focus-indicator-width)) * var(--spectrum-menu-item-spacing-multiplier));
     grid-template:
         '. chevronAreaCollapsible . headingIconArea sectionHeadingArea . . .' 1fr
         'selectedArea chevronAreaCollapsible checkmarkArea iconArea labelArea valueArea actionsArea chevronAreaDrillIn'
@@ -94,15 +53,9 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-itemCheckbox .spectrum-Checkbox-box {
-    margin-block-start: var(
-        --mod-menu-item-top-to-checkbox,
-        var(--spectrum-menu-item-top-to-checkbox)
-    );
+    margin-block-start: var(--mod-menu-item-top-to-checkbox, var(--spectrum-menu-item-top-to-checkbox));
     margin-block-end: 0;
-    margin-inline-end: var(
-        --mod-menu-item-text-to-control,
-        var(--spectrum-menu-item-text-to-control)
-    );
+    margin-inline-end: var(--mod-menu-item-text-to-control, var(--spectrum-menu-item-text-to-control));
 }
 
 .spectrum-Menu-itemSwitch {
@@ -110,10 +63,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-itemSwitch .spectrum-Switch-switch {
-    margin-block-start: var(
-        --mod-menu-item-top-to-action,
-        var(--spectrum-menu-item-top-to-action)
-    );
+    margin-block-start: var(--mod-menu-item-top-to-action, var(--spectrum-menu-item-top-to-action));
     margin-block-end: 0;
 }
 
@@ -127,192 +77,72 @@ governing permissions and limitations under the License.
 
 :host([focused]),
 :host(:focus) {
-    background-color: var(
-        --highcontrast-menu-item-background-color-focus,
-        var(
-            --mod-menu-item-background-color-key-focus,
-            var(--spectrum-menu-item-background-color-key-focus)
-        )
-    );
+    background-color: var(--highcontrast-menu-item-background-color-focus, var(--mod-menu-item-background-color-key-focus, var(--spectrum-menu-item-background-color-key-focus)));
     outline: none;
 }
 
 :host([focused]) > #label,
 :host(:focus) > #label {
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-content-color-focus,
-            var(--spectrum-menu-item-label-content-color-focus)
-        )
-    );
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-content-color-focus, var(--spectrum-menu-item-label-content-color-focus)));
 }
 
 :host([focused]) > [name='description']::slotted(*),
 :host(:focus) > [name='description']::slotted(*) {
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-description-color-focus,
-            var(--spectrum-menu-item-description-color-focus)
-        )
-    );
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-description-color-focus, var(--spectrum-menu-item-description-color-focus)));
 }
 
 :host([focused]) > ::slotted([slot='value']),
 :host(:focus) > ::slotted([slot='value']) {
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-value-color-focus,
-            var(--spectrum-menu-item-value-color-focus)
-        )
-    );
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-value-color-focus, var(--spectrum-menu-item-value-color-focus)));
 }
 
 :host([focused]) > .icon:not(.chevron, .checkmark),
 :host(:focus) > .icon:not(.chevron, .checkmark) {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-icon-color-focus,
-            var(--spectrum-menu-item-label-icon-color-focus)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-icon-color-focus,
-            var(--spectrum-menu-item-label-icon-color-focus)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-focus, var(--spectrum-menu-item-label-icon-color-focus)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-focus, var(--spectrum-menu-item-label-icon-color-focus)));
 }
 
 :host([focused]) > .chevron,
 :host(:focus) > .chevron {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-collapsible-icon-color,
-            var(--spectrum-menu-collapsible-icon-color)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-collapsible-icon-color,
-            var(--spectrum-menu-collapsible-icon-color)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-collapsible-icon-color, var(--spectrum-menu-collapsible-icon-color)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-collapsible-icon-color, var(--spectrum-menu-collapsible-icon-color)));
 }
 
 :host([focused]) > .checkmark,
 :host(:focus) > .checkmark {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-checkmark-icon-color-focus,
-            var(--spectrum-menu-checkmark-icon-color-focus)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-checkmark-icon-color-focus,
-            var(--spectrum-menu-checkmark-icon-color-focus)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-checkmark-icon-color-focus, var(--spectrum-menu-checkmark-icon-color-focus)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-checkmark-icon-color-focus, var(--spectrum-menu-checkmark-icon-color-focus)));
 }
 
 :host(:is(:active, [active])) {
-    background-color: var(
-        --highcontrast-menu-item-background-color-focus,
-        var(
-            --mod-menu-item-background-color-down,
-            var(--spectrum-menu-item-background-color-down)
-        )
-    );
+    background-color: var(--highcontrast-menu-item-background-color-focus, var(--mod-menu-item-background-color-down, var(--spectrum-menu-item-background-color-down)));
 }
 
 :host(:is(:active, [active])) > #label {
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-content-color-down,
-            var(--spectrum-menu-item-label-content-color-down)
-        )
-    );
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-content-color-down, var(--spectrum-menu-item-label-content-color-down)));
 }
 
 :host(:is(:active, [active])) > [name='description']::slotted(*) {
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-description-color-down,
-            var(--spectrum-menu-item-description-color-down)
-        )
-    );
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-description-color-down, var(--spectrum-menu-item-description-color-down)));
 }
 
 :host(:is(:active, [active])) > ::slotted([slot='value']) {
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-value-color-down,
-            var(--spectrum-menu-item-value-color-down)
-        )
-    );
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-value-color-down, var(--spectrum-menu-item-value-color-down)));
 }
 
 :host(:is(:active, [active])) > .icon:not(.chevron, .checkmark) {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-icon-color-down,
-            var(--spectrum-menu-item-label-icon-color-down)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-icon-color-down,
-            var(--spectrum-menu-item-label-icon-color-down)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-down, var(--spectrum-menu-item-label-icon-color-down)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-down, var(--spectrum-menu-item-label-icon-color-down)));
 }
 
 :host(:is(:active, [active])) > .chevron {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-collapsible-icon-color,
-            var(--spectrum-menu-collapsible-icon-color)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-collapsible-icon-color,
-            var(--spectrum-menu-collapsible-icon-color)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-collapsible-icon-color, var(--spectrum-menu-collapsible-icon-color)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-collapsible-icon-color, var(--spectrum-menu-collapsible-icon-color)));
 }
 
 :host(:is(:active, [active])) > .checkmark {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-checkmark-icon-color-down,
-            var(--spectrum-menu-checkmark-icon-color-down)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-checkmark-icon-color-down,
-            var(--spectrum-menu-checkmark-icon-color-down)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-checkmark-icon-color-down, var(--spectrum-menu-checkmark-icon-color-down)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-checkmark-icon-color-down, var(--spectrum-menu-checkmark-icon-color-down)));
 }
 
 :host([disabled]),
@@ -324,52 +154,24 @@ governing permissions and limitations under the License.
 :host([disabled]) ::slotted([slot='value']),
 :host([aria-disabled='true']) #label,
 :host([aria-disabled='true']) ::slotted([slot='value']) {
-    color: var(
-        --highcontrast-menu-item-color-disabled,
-        var(
-            --mod-menu-item-label-content-color-disabled,
-            var(--spectrum-menu-item-label-content-color-disabled)
-        )
-    );
+    color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
 }
 
 :host([disabled]) [name='description']::slotted(*),
 :host([aria-disabled='true']) [name='description']::slotted(*) {
-    color: var(
-        --highcontrast-menu-item-color-disabled,
-        var(
-            --mod-menu-item-description-color-disabled,
-            var(--spectrum-menu-item-description-color-disabled)
-        )
-    );
+    color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-description-color-disabled, var(--spectrum-menu-item-description-color-disabled)));
 }
 
 :host([disabled]) ::slotted([slot='icon']),
 :host([aria-disabled='true']) ::slotted([slot='icon']) {
-    color: var(
-        --highcontrast-menu-item-color-disabled,
-        var(
-            --mod-menu-item-label-icon-color-disabled,
-            var(--spectrum-menu-item-label-icon-color-disabled)
-        )
-    );
-    fill: var(
-        --highcontrast-menu-item-color-disabled,
-        var(
-            --mod-menu-item-label-icon-color-disabled,
-            var(--spectrum-menu-item-label-icon-color-disabled)
-        )
-    );
+    color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
+    fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
 }
 
 :host([focused]) .spectrum-Menu-back,
 :host([focused]) {
-    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow)
-        var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0
-        var(--spectrum-menu-item-focus-indicator-color-default);
-    outline: var(--spectrum-menu-item-focus-indicator-width)
-        var(--spectrum-menu-item-focus-indicator-outline-style)
-        var(--spectrum-menu-item-focus-indicator-color-default);
+    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow) var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0 var(--spectrum-menu-item-focus-indicator-color-default);
+    outline: var(--spectrum-menu-item-focus-indicator-width) var(--spectrum-menu-item-focus-indicator-outline-style) var(--spectrum-menu-item-focus-indicator-color-default);
     outline-offset: var(--spectrum-menu-item-focus-indicator-offset);
     border-radius: var(--spectrum-menu-item-corner-radius);
 }
@@ -381,34 +183,16 @@ governing permissions and limitations under the License.
 #label {
     --mod-switch-control-label-spacing: 0;
     --mod-switch-spacing-top-to-label: 0;
-    font-size: var(
-        --mod-menu-item-label-font-size,
-        var(--spectrum-menu-item-label-font-size)
-    );
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-item-label-content-color-default,
-            var(--spectrum-menu-item-label-content-color-default)
-        )
-    );
+    font-size: var(--mod-menu-item-label-font-size, var(--spectrum-menu-item-label-font-size));
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-label-content-color-default, var(--spectrum-menu-item-label-content-color-default)));
     hyphens: auto;
     overflow-wrap: break-word;
     grid-area: labelArea;
 }
 
 ::slotted([slot='value']) {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-item-value-color-default,
-            var(--spectrum-menu-item-value-color-default)
-        )
-    );
-    font-size: var(
-        --mod-menu-item-label-font-size,
-        var(--spectrum-menu-item-label-font-size)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-value-color-default, var(--spectrum-menu-item-value-color-default)));
+    font-size: var(--mod-menu-item-label-font-size, var(--spectrum-menu-item-label-font-size));
     grid-area: valueArea;
     justify-self: end;
 }
@@ -416,10 +200,7 @@ governing permissions and limitations under the License.
 .spectrum-Menu-itemActions,
 ::slotted([slot='value']) {
     align-self: start;
-    margin-inline-start: var(
-        --mod-menu-item-label-to-value-area-min-spacing,
-        var(--spectrum-menu-item-label-to-value-area-min-spacing)
-    );
+    margin-inline-start: var(--mod-menu-item-label-to-value-area-min-spacing, var(--spectrum-menu-item-label-to-value-area-min-spacing));
 }
 
 .spectrum-Menu-itemActions {
@@ -427,28 +208,13 @@ governing permissions and limitations under the License.
 }
 
 [name='description']::slotted(*) {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-item-description-color-default,
-            var(--spectrum-menu-item-description-color-default)
-        )
-    );
-    font-size: var(
-        --mod-menu-item-description-font-size,
-        var(--spectrum-menu-item-description-font-size)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-description-color-default, var(--spectrum-menu-item-description-color-default)));
+    font-size: var(--mod-menu-item-description-font-size, var(--spectrum-menu-item-description-font-size));
     hyphens: auto;
     overflow-wrap: break-word;
-    line-height: var(
-        --mod-menu-item-description-line-height,
-        var(--spectrum-menu-item-description-line-height)
-    );
+    line-height: var(--mod-menu-item-description-line-height, var(--spectrum-menu-item-description-line-height));
     grid-area: descriptionArea;
-    margin-block-start: var(
-        --mod-menu-item-label-to-description-spacing,
-        var(--spectrum-menu-item-label-to-description-spacing)
-    );
+    margin-block-start: var(--mod-menu-item-label-to-description-spacing, var(--spectrum-menu-item-label-to-description-spacing));
 }
 
 :host([no-wrap]) #label {
@@ -468,13 +234,7 @@ governing permissions and limitations under the License.
 :host([focused]) .spectrum-Menu-item--collapsible.is-open,
 :host(:is(:active, [active])) .spectrum-Menu-item--collapsible.is-open,
 .spectrum-Menu-item--collapsible.is-open:focus {
-    background-color: var(
-        --highcontrast-menu-item-background-color-default,
-        var(
-            --mod-menu-item-background-color-default,
-            var(--spectrum-menu-item-background-color-default)
-        )
-    );
+    background-color: var(--highcontrast-menu-item-background-color-default, var(--mod-menu-item-background-color-default, var(--spectrum-menu-item-background-color-default)));
 }
 
 .spectrum-Menu-item--collapsible ::slotted([slot='icon']) {
@@ -482,20 +242,8 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-item--collapsible > ::slotted([slot='icon']) {
-    padding-block-start: var(
-        --mod-menu-section-header-top-edge-to-text,
-        var(
-            --mod-menu-item-top-edge-to-text,
-            var(--spectrum-menu-item-top-edge-to-text)
-        )
-    );
-    padding-block-end: var(
-        --mod-menu-section-header-bottom-edge-to-text,
-        var(
-            --mod-menu-item-bottom-edge-to-text,
-            var(--spectrum-menu-item-bottom-edge-to-text)
-        )
-    );
+    padding-block-start: var(--mod-menu-section-header-top-edge-to-text, var(--mod-menu-item-top-edge-to-text, var(--spectrum-menu-item-top-edge-to-text)));
+    padding-block-end: var(--mod-menu-section-header-bottom-edge-to-text, var(--mod-menu-item-bottom-edge-to-text, var(--spectrum-menu-item-bottom-edge-to-text)));
 }
 
 .spectrum-Menu-item--collapsible .chevron {
@@ -503,179 +251,62 @@ governing permissions and limitations under the License.
 }
 
 :host([has-submenu]) .chevron {
-    fill: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-drillin-icon-color-default,
-            var(--spectrum-menu-drillin-icon-color-default)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-drillin-icon-color-default,
-            var(--spectrum-menu-drillin-icon-color-default)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-default, var(--mod-menu-drillin-icon-color-default, var(--spectrum-menu-drillin-icon-color-default)));
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-drillin-icon-color-default, var(--spectrum-menu-drillin-icon-color-default)));
     grid-area: chevronAreaDrillIn;
-    margin-inline-start: var(
-        --mod-menu-item-label-to-value-area-min-spacing,
-        var(--spectrum-menu-item-label-to-value-area-min-spacing)
-    );
+    margin-inline-start: var(--mod-menu-item-label-to-value-area-min-spacing, var(--spectrum-menu-item-label-to-value-area-min-spacing));
     margin-inline-end: 0;
 }
 
 :host([has-submenu]) .is-open {
-    --spectrum-menu-item-background-color-default: var(
-        --highcontrast-menu-item-selected-background-color,
-        var(
-            --mod-menu-item-background-color-hover,
-            var(--spectrum-menu-item-background-color-hover)
-        )
-    );
+    --spectrum-menu-item-background-color-default: var(--highcontrast-menu-item-selected-background-color, var(--mod-menu-item-background-color-hover, var(--spectrum-menu-item-background-color-hover)));
 }
 
 :host([has-submenu]) .is-open .icon:not(.chevron, .checkmark) {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-icon-color-hover,
-            var(--spectrum-menu-item-label-icon-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-icon-color-hover,
-            var(--spectrum-menu-item-label-icon-color-hover)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-hover, var(--spectrum-menu-item-label-icon-color-hover)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-hover, var(--spectrum-menu-item-label-icon-color-hover)));
 }
 
 :host([has-submenu]) .is-open .chevron {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-drillin-icon-color-hover,
-            var(--spectrum-menu-drillin-icon-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-drillin-icon-color-hover,
-            var(--spectrum-menu-drillin-icon-color-hover)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-hover, var(--spectrum-menu-drillin-icon-color-hover)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-hover, var(--spectrum-menu-drillin-icon-color-hover)));
 }
 
 :host([has-submenu]) .is-open .checkmark {
-    fill: var(
-        --highcontrast-menu-checkmark-icon-color-default,
-        var(
-            --mod-menu-checkmark-icon-color-hover,
-            var(--spectrum-menu-checkmark-icon-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-menu-checkmark-icon-color-default,
-        var(
-            --mod-menu-checkmark-icon-color-hover,
-            var(--spectrum-menu-checkmark-icon-color-hover)
-        )
-    );
+    fill: var(--highcontrast-menu-checkmark-icon-color-default, var(--mod-menu-checkmark-icon-color-hover, var(--spectrum-menu-checkmark-icon-color-hover)));
+    color: var(--highcontrast-menu-checkmark-icon-color-default, var(--mod-menu-checkmark-icon-color-hover, var(--spectrum-menu-checkmark-icon-color-hover)));
 }
 
 @media (hover: hover) {
     :host(:hover) {
-        background-color: var(
-            --highcontrast-menu-item-background-color-focus,
-            var(
-                --mod-menu-item-background-color-hover,
-                var(--spectrum-menu-item-background-color-hover)
-            )
-        );
+        background-color: var(--highcontrast-menu-item-background-color-focus, var(--mod-menu-item-background-color-hover, var(--spectrum-menu-item-background-color-hover)));
     }
 
     :host(:hover) > #label {
-        color: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-item-label-content-color-hover,
-                var(--spectrum-menu-item-label-content-color-hover)
-            )
-        );
+        color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-content-color-hover, var(--spectrum-menu-item-label-content-color-hover)));
     }
 
     :host(:hover) > [name='description']::slotted(*) {
-        color: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-item-description-color-hover,
-                var(--spectrum-menu-item-description-color-hover)
-            )
-        );
+        color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-description-color-hover, var(--spectrum-menu-item-description-color-hover)));
     }
 
     :host(:hover) > ::slotted([slot='value']) {
-        color: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-item-value-color-hover,
-                var(--spectrum-menu-item-value-color-hover)
-            )
-        );
+        color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-value-color-hover, var(--spectrum-menu-item-value-color-hover)));
     }
 
     :host(:hover) > .icon:not(.chevron, .checkmark) {
-        fill: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-item-label-icon-color-hover,
-                var(--spectrum-menu-item-label-icon-color-hover)
-            )
-        );
-        color: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-item-label-icon-color-hover,
-                var(--spectrum-menu-item-label-icon-color-hover)
-            )
-        );
+        fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-hover, var(--spectrum-menu-item-label-icon-color-hover)));
+        color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-icon-color-hover, var(--spectrum-menu-item-label-icon-color-hover)));
     }
 
     :host(:hover) > .chevron {
-        fill: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-collapsible-icon-color,
-                var(--spectrum-menu-collapsible-icon-color)
-            )
-        );
-        color: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-collapsible-icon-color,
-                var(--spectrum-menu-collapsible-icon-color)
-            )
-        );
+        fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-collapsible-icon-color, var(--spectrum-menu-collapsible-icon-color)));
+        color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-collapsible-icon-color, var(--spectrum-menu-collapsible-icon-color)));
     }
 
     :host(:hover) > .checkmark {
-        fill: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-checkmark-icon-color-hover,
-                var(--spectrum-menu-checkmark-icon-color-hover)
-            )
-        );
-        color: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-checkmark-icon-color-hover,
-                var(--spectrum-menu-checkmark-icon-color-hover)
-            )
-        );
+        fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-checkmark-icon-color-hover, var(--spectrum-menu-checkmark-icon-color-hover)));
+        color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-checkmark-icon-color-hover, var(--spectrum-menu-checkmark-icon-color-hover)));
     }
 
     :host([disabled]:hover),
@@ -688,121 +319,46 @@ governing permissions and limitations under the License.
     :host([disabled]:hover) ::slotted([slot='value']),
     :host([aria-disabled='true']:hover) #label,
     :host([aria-disabled='true']:hover) ::slotted([slot='value']) {
-        color: var(
-            --highcontrast-menu-item-color-disabled,
-            var(
-                --mod-menu-item-label-content-color-disabled,
-                var(--spectrum-menu-item-label-content-color-disabled)
-            )
-        );
+        color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
     }
 
     :host([disabled]:hover) [name='description']::slotted(*),
     :host([aria-disabled='true']:hover) [name='description']::slotted(*) {
-        color: var(
-            --highcontrast-menu-item-color-disabled,
-            var(
-                --mod-menu-item-description-color-disabled,
-                var(--spectrum-menu-item-description-color-disabled)
-            )
-        );
+        color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-description-color-disabled, var(--spectrum-menu-item-description-color-disabled)));
     }
 
     :host([disabled]:hover) ::slotted([slot='icon']),
     :host([aria-disabled='true']:hover) ::slotted([slot='icon']) {
-        color: var(
-            --highcontrast-menu-item-color-disabled,
-            var(
-                --mod-menu-item-label-icon-color-disabled,
-                var(--spectrum-menu-item-label-icon-color-disabled)
-            )
-        );
-        fill: var(
-            --highcontrast-menu-item-color-disabled,
-            var(
-                --mod-menu-item-label-icon-color-disabled,
-                var(--spectrum-menu-item-label-icon-color-disabled)
-            )
-        );
+        color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
+        fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
     }
 
     .spectrum-Menu-item--collapsible.is-open:hover {
-        background-color: var(
-            --highcontrast-menu-item-background-color-default,
-            var(
-                --mod-menu-item-background-color-default,
-                var(--spectrum-menu-item-background-color-default)
-            )
-        );
+        background-color: var(--highcontrast-menu-item-background-color-default, var(--mod-menu-item-background-color-default, var(--spectrum-menu-item-background-color-default)));
     }
 
     :host([has-submenu]:hover) .chevron {
-        fill: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-drillin-icon-color-hover,
-                var(--spectrum-menu-drillin-icon-color-hover)
-            )
-        );
-        color: var(
-            --highcontrast-menu-item-color-focus,
-            var(
-                --mod-menu-drillin-icon-color-hover,
-                var(--spectrum-menu-drillin-icon-color-hover)
-            )
-        );
+        fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-hover, var(--spectrum-menu-drillin-icon-color-hover)));
+        color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-hover, var(--spectrum-menu-drillin-icon-color-hover)));
     }
 }
 
 :host([has-submenu][focused]) .chevron,
 :host([has-submenu]:focus) .chevron {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-drillin-icon-color-focus,
-            var(--spectrum-menu-drillin-icon-color-focus)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-drillin-icon-color-focus,
-            var(--spectrum-menu-drillin-icon-color-focus)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-focus, var(--spectrum-menu-drillin-icon-color-focus)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-focus, var(--spectrum-menu-drillin-icon-color-focus)));
 }
 
 :host([has-submenu]:is(:active, [active])) .chevron {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-drillin-icon-color-down,
-            var(--spectrum-menu-drillin-icon-color-down)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-drillin-icon-color-down,
-            var(--spectrum-menu-drillin-icon-color-down)
-        )
-    );
+    fill: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-down, var(--spectrum-menu-drillin-icon-color-down)));
+    color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-drillin-icon-color-down, var(--spectrum-menu-drillin-icon-color-down)));
 }
 
 .spectrum-Menu-back {
-    padding-inline: 0
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
-    padding-inline: var(--mod-menu-back-padding-inline-start, 0)
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
+    padding-inline: 0 var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
+    padding-inline: var(--mod-menu-back-padding-inline-start, 0) var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
     padding-block: 0;
-    padding-block: var(--mod-menu-back-padding-block-start, 0)
-        var(--mod-menu-back-padding-block-end, 0);
+    padding-block: var(--mod-menu-back-padding-block-start, 0) var(--mod-menu-back-padding-block-end, 0);
     flex-flow: wrap;
     align-items: center;
     display: flex;
@@ -818,32 +374,14 @@ governing permissions and limitations under the License.
 }
 
 :host([focused]) .spectrum-Menu-backButton {
-    outline: var(--spectrum-focus-indicator-thickness) solid
-        var(--spectrum-focus-indicator-color);
-    outline-offset: calc(
-        (var(--spectrum-focus-indicator-thickness) + 1px) * -1
-    );
+    outline: var(--spectrum-focus-indicator-thickness) solid var(--spectrum-focus-indicator-color);
+    outline-offset: calc((var(--spectrum-focus-indicator-thickness) + 1px) * -1);
 }
 
 .spectrum-Menu-backHeading {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-back-heading-color,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
-    font-size: var(
-        --mod-menu-section-header-font-size,
-        var(--spectrum-menu-section-header-font-size)
-    );
-    font-weight: var(
-        --mod-menu-section-header-font-weight,
-        var(--spectrum-menu-section-header-font-weight)
-    );
-    line-height: var(
-        --mod-menu-section-header-line-height,
-        var(--spectrum-menu-section-header-line-height)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-heading-color, var(--spectrum-menu-section-header-color)));
+    font-size: var(--mod-menu-section-header-font-size, var(--spectrum-menu-section-header-font-size));
+    font-weight: var(--mod-menu-section-header-font-weight, var(--spectrum-menu-section-header-font-weight));
+    line-height: var(--mod-menu-section-header-line-height, var(--spectrum-menu-section-header-line-height));
     display: block;
 }

--- a/packages/menu/src/spectrum-menu-sectionHeading.css
+++ b/packages/menu/src/spectrum-menu-sectionHeading.css
@@ -12,76 +12,30 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Menu-back:focus-visible {
-    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow)
-        var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0
-        var(--spectrum-menu-item-focus-indicator-color-default);
-    outline: var(--spectrum-menu-item-focus-indicator-width)
-        var(--spectrum-menu-item-focus-indicator-outline-style)
-        var(--spectrum-menu-item-focus-indicator-color-default);
+    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow) var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0 var(--spectrum-menu-item-focus-indicator-color-default);
+    outline: var(--spectrum-menu-item-focus-indicator-width) var(--spectrum-menu-item-focus-indicator-outline-style) var(--spectrum-menu-item-focus-indicator-color-default);
     outline-offset: var(--spectrum-menu-item-focus-indicator-offset);
     border-radius: var(--spectrum-menu-item-corner-radius);
 }
 
 .header {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-section-header-color,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
-    font-size: var(
-        --mod-menu-section-header-font-size,
-        var(--spectrum-menu-section-header-font-size)
-    );
-    font-weight: var(
-        --mod-menu-section-header-font-weight,
-        var(--spectrum-menu-section-header-font-weight)
-    );
-    line-height: var(
-        --mod-menu-section-header-line-height,
-        var(--spectrum-menu-section-header-line-height)
-    );
-    min-inline-size: var(
-        --mod-menu-section-header-min-width,
-        var(--spectrum-menu-section-header-min-width)
-    );
-    padding-block-start: var(
-        --mod-menu-section-header-top-edge-to-text,
-        var(
-            --mod-menu-item-top-edge-to-text,
-            var(--spectrum-menu-item-top-edge-to-text)
-        )
-    );
-    padding-block-end: var(
-        --mod-menu-section-header-bottom-edge-to-text,
-        var(
-            --mod-menu-item-bottom-edge-to-text,
-            var(--spectrum-menu-item-bottom-edge-to-text)
-        )
-    );
-    padding-inline: var(
-        --mod-menu-item-label-inline-edge-to-content,
-        var(--spectrum-menu-item-label-inline-edge-to-content)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-section-header-color, var(--spectrum-menu-section-header-color)));
+    font-size: var(--mod-menu-section-header-font-size, var(--spectrum-menu-section-header-font-size));
+    font-weight: var(--mod-menu-section-header-font-weight, var(--spectrum-menu-section-header-font-weight));
+    line-height: var(--mod-menu-section-header-line-height, var(--spectrum-menu-section-header-line-height));
+    min-inline-size: var(--mod-menu-section-header-min-width, var(--spectrum-menu-section-header-min-width));
+    padding-block-start: var(--mod-menu-section-header-top-edge-to-text, var(--mod-menu-item-top-edge-to-text, var(--spectrum-menu-item-top-edge-to-text)));
+    padding-block-end: var(--mod-menu-section-header-bottom-edge-to-text, var(--mod-menu-item-bottom-edge-to-text, var(--spectrum-menu-item-bottom-edge-to-text)));
+    padding-inline: var(--mod-menu-item-label-inline-edge-to-content, var(--spectrum-menu-item-label-inline-edge-to-content));
     grid-area: sectionHeadingArea / 1 / sectionHeadingArea / -1;
     display: block;
 }
 
 .spectrum-Menu-back {
-    padding-inline: 0
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
-    padding-inline: var(--mod-menu-back-padding-inline-start, 0)
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
+    padding-inline: 0 var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
+    padding-inline: var(--mod-menu-back-padding-inline-start, 0) var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
     padding-block: 0;
-    padding-block: var(--mod-menu-back-padding-block-start, 0)
-        var(--mod-menu-back-padding-block-end, 0);
+    padding-block: var(--mod-menu-back-padding-block-start, 0) var(--mod-menu-back-padding-block-end, 0);
     flex-flow: wrap;
     align-items: center;
     display: flex;
@@ -101,32 +55,14 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-backButton:focus-visible {
-    outline: var(--spectrum-focus-indicator-thickness) solid
-        var(--spectrum-focus-indicator-color);
-    outline-offset: calc(
-        (var(--spectrum-focus-indicator-thickness) + 1px) * -1
-    );
+    outline: var(--spectrum-focus-indicator-thickness) solid var(--spectrum-focus-indicator-color);
+    outline-offset: calc((var(--spectrum-focus-indicator-thickness) + 1px) * -1);
 }
 
 .spectrum-Menu-backHeading {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-back-heading-color,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
-    font-size: var(
-        --mod-menu-section-header-font-size,
-        var(--spectrum-menu-section-header-font-size)
-    );
-    font-weight: var(
-        --mod-menu-section-header-font-weight,
-        var(--spectrum-menu-section-header-font-weight)
-    );
-    line-height: var(
-        --mod-menu-section-header-line-height,
-        var(--spectrum-menu-section-header-line-height)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-heading-color, var(--spectrum-menu-section-header-color)));
+    font-size: var(--mod-menu-section-header-font-size, var(--spectrum-menu-section-header-font-size));
+    font-weight: var(--mod-menu-section-header-font-weight, var(--spectrum-menu-section-header-font-weight));
+    line-height: var(--mod-menu-section-header-line-height, var(--spectrum-menu-section-header-line-height));
     display: block;
 }

--- a/packages/menu/src/spectrum-menu.css
+++ b/packages/menu/src/spectrum-menu.css
@@ -36,175 +36,68 @@ governing permissions and limitations under the License.
     --spectrum-menu-item-top-to-action: var(--spectrum-spacing-50);
     --spectrum-menu-item-top-to-checkbox: var(--spectrum-spacing-50);
     --spectrum-menu-item-label-line-height: var(--spectrum-line-height-100);
-    --spectrum-menu-item-label-line-height-cjk: var(
-        --spectrum-cjk-line-height-100
-    );
-    --spectrum-menu-item-label-to-description-spacing: var(
-        --spectrum-menu-item-label-to-description
-    );
-    --spectrum-menu-item-focus-indicator-width: var(
-        --mod-menu-item-focus-indicator-width,
-        var(--spectrum-border-width-200)
-    );
+    --spectrum-menu-item-label-line-height-cjk: var(--spectrum-cjk-line-height-100);
+    --spectrum-menu-item-label-to-description-spacing: var(--spectrum-menu-item-label-to-description);
+    --spectrum-menu-item-focus-indicator-width: var(--mod-menu-item-focus-indicator-width, var(--spectrum-border-width-200));
     --spectrum-menu-item-focus-indicator-color: var(--spectrum-blue-800);
-    --spectrum-menu-item-label-to-value-area-min-spacing: var(
-        --spectrum-spacing-100
-    );
-    --spectrum-menu-item-label-content-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-menu-item-label-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --spectrum-menu-item-label-content-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --spectrum-menu-item-label-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
-    --spectrum-menu-item-label-icon-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-menu-item-label-icon-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --spectrum-menu-item-label-icon-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --spectrum-menu-item-label-icon-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
-    --spectrum-menu-item-label-content-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
-    --spectrum-menu-item-label-icon-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
-    --spectrum-menu-item-description-line-height: var(
-        --spectrum-line-height-100
-    );
-    --spectrum-menu-item-description-line-height-cjk: var(
-        --spectrum-cjk-line-height-100
-    );
-    --spectrum-menu-item-description-color-default: var(
-        --spectrum-neutral-subdued-content-color-default
-    );
-    --spectrum-menu-item-description-color-hover: var(
-        --spectrum-neutral-subdued-content-color-hover
-    );
-    --spectrum-menu-item-description-color-down: var(
-        --spectrum-neutral-subdued-content-color-down
-    );
-    --spectrum-menu-item-description-color-focus: var(
-        --spectrum-neutral-subdued-content-color-key-focus
-    );
-    --spectrum-menu-item-description-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
+    --spectrum-menu-item-label-to-value-area-min-spacing: var(--spectrum-spacing-100);
+    --spectrum-menu-item-label-content-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-menu-item-label-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-menu-item-label-content-color-down: var(--spectrum-neutral-content-color-down);
+    --spectrum-menu-item-label-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-menu-item-label-icon-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-menu-item-label-icon-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-menu-item-label-icon-color-down: var(--spectrum-neutral-content-color-down);
+    --spectrum-menu-item-label-icon-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-menu-item-label-content-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-menu-item-label-icon-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-menu-item-description-line-height: var(--spectrum-line-height-100);
+    --spectrum-menu-item-description-line-height-cjk: var(--spectrum-cjk-line-height-100);
+    --spectrum-menu-item-description-color-default: var(--spectrum-neutral-subdued-content-color-default);
+    --spectrum-menu-item-description-color-hover: var(--spectrum-neutral-subdued-content-color-hover);
+    --spectrum-menu-item-description-color-down: var(--spectrum-neutral-subdued-content-color-down);
+    --spectrum-menu-item-description-color-focus: var(--spectrum-neutral-subdued-content-color-key-focus);
+    --spectrum-menu-item-description-color-disabled: var(--spectrum-disabled-content-color);
     --spectrum-menu-section-header-line-height: var(--spectrum-line-height-100);
-    --spectrum-menu-section-header-line-height-cjk: var(
-        --spectrum-cjk-line-height-100
-    );
-    --spectrum-menu-section-header-font-weight: var(
-        --spectrum-bold-font-weight
-    );
+    --spectrum-menu-section-header-line-height-cjk: var(--spectrum-cjk-line-height-100);
+    --spectrum-menu-section-header-font-weight: var(--spectrum-bold-font-weight);
     --spectrum-menu-section-header-color: var(--spectrum-gray-900);
     --spectrum-menu-collapsible-icon-color: var(--spectrum-gray-900);
-    --spectrum-menu-checkmark-icon-color-default: var(
-        --spectrum-accent-color-900
-    );
-    --spectrum-menu-checkmark-icon-color-hover: var(
-        --spectrum-accent-color-1000
-    );
-    --spectrum-menu-checkmark-icon-color-down: var(
-        --spectrum-accent-color-1100
-    );
-    --spectrum-menu-checkmark-icon-color-focus: var(
-        --spectrum-accent-color-1000
-    );
-    --spectrum-menu-drillin-icon-color-default: var(
-        --spectrum-neutral-subdued-content-color-default
-    );
-    --spectrum-menu-drillin-icon-color-hover: var(
-        --spectrum-neutral-subdued-content-color-hover
-    );
-    --spectrum-menu-drillin-icon-color-down: var(
-        --spectrum-neutral-subdued-content-color-down
-    );
-    --spectrum-menu-drillin-icon-color-focus: var(
-        --spectrum-neutral-subdued-content-color-key-focus
-    );
-    --spectrum-menu-item-value-color-default: var(
-        --spectrum-neutral-subdued-content-color-default
-    );
-    --spectrum-menu-item-value-color-hover: var(
-        --spectrum-neutral-subdued-content-color-hover
-    );
-    --spectrum-menu-item-value-color-down: var(
-        --spectrum-neutral-subdued-content-color-down
-    );
-    --spectrum-menu-item-value-color-focus: var(
-        --spectrum-neutral-subdued-content-color-key-focus
-    );
+    --spectrum-menu-checkmark-icon-color-default: var(--spectrum-accent-color-900);
+    --spectrum-menu-checkmark-icon-color-hover: var(--spectrum-accent-color-1000);
+    --spectrum-menu-checkmark-icon-color-down: var(--spectrum-accent-color-1100);
+    --spectrum-menu-checkmark-icon-color-focus: var(--spectrum-accent-color-1000);
+    --spectrum-menu-drillin-icon-color-default: var(--spectrum-neutral-subdued-content-color-default);
+    --spectrum-menu-drillin-icon-color-hover: var(--spectrum-neutral-subdued-content-color-hover);
+    --spectrum-menu-drillin-icon-color-down: var(--spectrum-neutral-subdued-content-color-down);
+    --spectrum-menu-drillin-icon-color-focus: var(--spectrum-neutral-subdued-content-color-key-focus);
+    --spectrum-menu-item-value-color-default: var(--spectrum-neutral-subdued-content-color-default);
+    --spectrum-menu-item-value-color-hover: var(--spectrum-neutral-subdued-content-color-hover);
+    --spectrum-menu-item-value-color-down: var(--spectrum-neutral-subdued-content-color-down);
+    --spectrum-menu-item-value-color-focus: var(--spectrum-neutral-subdued-content-color-key-focus);
     --spectrum-menu-checkmark-display-hidden: none;
     --spectrum-menu-checkmark-display-shown: block;
-    --spectrum-menu-checkmark-display: var(
-        --spectrum-menu-checkmark-display-shown
-    );
+    --spectrum-menu-checkmark-display: var(--spectrum-menu-checkmark-display-shown);
     --spectrum-menu-item-min-height: var(--spectrum-component-height-100);
     --spectrum-menu-item-icon-height: var(--spectrum-workflow-icon-size-100);
     --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-100);
     --spectrum-menu-item-label-font-size: var(--spectrum-font-size-100);
-    --spectrum-menu-item-label-text-to-visual: var(
-        --spectrum-text-to-visual-100
-    );
-    --spectrum-menu-item-label-inline-edge-to-content: var(
-        --spectrum-component-edge-to-text-100
-    );
-    --spectrum-menu-item-top-edge-to-text: var(
-        --spectrum-component-top-to-text-100
-    );
-    --spectrum-menu-item-bottom-edge-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
+    --spectrum-menu-item-label-text-to-visual: var(--spectrum-text-to-visual-100);
+    --spectrum-menu-item-label-inline-edge-to-content: var(--spectrum-component-edge-to-text-100);
+    --spectrum-menu-item-top-edge-to-text: var(--spectrum-component-top-to-text-100);
+    --spectrum-menu-item-bottom-edge-to-text: var(--spectrum-component-bottom-to-text-100);
     --spectrum-menu-item-text-to-control: var(--spectrum-text-to-control-100);
     --spectrum-menu-item-description-font-size: var(--spectrum-font-size-75);
     --spectrum-menu-section-header-font-size: var(--spectrum-font-size-100);
-    --spectrum-menu-section-header-min-width: var(
-        --spectrum-component-height-100
-    );
-    --spectrum-menu-item-selectable-edge-to-text-not-selected: var(
-        --spectrum-menu-item-selectable-edge-to-text-not-selected-medium
-    );
-    --spectrum-menu-item-checkmark-height: var(
-        --spectrum-menu-item-checkmark-height-medium
-    );
-    --spectrum-menu-item-checkmark-width: var(
-        --spectrum-menu-item-checkmark-width-medium
-    );
-    --spectrum-menu-item-top-to-checkmark: var(
-        --spectrum-menu-item-top-to-selected-icon-medium
-    );
-    --spectrum-menu-back-icon-margin: var(
-        --spectrum-navigational-indicator-top-to-back-icon-medium
-    );
-    --spectrum-menu-item-collapsible-no-icon-submenu-item-padding-x-start: calc(
-        var(--spectrum-menu-item-label-inline-edge-to-content) +
-            var(--spectrum-menu-item-checkmark-width) +
-            var(--spectrum-menu-item-label-text-to-visual) +
-            var(--spectrum-menu-item-focus-indicator-width)
-    );
-    --spectrum-menu-item-focus-indicator-color-default: var(
-        --highcontrast-menu-item-focus-indicator-color,
-        var(
-            --mod-menu-item-focus-indicator-color,
-            var(--spectrum-menu-item-focus-indicator-color)
-        )
-    );
-    --spectrum-menu-item-focus-indicator-border-width: calc(
-        var(--spectrum-menu-item-focus-indicator-width) *
-            var(--spectrum-menu-item-focus-indicator-direction-scalar, 1)
-    );
+    --spectrum-menu-section-header-min-width: var(--spectrum-component-height-100);
+    --spectrum-menu-item-selectable-edge-to-text-not-selected: var(--spectrum-menu-item-selectable-edge-to-text-not-selected-medium);
+    --spectrum-menu-item-checkmark-height: var(--spectrum-menu-item-checkmark-height-medium);
+    --spectrum-menu-item-checkmark-width: var(--spectrum-menu-item-checkmark-width-medium);
+    --spectrum-menu-item-top-to-checkmark: var(--spectrum-menu-item-top-to-selected-icon-medium);
+    --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-medium);
+    --spectrum-menu-item-collapsible-no-icon-submenu-item-padding-x-start: calc(var(--spectrum-menu-item-label-inline-edge-to-content) + var(--spectrum-menu-item-checkmark-width) + var(--spectrum-menu-item-label-text-to-visual) + var(--spectrum-menu-item-focus-indicator-width));
+    --spectrum-menu-item-focus-indicator-color-default: var(--highcontrast-menu-item-focus-indicator-color, var(--mod-menu-item-focus-indicator-color, var(--spectrum-menu-item-focus-indicator-color)));
+    --spectrum-menu-item-focus-indicator-border-width: calc(var(--spectrum-menu-item-focus-indicator-width) * var(--spectrum-menu-item-focus-indicator-direction-scalar, 1));
 }
 
 :host([size='s']) {
@@ -212,39 +105,19 @@ governing permissions and limitations under the License.
     --spectrum-menu-item-icon-height: var(--spectrum-workflow-icon-size-75);
     --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-75);
     --spectrum-menu-item-label-font-size: var(--spectrum-font-size-75);
-    --spectrum-menu-item-label-text-to-visual: var(
-        --spectrum-text-to-visual-75
-    );
-    --spectrum-menu-item-label-inline-edge-to-content: var(
-        --spectrum-component-edge-to-text-75
-    );
-    --spectrum-menu-item-top-edge-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --spectrum-menu-item-bottom-edge-to-text: var(
-        --spectrum-component-bottom-to-text-75
-    );
+    --spectrum-menu-item-label-text-to-visual: var(--spectrum-text-to-visual-75);
+    --spectrum-menu-item-label-inline-edge-to-content: var(--spectrum-component-edge-to-text-75);
+    --spectrum-menu-item-top-edge-to-text: var(--spectrum-component-top-to-text-75);
+    --spectrum-menu-item-bottom-edge-to-text: var(--spectrum-component-bottom-to-text-75);
     --spectrum-menu-item-text-to-control: var(--spectrum-text-to-control-75);
     --spectrum-menu-item-description-font-size: var(--spectrum-font-size-50);
     --spectrum-menu-section-header-font-size: var(--spectrum-font-size-75);
-    --spectrum-menu-section-header-min-width: var(
-        --spectrum-component-height-75
-    );
-    --spectrum-menu-item-selectable-edge-to-text-not-selected: var(
-        --spectrum-menu-item-selectable-edge-to-text-not-selected-small
-    );
-    --spectrum-menu-item-checkmark-height: var(
-        --spectrum-menu-item-checkmark-height-small
-    );
-    --spectrum-menu-item-checkmark-width: var(
-        --spectrum-menu-item-checkmark-width-small
-    );
-    --spectrum-menu-item-top-to-checkmark: var(
-        --spectrum-menu-item-top-to-selected-icon-small
-    );
-    --spectrum-menu-back-icon-margin: var(
-        --spectrum-navigational-indicator-top-to-back-icon-small
-    );
+    --spectrum-menu-section-header-min-width: var(--spectrum-component-height-75);
+    --spectrum-menu-item-selectable-edge-to-text-not-selected: var(--spectrum-menu-item-selectable-edge-to-text-not-selected-small);
+    --spectrum-menu-item-checkmark-height: var(--spectrum-menu-item-checkmark-height-small);
+    --spectrum-menu-item-checkmark-width: var(--spectrum-menu-item-checkmark-width-small);
+    --spectrum-menu-item-top-to-checkmark: var(--spectrum-menu-item-top-to-selected-icon-small);
+    --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-small);
 }
 
 :host([size='l']) {
@@ -252,39 +125,19 @@ governing permissions and limitations under the License.
     --spectrum-menu-item-icon-height: var(--spectrum-workflow-icon-size-200);
     --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-200);
     --spectrum-menu-item-label-font-size: var(--spectrum-font-size-200);
-    --spectrum-menu-item-label-text-to-visual: var(
-        --spectrum-text-to-visual-200
-    );
-    --spectrum-menu-item-label-inline-edge-to-content: var(
-        --spectrum-component-edge-to-text-200
-    );
-    --spectrum-menu-item-top-edge-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --spectrum-menu-item-bottom-edge-to-text: var(
-        --spectrum-component-bottom-to-text-200
-    );
+    --spectrum-menu-item-label-text-to-visual: var(--spectrum-text-to-visual-200);
+    --spectrum-menu-item-label-inline-edge-to-content: var(--spectrum-component-edge-to-text-200);
+    --spectrum-menu-item-top-edge-to-text: var(--spectrum-component-top-to-text-200);
+    --spectrum-menu-item-bottom-edge-to-text: var(--spectrum-component-bottom-to-text-200);
     --spectrum-menu-item-text-to-control: var(--spectrum-text-to-control-200);
     --spectrum-menu-item-description-font-size: var(--spectrum-font-size-100);
     --spectrum-menu-section-header-font-size: var(--spectrum-font-size-200);
-    --spectrum-menu-section-header-min-width: var(
-        --spectrum-component-height-200
-    );
-    --spectrum-menu-item-selectable-edge-to-text-not-selected: var(
-        --spectrum-menu-item-selectable-edge-to-text-not-selected-large
-    );
-    --spectrum-menu-item-checkmark-height: var(
-        --spectrum-menu-item-checkmark-height-large
-    );
-    --spectrum-menu-item-checkmark-width: var(
-        --spectrum-menu-item-checkmark-width-large
-    );
-    --spectrum-menu-item-top-to-checkmark: var(
-        --spectrum-menu-item-top-to-selected-icon-large
-    );
-    --spectrum-menu-back-icon-margin: var(
-        --spectrum-navigational-indicator-top-to-back-icon-large
-    );
+    --spectrum-menu-section-header-min-width: var(--spectrum-component-height-200);
+    --spectrum-menu-item-selectable-edge-to-text-not-selected: var(--spectrum-menu-item-selectable-edge-to-text-not-selected-large);
+    --spectrum-menu-item-checkmark-height: var(--spectrum-menu-item-checkmark-height-large);
+    --spectrum-menu-item-checkmark-width: var(--spectrum-menu-item-checkmark-width-large);
+    --spectrum-menu-item-top-to-checkmark: var(--spectrum-menu-item-top-to-selected-icon-large);
+    --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-large);
 }
 
 :host([size='xl']) {
@@ -292,39 +145,19 @@ governing permissions and limitations under the License.
     --spectrum-menu-item-icon-height: var(--spectrum-workflow-icon-size-300);
     --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-300);
     --spectrum-menu-item-label-font-size: var(--spectrum-font-size-300);
-    --spectrum-menu-item-label-text-to-visual: var(
-        --spectrum-text-to-visual-300
-    );
-    --spectrum-menu-item-label-inline-edge-to-content: var(
-        --spectrum-component-edge-to-text-300
-    );
-    --spectrum-menu-item-top-edge-to-text: var(
-        --spectrum-component-top-to-text-300
-    );
-    --spectrum-menu-item-bottom-edge-to-text: var(
-        --spectrum-component-bottom-to-text-300
-    );
+    --spectrum-menu-item-label-text-to-visual: var(--spectrum-text-to-visual-300);
+    --spectrum-menu-item-label-inline-edge-to-content: var(--spectrum-component-edge-to-text-300);
+    --spectrum-menu-item-top-edge-to-text: var(--spectrum-component-top-to-text-300);
+    --spectrum-menu-item-bottom-edge-to-text: var(--spectrum-component-bottom-to-text-300);
     --spectrum-menu-item-text-to-control: var(--spectrum-text-to-control-300);
     --spectrum-menu-item-description-font-size: var(--spectrum-font-size-200);
     --spectrum-menu-section-header-font-size: var(--spectrum-font-size-300);
-    --spectrum-menu-section-header-min-width: var(
-        --spectrum-component-height-300
-    );
-    --spectrum-menu-item-selectable-edge-to-text-not-selected: var(
-        --spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large
-    );
-    --spectrum-menu-item-checkmark-height: var(
-        --spectrum-menu-item-checkmark-height-extra-large
-    );
-    --spectrum-menu-item-checkmark-width: var(
-        --spectrum-menu-item-checkmark-width-extra-large
-    );
-    --spectrum-menu-item-top-to-checkmark: var(
-        --spectrum-menu-item-top-to-selected-icon-extra-large
-    );
-    --spectrum-menu-back-icon-margin: var(
-        --spectrum-navigational-indicator-top-to-back-icon-extra-large
-    );
+    --spectrum-menu-section-header-min-width: var(--spectrum-component-height-300);
+    --spectrum-menu-item-selectable-edge-to-text-not-selected: var(--spectrum-menu-item-selectable-edge-to-text-not-selected-extra-large);
+    --spectrum-menu-item-checkmark-height: var(--spectrum-menu-item-checkmark-height-extra-large);
+    --spectrum-menu-item-checkmark-width: var(--spectrum-menu-item-checkmark-width-extra-large);
+    --spectrum-menu-item-top-to-checkmark: var(--spectrum-menu-item-top-to-selected-icon-extra-large);
+    --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-extra-large);
 }
 
 :host:dir(rtl),
@@ -346,136 +179,53 @@ governing permissions and limitations under the License.
 :host:lang(ja),
 :host:lang(ko),
 :host:lang(zh) {
-    --spectrum-menu-item-label-line-height: var(
-        --mod-menu-item-label-line-height-cjk,
-        var(--spectrum-menu-item-label-line-height-cjk)
-    );
-    --spectrum-menu-item-description-line-height: var(
-        --mod-menu-item-description-line-height-cjk,
-        var(--spectrum-menu-item-description-line-height-cjk)
-    );
-    --spectrum-menu-section-header-line-height: var(
-        --mod-menu-section-header-line-height-cjk,
-        var(--spectrum-menu-section-header-line-height-cjk)
-    );
+    --spectrum-menu-item-label-line-height: var(--mod-menu-item-label-line-height-cjk, var(--spectrum-menu-item-label-line-height-cjk));
+    --spectrum-menu-item-description-line-height: var(--mod-menu-item-description-line-height-cjk, var(--spectrum-menu-item-description-line-height-cjk));
+    --spectrum-menu-section-header-line-height: var(--mod-menu-section-header-line-height-cjk, var(--spectrum-menu-section-header-line-height-cjk));
 }
 
 :host([selects]) ::slotted(sp-menu-item) {
-    --spectrum-menu-checkmark-display: var(
-        --spectrum-menu-checkmark-display-hidden
-    );
-    padding-inline-start: var(
-        --mod-menu-item-selectable-edge-to-text-not-selected,
-        var(--spectrum-menu-item-selectable-edge-to-text-not-selected)
-    );
+    --spectrum-menu-checkmark-display: var(--spectrum-menu-checkmark-display-hidden);
+    padding-inline-start: var(--mod-menu-item-selectable-edge-to-text-not-selected, var(--spectrum-menu-item-selectable-edge-to-text-not-selected));
 }
 
 :host([selects]) ::slotted(sp-menu-item[selected]) {
-    --spectrum-menu-checkmark-display: var(
-        --spectrum-menu-checkmark-display-shown
-    );
-    padding-inline-start: var(
-        --mod-menu-item-label-inline-edge-to-content,
-        var(--spectrum-menu-item-label-inline-edge-to-content)
-    );
+    --spectrum-menu-checkmark-display: var(--spectrum-menu-checkmark-display-shown);
+    padding-inline-start: var(--mod-menu-item-label-inline-edge-to-content, var(--spectrum-menu-item-label-inline-edge-to-content));
 }
 
 .spectrum-Menu-backIcon {
-    margin-block: var(
-        --mod-menu-back-icon-margin-block,
-        var(--spectrum-menu-back-icon-margin)
-    );
-    margin-inline: var(
-        --mod-menu-back-icon-margin-inline,
-        var(--spectrum-menu-back-icon-margin)
-    );
-    fill: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-back-icon-color-default,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-back-icon-color-default,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
+    margin-block: var(--mod-menu-back-icon-margin-block, var(--spectrum-menu-back-icon-margin));
+    margin-inline: var(--mod-menu-back-icon-margin-inline, var(--spectrum-menu-back-icon-margin));
+    fill: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-icon-color-default, var(--spectrum-menu-section-header-color)));
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-icon-color-default, var(--spectrum-menu-section-header-color)));
 }
 
 .spectrum-Menu-back:focus-visible {
-    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow)
-        var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0
-        var(--spectrum-menu-item-focus-indicator-color-default);
-    outline: var(--spectrum-menu-item-focus-indicator-width)
-        var(--spectrum-menu-item-focus-indicator-outline-style)
-        var(--spectrum-menu-item-focus-indicator-color-default);
+    box-shadow: var(--spectrum-menu-item-focus-indicator-shadow) var(--spectrum-menu-item-focus-indicator-border-width) 0 0 0 var(--spectrum-menu-item-focus-indicator-color-default);
+    outline: var(--spectrum-menu-item-focus-indicator-width) var(--spectrum-menu-item-focus-indicator-outline-style) var(--spectrum-menu-item-focus-indicator-color-default);
     outline-offset: var(--spectrum-menu-item-focus-indicator-offset);
     border-radius: var(--spectrum-menu-item-corner-radius);
 }
 
 .spectrum-Menu-sectionHeading {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-section-header-color,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
-    font-size: var(
-        --mod-menu-section-header-font-size,
-        var(--spectrum-menu-section-header-font-size)
-    );
-    font-weight: var(
-        --mod-menu-section-header-font-weight,
-        var(--spectrum-menu-section-header-font-weight)
-    );
-    line-height: var(
-        --mod-menu-section-header-line-height,
-        var(--spectrum-menu-section-header-line-height)
-    );
-    min-inline-size: var(
-        --mod-menu-section-header-min-width,
-        var(--spectrum-menu-section-header-min-width)
-    );
-    padding-block-start: var(
-        --mod-menu-section-header-top-edge-to-text,
-        var(
-            --mod-menu-item-top-edge-to-text,
-            var(--spectrum-menu-item-top-edge-to-text)
-        )
-    );
-    padding-block-end: var(
-        --mod-menu-section-header-bottom-edge-to-text,
-        var(
-            --mod-menu-item-bottom-edge-to-text,
-            var(--spectrum-menu-item-bottom-edge-to-text)
-        )
-    );
-    padding-inline: var(
-        --mod-menu-item-label-inline-edge-to-content,
-        var(--spectrum-menu-item-label-inline-edge-to-content)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-section-header-color, var(--spectrum-menu-section-header-color)));
+    font-size: var(--mod-menu-section-header-font-size, var(--spectrum-menu-section-header-font-size));
+    font-weight: var(--mod-menu-section-header-font-weight, var(--spectrum-menu-section-header-font-weight));
+    line-height: var(--mod-menu-section-header-line-height, var(--spectrum-menu-section-header-line-height));
+    min-inline-size: var(--mod-menu-section-header-min-width, var(--spectrum-menu-section-header-min-width));
+    padding-block-start: var(--mod-menu-section-header-top-edge-to-text, var(--mod-menu-item-top-edge-to-text, var(--spectrum-menu-item-top-edge-to-text)));
+    padding-block-end: var(--mod-menu-section-header-bottom-edge-to-text, var(--mod-menu-item-bottom-edge-to-text, var(--spectrum-menu-item-bottom-edge-to-text)));
+    padding-inline: var(--mod-menu-item-label-inline-edge-to-content, var(--spectrum-menu-item-label-inline-edge-to-content));
     grid-area: sectionHeadingArea / 1 / sectionHeadingArea / -1;
     display: block;
 }
 
 .spectrum-Menu-back {
-    padding-inline: 0
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
-    padding-inline: var(--mod-menu-back-padding-inline-start, 0)
-        var(
-            --mod-menu-back-padding-inline-end,
-            var(--spectrum-menu-item-label-inline-edge-to-content)
-        );
+    padding-inline: 0 var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
+    padding-inline: var(--mod-menu-back-padding-inline-start, 0) var(--mod-menu-back-padding-inline-end, var(--spectrum-menu-item-label-inline-edge-to-content));
     padding-block: 0;
-    padding-block: var(--mod-menu-back-padding-block-start, 0)
-        var(--mod-menu-back-padding-block-end, 0);
+    padding-block: var(--mod-menu-back-padding-block-start, 0) var(--mod-menu-back-padding-block-end, 0);
     flex-flow: wrap;
     align-items: center;
     display: flex;
@@ -495,32 +245,14 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-backButton:focus-visible {
-    outline: var(--spectrum-focus-indicator-thickness) solid
-        var(--spectrum-focus-indicator-color);
-    outline-offset: calc(
-        (var(--spectrum-focus-indicator-thickness) + 1px) * -1
-    );
+    outline: var(--spectrum-focus-indicator-thickness) solid var(--spectrum-focus-indicator-color);
+    outline-offset: calc((var(--spectrum-focus-indicator-thickness) + 1px) * -1);
 }
 
 .spectrum-Menu-backHeading {
-    color: var(
-        --highcontrast-menu-item-color-default,
-        var(
-            --mod-menu-back-heading-color,
-            var(--spectrum-menu-section-header-color)
-        )
-    );
-    font-size: var(
-        --mod-menu-section-header-font-size,
-        var(--spectrum-menu-section-header-font-size)
-    );
-    font-weight: var(
-        --mod-menu-section-header-font-weight,
-        var(--spectrum-menu-section-header-font-weight)
-    );
-    line-height: var(
-        --mod-menu-section-header-line-height,
-        var(--spectrum-menu-section-header-line-height)
-    );
+    color: var(--highcontrast-menu-item-color-default, var(--mod-menu-back-heading-color, var(--spectrum-menu-section-header-color)));
+    font-size: var(--mod-menu-section-header-font-size, var(--spectrum-menu-section-header-font-size));
+    font-weight: var(--mod-menu-section-header-font-weight, var(--spectrum-menu-section-header-font-weight));
+    line-height: var(--mod-menu-section-header-line-height, var(--spectrum-menu-section-header-line-height));
     display: block;
 }

--- a/packages/meter/src/spectrum-meter.css
+++ b/packages/meter/src/spectrum-meter.css
@@ -12,40 +12,22 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --mod-progressbar-size-default: var(
-        --mod-meter-inline-size,
-        var(--spectrum-meter-inline-size)
-    );
-    --mod-progressbar-max-size: var(
-        --mod-meter-max-width,
-        var(--spectrum-meter-max-width)
-    );
-    --mod-progressbar-min-size: var(
-        --mod-meter-min-width,
-        var(--spectrum-meter-min-width)
-    );
+    --mod-progressbar-size-default: var(--mod-meter-inline-size, var(--spectrum-meter-inline-size));
+    --mod-progressbar-max-size: var(--mod-meter-max-width, var(--spectrum-meter-max-width));
+    --mod-progressbar-min-size: var(--mod-meter-min-width, var(--spectrum-meter-min-width));
     --mod-progressbar-thickness: var(--spectrum-meter-thickness);
     --mod-progressbar-font-size: var(--spectrum-meter-font-size);
     --mod-progressbar-spacing-top-to-text: var(--spectrum-meter-top-to-text);
 }
 
 :host([variant='positive']) {
-    --mod-progressbar-fill-color: var(
-        --mod-meter-fill-color-positive,
-        var(--spectrum-meter-fill-color-positive)
-    );
+    --mod-progressbar-fill-color: var(--mod-meter-fill-color-positive, var(--spectrum-meter-fill-color-positive));
 }
 
 :host([variant='notice']) {
-    --mod-progressbar-fill-color: var(
-        --mod-meter-fill-color-notice,
-        var(--spectrum-meter-fill-color-notice)
-    );
+    --mod-progressbar-fill-color: var(--mod-meter-fill-color-notice, var(--spectrum-meter-fill-color-notice));
 }
 
 :host([variant='negative']) {
-    --mod-progressbar-fill-color: var(
-        --mod-meter-fill-color-negative,
-        var(--spectrum-meter-fill-color-negative)
-    );
+    --mod-progressbar-fill-color: var(--mod-meter-fill-color-negative, var(--spectrum-meter-fill-color-negative));
 }

--- a/packages/meter/src/spectrum-progress-bar.css
+++ b/packages/meter/src/spectrum-progress-bar.css
@@ -12,23 +12,11 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    font-size: var(
-        --mod-progressbar-font-size,
-        var(--spectrum-progressbar-font-size)
-    );
+    font-size: var(--mod-progressbar-font-size, var(--spectrum-progressbar-font-size));
     vertical-align: top;
-    inline-size: var(
-        --mod-progressbar-size-default,
-        var(--spectrum-progressbar-size-default)
-    );
-    max-inline-size: var(
-        --mod-progressbar-max-size,
-        var(--spectrum-progressbar-max-size)
-    );
-    min-inline-size: var(
-        --mod-progressbar-min-size,
-        var(--spectrum-progressbar-min-size)
-    );
+    inline-size: var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default));
+    max-inline-size: var(--mod-progressbar-max-size, var(--spectrum-progressbar-max-size));
+    min-inline-size: var(--mod-progressbar-min-size, var(--spectrum-progressbar-min-size));
     flex-flow: wrap;
     justify-content: space-between;
     align-items: center;
@@ -39,22 +27,10 @@ governing permissions and limitations under the License.
 .label,
 .percentage {
     text-align: start;
-    line-height: var(
-        --mod-progressbar-line-height,
-        var(--spectrum-progressbar-line-height)
-    );
-    color: var(
-        --mod-progressbar-text-color,
-        var(--spectrum-progressbar-text-color)
-    );
-    margin-block-start: var(
-        --mod-progressbar-spacing-top-to-text,
-        var(--spectrum-progressbar-spacing-top-to-text)
-    );
-    margin-block-end: var(
-        --mod-progressbar-spacing-label-to-progressbar,
-        var(--spectrum-progressbar-spacing-label-to-progressbar)
-    );
+    line-height: var(--mod-progressbar-line-height, var(--spectrum-progressbar-line-height));
+    color: var(--mod-progressbar-text-color, var(--spectrum-progressbar-text-color));
+    margin-block-start: var(--mod-progressbar-spacing-top-to-text, var(--spectrum-progressbar-spacing-top-to-text));
+    margin-block-end: var(--mod-progressbar-spacing-label-to-progressbar, var(--spectrum-progressbar-spacing-label-to-progressbar));
 }
 
 .label:lang(ja),
@@ -63,10 +39,7 @@ governing permissions and limitations under the License.
 .percentage:lang(ja),
 .percentage:lang(ko),
 .percentage:lang(zh) {
-    line-height: var(
-        --mod-progressbar-line-height-cjk,
-        var(--spectrum-progressbar-line-height-cjk)
-    );
+    line-height: var(--mod-progressbar-line-height-cjk, var(--spectrum-progressbar-line-height-cjk));
 }
 
 .label {
@@ -75,60 +48,30 @@ governing permissions and limitations under the License.
 
 .percentage {
     align-self: flex-start;
-    margin-inline-start: var(
-        --mod-progressbar-spacing-label-to-text,
-        var(--spectrum-progressbar-spacing-label-to-text)
-    );
+    margin-inline-start: var(--mod-progressbar-spacing-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
 }
 
 .track {
     inline-size: 100%;
-    block-size: var(
-        --mod-progressbar-thickness,
-        var(--spectrum-progressbar-thickness)
-    );
+    block-size: var(--mod-progressbar-thickness, var(--spectrum-progressbar-thickness));
     border-radius: var(--spectrum-progressbar-corner-radius);
-    background: var(
-        --highcontrast-progressbar-track-color,
-        var(
-            --mod-progressbar-track-color,
-            var(--spectrum-progressbar-track-color)
-        )
-    );
+    background: var(--highcontrast-progressbar-track-color, var(--mod-progressbar-track-color, var(--spectrum-progressbar-track-color)));
     overflow: hidden;
 }
 
 .fill {
-    block-size: var(
-        --mod-progressbar-thickness,
-        var(--spectrum-progressbar-thickness)
-    );
-    background: var(
-        --highcontrast-progressbar-fill-color,
-        var(
-            --mod-progressbar-fill-color,
-            var(--spectrum-progressbar-fill-color)
-        )
-    );
+    block-size: var(--mod-progressbar-thickness, var(--spectrum-progressbar-thickness));
+    background: var(--highcontrast-progressbar-fill-color, var(--mod-progressbar-fill-color, var(--spectrum-progressbar-fill-color)));
     border: none;
     transition: width 1s;
 }
 
 :host([indeterminate]) .fill {
-    inline-size: var(
-        --mod-progressbar-fill-size-indeterminate,
-        var(--spectrum-progressbar-fill-size-indeterminate)
-    );
-    animation-timing-function: var(
-        --mod-progressbar-animation-ease-in-out-indeterminate,
-        var(--spectrum-progressbar-animation-ease-in-out-indeterminate)
-    );
+    inline-size: var(--mod-progressbar-fill-size-indeterminate, var(--spectrum-progressbar-fill-size-indeterminate));
+    animation-timing-function: var(--mod-progressbar-animation-ease-in-out-indeterminate, var(--spectrum-progressbar-animation-ease-in-out-indeterminate));
     will-change: transform;
     animation-name: indeterminate-loop-ltr;
-    animation-duration: var(
-        --mod-progressbar-animation-duration-indeterminate,
-        var(--spectrum-progressbar-animation-duration-indeterminate)
-    );
+    animation-duration: var(--mod-progressbar-animation-duration-indeterminate, var(--spectrum-progressbar-animation-duration-indeterminate));
     animation-iteration-count: infinite;
     position: relative;
 }
@@ -145,46 +88,30 @@ governing permissions and limitations under the License.
 }
 
 :host([side-label]) .track {
-    flex: 1 1
-        var(
-            --mod-progressbar-size-default,
-            var(--spectrum-progressbar-size-default)
-        );
+    flex: 1 1 var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default));
 }
 
 :host([side-label]) .label {
     flex-grow: 0;
     margin-block-end: 0;
-    margin-inline-end: var(
-        --mod-progressbar-spacing-label-to-text,
-        var(--spectrum-progressbar-spacing-label-to-text)
-    );
+    margin-inline-end: var(--mod-progressbar-spacing-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
 }
 
 :host([side-label]) .percentage {
     text-align: end;
     order: 3;
     margin-block-end: 0;
-    margin-inline-start: var(
-        --mod-spacing-progressbar-label-to-text,
-        var(--spectrum-progressbar-spacing-label-to-text)
-    );
+    margin-inline-start: var(--mod-spacing-progressbar-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
 }
 
 :host([static-color='white']) .fill {
-    background: var(
-        --mod-progressbar-fill-color-white,
-        var(--spectrum-progressbar-fill-color-white)
-    );
+    background: var(--mod-progressbar-fill-color-white, var(--spectrum-progressbar-fill-color-white));
 }
 
 :host([static-color='white']) .fill,
 :host([static-color='white']) .label,
 :host([static-color='white']) .percentage {
-    color: var(
-        --mod-progressbar-label-and-value-white,
-        var(--spectrum-progressbar-label-and-value-white)
-    );
+    color: var(--mod-progressbar-label-and-value-white, var(--spectrum-progressbar-label-and-value-white));
 }
 
 :host([static-color='white']) .track {
@@ -193,45 +120,21 @@ governing permissions and limitations under the License.
 
 @keyframes indeterminate-loop-ltr {
     0% {
-        transform: translate(
-            calc(
-                var(
-                        --mod-progressbar-fill-size-indeterminate,
-                        var(--spectrum-progressbar-fill-size-indeterminate)
-                    ) * -1
-            )
-        );
+        transform: translate(calc(var(--mod-progressbar-fill-size-indeterminate, var(--spectrum-progressbar-fill-size-indeterminate)) * -1));
     }
 
     to {
-        transform: translate(
-            var(
-                --mod-progressbar-size-default,
-                var(--spectrum-progressbar-size-default)
-            )
-        );
+        transform: translate(var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default)));
     }
 }
 
 @keyframes indeterminate-loop-rtl {
     0% {
-        transform: translate(
-            var(
-                --mod-progressbar-size-default,
-                var(--spectrum-progressbar-fill-size-indeterminate)
-            )
-        );
+        transform: translate(var(--mod-progressbar-size-default, var(--spectrum-progressbar-fill-size-indeterminate)));
     }
 
     to {
-        transform: translate(
-            calc(
-                var(
-                        --mod-progressbar-size-default,
-                        var(--spectrum-progressbar-size-default)
-                    ) * -1
-            )
-        );
+        transform: translate(calc(var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default)) * -1));
     }
 }
 

--- a/packages/modal/src/spectrum-modal-wrapper.css
+++ b/packages/modal/src/spectrum-modal-wrapper.css
@@ -20,11 +20,7 @@ governing permissions and limitations under the License.
     visibility: hidden;
     pointer-events: none;
     z-index: 1;
-    transition: visibility 0s linear
-        var(
-            --mod-modal-transition-animation-duration,
-            var(--spectrum-modal-transition-animation-duration)
-        );
+    transition: visibility 0s linear var(--mod-modal-transition-animation-duration, var(--spectrum-modal-transition-animation-duration));
     justify-content: center;
     align-items: center;
     display: flex;
@@ -37,8 +33,7 @@ governing permissions and limitations under the License.
     visibility: visible;
 }
 
-@media only screen and (device-height <= 350px),
-    only screen and (device-width <= 400px) {
+@media only screen and (device-height <= 350px), only screen and (device-width <= 400px) {
     :host([responsive]) {
         inline-size: 100%;
         block-size: 100%;

--- a/packages/modal/src/spectrum-modal.css
+++ b/packages/modal/src/spectrum-modal.css
@@ -20,23 +20,9 @@ governing permissions and limitations under the License.
         opacity 0.13s ease-in-out,
         visibility 0s linear 0.13s;
     transition:
-        transform
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        opacity
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        visibility 0s linear
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            );
+        transform var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        opacity var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        visibility 0s linear var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s));
 }
 
 :host([open]) .modal {
@@ -44,101 +30,33 @@ governing permissions and limitations under the License.
     visibility: visible;
     opacity: 1;
     transition-delay: 0s;
-    transition-delay: var(
-        --mod-overlay-animation-duration-opened,
-        var(--spectrum-animation-duration-0, 0s)
-    );
+    transition-delay: var(--mod-overlay-animation-duration-opened, var(--spectrum-animation-duration-0, 0s));
 }
 
 .modal {
-    transform: translateY(
-        var(
-            --mod-modal-confirm-entry-animation-distance,
-            var(--spectrum-modal-confirm-entry-animation-distance)
-        )
-    );
+    transform: translateY(var(--mod-modal-confirm-entry-animation-distance, var(--spectrum-modal-confirm-entry-animation-distance)));
     z-index: 1;
-    max-block-size: var(
-        --mod-modal-max-height,
-        var(--spectrum-modal-max-height)
-    );
-    max-inline-size: var(
-        --mod-modal-max-width,
-        var(--spectrum-modal-max-width)
-    );
-    background: var(
-        --mod-modal-background-color,
-        var(--spectrum-modal-background-color)
-    );
-    border-radius: var(
-        --mod-modal-confirm-border-radius,
-        var(--spectrum-modal-confirm-border-radius)
-    );
+    max-block-size: var(--mod-modal-max-height, var(--spectrum-modal-max-height));
+    max-inline-size: var(--mod-modal-max-width, var(--spectrum-modal-max-width));
+    background: var(--mod-modal-background-color, var(--spectrum-modal-background-color));
+    border-radius: var(--mod-modal-confirm-border-radius, var(--spectrum-modal-confirm-border-radius));
     pointer-events: auto;
     transition:
-        opacity
-            var(
-                --mod-modal-confirm-exit-animation-duration,
-                var(--spectrum-modal-confirm-exit-animation-duration)
-            )
-            var(--spectrum-animation-ease-in)
-            var(
-                --mod-modal-confirm-exit-animation-delay,
-                var(--spectrum-modal-confirm-exit-animation-delay)
-            ),
-        visibility 0s linear
-            calc(
-                var(
-                        --mod-modal-confirm-exit-animation-delay,
-                        var(--spectrum-modal-confirm-exit-animation-delay)
-                    ) +
-                    var(
-                        --mod-modal-confirm-exit-animation-duration,
-                        var(--spectrum-modal-confirm-exit-animation-duration)
-                    )
-            ),
-        transform 0s linear
-            calc(
-                var(
-                        --mod-modal-confirm-exit-animation-delay,
-                        var(--spectrum-modal-confirm-exit-animation-delay)
-                    ) +
-                    var(
-                        --mod-modal-confirm-exit-animation-duration,
-                        var(--spectrum-modal-confirm-exit-animation-duration)
-                    )
-            );
+        opacity var(--mod-modal-confirm-exit-animation-duration, var(--spectrum-modal-confirm-exit-animation-duration)) var(--spectrum-animation-ease-in) var(--mod-modal-confirm-exit-animation-delay, var(--spectrum-modal-confirm-exit-animation-delay)),
+        visibility 0s linear calc(var(--mod-modal-confirm-exit-animation-delay, var(--spectrum-modal-confirm-exit-animation-delay)) + var(--mod-modal-confirm-exit-animation-duration, var(--spectrum-modal-confirm-exit-animation-duration))),
+        transform 0s linear calc(var(--mod-modal-confirm-exit-animation-delay, var(--spectrum-modal-confirm-exit-animation-delay)) + var(--mod-modal-confirm-exit-animation-duration, var(--spectrum-modal-confirm-exit-animation-duration)));
     outline: none;
     overflow: hidden;
 }
 
 :host([open]) .modal {
     transition:
-        transform
-            var(
-                --mod-modal-confirm-entry-animation-duration,
-                var(--spectrum-modal-confirm-entry-animation-duration)
-            )
-            var(--spectrum-animation-ease-out)
-            var(
-                --mod-modal-confirm-entry-animation-delay,
-                var(--spectrum-modal-confirm-entry-animation-delay)
-            ),
-        opacity
-            var(
-                --mod-modal-confirm-entry-animation-duration,
-                var(--spectrum-modal-confirm-entry-animation-duration)
-            )
-            var(--spectrum-animation-ease-out)
-            var(
-                --mod-modal-confirm-entry-animation-delay,
-                var(--spectrum-modal-confirm-entry-animation-delay)
-            );
+        transform var(--mod-modal-confirm-entry-animation-duration, var(--spectrum-modal-confirm-entry-animation-duration)) var(--spectrum-animation-ease-out) var(--mod-modal-confirm-entry-animation-delay, var(--spectrum-modal-confirm-entry-animation-delay)),
+        opacity var(--mod-modal-confirm-entry-animation-duration, var(--spectrum-modal-confirm-entry-animation-duration)) var(--spectrum-animation-ease-out) var(--mod-modal-confirm-entry-animation-delay, var(--spectrum-modal-confirm-entry-animation-delay));
     transform: translateY(0);
 }
 
-@media only screen and (device-height <= 350px),
-    only screen and (device-width <= 400px) {
+@media only screen and (device-height <= 350px), only screen and (device-width <= 400px) {
     :host([responsive]) .modal {
         inline-size: 100%;
         block-size: 100%;
@@ -152,22 +70,10 @@ governing permissions and limitations under the License.
     max-inline-size: none;
     max-block-size: none;
     position: fixed;
-    inset-block-start: var(
-        --mod-modal-fullscreen-margin,
-        var(--spectrum-modal-fullscreen-margin)
-    );
-    inset-block-end: var(
-        --mod-modal-fullscreen-margin,
-        var(--spectrum-modal-fullscreen-margin)
-    );
-    inset-inline-start: var(
-        --mod-modal-fullscreen-margin,
-        var(--spectrum-modal-fullscreen-margin)
-    );
-    inset-inline-end: var(
-        --mod-modal-fullscreen-margin,
-        var(--spectrum-modal-fullscreen-margin)
-    );
+    inset-block-start: var(--mod-modal-fullscreen-margin, var(--spectrum-modal-fullscreen-margin));
+    inset-block-end: var(--mod-modal-fullscreen-margin, var(--spectrum-modal-fullscreen-margin));
+    inset-inline-start: var(--mod-modal-fullscreen-margin, var(--spectrum-modal-fullscreen-margin));
+    inset-inline-end: var(--mod-modal-fullscreen-margin, var(--spectrum-modal-fullscreen-margin));
 }
 
 .fullscreenTakeover {

--- a/packages/number-field/src/spectrum-number-field.css
+++ b/packages/number-field/src/spectrum-number-field.css
@@ -31,193 +31,91 @@ governing permissions and limitations under the License.
 
     :host([disabled]) #textfield {
         --highcontrast-stepper-border-color: GrayText;
-        --highcontrast-stepper-buttons-border-width: var(
-            --mod-stepper-border-width,
-            var(--spectrum-stepper-border-width)
-        );
+        --highcontrast-stepper-buttons-border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
     }
 
     :host([focused]:not([disabled])) #textfield,
     :host(:not([disabled])) #textfield:focus {
-        --highcontrast-stepper-border-color: var(
-            --highcontrast-stepper-border-color-focus
-        );
+        --highcontrast-stepper-border-color: var(--highcontrast-stepper-border-color-focus);
     }
 
     @media (hover: hover) {
         :host(:not([disabled]):hover) #textfield {
-            --highcontrast-stepper-border-color: var(
-                --highcontrast-stepper-border-color-hover
-            );
+            --highcontrast-stepper-border-color: var(--highcontrast-stepper-border-color-hover);
         }
 
         :host([focused]:not([disabled]):hover) #textfield,
         :host(:not([disabled]):hover) #textfield:focus {
-            --highcontrast-stepper-border-color: var(
-                --highcontrast-stepper-border-color-focus-hover
-            );
+            --highcontrast-stepper-border-color: var(--highcontrast-stepper-border-color-focus-hover);
         }
     }
 
     :host([keyboard-focused]:not([disabled])) #textfield,
     :host(:not([disabled])) #textfield:focus-visible {
-        --highcontrast-stepper-border-color: var(
-            --highcontrast-stepper-border-color-keyboard-focus
-        );
+        --highcontrast-stepper-border-color: var(--highcontrast-stepper-border-color-keyboard-focus);
     }
 
     .input {
-        --highcontrast-textfield-border-color: var(
-            --highcontrast-stepper-border-color
-        );
+        --highcontrast-textfield-border-color: var(--highcontrast-stepper-border-color);
     }
 
     .button {
-        --highcontrast-infield-button-border-color: var(
-            --highcontrast-stepper-border-color
-        );
-        --highcontrast-infield-button-border-color-active: var(
-            --highcontrast-stepper-border-color
-        );
+        --highcontrast-infield-button-border-color: var(--highcontrast-stepper-border-color);
+        --highcontrast-infield-button-border-color-active: var(--highcontrast-stepper-border-color);
     }
 }
 
 :host {
-    --spectrum-stepper-border-color: var(
-        --highcontrast-stepper-border-color,
-        var(
-            --mod-stepper-border-color,
-            var(--spectrum-stepper-border-color-default)
-        )
-    );
-    --spectrum-stepper-border-radius: var(
-        --mod-stepper-border-radius,
-        var(--spectrum-corner-radius-100)
-    );
-    --spectrum-stepper-focus-indicator-width: var(
-        --mod-stepper-focus-indicator-width,
-        var(--spectrum-focus-indicator-thickness)
-    );
-    --spectrum-stepper-focus-indicator-gap: var(
-        --mod-stepper-focus-indicator-gap,
-        var(--spectrum-focus-indicator-gap)
-    );
-    --spectrum-stepper-focus-indicator-color: var(
-        --highcontrast-stepper-focus-indicator-color,
-        var(
-            --mod-stepper-focus-indicator-color,
-            var(--spectrum-focus-indicator-color)
-        )
-    );
-    --spectrum-stepper-animation-duration: var(
-        --mod-stepper-animation-duration,
-        var(--spectrum-animation-duration-100)
-    );
+    --spectrum-stepper-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color, var(--spectrum-stepper-border-color-default)));
+    --spectrum-stepper-border-radius: var(--mod-stepper-border-radius, var(--spectrum-corner-radius-100));
+    --spectrum-stepper-focus-indicator-width: var(--mod-stepper-focus-indicator-width, var(--spectrum-focus-indicator-thickness));
+    --spectrum-stepper-focus-indicator-gap: var(--mod-stepper-focus-indicator-gap, var(--spectrum-focus-indicator-gap));
+    --spectrum-stepper-focus-indicator-color: var(--highcontrast-stepper-focus-indicator-color, var(--mod-stepper-focus-indicator-color, var(--spectrum-focus-indicator-color)));
+    --spectrum-stepper-animation-duration: var(--mod-stepper-animation-duration, var(--spectrum-animation-duration-100));
 }
 
 #textfield,
 :host([size='m']) #textfield {
-    --spectrum-stepper-button-width: var(
-        --mod-stepper-button-width,
-        var(--spectrum-in-field-button-width-stacked-medium)
-    );
-    --spectrum-stepper-height: var(
-        --mod-stepper-height,
-        var(--spectrum-component-height-100)
-    );
+    --spectrum-stepper-button-width: var(--mod-stepper-button-width, var(--spectrum-in-field-button-width-stacked-medium));
+    --spectrum-stepper-height: var(--mod-stepper-height, var(--spectrum-component-height-100));
 }
 
 :host([size='s']) #textfield {
-    --spectrum-stepper-button-width: var(
-        --mod-stepper-button-width,
-        var(--spectrum-in-field-button-width-stacked-small)
-    );
-    --spectrum-stepper-height: var(
-        --mod-stepper-height,
-        var(--spectrum-component-height-75)
-    );
+    --spectrum-stepper-button-width: var(--mod-stepper-button-width, var(--spectrum-in-field-button-width-stacked-small));
+    --spectrum-stepper-height: var(--mod-stepper-height, var(--spectrum-component-height-75));
 }
 
 :host([size='l']) #textfield {
-    --spectrum-stepper-button-width: var(
-        --mod-stepper-button-width,
-        var(--spectrum-in-field-button-width-stacked-large)
-    );
-    --spectrum-stepper-height: var(
-        --mod-stepper-height,
-        var(--spectrum-component-height-200)
-    );
+    --spectrum-stepper-button-width: var(--mod-stepper-button-width, var(--spectrum-in-field-button-width-stacked-large));
+    --spectrum-stepper-height: var(--mod-stepper-height, var(--spectrum-component-height-200));
 }
 
 :host([size='xl']) #textfield {
-    --spectrum-stepper-button-width: var(
-        --mod-stepper-button-width,
-        var(--spectrum-in-field-button-width-stacked-extra-large)
-    );
-    --spectrum-stepper-height: var(
-        --mod-stepper-height,
-        var(--spectrum-component-height-300)
-    );
+    --spectrum-stepper-button-width: var(--mod-stepper-button-width, var(--spectrum-in-field-button-width-stacked-extra-large));
+    --spectrum-stepper-height: var(--mod-stepper-height, var(--spectrum-component-height-300));
 }
 
 :host([disabled]) #textfield {
-    --spectrum-stepper-buttons-border-width: var(
-        --spectrum-stepper-button-border-width-disabled
-    );
-    --spectrum-stepper-buttons-background-color: var(
-        --spectrum-stepper-buttons-background-color-disabled
-    );
+    --spectrum-stepper-buttons-border-width: var(--spectrum-stepper-button-border-width-disabled);
+    --spectrum-stepper-buttons-background-color: var(--spectrum-stepper-buttons-background-color-disabled);
 }
 
 :host([invalid]) #textfield {
-    --mod-stepper-border-color: var(
-        --mod-stepper-border-color-invalid,
-        var(--spectrum-negative-border-color-default)
-    );
-    --mod-stepper-border-color-hover: var(
-        --mod-stepper-border-color-hover-invalid,
-        var(--spectrum-negative-border-color-hover)
-    );
-    --mod-stepper-border-color-focus: var(
-        --mod-stepper-border-color-focus-invalid,
-        var(--spectrum-negative-border-color-focus)
-    );
-    --mod-stepper-border-color-focus-hover: var(
-        --mod-stepper-border-color-focus-hover-invalid,
-        var(--spectrum-negative-border-color-focus-hover)
-    );
-    --mod-stepper-border-color-keyboard-focus: var(
-        --mod-stepper-border-color-keyboard-focus-invalid,
-        var(--spectrum-negative-border-color-key-focus)
-    );
+    --mod-stepper-border-color: var(--mod-stepper-border-color-invalid, var(--spectrum-negative-border-color-default));
+    --mod-stepper-border-color-hover: var(--mod-stepper-border-color-hover-invalid, var(--spectrum-negative-border-color-hover));
+    --mod-stepper-border-color-focus: var(--mod-stepper-border-color-focus-invalid, var(--spectrum-negative-border-color-focus));
+    --mod-stepper-border-color-focus-hover: var(--mod-stepper-border-color-focus-hover-invalid, var(--spectrum-negative-border-color-focus-hover));
+    --mod-stepper-border-color-keyboard-focus: var(--mod-stepper-border-color-keyboard-focus-invalid, var(--spectrum-negative-border-color-key-focus));
 }
 
 :host([focused]:not([disabled])) #textfield,
 :host(:not([disabled])) #textfield:focus {
-    --mod-stepper-border-color: var(
-        --highcontrast-stepper-border-color-focus,
-        var(
-            --mod-stepper-border-color-focus,
-            var(--spectrum-stepper-border-color-focus)
-        )
-    );
-    --mod-stepper-buttons-border-color: var(
-        --highcontrast-stepper-border-color-focus,
-        var(
-            --mod-stepper-border-color-focus,
-            var(--spectrum-stepper-border-color-focus)
-        )
-    );
+    --mod-stepper-border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
+    --mod-stepper-buttons-border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
 }
 
 :host([keyboard-focused]:not([disabled])) #textfield {
-    --mod-stepper-border-color: var(
-        --highcontrast-stepper-border-color-focus,
-        var(
-            --mod-stepper-border-color-focus,
-            var(--spectrum-stepper-border-color-keyboard-focus)
-        )
-    );
+    --mod-stepper-border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-keyboard-focus)));
 }
 
 :host([quiet]) #textfield {
@@ -229,183 +127,82 @@ governing permissions and limitations under the License.
 }
 
 :host([quiet][invalid]) #textfield {
-    --mod-stepper-border-color: var(
-        --mod-stepper-border-color-invalid,
-        var(--spectrum-negative-border-color-default)
-    );
+    --mod-stepper-border-color: var(--mod-stepper-border-color-invalid, var(--spectrum-negative-border-color-default));
 }
 
 :host {
-    --mod-infield-button-border-color: var(
-        --mod-stepper-buttons-border-color,
-        var(--spectrum-stepper-buttons-border-color)
-    );
-    --mod-infield-button-border-color-quiet-disabled: var(
-        --spectrum-disabled-border-color
-    );
-    --mod-infield-button-border-width: var(
-        --mod-stepper-button-border-width,
-        var(--spectrum-stepper-button-border-width)
-    );
-    --mod-textfield-border-width: var(
-        --mod-stepper-border-width,
-        var(--spectrum-stepper-border-width)
-    );
+    --mod-infield-button-border-color: var(--mod-stepper-buttons-border-color, var(--spectrum-stepper-buttons-border-color));
+    --mod-infield-button-border-color-quiet-disabled: var(--spectrum-disabled-border-color);
+    --mod-infield-button-border-width: var(--mod-stepper-button-border-width, var(--spectrum-stepper-button-border-width));
+    --mod-textfield-border-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
     --mod-textfield-border-color: var(--spectrum-stepper-border-color);
 }
 
 :host(:not([disabled])[focused]) #textfield,
 :host(:not([disabled])) #textfield:focus {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color-focus,
-        var(
-            --mod-stepper-buttons-border-color-focus,
-            var(--spectrum-stepper-buttons-border-color-focus)
-        )
-    );
+    --mod-infield-button-border-color: var(--highcontrast-stepper-border-color-focus, var(--mod-stepper-buttons-border-color-focus, var(--spectrum-stepper-buttons-border-color-focus)));
     --mod-textfield-focus-indicator-width: 0;
 }
 
 :host([keyboard-focused]:not([disabled])) #textfield,
 :host(:not([disabled])) #textfield:focus-visible {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color-keyboard-focus,
-        var(
-            --mod-stepper-buttons-border-color-keyboard-focus,
-            var(--spectrum-stepper-buttons-border-color-keyboard-focus)
-        )
-    );
+    --mod-infield-button-border-color: var(--highcontrast-stepper-border-color-keyboard-focus, var(--mod-stepper-buttons-border-color-keyboard-focus, var(--spectrum-stepper-buttons-border-color-keyboard-focus)));
     --mod-textfield-focus-indicator-width: 0;
-    --mod-textfield-border-color: var(
-        --highcontrast-stepper-border-color-keyboard-focus,
-        var(
-            --mod-stepper-border-color-keyboard-focus,
-            var(--spectrum-stepper-border-color-keyboard-focus)
-        )
-    );
+    --mod-textfield-border-color: var(--highcontrast-stepper-border-color-keyboard-focus, var(--mod-stepper-border-color-keyboard-focus, var(--spectrum-stepper-border-color-keyboard-focus)));
     outline: var(--spectrum-stepper-focus-indicator-width) solid;
     outline-color: var(--spectrum-stepper-focus-indicator-color);
     outline-offset: var(--spectrum-stepper-focus-indicator-gap);
 }
 
 :host([invalid]) #textfield {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color,
-        var(
-            --mod-stepper-border-color-invalid,
-            var(--spectrum-stepper-border-color-invalid)
-        )
-    );
+    --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-invalid, var(--spectrum-stepper-border-color-invalid)));
     --mod-textfield-icon-spacing-inline-start-invalid: 0;
 }
 
 :host([invalid][focused]) #textfield,
 :host([invalid]) #textfield:focus {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color,
-        var(
-            --mod-stepper-border-color-focus-invalid,
-            var(--spectrum-stepper-border-color-focus-invalid)
-        )
-    );
+    --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-focus-invalid, var(--spectrum-stepper-border-color-focus-invalid)));
 }
 
 :host([invalid][keyboard-focused]) #textfield,
 :host([invalid]) #textfield:focus-visible {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color,
-        var(
-            --mod-stepper-border-color-keyboard-focus-invalid,
-            var(--spectrum-stepper-border-color-keyboard-focus-invalid)
-        )
-    );
+    --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-keyboard-focus-invalid, var(--spectrum-stepper-border-color-keyboard-focus-invalid)));
 }
 
 :host([quiet]) #textfield {
-    --mod-infield-button-width-stacked: var(
-        --mod-stepper-button-width-quiet,
-        var(--spectrum-stepper-button-width)
-    );
+    --mod-infield-button-width-stacked: var(--mod-stepper-button-width-quiet, var(--spectrum-stepper-button-width));
     --mod-infield-button-border-color: var(--spectrum-stepper-border-color);
-    --mod-infield-button-border-color-quiet: var(
-        --spectrum-stepper-border-color
-    );
-    --mod-infield-button-border-block-end-width: var(
-        --mod-stepper-border-width,
-        var(--spectrum-stepper-border-width)
-    );
-    --mod-infield-button-stacked-bottom-border-block-end-width: var(
-        --mod-stepper-border-width,
-        var(--spectrum-stepper-border-width)
-    );
+    --mod-infield-button-border-color-quiet: var(--spectrum-stepper-border-color);
+    --mod-infield-button-border-block-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
+    --mod-infield-button-stacked-bottom-border-block-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
     --mod-infield-button-stacked-bottom-border-radius-end-end: 0;
     --mod-infield-button-stacked-bottom-border-radius-end-start: 0;
     --mod-infield-button-fill-justify-content: flex-end;
-    --mod-infield-button-inner-edge-to-fill: var(
-        --spectrum-stepper-button-edge-to-fill
-    );
-    --mod-infield-button-edge-to-fill: var(
-        --spectrum-stepper-button-edge-to-fill
-    );
+    --mod-infield-button-inner-edge-to-fill: var(--spectrum-stepper-button-edge-to-fill);
+    --mod-infield-button-edge-to-fill: var(--spectrum-stepper-button-edge-to-fill);
     --mod-textfield-focus-indicator-color: transparent;
     --mod-textfield-background-color: transparent;
-    --mod-textfield-border-color-hover: var(
-        --highcontrast-stepper-border-color,
-        var(
-            --mod-stepper-border-color-hover,
-            var(--spectrum-stepper-border-color-hover)
-        )
-    );
+    --mod-textfield-border-color-hover: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-hover, var(--spectrum-stepper-border-color-hover)));
 }
 
 :host([quiet][focused]:not([disabled])) #textfield,
 :host([quiet]:not([disabled])) #textfield:focus {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color,
-        var(
-            --mod-stepper-border-color-focus,
-            var(--spectrum-stepper-border-color-focus)
-        )
-    );
+    --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-focus, var(--spectrum-stepper-border-color-focus)));
 }
 
 :host([quiet][keyboard-focused]:not([disabled])) #textfield {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color,
-        var(
-            --mod-stepper-border-color-keyboard-focus,
-            var(--spectrum-stepper-border-color-keyboard-focus)
-        )
-    );
+    --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-keyboard-focus, var(--spectrum-stepper-border-color-keyboard-focus)));
 }
 
 @media (hover: hover) {
     :host(:not([disabled]):hover) #textfield {
-        --mod-stepper-border-color: var(
-            --highcontrast-stepper-border-color-hover,
-            var(
-                --mod-stepper-border-color-hover,
-                var(--spectrum-stepper-border-color-hover)
-            )
-        );
+        --mod-stepper-border-color: var(--highcontrast-stepper-border-color-hover, var(--mod-stepper-border-color-hover, var(--spectrum-stepper-border-color-hover)));
     }
 
     :host([focused]:not([disabled]):hover) #textfield,
     :host(:not([disabled]):hover) #textfield:focus {
-        --mod-stepper-border-color: var(
-            --highcontrast-stepper-border-color-focus-hover,
-            var(
-                --mod-stepper-border-color-focus-hover,
-                var(--spectrum-stepper-border-color-focus-hover)
-            )
-        );
-        --mod-stepper-buttons-border-color: var(
-            --highcontrast-stepper-border-color-focus-hover,
-            var(
-                --mod-stepper-border-color-focus-hover,
-                var(--spectrum-stepper-border-color-focus-hover)
-            )
-        );
+        --mod-stepper-border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
+        --mod-stepper-buttons-border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
     }
 
     :host([quiet]:not([disabled]):hover) #textfield {
@@ -413,103 +210,42 @@ governing permissions and limitations under the License.
     }
 
     :host(:hover) #textfield:not(.is-invalid, .is-disabled) {
-        --mod-infield-button-border-color: var(
-            --mod-stepper-buttons-border-color-hover,
-            var(--spectrum-stepper-buttons-border-color-hover)
-        );
+        --mod-infield-button-border-color: var(--mod-stepper-buttons-border-color-hover, var(--spectrum-stepper-buttons-border-color-hover));
     }
 
     :host(:not([disabled])[focused]:hover) #textfield,
     :host(:not([disabled]):hover) #textfield:focus {
-        --mod-infield-button-border-color: var(
-            --mod-stepper-buttons-border-color-focus-hover,
-            var(--spectrum-stepper-buttons-border-color-focus-hover)
-        );
+        --mod-infield-button-border-color: var(--mod-stepper-buttons-border-color-focus-hover, var(--spectrum-stepper-buttons-border-color-focus-hover));
         --mod-textfield-focus-indicator-width: 0;
-        --mod-textfield-border-color: var(
-            --highcontrast-stepper-border-color-focus-hover,
-            var(
-                --mod-stepper-border-color-focus-hover,
-                var(--spectrum-stepper-border-color-focus-hover)
-            )
-        );
+        --mod-textfield-border-color: var(--highcontrast-stepper-border-color-focus-hover, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
     }
 
     :host([invalid]:hover) #textfield {
-        --mod-infield-button-border-color: var(
-            --highcontrast-stepper-border-color,
-            var(
-                --mod-stepper-border-color-hover-invalid,
-                var(--spectrum-negative-border-color-hover)
-            )
-        );
+        --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-hover-invalid, var(--spectrum-negative-border-color-hover)));
     }
 
     :host([invalid][focused]:hover) #textfield,
     :host([invalid]:hover) #textfield:focus {
-        --mod-infield-button-border-color: var(
-            --highcontrast-stepper-border-color,
-            var(
-                --mod-stepper-border-color-focus-hover-invalid,
-                var(--spectrum-stepper-border-color-focus-hover-invalid)
-            )
-        );
+        --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-focus-hover-invalid, var(--spectrum-stepper-border-color-focus-hover-invalid)));
     }
 
     :host([quiet]:not([disabled]):hover) #textfield {
-        --mod-textfield-border-color-hover: var(
-            --highcontrast-stepper-border-color,
-            var(
-                --mod-stepper-border-color-hover,
-                var(--spectrum-stepper-border-color-hover)
-            )
-        );
-        --mod-infield-button-border-color: var(
-            --highcontrast-stepper-border-color,
-            var(
-                --mod-stepper-border-color-hover,
-                var(--spectrum-stepper-border-color-hover)
-            )
-        );
+        --mod-textfield-border-color-hover: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-hover, var(--spectrum-stepper-border-color-hover)));
+        --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-hover, var(--spectrum-stepper-border-color-hover)));
     }
 
     :host([quiet][focused]:not([disabled]):hover) #textfield,
     :host([quiet]:not([disabled]):hover) #textfield:focus {
-        --mod-infield-button-border-color: var(
-            --highcontrast-stepper-border-color,
-            var(
-                --mod-stepper-border-color-focus-hover,
-                var(--spectrum-stepper-border-color-focus-hover)
-            )
-        );
+        --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-focus-hover, var(--spectrum-stepper-border-color-focus-hover)));
     }
 
     :host([quiet][keyboard-focused]:not([disabled]):hover) #textfield {
-        --mod-infield-button-border-color: var(
-            --highcontrast-stepper-border-color,
-            var(
-                --mod-stepper-border-color-hover,
-                var(--spectrum-stepper-border-color-hover)
-            )
-        );
+        --mod-infield-button-border-color: var(--highcontrast-stepper-border-color, var(--mod-stepper-border-color-hover, var(--spectrum-stepper-border-color-hover)));
     }
 }
 
 #textfield {
-    --spectrum-stepper-width: var(
-        --mod-stepper-width,
-        calc(
-            var(--spectrum-stepper-height) *
-                var(
-                    --mod-stepper-min-width-multiplier,
-                    var(--spectrum-text-field-minimum-width-multiplier)
-                ) + var(--spectrum-stepper-button-width) +
-                var(
-                    --mod-stepper-border-width,
-                    var(--spectrum-stepper-border-width)
-                ) * 2
-        )
-    );
+    --spectrum-stepper-width: var(--mod-stepper-width, calc(var(--spectrum-stepper-height) * var(--mod-stepper-min-width-multiplier, var(--spectrum-text-field-minimum-width-multiplier)) + var(--spectrum-stepper-button-width) + var(--mod-stepper-border-width, var(--spectrum-stepper-border-width)) * 2));
     inline-size: var(--spectrum-stepper-width);
     block-size: var(--spectrum-stepper-height);
     border-radius: var(--spectrum-stepper-border-radius);
@@ -533,23 +269,10 @@ governing permissions and limitations under the License.
     block-size: var(--spectrum-stepper-height);
     inline-size: var(--spectrum-stepper-button-width);
     border-color: var(--spectrum-stepper-border-color);
-    border-style: var(
-        --mod-stepper-buttons-border-style,
-        var(--spectrum-stepper-buttons-border-style)
-    );
-    border-width: var(
-        --highcontrast-stepper-buttons-border-width,
-        var(
-            --mod-stepper-buttons-border-width,
-            var(--spectrum-stepper-buttons-border-width)
-        )
-    );
-    background-color: var(
-        --mod-stepper-buttons-background-color,
-        var(--spectrum-stepper-buttons-background-color)
-    );
-    transition: border-color var(--spectrum-stepper-animation-duration)
-        ease-in-out;
+    border-style: var(--mod-stepper-buttons-border-style, var(--spectrum-stepper-buttons-border-style));
+    border-width: var(--highcontrast-stepper-buttons-border-width, var(--mod-stepper-buttons-border-width, var(--spectrum-stepper-buttons-border-width)));
+    background-color: var(--mod-stepper-buttons-background-color, var(--spectrum-stepper-buttons-background-color));
+    transition: border-color var(--spectrum-stepper-animation-duration) ease-in-out;
     border-inline-start-width: 0;
     flex-direction: column;
     justify-content: center;
@@ -563,10 +286,7 @@ governing permissions and limitations under the License.
 }
 
 #textfield.hide-stepper .input {
-    border-inline-end-width: var(
-        --mod-stepper-border-width,
-        var(--spectrum-stepper-border-width)
-    );
+    border-inline-end-width: var(--mod-stepper-border-width, var(--spectrum-stepper-border-width));
 }
 
 :host([quiet]) #textfield {
@@ -589,12 +309,7 @@ governing permissions and limitations under the License.
     block-size: var(--spectrum-stepper-focus-indicator-width);
     background-color: var(--spectrum-stepper-focus-indicator-color);
     position: absolute;
-    inset-block-end: calc(
-        (
-                var(--spectrum-stepper-focus-indicator-gap) +
-                    var(--spectrum-stepper-focus-indicator-width)
-            ) * -1
-    );
+    inset-block-end: calc((var(--spectrum-stepper-focus-indicator-gap) + var(--spectrum-stepper-focus-indicator-width)) * -1);
     inset-inline-start: 0;
 }
 

--- a/packages/picker-button/src/spectrum-picker-button.css
+++ b/packages/picker-button/src/spectrum-picker-button.css
@@ -13,15 +13,9 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .root {
     background-color: initial;
-    block-size: var(
-        --mod-picker-button-width,
-        var(--spectrum-picker-button-width)
-    );
+    block-size: var(--mod-picker-button-width, var(--spectrum-picker-button-width));
     box-sizing: border-box;
-    padding: var(
-        --mod-picker-button-padding,
-        var(--spectrum-picker-button-padding)
-    );
+    padding: var(--mod-picker-button-padding, var(--spectrum-picker-button-padding));
     border-style: none;
     justify-content: center;
     align-items: center;
@@ -30,231 +24,111 @@ governing permissions and limitations under the License.
 
 @media (hover: hover) {
     .root:hover .spectrum-PickerButton-fill {
-        background-color: var(
-            --mod-picker-button-background-color-hover,
-            var(--spectrum-picker-button-background-color-hover)
-        );
+        background-color: var(--mod-picker-button-background-color-hover, var(--spectrum-picker-button-background-color-hover));
     }
 
     .root:hover .spectrum-PickerButton-label {
-        color: var(
-            --mod-picker-button-font-color-hover,
-            var(--spectrum-picker-button-font-color-hover)
-        );
+        color: var(--mod-picker-button-font-color-hover, var(--spectrum-picker-button-font-color-hover));
     }
 
     .root:hover .spectrum-PickerButton-icon {
-        color: var(
-            --mod-picker-button-icon-color-hover,
-            var(--spectrum-picker-button-icon-color-hover)
-        );
+        color: var(--mod-picker-button-icon-color-hover, var(--spectrum-picker-button-icon-color-hover));
     }
 }
 
 :host([open]) .root .spectrum-PickerButton-fill,
 :host(:is(:active, [active])) .root .spectrum-PickerButton-fill {
-    background-color: var(
-        --mod-picker-button-background-color-down,
-        var(--spectrum-picker-button-background-color-down)
-    );
+    background-color: var(--mod-picker-button-background-color-down, var(--spectrum-picker-button-background-color-down));
 }
 
 :host([open]) .root .spectrum-PickerButton-label,
 :host(:is(:active, [active])) .root .spectrum-PickerButton-label {
-    color: var(
-        --mod-picker-button-font-color-down,
-        var(--spectrum-picker-button-font-color-down)
-    );
+    color: var(--mod-picker-button-font-color-down, var(--spectrum-picker-button-font-color-down));
 }
 
 :host([open]) .root .spectrum-PickerButton-icon,
 :host(:is(:active, [active])) .root .spectrum-PickerButton-icon {
-    color: var(
-        --mod-picker-button-icon-color-down,
-        var(--spectrum-picker-button-icon-color-down)
-    );
+    color: var(--mod-picker-button-icon-color-down, var(--spectrum-picker-button-icon-color-down));
 }
 
 :host([focused]) .root .spectrum-PickerButton-fill,
 .root.is-keyboardFocused .spectrum-PickerButton-fill,
 .root:focus .spectrum-PickerButton-fill,
 .root:focus-visible .spectrum-PickerButton-fill {
-    background-color: var(
-        --mod-picker-button-background-color-key-focus,
-        var(--spectrum-picker-button-background-color-key-focus)
-    );
+    background-color: var(--mod-picker-button-background-color-key-focus, var(--spectrum-picker-button-background-color-key-focus));
 }
 
 :host([focused]) .root .spectrum-PickerButton-label,
 .root.is-keyboardFocused .spectrum-PickerButton-label,
 .root:focus .spectrum-PickerButton-label,
 .root:focus-visible .spectrum-PickerButton-label {
-    color: var(
-        --mod-picker-button-font-color-key-focus,
-        var(--spectrum-picker-button-font-color-key-focus)
-    );
+    color: var(--mod-picker-button-font-color-key-focus, var(--spectrum-picker-button-font-color-key-focus));
 }
 
 :host([focused]) .root .spectrum-PickerButton-icon,
 .root.is-keyboardFocused .spectrum-PickerButton-icon,
 .root:focus .spectrum-PickerButton-icon,
 .root:focus-visible .spectrum-PickerButton-icon {
-    color: var(
-        --mod-picker-button-icon-color-key-focus,
-        var(--spectrum-picker-button-icon-color-key-focus)
-    );
+    color: var(--mod-picker-button-icon-color-key-focus, var(--spectrum-picker-button-icon-color-key-focus));
 }
 
 .root.is-disabled,
 :host([disabled]) .root {
-    --mod-picker-button-background-color: var(
-        --mod-picker-button-background-color-disabled,
-        var(--spectrum-picker-button-background-color-disabled)
-    );
-    --mod-picker-button-background-color-hover: var(
-        --mod-picker-button-background-color-hover-disabled,
-        var(--spectrum-picker-button-background-color-hover-disabled)
-    );
-    --mod-picker-button-background-color-down: var(
-        --mod-picker-button-background-color-down-disabled,
-        var(--spectrum-picker-button-background-color-down-disabled)
-    );
-    --mod-picker-button-border-color: var(
-        --mod-picker-button-border-color-disabled,
-        var(--spectrum-picker-button-border-color-disabled)
-    );
-    --mod-picker-button-font-color: var(
-        --mod-picker-button-font-color-disabled,
-        var(--spectrum-picker-button-font-color-disabled)
-    );
-    --mod-picker-button-font-color-hover: var(
-        --mod-picker-button-font-color-hover-disabled,
-        var(--spectrum-picker-button-font-color-hover-disabled)
-    );
-    --mod-picker-button-font-color-down: var(
-        --mod-picker-button-font-color-down-disabled,
-        var(--spectrum-picker-button-font-color-down-disabled)
-    );
-    --mod-picker-button-icon-color: var(
-        --mod-picker-button-icon-color-disabled,
-        var(--spectrum-picker-button-icon-color-disabled)
-    );
-    --mod-picker-button-icon-color-hover: var(
-        --mod-picker-button-icon-color-hover-disabled,
-        var(--spectrum-picker-button-icon-color-hover-disabled)
-    );
-    --mod-picker-button-icon-color-down: var(
-        --mod-picker-button-icon-color-down-disabled,
-        var(--spectrum-picker-button-icon-color-down-disabled)
-    );
+    --mod-picker-button-background-color: var(--mod-picker-button-background-color-disabled, var(--spectrum-picker-button-background-color-disabled));
+    --mod-picker-button-background-color-hover: var(--mod-picker-button-background-color-hover-disabled, var(--spectrum-picker-button-background-color-hover-disabled));
+    --mod-picker-button-background-color-down: var(--mod-picker-button-background-color-down-disabled, var(--spectrum-picker-button-background-color-down-disabled));
+    --mod-picker-button-border-color: var(--mod-picker-button-border-color-disabled, var(--spectrum-picker-button-border-color-disabled));
+    --mod-picker-button-font-color: var(--mod-picker-button-font-color-disabled, var(--spectrum-picker-button-font-color-disabled));
+    --mod-picker-button-font-color-hover: var(--mod-picker-button-font-color-hover-disabled, var(--spectrum-picker-button-font-color-hover-disabled));
+    --mod-picker-button-font-color-down: var(--mod-picker-button-font-color-down-disabled, var(--spectrum-picker-button-font-color-down-disabled));
+    --mod-picker-button-icon-color: var(--mod-picker-button-icon-color-disabled, var(--spectrum-picker-button-icon-color-disabled));
+    --mod-picker-button-icon-color-hover: var(--mod-picker-button-icon-color-hover-disabled, var(--spectrum-picker-button-icon-color-hover-disabled));
+    --mod-picker-button-icon-color-down: var(--mod-picker-button-icon-color-down-disabled, var(--spectrum-picker-button-icon-color-down-disabled));
 }
 
 :host([quiet]) .root {
-    --mod-picker-button-background-color: var(
-        --mod-picker-button-background-color-quiet,
-        transparent
-    );
-    --mod-picker-button-background-color-hover: var(
-        --mod-picker-button-background-color-hover-quiet,
-        transparent
-    );
-    --mod-picker-button-background-color-down: var(
-        --mod-picker-button-background-color-down-quiet,
-        transparent
-    );
-    --mod-picker-button-background-color-key-focus: var(
-        --mod-picker-button-background-color-key-focus-quiet,
-        transparent
-    );
-    --mod-picker-button-border-color: var(
-        --mod-picker-button-border-color-quiet,
-        transparent
-    );
+    --mod-picker-button-background-color: var(--mod-picker-button-background-color-quiet, transparent);
+    --mod-picker-button-background-color-hover: var(--mod-picker-button-background-color-hover-quiet, transparent);
+    --mod-picker-button-background-color-down: var(--mod-picker-button-background-color-down-quiet, transparent);
+    --mod-picker-button-background-color-key-focus: var(--mod-picker-button-background-color-key-focus-quiet, transparent);
+    --mod-picker-button-border-color: var(--mod-picker-button-border-color-quiet, transparent);
 }
 
 :host([quiet]) .root.is-disabled,
 :host([quiet][disabled]) .root {
-    --mod-picker-button-background-color: var(
-        --mod-picker-button-background-color-quiet,
-        transparent
-    );
+    --mod-picker-button-background-color: var(--mod-picker-button-background-color-quiet, transparent);
 }
 
 :host([position='right']) .spectrum-PickerButton-fill {
-    border-start-start-radius: var(
-        --mod-picker-button-border-radius-sided,
-        var(--spectrum-picker-button-border-radius-sided)
-    );
-    border-end-start-radius: var(
-        --mod-picker-button-border-radius-sided,
-        var(--spectrum-picker-button-border-radius-sided)
-    );
+    border-start-start-radius: var(--mod-picker-button-border-radius-sided, var(--spectrum-picker-button-border-radius-sided));
+    border-end-start-radius: var(--mod-picker-button-border-radius-sided, var(--spectrum-picker-button-border-radius-sided));
 }
 
 :host([position='right'][rounded]) .spectrum-PickerButton-fill {
-    border-start-start-radius: var(
-        --mod-picker-button-border-radius-rounded-sided,
-        var(--spectrum-picker-button-border-radius-rounded-sided)
-    );
-    border-end-start-radius: var(
-        --mod-picker-button-border-radius-rounded-sided,
-        var(--spectrum-picker-button-border-radius-rounded-sided)
-    );
+    border-start-start-radius: var(--mod-picker-button-border-radius-rounded-sided, var(--spectrum-picker-button-border-radius-rounded-sided));
+    border-end-start-radius: var(--mod-picker-button-border-radius-rounded-sided, var(--spectrum-picker-button-border-radius-rounded-sided));
 }
 
 :host([position='left']) .spectrum-PickerButton-fill {
-    border-start-end-radius: var(
-        --mod-picker-button-border-radius-sided,
-        var(--spectrum-picker-button-border-radius-sided)
-    );
-    border-end-end-radius: var(
-        --mod-picker-button-border-radius-sided,
-        var(--spectrum-picker-button-border-radius-sided)
-    );
+    border-start-end-radius: var(--mod-picker-button-border-radius-sided, var(--spectrum-picker-button-border-radius-sided));
+    border-end-end-radius: var(--mod-picker-button-border-radius-sided, var(--spectrum-picker-button-border-radius-sided));
 }
 
 :host([position='left'][rounded]) .spectrum-PickerButton-fill {
-    border-start-end-radius: var(
-        --mod-picker-button-border-radius-rounded-sided,
-        var(--spectrum-picker-button-border-radius-rounded-sided)
-    );
-    border-end-end-radius: var(
-        --mod-picker-button-border-radius-rounded-sided,
-        var(--spectrum-picker-button-border-radius-rounded-sided)
-    );
+    border-start-end-radius: var(--mod-picker-button-border-radius-rounded-sided, var(--spectrum-picker-button-border-radius-rounded-sided));
+    border-end-end-radius: var(--mod-picker-button-border-radius-rounded-sided, var(--spectrum-picker-button-border-radius-rounded-sided));
 }
 
 .spectrum-PickerButton-label {
-    color: var(
-        --mod-picker-button-font-color,
-        var(--spectrum-picker-button-font-color)
-    );
+    color: var(--mod-picker-button-font-color, var(--spectrum-picker-button-font-color));
     white-space: nowrap;
-    font-family: var(
-        --mod-picker-button-font-family,
-        var(--spectrum-picker-button-font-family)
-    );
-    font-style: var(
-        --mod-picker-button-font-style,
-        var(--spectrum-picker-button-font-style)
-    );
-    font-weight: var(
-        --mod-picker-button-font-weight,
-        var(--spectrum-picker-button-font-weight)
-    );
-    font-size: var(
-        --mod-picker-button-font-size,
-        var(--spectrum-picker-button-font-size)
-    );
+    font-family: var(--mod-picker-button-font-family, var(--spectrum-picker-button-font-family));
+    font-style: var(--mod-picker-button-font-style, var(--spectrum-picker-button-font-style));
+    font-weight: var(--mod-picker-button-font-weight, var(--spectrum-picker-button-font-weight));
+    font-size: var(--mod-picker-button-font-size, var(--spectrum-picker-button-font-size));
     flex: auto;
-    padding-block-start: var(
-        --mod-picker-button-label-padding,
-        var(--spectrum-picker-button-label-padding)
-    );
-    padding-block-end: var(
-        --mod-picker-button-label-padding,
-        var(--spectrum-picker-button-label-padding)
-    );
+    padding-block-start: var(--mod-picker-button-label-padding, var(--spectrum-picker-button-label-padding));
+    padding-block-end: var(--mod-picker-button-label-padding, var(--spectrum-picker-button-label-padding));
     overflow: hidden;
 }
 
@@ -265,90 +139,33 @@ governing permissions and limitations under the License.
     justify-content: center;
     align-items: center;
     gap: var(--mod-picker-button-gap, var(--spectrum-picker-button-gap));
-    background-color: var(
-        --mod-picker-button-background-color,
-        var(--spectrum-picker-button-background-color)
-    );
-    border-color: var(
-        --mod-picker-button-border-color,
-        var(--spectrum-picker-button-border-color)
-    );
-    border-width: var(
-        --mod-picker-button-border-width,
-        var(--spectrum-picker-button-border-width)
-    );
-    padding: calc(
-        var(
-                --mod-picker-button-fill-padding,
-                var(--spectrum-picker-button-fill-padding)
-            ) -
-            var(
-                --mod-picker-button-padding,
-                var(--spectrum-picker-button-padding)
-            ) -
-            var(
-                --mod-picker-button-border-width,
-                var(--spectrum-picker-button-border-width)
-            )
-    );
-    transition: border-color
-        var(
-            --mod-picker-button-background-animation-duration,
-            var(--spectrum-picker-button-background-animation-duration)
-        )
-        ease-in-out;
+    background-color: var(--mod-picker-button-background-color, var(--spectrum-picker-button-background-color));
+    border-color: var(--mod-picker-button-border-color, var(--spectrum-picker-button-border-color));
+    border-width: var(--mod-picker-button-border-width, var(--spectrum-picker-button-border-width));
+    padding: calc(var(--mod-picker-button-fill-padding, var(--spectrum-picker-button-fill-padding)) - var(--mod-picker-button-padding, var(--spectrum-picker-button-padding)) - var(--mod-picker-button-border-width, var(--spectrum-picker-button-border-width)));
+    transition: border-color var(--mod-picker-button-background-animation-duration, var(--spectrum-picker-button-background-animation-duration)) ease-in-out;
     border-style: solid;
-    border-start-start-radius: var(
-        --mod-picker-button-border-radius,
-        var(--spectrum-picker-button-border-radius)
-    );
-    border-start-end-radius: var(
-        --mod-picker-button-border-radius,
-        var(--spectrum-picker-button-border-radius)
-    );
-    border-end-end-radius: var(
-        --mod-picker-button-border-radius,
-        var(--spectrum-picker-button-border-radius)
-    );
-    border-end-start-radius: var(
-        --mod-picker-button-border-radius,
-        var(--spectrum-picker-button-border-radius)
-    );
+    border-start-start-radius: var(--mod-picker-button-border-radius, var(--spectrum-picker-button-border-radius));
+    border-start-end-radius: var(--mod-picker-button-border-radius, var(--spectrum-picker-button-border-radius));
+    border-end-end-radius: var(--mod-picker-button-border-radius, var(--spectrum-picker-button-border-radius));
+    border-end-start-radius: var(--mod-picker-button-border-radius, var(--spectrum-picker-button-border-radius));
     display: flex;
 }
 
 .spectrum-PickerButton-icon {
-    color: var(
-        --mod-picker-button-icon-color,
-        var(--spectrum-picker-button-icon-color)
-    );
+    color: var(--mod-picker-button-icon-color, var(--spectrum-picker-button-icon-color));
     flex-shrink: 0;
 }
 
 :host([rounded]) .spectrum-PickerButton-fill {
-    border-start-start-radius: var(
-        --mod-picker-button-border-radius-rounded,
-        var(--spectrum-picker-button-border-radius-rounded)
-    );
-    border-start-end-radius: var(
-        --mod-picker-button-border-radius-rounded,
-        var(--spectrum-picker-button-border-radius-rounded)
-    );
-    border-end-end-radius: var(
-        --mod-picker-button-border-radius-rounded,
-        var(--spectrum-picker-button-border-radius-rounded)
-    );
-    border-end-start-radius: var(
-        --mod-picker-button-border-radius-rounded,
-        var(--spectrum-picker-button-border-radius-rounded)
-    );
+    border-start-start-radius: var(--mod-picker-button-border-radius-rounded, var(--spectrum-picker-button-border-radius-rounded));
+    border-start-end-radius: var(--mod-picker-button-border-radius-rounded, var(--spectrum-picker-button-border-radius-rounded));
+    border-end-end-radius: var(--mod-picker-button-border-radius-rounded, var(--spectrum-picker-button-border-radius-rounded));
+    border-end-start-radius: var(--mod-picker-button-border-radius-rounded, var(--spectrum-picker-button-border-radius-rounded));
 }
 
 .uiicononly {
-    inline-size: var(
-        --mod-picker-button-height,
-        var(--spectrum-picker-button-height)
-    );
+    inline-size: var(--mod-picker-button-height, var(--spectrum-picker-button-height));
 }
 
 .uiicononly .spectrum-PickerButton-label {

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -15,59 +15,18 @@ governing permissions and limitations under the License.
     cursor: pointer;
     -webkit-user-select: none;
     user-select: none;
-    font-family: var(
-        --mod-button-font-family,
-        var(
-            --mod-sans-font-family-stack,
-            var(--spectrum-sans-font-family-stack)
-        )
-    );
+    font-family: var(--mod-button-font-family, var(--mod-sans-font-family-stack, var(--spectrum-sans-font-family-stack)));
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    line-height: var(
-        --mod-button-line-height,
-        var(--mod-line-height-100, var(--spectrum-line-height-100))
-    );
+    line-height: var(--mod-button-line-height, var(--mod-line-height-100, var(--spectrum-line-height-100)));
     text-transform: none;
     vertical-align: top;
     -webkit-appearance: button;
     transition:
-        background
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        border-color
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        color
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out,
-        box-shadow
-            var(
-                --mod-button-animation-duration,
-                var(
-                    --mod-animation-duration-100,
-                    var(--spectrum-animation-duration-100)
-                )
-            )
-            ease-out;
+        background var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        border-color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        color var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out,
+        box-shadow var(--mod-button-animation-duration, var(--mod-animation-duration-100, var(--spectrum-animation-duration-100))) ease-out;
     justify-content: center;
     align-items: center;
     margin: 0;
@@ -90,235 +49,99 @@ governing permissions and limitations under the License.
 :host {
     --spectrum-picker-font-size: var(--spectrum-font-size-100);
     --spectrum-picker-font-weight: var(--spectrum-regular-font-weight);
-    --spectrum-picker-placeholder-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-picker-placeholder-font-style: var(--spectrum-default-font-style);
     --spectrum-picker-line-height: var(--spectrum-line-height-100);
     --spectrum-picker-block-size: var(--spectrum-component-height-100);
     --spectrum-picker-inline-size: var(--spectrum-field-width);
     --spectrum-picker-border-radius: var(--spectrum-corner-radius-100);
-    --spectrum-picker-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-100
-    );
-    --spectrum-picker-spacing-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --spectrum-picker-spacing-edge-to-text: var(
-        --spectrum-component-edge-to-text-100
-    );
-    --spectrum-picker-spacing-edge-to-text-quiet: var(
-        --spectrum-field-edge-to-text-quiet
-    );
-    --spectrum-picker-spacing-label-to-picker: var(
-        --spectrum-field-label-to-component
-    );
+    --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-100);
+    --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
+    --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-100);
+    --spectrum-picker-spacing-edge-to-text-quiet: var(--spectrum-field-edge-to-text-quiet);
+    --spectrum-picker-spacing-label-to-picker: var(--spectrum-field-label-to-component);
     --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-100);
-    --spectrum-picker-spacing-text-to-icon-inline-end: var(
-        --spectrum-field-text-to-alert-icon-medium
-    );
-    --spectrum-picker-spacing-icon-to-disclosure-icon: var(
-        --spectrum-picker-visual-to-disclosure-icon-medium
-    );
-    --spectrum-picker-spacing-label-to-picker-quiet: var(
-        --spectrum-field-label-to-component-quiet-medium
-    );
-    --spectrum-picker-spacing-top-to-alert-icon: var(
-        --spectrum-field-top-to-alert-icon-medium
-    );
-    --spectrum-picker-spacing-top-to-progress-circle: var(
-        --spectrum-field-top-to-progress-circle-medium
-    );
-    --spectrum-picker-spacing-top-to-disclosure-icon: var(
-        --spectrum-field-top-to-disclosure-icon-100
-    );
-    --spectrum-picker-spacing-edge-to-disclosure-icon: var(
-        --spectrum-field-end-edge-to-disclosure-icon-100
-    );
-    --spectrum-picker-spacing-edge-to-disclosure-icon-quiet: var(
-        --spectrum-picker-end-edge-to-disclousure-icon-quiet
-    );
-    --spectrum-picker-animation-duration: var(
-        --spectrum-animation-duration-100
-    );
-    --spectrum-picker-font-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-picker-font-color-default-open: var(
-        --spectrum-neutral-content-color-focus
-    );
-    --spectrum-picker-font-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --spectrum-picker-font-color-hover-open: var(
-        --spectrum-neutral-content-color-focus-hover
-    );
-    --spectrum-picker-font-color-active: var(
-        --spectrum-neutral-content-color-down
-    );
-    --spectrum-picker-font-color-key-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
-    --spectrum-picker-icon-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-picker-icon-color-default-open: var(
-        --spectrum-neutral-content-color-focus
-    );
-    --spectrum-picker-icon-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --spectrum-picker-icon-color-hover-open: var(
-        --spectrum-neutral-content-color-focus-hover
-    );
-    --spectrum-picker-icon-color-active: var(
-        --spectrum-neutral-content-color-down
-    );
-    --spectrum-picker-icon-color-key-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
-    --spectrum-picker-border-color-error-default: var(
-        --spectrum-negative-border-color-default
-    );
-    --spectrum-picker-border-color-error-default-open: var(
-        --spectrum-negative-border-color-focus
-    );
-    --spectrum-picker-border-color-error-hover: var(
-        --spectrum-negative-border-color-hover
-    );
-    --spectrum-picker-border-color-error-hover-open: var(
-        --spectrum-negative-border-color-focus-hover
-    );
-    --spectrum-picker-border-color-error-active: var(
-        --spectrum-negative-border-color-down
-    );
-    --spectrum-picker-border-color-error-key-focus: var(
-        --spectrum-negative-border-color-key-focus
-    );
+    --spectrum-picker-spacing-text-to-icon-inline-end: var(--spectrum-field-text-to-alert-icon-medium);
+    --spectrum-picker-spacing-icon-to-disclosure-icon: var(--spectrum-picker-visual-to-disclosure-icon-medium);
+    --spectrum-picker-spacing-label-to-picker-quiet: var(--spectrum-field-label-to-component-quiet-medium);
+    --spectrum-picker-spacing-top-to-alert-icon: var(--spectrum-field-top-to-alert-icon-medium);
+    --spectrum-picker-spacing-top-to-progress-circle: var(--spectrum-field-top-to-progress-circle-medium);
+    --spectrum-picker-spacing-top-to-disclosure-icon: var(--spectrum-field-top-to-disclosure-icon-100);
+    --spectrum-picker-spacing-edge-to-disclosure-icon: var(--spectrum-field-end-edge-to-disclosure-icon-100);
+    --spectrum-picker-spacing-edge-to-disclosure-icon-quiet: var(--spectrum-picker-end-edge-to-disclousure-icon-quiet);
+    --spectrum-picker-animation-duration: var(--spectrum-animation-duration-100);
+    --spectrum-picker-font-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-picker-font-color-default-open: var(--spectrum-neutral-content-color-focus);
+    --spectrum-picker-font-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-picker-font-color-hover-open: var(--spectrum-neutral-content-color-focus-hover);
+    --spectrum-picker-font-color-active: var(--spectrum-neutral-content-color-down);
+    --spectrum-picker-font-color-key-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-picker-icon-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-picker-icon-color-default-open: var(--spectrum-neutral-content-color-focus);
+    --spectrum-picker-icon-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-picker-icon-color-hover-open: var(--spectrum-neutral-content-color-focus-hover);
+    --spectrum-picker-icon-color-active: var(--spectrum-neutral-content-color-down);
+    --spectrum-picker-icon-color-key-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-picker-border-color-error-default: var(--spectrum-negative-border-color-default);
+    --spectrum-picker-border-color-error-default-open: var(--spectrum-negative-border-color-focus);
+    --spectrum-picker-border-color-error-hover: var(--spectrum-negative-border-color-hover);
+    --spectrum-picker-border-color-error-hover-open: var(--spectrum-negative-border-color-focus-hover);
+    --spectrum-picker-border-color-error-active: var(--spectrum-negative-border-color-down);
+    --spectrum-picker-border-color-error-key-focus: var(--spectrum-negative-border-color-key-focus);
     --spectrum-picker-icon-color-error: var(--spectrum-negative-visual-color);
-    --spectrum-picker-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --spectrum-picker-font-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
-    --spectrum-picker-icon-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
+    --spectrum-picker-background-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-picker-font-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-picker-icon-color-disabled: var(--spectrum-disabled-content-color);
     --spectrum-picker-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
-    --spectrum-picker-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
-    --spectrum-picker-focus-indicator-color: var(
-        --spectrum-focus-indicator-color
-    );
+    --spectrum-picker-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
+    --spectrum-picker-focus-indicator-color: var(--spectrum-focus-indicator-color);
 }
 
 :host([size='s']) {
     --spectrum-picker-font-size: var(--spectrum-font-size-75);
     --spectrum-picker-block-size: var(--spectrum-component-height-75);
-    --spectrum-picker-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --spectrum-picker-spacing-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-75
-    );
-    --spectrum-picker-spacing-edge-to-text: var(
-        --spectrum-component-edge-to-text-75
-    );
+    --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
+    --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-75);
     --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-75);
-    --spectrum-picker-spacing-text-to-icon-inline-end: var(
-        --spectrum-field-text-to-alert-icon-small
-    );
-    --spectrum-picker-spacing-icon-to-disclosure-icon: var(
-        --spectrum-picker-visual-to-disclosure-icon-small
-    );
-    --spectrum-picker-spacing-label-to-picker-quiet: var(
-        --spectrum-field-label-to-component-quiet-small
-    );
-    --spectrum-picker-spacing-top-to-alert-icon: var(
-        --spectrum-field-top-to-alert-icon-small
-    );
-    --spectrum-picker-spacing-top-to-progress-circle: var(
-        --spectrum-field-top-to-progress-circle-small
-    );
-    --spectrum-picker-spacing-top-to-disclosure-icon: var(
-        --spectrum-field-top-to-disclosure-icon-75
-    );
-    --spectrum-picker-spacing-edge-to-disclosure-icon: var(
-        --spectrum-field-end-edge-to-disclosure-icon-75
-    );
+    --spectrum-picker-spacing-text-to-icon-inline-end: var(--spectrum-field-text-to-alert-icon-small);
+    --spectrum-picker-spacing-icon-to-disclosure-icon: var(--spectrum-picker-visual-to-disclosure-icon-small);
+    --spectrum-picker-spacing-label-to-picker-quiet: var(--spectrum-field-label-to-component-quiet-small);
+    --spectrum-picker-spacing-top-to-alert-icon: var(--spectrum-field-top-to-alert-icon-small);
+    --spectrum-picker-spacing-top-to-progress-circle: var(--spectrum-field-top-to-progress-circle-small);
+    --spectrum-picker-spacing-top-to-disclosure-icon: var(--spectrum-field-top-to-disclosure-icon-75);
+    --spectrum-picker-spacing-edge-to-disclosure-icon: var(--spectrum-field-end-edge-to-disclosure-icon-75);
 }
 
 :host([size='l']) {
     --spectrum-picker-font-size: var(--spectrum-font-size-200);
     --spectrum-picker-block-size: var(--spectrum-component-height-200);
-    --spectrum-picker-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --spectrum-picker-spacing-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-200
-    );
-    --spectrum-picker-spacing-edge-to-text: var(
-        --spectrum-component-edge-to-text-200
-    );
+    --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
+    --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
+    --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-200);
     --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-200);
-    --spectrum-picker-spacing-text-to-icon-inline-end: var(
-        --spectrum-field-text-to-alert-icon-large
-    );
-    --spectrum-picker-spacing-icon-to-disclosure-icon: var(
-        --spectrum-picker-visual-to-disclosure-icon-large
-    );
-    --spectrum-picker-spacing-label-to-picker-quiet: var(
-        --spectrum-field-label-to-component-quiet-large
-    );
-    --spectrum-picker-spacing-top-to-alert-icon: var(
-        --spectrum-field-top-to-alert-icon-large
-    );
-    --spectrum-picker-spacing-top-to-progress-circle: var(
-        --spectrum-field-top-to-progress-circle-large
-    );
-    --spectrum-picker-spacing-top-to-disclosure-icon: var(
-        --spectrum-field-top-to-disclosure-icon-200
-    );
-    --spectrum-picker-spacing-edge-to-disclosure-icon: var(
-        --spectrum-field-end-edge-to-disclosure-icon-200
-    );
+    --spectrum-picker-spacing-text-to-icon-inline-end: var(--spectrum-field-text-to-alert-icon-large);
+    --spectrum-picker-spacing-icon-to-disclosure-icon: var(--spectrum-picker-visual-to-disclosure-icon-large);
+    --spectrum-picker-spacing-label-to-picker-quiet: var(--spectrum-field-label-to-component-quiet-large);
+    --spectrum-picker-spacing-top-to-alert-icon: var(--spectrum-field-top-to-alert-icon-large);
+    --spectrum-picker-spacing-top-to-progress-circle: var(--spectrum-field-top-to-progress-circle-large);
+    --spectrum-picker-spacing-top-to-disclosure-icon: var(--spectrum-field-top-to-disclosure-icon-200);
+    --spectrum-picker-spacing-edge-to-disclosure-icon: var(--spectrum-field-end-edge-to-disclosure-icon-200);
 }
 
 :host([size='xl']) {
     --spectrum-picker-font-size: var(--spectrum-font-size-300);
     --spectrum-picker-block-size: var(--spectrum-component-height-300);
-    --spectrum-picker-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-300
-    );
-    --spectrum-picker-spacing-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-300
-    );
-    --spectrum-picker-spacing-edge-to-text: var(
-        --spectrum-component-edge-to-text-300
-    );
+    --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
+    --spectrum-picker-spacing-bottom-to-text: var(--spectrum-component-bottom-to-text-300);
+    --spectrum-picker-spacing-edge-to-text: var(--spectrum-component-edge-to-text-300);
     --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-300);
-    --spectrum-picker-spacing-text-to-icon-inline-end: var(
-        --spectrum-field-text-to-alert-icon-extra-large
-    );
-    --spectrum-picker-spacing-icon-to-disclosure-icon: var(
-        --spectrum-picker-visual-to-disclosure-icon-extra-large
-    );
-    --spectrum-picker-spacing-label-to-picker-quiet: var(
-        --spectrum-field-label-to-component-quiet-extra-large
-    );
-    --spectrum-picker-spacing-top-to-alert-icon: var(
-        --spectrum-field-top-to-alert-icon-extra-large
-    );
-    --spectrum-picker-spacing-top-to-progress-circle: var(
-        --spectrum-field-top-to-progress-circle-extra-large
-    );
-    --spectrum-picker-spacing-top-to-disclosure-icon: var(
-        --spectrum-field-top-to-disclosure-icon-300
-    );
-    --spectrum-picker-spacing-edge-to-disclosure-icon: var(
-        --spectrum-field-end-edge-to-disclosure-icon-300
-    );
+    --spectrum-picker-spacing-text-to-icon-inline-end: var(--spectrum-field-text-to-alert-icon-extra-large);
+    --spectrum-picker-spacing-icon-to-disclosure-icon: var(--spectrum-picker-visual-to-disclosure-icon-extra-large);
+    --spectrum-picker-spacing-label-to-picker-quiet: var(--spectrum-field-label-to-component-quiet-extra-large);
+    --spectrum-picker-spacing-top-to-alert-icon: var(--spectrum-field-top-to-alert-icon-extra-large);
+    --spectrum-picker-spacing-top-to-progress-circle: var(--spectrum-field-top-to-progress-circle-extra-large);
+    --spectrum-picker-spacing-top-to-disclosure-icon: var(--spectrum-field-top-to-disclosure-icon-300);
+    --spectrum-picker-spacing-edge-to-disclosure-icon: var(--spectrum-field-end-edge-to-disclosure-icon-300);
 }
 
 @media (forced-colors: active) {
@@ -346,165 +169,45 @@ governing permissions and limitations under the License.
 #button {
     box-sizing: border-box;
     max-inline-size: 100%;
-    min-inline-size: calc(
-        var(--spectrum-picker-minimum-width-multiplier) *
-            var(--mod-picker-block-size, var(--spectrum-picker-block-size))
-    );
-    inline-size: var(
-        --mod-picker-inline-size,
-        var(--spectrum-picker-inline-size)
-    );
+    min-inline-size: calc(var(--spectrum-picker-minimum-width-multiplier) * var(--mod-picker-block-size, var(--spectrum-picker-block-size)));
+    inline-size: var(--mod-picker-inline-size, var(--spectrum-picker-inline-size));
     block-size: var(--mod-picker-block-size, var(--spectrum-picker-block-size));
-    border-width: var(
-        --mod-picker-border-width,
-        var(--spectrum-picker-border-width)
-    );
-    border-radius: var(
-        --mod-picker-border-radius,
-        var(--spectrum-picker-border-radius)
-    );
+    border-width: var(--mod-picker-border-width, var(--spectrum-picker-border-width));
+    border-radius: var(--mod-picker-border-radius, var(--spectrum-picker-border-radius));
     transition:
-        background-color
-            var(
-                --mod-picker-animation-duration,
-                var(--spectrum-picker-animation-duration)
-            ),
-        box-shadow
-            var(
-                --mod-picker-animation-duration,
-                var(--spectrum-picker-animation-duration)
-            ),
-        border-color
-            var(
-                --mod-picker-animation-duration,
-                var(--spectrum-picker-animation-duration)
-            )
-            ease-in-out;
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-default,
-            var(--spectrum-picker-font-color-default)
-        )
-    );
-    background-color: var(
-        --highcontrast-picker-background-color,
-        var(
-            --mod-picker-background-color-default,
-            var(--spectrum-picker-background-color-default)
-        )
-    );
+        background-color var(--mod-picker-animation-duration, var(--spectrum-picker-animation-duration)),
+        box-shadow var(--mod-picker-animation-duration, var(--spectrum-picker-animation-duration)),
+        border-color var(--mod-picker-animation-duration, var(--spectrum-picker-animation-duration)) ease-in-out;
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-default, var(--spectrum-picker-background-color-default)));
     border-style: solid;
-    border-color: var(
-        --highcontrast-picker-border-color-default,
-        var(
-            --mod-picker-border-color-default,
-            var(--spectrum-picker-border-color-default)
-        )
-    );
-    margin-block-start: var(
-        --mod-picker-spacing-label-to-picker,
-        var(--spectrum-picker-spacing-label-to-picker)
-    );
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-default, var(--spectrum-picker-border-color-default)));
+    margin-block-start: var(--mod-picker-spacing-label-to-picker, var(--spectrum-picker-spacing-label-to-picker));
     padding-block: 0;
-    padding-inline-start: var(
-        --mod-picker-spacing-edge-to-text,
-        var(--spectrum-picker-spacing-edge-to-text)
-    );
-    padding-inline-end: var(
-        --mod-picker-spacing-edge-to-disclosure-icon,
-        var(--spectrum-picker-spacing-edge-to-disclosure-icon)
-    );
+    padding-inline-start: var(--mod-picker-spacing-edge-to-text, var(--spectrum-picker-spacing-edge-to-text));
+    padding-inline-end: var(--mod-picker-spacing-edge-to-disclosure-icon, var(--spectrum-picker-spacing-edge-to-disclosure-icon));
     display: flex;
 }
 
 #button:after {
     pointer-events: none;
     content: '';
-    block-size: calc(
-        100% +
-            var(
-                --mod-picker-focus-indicator-gap,
-                var(--spectrum-picker-focus-indicator-gap)
-            ) * 2 +
-            var(--mod-picker-border-width, var(--spectrum-picker-border-width)) *
-            2
-    );
-    inline-size: calc(
-        100% +
-            var(
-                --mod-picker-focus-indicator-gap,
-                var(--spectrum-picker-focus-indicator-gap)
-            ) * 2 +
-            var(--mod-picker-border-width, var(--spectrum-picker-border-width)) *
-            2
-    );
+    block-size: calc(100% + var(--mod-picker-focus-indicator-gap, var(--spectrum-picker-focus-indicator-gap)) * 2 + var(--mod-picker-border-width, var(--spectrum-picker-border-width)) * 2);
+    inline-size: calc(100% + var(--mod-picker-focus-indicator-gap, var(--spectrum-picker-focus-indicator-gap)) * 2 + var(--mod-picker-border-width, var(--spectrum-picker-border-width)) * 2);
     border-style: solid;
-    border-width: var(
-        --mod-picker-focus-indicator-thickness,
-        var(--spectrum-picker-focus-indicator-thickness)
-    );
-    border-radius: calc(
-        var(--mod-picker-border-radius, var(--spectrum-picker-border-radius)) +
-            var(
-                --mod-picker-focus-indicator-gap,
-                var(--spectrum-picker-focus-indicator-gap)
-            ) +
-            var(--mod-picker-border-width, var(--spectrum-picker-border-width))
-    );
+    border-width: var(--mod-picker-focus-indicator-thickness, var(--spectrum-picker-focus-indicator-thickness));
+    border-radius: calc(var(--mod-picker-border-radius, var(--spectrum-picker-border-radius)) + var(--mod-picker-focus-indicator-gap, var(--spectrum-picker-focus-indicator-gap)) + var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
     border-color: #0000;
-    margin-block-start: calc(
-        (
-                var(
-                        --mod-picker-focus-indicator-gap,
-                        var(--spectrum-picker-focus-indicator-gap)
-                    ) +
-                    var(
-                        --mod-picker-focus-indicator-thickness,
-                        var(--spectrum-picker-focus-indicator-thickness)
-                    ) +
-                    var(
-                        --mod-picker-border-width,
-                        var(--spectrum-picker-border-width)
-                    )
-            ) * -1
-    );
-    margin-inline-start: calc(
-        (
-                var(
-                        --mod-picker-focus-indicator-gap,
-                        var(--spectrum-picker-focus-indicator-gap)
-                    ) +
-                    var(
-                        --mod-picker-focus-indicator-thickness,
-                        var(--spectrum-picker-focus-indicator-thickness)
-                    ) +
-                    var(
-                        --mod-picker-border-width,
-                        var(--spectrum-picker-border-width)
-                    )
-            ) * -1
-    );
+    margin-block-start: calc((var(--mod-picker-focus-indicator-gap, var(--spectrum-picker-focus-indicator-gap)) + var(--mod-picker-focus-indicator-thickness, var(--spectrum-picker-focus-indicator-thickness)) + var(--mod-picker-border-width, var(--spectrum-picker-border-width))) * -1);
+    margin-inline-start: calc((var(--mod-picker-focus-indicator-gap, var(--spectrum-picker-focus-indicator-gap)) + var(--mod-picker-focus-indicator-thickness, var(--spectrum-picker-focus-indicator-thickness)) + var(--mod-picker-border-width, var(--spectrum-picker-border-width))) * -1);
     position: absolute;
     inset-block: 0;
     inset-inline: 0;
 }
 
 #button:active {
-    background-color: var(
-        --highcontrast-picker-background-color,
-        var(
-            --mod-picker-background-color-active,
-            var(--spectrum-picker-background-color-active)
-        )
-    );
-    border-color: var(
-        --highcontrast-picker-border-color-default,
-        var(
-            --mod-picker-border-active,
-            var(--spectrum-picker-border-color-active)
-        )
-    );
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-active, var(--spectrum-picker-background-color-active)));
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-active, var(--spectrum-picker-border-color-active)));
 }
 
 #button:active:after {
@@ -512,356 +215,141 @@ governing permissions and limitations under the License.
 }
 
 #button.placeholder:active .label {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-active,
-            var(--spectrum-picker-font-color-active)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-active, var(--spectrum-picker-font-color-active)));
 }
 
 #button.is-keyboardFocused,
 #button:focus-visible {
-    background-color: var(
-        --highcontrast-picker-background-color,
-        var(
-            --mod-picker-background-color-key-focus,
-            var(--spectrum-picker-background-color-key-focus)
-        )
-    );
-    border-color: var(
-        --highcontrast-picker-border-color-default,
-        var(
-            --mod-picker-border-color-key-focus,
-            var(--spectrum-picker-border-color-key-focus)
-        )
-    );
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-key-focus,
-            var(--spectrum-picker-font-color-key-focus)
-        )
-    );
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-key-focus, var(--spectrum-picker-background-color-key-focus)));
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-key-focus, var(--spectrum-picker-border-color-key-focus)));
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-key-focus, var(--spectrum-picker-font-color-key-focus)));
     outline: none;
 }
 
 #button.is-keyboardFocused:after,
 #button:focus-visible:after {
-    border-color: var(
-        --highcontrast-picker-focus-indicator-color,
-        var(
-            --mod-picker-focus-indicator-color,
-            var(--spectrum-picker-focus-indicator-color)
-        )
-    );
+    border-color: var(--highcontrast-picker-focus-indicator-color, var(--mod-picker-focus-indicator-color, var(--spectrum-picker-focus-indicator-color)));
 }
 
 #button.is-keyboardFocused .label.placeholder,
 #button:focus-visible .label.placeholder {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-key-focus,
-            var(--spectrum-picker-font-color-key-focus)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-key-focus, var(--spectrum-picker-font-color-key-focus)));
 }
 
 #button.is-keyboardFocused .picker,
 #button:focus-visible .picker {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-icon-color-key-focus,
-            var(--spectrum-picker-icon-color-key-focus)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-key-focus, var(--spectrum-picker-icon-color-key-focus)));
 }
 
 :host([open]) #button:not(.spectrum-Picker--quiet, :disabled, .is-disabled) {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-default-open,
-            var(--spectrum-picker-font-color-default-open)
-        )
-    );
-    background-color: var(
-        --highcontrast-picker-background-color,
-        var(
-            --mod-picker-background-color-default-open,
-            var(--spectrum-picker-background-color-default-open)
-        )
-    );
-    border-color: var(
-        --highcontrast-picker-border-color-default,
-        var(
-            --mod-picker-border-default-open,
-            var(--spectrum-picker-border-color-default-open)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default-open, var(--spectrum-picker-font-color-default-open)));
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-default-open, var(--spectrum-picker-background-color-default-open)));
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-default-open, var(--spectrum-picker-border-color-default-open)));
 }
 
-:host([open])
-    #button:not(.spectrum-Picker--quiet, :disabled, .is-disabled)
-    .picker {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-icon-color-default-open,
-            var(--spectrum-picker-icon-color-default-open)
-        )
-    );
+:host([open]) #button:not(.spectrum-Picker--quiet, :disabled, .is-disabled) .picker {
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-default-open, var(--spectrum-picker-icon-color-default-open)));
 }
 
 :host([invalid]) #button:not(:disabled, .is-disabled) {
-    border-color: var(
-        --highcontrast-picker-border-color-default,
-        var(
-            --mod-picker-border-color-error-default,
-            var(--spectrum-picker-border-color-error-default)
-        )
-    );
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-default, var(--spectrum-picker-border-color-error-default)));
 }
 
 :host([invalid]) #button:not(:disabled, .is-disabled) .validation-icon {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-icon-color-error,
-            var(--spectrum-picker-icon-color-error)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-error, var(--spectrum-picker-icon-color-error)));
 }
 
 :host([invalid]) #button:not(:disabled, .is-disabled):active {
-    border-color: var(
-        --highcontrast-picker-border-color-default,
-        var(
-            --mod-picker-border-color-error-active,
-            var(--spectrum-picker-border-color-error-active)
-        )
-    );
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-active, var(--spectrum-picker-border-color-error-active)));
 }
 
 :host([invalid][open]) #button:not(:disabled, .is-disabled) {
-    border-color: var(
-        --highcontrast-picker-border-color-default,
-        var(
-            --mod-picker-border-color-error-default-open,
-            var(--spectrum-picker-border-color-error-default-open)
-        )
-    );
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-default-open, var(--spectrum-picker-border-color-error-default-open)));
 }
 
 :host([invalid]) #button.is-keyboardFocused:not(:disabled, .is-disabled),
 :host([invalid]) #button:not(:disabled, .is-disabled):focus-visible {
-    border-color: var(
-        --highcontrast-picker-border-color-default,
-        var(
-            --mod-picker-border-color-error-key-focus,
-            var(--spectrum-picker-border-color-error-key-focus)
-        )
-    );
+    border-color: var(--highcontrast-picker-border-color-default, var(--mod-picker-border-color-error-key-focus, var(--spectrum-picker-border-color-error-key-focus)));
 }
 
 :host([pending]) #button .picker {
-    color: var(
-        --highcontrast-picker-content-color-disabled,
-        var(
-            --mod-picker-icon-color-disabled,
-            var(--spectrum-picker-icon-color-disabled)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
 }
 
 :host([invalid]) #button .label,
 :host([pending]) #button .label {
-    margin-inline-end: var(
-        --mod-picker-spacing-text-to-icon-inline-end,
-        var(
-            --mod-picker-spacing-text-to-alert-icon-inline-start,
-            var(--spectrum-picker-spacing-text-to-icon-inline-end)
-        )
-    );
+    margin-inline-end: var(--mod-picker-spacing-text-to-icon-inline-end, var(--mod-picker-spacing-text-to-alert-icon-inline-start, var(--spectrum-picker-spacing-text-to-icon-inline-end)));
 }
 
 .icon {
     flex-shrink: 0;
-    margin-inline-end: var(
-        --mod-picker-spacing-text-to-icon,
-        var(--spectrum-picker-spacing-text-to-icon)
-    );
+    margin-inline-end: var(--mod-picker-spacing-text-to-icon, var(--spectrum-picker-spacing-text-to-icon));
 }
 
 .label {
     white-space: nowrap;
     font-size: var(--mod-picker-font-size, var(--spectrum-picker-font-size));
-    line-height: var(
-        --mod-picker-line-height,
-        var(--spectrum-picker-line-height)
-    );
-    font-weight: var(
-        --mod-picker-font-weight,
-        var(--spectrum-picker-font-weight)
-    );
+    line-height: var(--mod-picker-line-height, var(--spectrum-picker-line-height));
+    font-weight: var(--mod-picker-font-weight, var(--spectrum-picker-font-weight));
     text-overflow: ellipsis;
     text-align: start;
     flex: auto;
-    padding-block-start: var(
-        --mod-picker-spacing-top-to-text,
-        var(--spectrum-picker-spacing-top-to-text)
-    );
-    padding-block-end: calc(
-        var(
-                --mod-picker-spacing-bottom-to-text,
-                var(--spectrum-picker-spacing-bottom-to-text)
-            ) -
-            var(--mod-picker-border-width, var(--spectrum-picker-border-width))
-    );
+    padding-block-start: var(--mod-picker-spacing-top-to-text, var(--spectrum-picker-spacing-top-to-text));
+    padding-block-end: calc(var(--mod-picker-spacing-bottom-to-text, var(--spectrum-picker-spacing-bottom-to-text)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
     overflow: hidden;
 }
 
 .label.placeholder {
-    font-weight: var(
-        --mod-picker-placeholder-font-weight,
-        var(--spectrum-picker-font-weight)
-    );
-    font-style: var(
-        --mod-picker-placeholder-font-style,
-        var(--spectrum-picker-placeholder-font-style)
-    );
-    transition: color
-        var(
-            --mod-picker-animation-duration,
-            var(--spectrum-picker-animation-duration)
-        )
-        ease-in-out;
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-default,
-            var(--spectrum-picker-font-color-default)
-        )
-    );
+    font-weight: var(--mod-picker-placeholder-font-weight, var(--spectrum-picker-font-weight));
+    font-style: var(--mod-picker-placeholder-font-style, var(--spectrum-picker-placeholder-font-style));
+    transition: color var(--mod-picker-animation-duration, var(--spectrum-picker-animation-duration)) ease-in-out;
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
 }
 
 .label.placeholder:active {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-active,
-            var(--spectrum-picker-font-color-active)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-active, var(--spectrum-picker-font-color-active)));
 }
 
 .picker {
     vertical-align: top;
-    transition: color
-        var(
-            --mod-picker-animation-duration,
-            var(--spectrum-picker-animation-duration)
-        )
-        ease-out;
-    margin-inline-start: var(
-        --mod-picker-spacing-icon-to-disclosure-icon,
-        var(--spectrum-picker-spacing-icon-to-disclosure-icon)
-    );
-    margin-block: var(
-        --mod-picker-spacing-top-to-disclosure-icon,
-        var(--spectrum-picker-spacing-top-to-disclosure-icon)
-    );
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-icon-color-default,
-            var(--spectrum-picker-icon-color-default)
-        )
-    );
+    transition: color var(--mod-picker-animation-duration, var(--spectrum-picker-animation-duration)) ease-out;
+    margin-inline-start: var(--mod-picker-spacing-icon-to-disclosure-icon, var(--spectrum-picker-spacing-icon-to-disclosure-icon));
+    margin-block: var(--mod-picker-spacing-top-to-disclosure-icon, var(--spectrum-picker-spacing-top-to-disclosure-icon));
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-default, var(--spectrum-picker-icon-color-default)));
     flex-shrink: 0;
     display: inline-block;
     position: relative;
 }
 
 .picker:active {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-icon-color-active,
-            var(--spectrum-picker-icon-color-active)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-active, var(--spectrum-picker-icon-color-active)));
 }
 
 .validation-icon {
     flex-shrink: 0;
-    margin-block-start: calc(
-        var(
-                --mod-picker-spacing-top-to-alert-icon,
-                var(--spectrum-picker-spacing-top-to-alert-icon)
-            ) -
-            var(--mod-picker-border-width, var(--spectrum-picker-border-width))
-    );
-    margin-block-end: calc(
-        var(
-                --mod-picker-spacing-top-to-alert-icon,
-                var(--spectrum-picker-spacing-top-to-alert-icon)
-            ) -
-            var(--mod-picker-border-width, var(--spectrum-picker-border-width))
-    );
+    margin-block-start: calc(var(--mod-picker-spacing-top-to-alert-icon, var(--spectrum-picker-spacing-top-to-alert-icon)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
+    margin-block-end: calc(var(--mod-picker-spacing-top-to-alert-icon, var(--spectrum-picker-spacing-top-to-alert-icon)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
 }
 
 #button .progress-circle {
-    margin-block-start: calc(
-        var(
-                --mod-picker-spacing-top-to-progress-circle,
-                var(--spectrum-picker-spacing-top-to-progress-circle)
-            ) -
-            var(--mod-picker-border-width, var(--spectrum-picker-border-width))
-    );
-    margin-block-end: calc(
-        var(
-                --mod-picker-spacing-top-to-progress-circle,
-                var(--spectrum-picker-spacing-top-to-progress-circle)
-            ) -
-            var(--mod-picker-border-width, var(--spectrum-picker-border-width))
-    );
+    margin-block-start: calc(var(--mod-picker-spacing-top-to-progress-circle, var(--spectrum-picker-spacing-top-to-progress-circle)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
+    margin-block-end: calc(var(--mod-picker-spacing-top-to-progress-circle, var(--spectrum-picker-spacing-top-to-progress-circle)) - var(--mod-picker-border-width, var(--spectrum-picker-border-width)));
 }
 
 .label ~ .picker {
-    margin-inline-start: var(
-        --mod-picker-spacing-text-to-icon,
-        var(--spectrum-picker-spacing-text-to-icon)
-    );
+    margin-inline-start: var(--mod-picker-spacing-text-to-icon, var(--spectrum-picker-spacing-text-to-icon));
 }
 
 :host([quiet]) #button {
     inline-size: auto;
     min-inline-size: 0;
-    padding-inline: var(
-        --mod-picker-spacing-edge-to-text-quiet,
-        var(--spectrum-picker-spacing-edge-to-text-quiet)
-    );
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-default,
-            var(--spectrum-picker-font-color-default)
-        )
-    );
+    padding-inline: var(--mod-picker-spacing-edge-to-text-quiet, var(--spectrum-picker-spacing-edge-to-text-quiet));
+    color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-default, var(--spectrum-picker-font-color-default)));
     background-color: initial;
     background-color: var(--highcontrast-picker-background-color, transparent);
     border: none;
     border-radius: 0;
-    margin-block-start: calc(
-        var(
-                --mod-picker-spacing-label-to-picker-quiet,
-                var(--spectrum-picker-spacing-label-to-picker-quiet)
-            ) + 1px
-    );
+    margin-block-start: calc(var(--mod-picker-spacing-label-to-picker-quiet, var(--spectrum-picker-spacing-label-to-picker-quiet)) + 1px);
 }
 
 :host([quiet]) #button.label-inline {
@@ -869,10 +357,7 @@ governing permissions and limitations under the License.
 }
 
 :host([quiet]) #button .picker {
-    margin-inline-end: var(
-        --mod-picker-spacing-edge-to-disclosure-icon-quiet,
-        var(--spectrum-picker-spacing-edge-to-disclosure-icon-quiet)
-    );
+    margin-inline-end: var(--mod-picker-spacing-edge-to-disclosure-icon-quiet, var(--spectrum-picker-spacing-edge-to-disclosure-icon-quiet));
 }
 
 :host([quiet]) #button:after {
@@ -883,112 +368,40 @@ governing permissions and limitations under the License.
 
 @media (hover: hover) {
     #button:hover {
-        color: var(
-            --highcontrast-picker-content-color-default,
-            var(
-                --mod-picker-font-color-hover,
-                var(--spectrum-picker-font-color-hover)
-            )
-        );
-        background-color: var(
-            --highcontrast-picker-background-color,
-            var(
-                --mod-picker-background-color-hover,
-                var(--spectrum-picker-background-color-hover)
-            )
-        );
-        border-color: var(
-            --highcontrast-picker-border-color-hover,
-            var(
-                --mod-picker-border-color-hover,
-                var(--spectrum-picker-border-color-hover)
-            )
-        );
+        color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-hover, var(--spectrum-picker-font-color-hover)));
+        background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-hover, var(--spectrum-picker-background-color-hover)));
+        border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-hover, var(--spectrum-picker-border-color-hover)));
     }
 
     #button:hover .picker {
-        color: var(
-            --highcontrast-picker-content-color-default,
-            var(
-                --mod-picker-icon-color-hover,
-                var(--spectrum-picker-icon-color-hover)
-            )
-        );
+        color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-hover, var(--spectrum-picker-icon-color-hover)));
     }
 
-    :host([open])
-        #button:not(.spectrum-Picker--quiet, :disabled, .is-disabled):hover {
-        color: var(
-            --highcontrast-picker-content-color-default,
-            var(
-                --mod-picker-font-color-hover-open,
-                var(--spectrum-picker-font-color-hover-open)
-            )
-        );
-        background-color: var(
-            --highcontrast-picker-background-color,
-            var(
-                --mod-picker-background-color-hover-open,
-                var(--spectrum-picker-background-color-hover-open)
-            )
-        );
-        border-color: var(
-            --highcontrast-picker-border-color-hover,
-            var(
-                --mod-picker-border-color-hover-open,
-                var(--spectrum-picker-border-color-hover-open)
-            )
-        );
+    :host([open]) #button:not(.spectrum-Picker--quiet, :disabled, .is-disabled):hover {
+        color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-hover-open, var(--spectrum-picker-font-color-hover-open)));
+        background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-hover-open, var(--spectrum-picker-background-color-hover-open)));
+        border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-hover-open, var(--spectrum-picker-border-color-hover-open)));
     }
 
-    :host([open])
-        #button:not(.spectrum-Picker--quiet, :disabled, .is-disabled):hover
-        .picker {
-        color: var(
-            --highcontrast-picker-content-color-default,
-            var(
-                --mod-picker-icon-color-hover-open,
-                var(--spectrum-picker-icon-color-hover-open)
-            )
-        );
+    :host([open]) #button:not(.spectrum-Picker--quiet, :disabled, .is-disabled):hover .picker {
+        color: var(--highcontrast-picker-content-color-default, var(--mod-picker-icon-color-hover-open, var(--spectrum-picker-icon-color-hover-open)));
     }
 
     :host([invalid]) #button:not(:disabled, .is-disabled):hover {
-        border-color: var(
-            --highcontrast-picker-border-color-hover,
-            var(
-                --mod-picker-border-color-error-hover,
-                var(--spectrum-picker-border-color-error-hover)
-            )
-        );
+        border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-error-hover, var(--spectrum-picker-border-color-error-hover)));
     }
 
     :host([invalid][open]) #button:not(:disabled, .is-disabled):hover {
-        border-color: var(
-            --highcontrast-picker-border-color-hover,
-            var(
-                --mod-picker-border-color-error-hover-open,
-                var(--spectrum-picker-border-color-error-hover-open)
-            )
-        );
+        border-color: var(--highcontrast-picker-border-color-hover, var(--mod-picker-border-color-error-hover-open, var(--spectrum-picker-border-color-error-hover-open)));
     }
 
     .label.placeholder:hover {
-        color: var(
-            --highcontrast-picker-content-color-default,
-            var(
-                --mod-picker-font-color-hover,
-                var(--spectrum-picker-font-color-hover)
-            )
-        );
+        color: var(--highcontrast-picker-content-color-default, var(--mod-picker-font-color-hover, var(--spectrum-picker-font-color-hover)));
     }
 
     :host([quiet]) #button:hover {
         background-color: initial;
-        background-color: var(
-            --highcontrast-picker-background-color,
-            transparent
-        );
+        background-color: var(--highcontrast-picker-background-color, transparent);
     }
 }
 
@@ -1000,32 +413,8 @@ governing permissions and limitations under the License.
 
 :host([quiet]) #button.is-keyboardFocused:after,
 :host([quiet]) #button:focus-visible:after {
-    box-shadow: 0
-        var(
-            --mod-picker-focus-indicator-thickness,
-            var(--spectrum-picker-focus-indicator-thickness)
-        )
-        0 0
-        var(
-            --highcontrast-picker-focus-indicator-color,
-            var(
-                --mod-picker-focus-indicator-color,
-                var(--spectrum-picker-focus-indicator-color)
-            )
-        );
-    margin: calc(
-            (
-                    var(
-                            --mod-picker-focus-indicator-gap,
-                            var(--spectrum-picker-focus-indicator-gap)
-                        ) +
-                        var(
-                            --mod-picker-border-width,
-                            var(--spectrum-picker-border-width)
-                        )
-                ) * -1
-        )
-        0;
+    box-shadow: 0 var(--mod-picker-focus-indicator-thickness, var(--spectrum-picker-focus-indicator-thickness)) 0 0 var(--highcontrast-picker-focus-indicator-color, var(--mod-picker-focus-indicator-color, var(--spectrum-picker-focus-indicator-color)));
+    margin: calc((var(--mod-picker-focus-indicator-gap, var(--spectrum-picker-focus-indicator-gap)) + var(--mod-picker-border-width, var(--spectrum-picker-border-width))) * -1) 0;
     border: none;
     border-radius: 0;
 }
@@ -1046,24 +435,9 @@ governing permissions and limitations under the License.
 :host([disabled]) #button,
 #button:disabled {
     cursor: default;
-    background-color: var(
-        --highcontrast-picker-background-color,
-        var(
-            --mod-picker-background-color-disabled,
-            var(--spectrum-picker-background-color-disabled)
-        )
-    );
-    border-color: var(
-        --highcontrast-picker-border-color-disabled,
-        var(--spectrum-picker-border-color-disabled)
-    );
-    color: var(
-        --highcontrast-picker-content-color-disabled,
-        var(
-            --mod-picker-font-color-disabled,
-            var(--spectrum-picker-font-color-disabled)
-        )
-    );
+    background-color: var(--highcontrast-picker-background-color, var(--mod-picker-background-color-disabled, var(--spectrum-picker-background-color-disabled)));
+    border-color: var(--highcontrast-picker-border-color-disabled, var(--spectrum-picker-border-color-disabled));
+    color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
 }
 
 :host([disabled]) #button .icon,
@@ -1072,22 +446,10 @@ governing permissions and limitations under the License.
 #button:disabled .icon,
 #button:disabled .picker,
 #button:disabled .validation-icon {
-    color: var(
-        --highcontrast-picker-content-color-disabled,
-        var(
-            --mod-picker-icon-color-disabled,
-            var(--spectrum-picker-icon-color-disabled)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-icon-color-disabled, var(--spectrum-picker-icon-color-disabled)));
 }
 
 :host([disabled]) #button .label.placeholder,
 #button:disabled .label.placeholder {
-    color: var(
-        --highcontrast-picker-content-color-disabled,
-        var(
-            --mod-picker-font-color-disabled,
-            var(--spectrum-picker-font-color-disabled)
-        )
-    );
+    color: var(--highcontrast-picker-content-color-disabled, var(--mod-picker-font-color-disabled, var(--spectrum-picker-font-color-disabled)));
 }

--- a/packages/popover/src/spectrum-popover.css
+++ b/packages/popover/src/spectrum-popover.css
@@ -20,23 +20,9 @@ governing permissions and limitations under the License.
         opacity 0.13s ease-in-out,
         visibility 0s linear 0.13s;
     transition:
-        transform
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        opacity
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        visibility 0s linear
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            );
+        transform var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        opacity var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        visibility 0s linear var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s));
 }
 
 :host([open]) {
@@ -44,21 +30,14 @@ governing permissions and limitations under the License.
     visibility: visible;
     opacity: 1;
     transition-delay: 0s;
-    transition-delay: var(
-        --mod-overlay-animation-duration-opened,
-        var(--spectrum-animation-duration-0, 0s)
-    );
+    transition-delay: var(--mod-overlay-animation-duration-opened, var(--spectrum-animation-duration-0, 0s));
 }
 
 :host {
     --spectrum-popover-animation-distance: var(--spectrum-spacing-100);
-    --spectrum-popover-background-color: var(
-        --spectrum-background-layer-2-color
-    );
+    --spectrum-popover-background-color: var(--spectrum-background-layer-2-color);
     --spectrum-popover-border-color: var(--spectrum-gray-400);
-    --spectrum-popover-content-area-spacing-vertical: var(
-        --spectrum-popover-top-to-content-area
-    );
+    --spectrum-popover-content-area-spacing-vertical: var(--spectrum-popover-top-to-content-area);
     --spectrum-popover-shadow-horizontal: var(--spectrum-drop-shadow-x);
     --spectrum-popover-shadow-vertical: var(--spectrum-drop-shadow-y);
     --spectrum-popover-shadow-blur: var(--spectrum-drop-shadow-blur);
@@ -66,14 +45,8 @@ governing permissions and limitations under the License.
     --spectrum-popover-corner-radius: var(--spectrum-corner-radius-100);
     --spectrum-popover-pointer-width: var(--spectrum-popover-tip-width);
     --spectrum-popover-pointer-height: var(--spectrum-popover-tip-height);
-    --spectrum-popover-pointer-edge-offset: calc(
-        var(--spectrum-corner-radius-100) + var(--spectrum-popover-tip-width) /
-            2
-    );
-    --spectrum-popover-pointer-edge-spacing: calc(
-        var(--spectrum-popover-pointer-edge-offset) -
-            var(--spectrum-popover-tip-width) / 2
-    );
+    --spectrum-popover-pointer-edge-offset: calc(var(--spectrum-corner-radius-100) + var(--spectrum-popover-tip-width) / 2);
+    --spectrum-popover-pointer-edge-spacing: calc(var(--spectrum-popover-pointer-edge-offset) - var(--spectrum-popover-tip-width) / 2);
 }
 
 @media (forced-colors: active) {
@@ -83,44 +56,14 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    --spectrum-popover-filter: drop-shadow(
-        var(
-                --mod-popover-shadow-horizontal,
-                var(--spectrum-popover-shadow-horizontal)
-            )
-            var(
-                --mod-popover-shadow-vertical,
-                var(--spectrum-popover-shadow-vertical)
-            )
-            var(--mod-popover-shadow-blur, var(--spectrum-popover-shadow-blur))
-            var(
-                --mod-popover-shadow-color,
-                var(--spectrum-popover-shadow-color)
-            )
-    );
+    --spectrum-popover-filter: drop-shadow(var(--mod-popover-shadow-horizontal, var(--spectrum-popover-shadow-horizontal)) var(--mod-popover-shadow-vertical, var(--spectrum-popover-shadow-vertical)) var(--mod-popover-shadow-blur, var(--spectrum-popover-shadow-blur)) var(--mod-popover-shadow-color, var(--spectrum-popover-shadow-color)));
     box-sizing: border-box;
-    padding: var(
-            --mod-popover-content-area-spacing-vertical,
-            var(--spectrum-popover-content-area-spacing-vertical)
-        )
-        0;
-    border-radius: var(
-        --mod-popover-corner-radius,
-        var(--spectrum-popover-corner-radius)
-    );
+    padding: var(--mod-popover-content-area-spacing-vertical, var(--spectrum-popover-content-area-spacing-vertical)) 0;
+    border-radius: var(--mod-popover-corner-radius, var(--spectrum-popover-corner-radius));
     border-style: solid;
-    border-color: var(
-        --highcontrast-popover-border-color,
-        var(--mod-popover-border-color, var(--spectrum-popover-border-color))
-    );
-    border-width: var(
-        --mod-popover-border-width,
-        var(--spectrum-popover-border-width)
-    );
-    background-color: var(
-        --mod-popover-background-color,
-        var(--spectrum-popover-background-color)
-    );
+    border-color: var(--highcontrast-popover-border-color, var(--mod-popover-border-color, var(--spectrum-popover-border-color)));
+    border-width: var(--mod-popover-border-width, var(--spectrum-popover-border-width));
+    background-color: var(--mod-popover-background-color, var(--spectrum-popover-background-color));
     filter: var(--mod-popover-filter, var(--spectrum-popover-filter));
     outline: none;
     flex-direction: column;
@@ -131,18 +74,9 @@ governing permissions and limitations under the License.
 :host([tip]) #tip .triangle {
     stroke-linecap: square;
     stroke-linejoin: miter;
-    fill: var(
-        --mod-popover-background-color,
-        var(--spectrum-popover-background-color)
-    );
-    stroke: var(
-        --highcontrast-popover-border-color,
-        var(--mod-popover-border-color, var(--spectrum-popover-border-color))
-    );
-    stroke-width: var(
-        --mod-popover-border-width,
-        var(--spectrum-popover-border-width)
-    );
+    fill: var(--mod-popover-background-color, var(--spectrum-popover-background-color));
+    stroke: var(--highcontrast-popover-border-color, var(--mod-popover-border-color, var(--spectrum-popover-border-color)));
+    stroke-width: var(--mod-popover-border-width, var(--spectrum-popover-border-width));
 }
 
 * {
@@ -154,16 +88,7 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--top-right,
 :host([tip]) .spectrum-Popover--top-start,
 :host([placement*='top'][tip]) {
-    margin-block-end: calc(
-        var(
-                --mod-popover-pointer-height,
-                var(--spectrum-popover-pointer-height)
-            ) -
-            var(
-                --mod-popover-border-width,
-                var(--spectrum-popover-border-width)
-            )
-    );
+    margin-block-end: calc(var(--mod-popover-pointer-height, var(--spectrum-popover-pointer-height)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
 :host([open]) .spectrum-Popover--top-end,
@@ -171,14 +96,7 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Popover--top-right,
 :host([open]) .spectrum-Popover--top-start,
 :host([placement*='top'][open]) {
-    transform: translateY(
-        calc(
-            var(
-                    --mod-popover-animation-distance,
-                    var(--spectrum-popover-animation-distance)
-                ) * -1
-        )
-    );
+    transform: translateY(calc(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)) * -1));
 }
 
 :host([tip]) .spectrum-Popover--bottom-end,
@@ -186,16 +104,7 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--bottom-right,
 :host([tip]) .spectrum-Popover--bottom-start,
 :host([placement*='bottom'][tip]) {
-    margin-block-start: calc(
-        var(
-                --mod-popover-pointer-height,
-                var(--spectrum-popover-pointer-height)
-            ) -
-            var(
-                --mod-popover-border-width,
-                var(--spectrum-popover-border-width)
-            )
-    );
+    margin-block-start: calc(var(--mod-popover-pointer-height, var(--spectrum-popover-pointer-height)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
 :host([open]) .spectrum-Popover--bottom-end,
@@ -203,85 +112,43 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Popover--bottom-right,
 :host([open]) .spectrum-Popover--bottom-start,
 :host([placement*='bottom'][open]) {
-    transform: translateY(
-        var(
-            --mod-popover-animation-distance,
-            var(--spectrum-popover-animation-distance)
-        )
-    );
+    transform: translateY(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)));
 }
 
 :host([tip]) .spectrum-Popover--right-bottom,
 :host([tip]) .spectrum-Popover--right-top,
 :host([placement*='right'][tip]) {
-    margin-left: calc(
-        var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) -
-            var(
-                --mod-popover-border-width,
-                var(--spectrum-popover-border-width)
-            )
-    );
+    margin-left: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
 :host([open]) .spectrum-Popover--right-bottom,
 :host([open]) .spectrum-Popover--right-top,
 :host([placement*='right'][open]) {
-    transform: translateX(
-        var(
-            --mod-popover-animation-distance,
-            var(--spectrum-popover-animation-distance)
-        )
-    );
+    transform: translateX(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)));
 }
 
 :host([tip]) .spectrum-Popover--left-bottom,
 :host([tip]) .spectrum-Popover--left-top,
 :host([placement*='left'][tip]) {
-    margin-right: calc(
-        var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) -
-            var(
-                --mod-popover-border-width,
-                var(--spectrum-popover-border-width)
-            )
-    );
+    margin-right: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
 :host([open]) .spectrum-Popover--left-bottom,
 :host([open]) .spectrum-Popover--left-top,
 :host([placement*='left'][open]) {
-    transform: translateX(
-        calc(
-            var(
-                    --mod-popover-animation-distance,
-                    var(--spectrum-popover-animation-distance)
-                ) * -1
-        )
-    );
+    transform: translateX(calc(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)) * -1));
 }
 
 :host([tip]) .spectrum-Popover--start-bottom,
 :host([tip]) .spectrum-Popover--start-top,
 :host([tip]) .spectrum-Popover--start {
-    margin-inline-end: calc(
-        var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) -
-            var(
-                --mod-popover-border-width,
-                var(--spectrum-popover-border-width)
-            )
-    );
+    margin-inline-end: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
 :host([open]) .spectrum-Popover--start-bottom,
 :host([open]) .spectrum-Popover--start-top,
 :host([open]) .spectrum-Popover--start {
-    transform: translateX(
-        calc(
-            var(
-                    --mod-popover-animation-distance,
-                    var(--spectrum-popover-animation-distance)
-                ) * -1
-        )
-    );
+    transform: translateX(calc(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)) * -1));
 }
 
 :host([open]) .spectrum-Popover--start-bottom:dir(rtl),
@@ -290,35 +157,19 @@ governing permissions and limitations under the License.
 :host([dir='rtl'][open]) .spectrum-Popover--start-bottom,
 :host([dir='rtl'][open]) .spectrum-Popover--start-top,
 :host([dir='rtl'][open]) .spectrum-Popover--start {
-    transform: translateX(
-        var(
-            --mod-popover-animation-distance,
-            var(--spectrum-popover-animation-distance)
-        )
-    );
+    transform: translateX(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)));
 }
 
 :host([tip]) .spectrum-Popover--end-bottom,
 :host([tip]) .spectrum-Popover--end-top,
 :host([tip]) .spectrum-Popover--end {
-    margin-inline-start: calc(
-        var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) -
-            var(
-                --mod-popover-border-width,
-                var(--spectrum-popover-border-width)
-            )
-    );
+    margin-inline-start: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
 :host([open]) .spectrum-Popover--end-bottom,
 :host([open]) .spectrum-Popover--end-top,
 :host([open]) .spectrum-Popover--end {
-    transform: translateX(
-        var(
-            --mod-popover-animation-distance,
-            var(--spectrum-popover-animation-distance)
-        )
-    );
+    transform: translateX(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)));
 }
 
 :host([open]) .spectrum-Popover--end-bottom:dir(rtl),
@@ -327,14 +178,7 @@ governing permissions and limitations under the License.
 :host([dir='rtl'][open]) .spectrum-Popover--end-bottom,
 :host([dir='rtl'][open]) .spectrum-Popover--end-top,
 :host([dir='rtl'][open]) .spectrum-Popover--end {
-    transform: translateX(
-        calc(
-            var(
-                    --mod-popover-animation-distance,
-                    var(--spectrum-popover-animation-distance)
-                ) * -1
-        )
-    );
+    transform: translateX(calc(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)) * -1));
 }
 
 :host([tip]) #tip,
@@ -348,14 +192,8 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--top-left #tip,
 :host([tip]) .spectrum-Popover--top-right #tip,
 :host([tip]) .spectrum-Popover--top-start #tip {
-    inline-size: var(
-        --mod-popover-pointer-width,
-        var(--spectrum-popover-pointer-width)
-    );
-    block-size: var(
-        --mod-popover-pointer-height,
-        var(--spectrum-popover-pointer-height)
-    );
+    inline-size: var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width));
+    block-size: var(--mod-popover-pointer-height, var(--spectrum-popover-pointer-height));
     margin: auto;
     position: absolute;
     inset-block-start: 100%;
@@ -364,33 +202,19 @@ governing permissions and limitations under the License.
 }
 
 :host([tip]) .spectrum-Popover--top-left #tip {
-    inset-inline: var(
-            --mod-popover-pointer-edge-spacing,
-            var(--spectrum-popover-pointer-edge-spacing)
-        )
-        auto;
+    inset-inline: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing)) auto;
 }
 
 :host([tip]) .spectrum-Popover--top-right #tip {
-    inset-inline: auto
-        var(
-            --mod-popover-pointer-edge-spacing,
-            var(--spectrum-popover-pointer-edge-spacing)
-        );
+    inset-inline: auto var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
 }
 
 :host([tip]) .spectrum-Popover--top-start #tip {
-    margin-inline-start: var(
-        --mod-popover-pointer-edge-spacing,
-        var(--spectrum-popover-pointer-edge-spacing)
-    );
+    margin-inline-start: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
 }
 
 :host([tip]) .spectrum-Popover--top-end #tip {
-    margin-inline-end: var(
-        --mod-popover-pointer-edge-spacing,
-        var(--spectrum-popover-pointer-edge-spacing)
-    );
+    margin-inline-end: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
 }
 
 :host([tip][placement*='bottom']) #tip,
@@ -403,33 +227,19 @@ governing permissions and limitations under the License.
 }
 
 :host([tip]) .spectrum-Popover--bottom-left #tip {
-    inset-inline: var(
-            --mod-popover-pointer-edge-spacing,
-            var(--spectrum-popover-pointer-edge-spacing)
-        )
-        auto;
+    inset-inline: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing)) auto;
 }
 
 :host([tip]) .spectrum-Popover--bottom-right #tip {
-    inset-inline: auto
-        var(
-            --mod-popover-pointer-edge-spacing,
-            var(--spectrum-popover-pointer-edge-spacing)
-        );
+    inset-inline: auto var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
 }
 
 :host([tip]) .spectrum-Popover--bottom-start #tip {
-    margin-inline-start: var(
-        --mod-popover-pointer-edge-spacing,
-        var(--spectrum-popover-pointer-edge-spacing)
-    );
+    margin-inline-start: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
 }
 
 :host([tip]) .spectrum-Popover--bottom-end #tip {
-    margin-inline-end: var(
-        --mod-popover-pointer-edge-spacing,
-        var(--spectrum-popover-pointer-edge-spacing)
-    );
+    margin-inline-end: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
 }
 
 :host([tip]) .spectrum-Popover--end #tip,
@@ -444,14 +254,8 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--start #tip,
 :host([tip]) .spectrum-Popover--start-bottom #tip,
 :host([tip]) .spectrum-Popover--start-top #tip {
-    inline-size: var(
-        --mod-popover-pointer-height,
-        var(--spectrum-popover-pointer-height)
-    );
-    block-size: var(
-        --mod-popover-pointer-width,
-        var(--spectrum-popover-pointer-width)
-    );
+    inline-size: var(--mod-popover-pointer-height, var(--spectrum-popover-pointer-height));
+    block-size: var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width));
     inset-block: 0;
 }
 
@@ -474,22 +278,14 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--left-top #tip,
 :host([tip]) .spectrum-Popover--right-top #tip,
 :host([tip]) .spectrum-Popover--start-top #tip {
-    inset-block: var(
-            --mod-popover-pointer-edge-spacing,
-            var(--spectrum-popover-pointer-edge-spacing)
-        )
-        auto;
+    inset-block: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing)) auto;
 }
 
 :host([tip]) .spectrum-Popover--end-bottom #tip,
 :host([tip]) .spectrum-Popover--left-bottom #tip,
 :host([tip]) .spectrum-Popover--right-bottom #tip,
 :host([tip]) .spectrum-Popover--start-bottom #tip {
-    inset-block: auto
-        var(
-            --mod-popover-pointer-edge-spacing,
-            var(--spectrum-popover-pointer-edge-spacing)
-        );
+    inset-block: auto var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
 }
 
 :host([tip]) .spectrum-Popover--start #tip,

--- a/packages/progress-bar/src/spectrum-progress-bar.css
+++ b/packages/progress-bar/src/spectrum-progress-bar.css
@@ -12,23 +12,11 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    font-size: var(
-        --mod-progressbar-font-size,
-        var(--spectrum-progressbar-font-size)
-    );
+    font-size: var(--mod-progressbar-font-size, var(--spectrum-progressbar-font-size));
     vertical-align: top;
-    inline-size: var(
-        --mod-progressbar-size-default,
-        var(--spectrum-progressbar-size-default)
-    );
-    max-inline-size: var(
-        --mod-progressbar-max-size,
-        var(--spectrum-progressbar-max-size)
-    );
-    min-inline-size: var(
-        --mod-progressbar-min-size,
-        var(--spectrum-progressbar-min-size)
-    );
+    inline-size: var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default));
+    max-inline-size: var(--mod-progressbar-max-size, var(--spectrum-progressbar-max-size));
+    min-inline-size: var(--mod-progressbar-min-size, var(--spectrum-progressbar-min-size));
     flex-flow: wrap;
     justify-content: space-between;
     align-items: center;
@@ -39,22 +27,10 @@ governing permissions and limitations under the License.
 .label,
 .percentage {
     text-align: start;
-    line-height: var(
-        --mod-progressbar-line-height,
-        var(--spectrum-progressbar-line-height)
-    );
-    color: var(
-        --mod-progressbar-text-color,
-        var(--spectrum-progressbar-text-color)
-    );
-    margin-block-start: var(
-        --mod-progressbar-spacing-top-to-text,
-        var(--spectrum-progressbar-spacing-top-to-text)
-    );
-    margin-block-end: var(
-        --mod-progressbar-spacing-label-to-progressbar,
-        var(--spectrum-progressbar-spacing-label-to-progressbar)
-    );
+    line-height: var(--mod-progressbar-line-height, var(--spectrum-progressbar-line-height));
+    color: var(--mod-progressbar-text-color, var(--spectrum-progressbar-text-color));
+    margin-block-start: var(--mod-progressbar-spacing-top-to-text, var(--spectrum-progressbar-spacing-top-to-text));
+    margin-block-end: var(--mod-progressbar-spacing-label-to-progressbar, var(--spectrum-progressbar-spacing-label-to-progressbar));
 }
 
 .label:lang(ja),
@@ -63,10 +39,7 @@ governing permissions and limitations under the License.
 .percentage:lang(ja),
 .percentage:lang(ko),
 .percentage:lang(zh) {
-    line-height: var(
-        --mod-progressbar-line-height-cjk,
-        var(--spectrum-progressbar-line-height-cjk)
-    );
+    line-height: var(--mod-progressbar-line-height-cjk, var(--spectrum-progressbar-line-height-cjk));
 }
 
 .label {
@@ -75,60 +48,30 @@ governing permissions and limitations under the License.
 
 .percentage {
     align-self: flex-start;
-    margin-inline-start: var(
-        --mod-progressbar-spacing-label-to-text,
-        var(--spectrum-progressbar-spacing-label-to-text)
-    );
+    margin-inline-start: var(--mod-progressbar-spacing-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
 }
 
 .track {
     inline-size: 100%;
-    block-size: var(
-        --mod-progressbar-thickness,
-        var(--spectrum-progressbar-thickness)
-    );
+    block-size: var(--mod-progressbar-thickness, var(--spectrum-progressbar-thickness));
     border-radius: var(--spectrum-progressbar-corner-radius);
-    background: var(
-        --highcontrast-progressbar-track-color,
-        var(
-            --mod-progressbar-track-color,
-            var(--spectrum-progressbar-track-color)
-        )
-    );
+    background: var(--highcontrast-progressbar-track-color, var(--mod-progressbar-track-color, var(--spectrum-progressbar-track-color)));
     overflow: hidden;
 }
 
 .fill {
-    block-size: var(
-        --mod-progressbar-thickness,
-        var(--spectrum-progressbar-thickness)
-    );
-    background: var(
-        --highcontrast-progressbar-fill-color,
-        var(
-            --mod-progressbar-fill-color,
-            var(--spectrum-progressbar-fill-color)
-        )
-    );
+    block-size: var(--mod-progressbar-thickness, var(--spectrum-progressbar-thickness));
+    background: var(--highcontrast-progressbar-fill-color, var(--mod-progressbar-fill-color, var(--spectrum-progressbar-fill-color)));
     border: none;
     transition: width 1s;
 }
 
 :host([indeterminate]) .fill {
-    inline-size: var(
-        --mod-progressbar-fill-size-indeterminate,
-        var(--spectrum-progressbar-fill-size-indeterminate)
-    );
-    animation-timing-function: var(
-        --mod-progressbar-animation-ease-in-out-indeterminate,
-        var(--spectrum-progressbar-animation-ease-in-out-indeterminate)
-    );
+    inline-size: var(--mod-progressbar-fill-size-indeterminate, var(--spectrum-progressbar-fill-size-indeterminate));
+    animation-timing-function: var(--mod-progressbar-animation-ease-in-out-indeterminate, var(--spectrum-progressbar-animation-ease-in-out-indeterminate));
     will-change: transform;
     animation-name: indeterminate-loop-ltr;
-    animation-duration: var(
-        --mod-progressbar-animation-duration-indeterminate,
-        var(--spectrum-progressbar-animation-duration-indeterminate)
-    );
+    animation-duration: var(--mod-progressbar-animation-duration-indeterminate, var(--spectrum-progressbar-animation-duration-indeterminate));
     animation-iteration-count: infinite;
     position: relative;
 }
@@ -145,46 +88,30 @@ governing permissions and limitations under the License.
 }
 
 :host([side-label]) .track {
-    flex: 1 1
-        var(
-            --mod-progressbar-size-default,
-            var(--spectrum-progressbar-size-default)
-        );
+    flex: 1 1 var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default));
 }
 
 :host([side-label]) .label {
     flex-grow: 0;
     margin-block-end: 0;
-    margin-inline-end: var(
-        --mod-progressbar-spacing-label-to-text,
-        var(--spectrum-progressbar-spacing-label-to-text)
-    );
+    margin-inline-end: var(--mod-progressbar-spacing-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
 }
 
 :host([side-label]) .percentage {
     text-align: end;
     order: 3;
     margin-block-end: 0;
-    margin-inline-start: var(
-        --mod-spacing-progressbar-label-to-text,
-        var(--spectrum-progressbar-spacing-label-to-text)
-    );
+    margin-inline-start: var(--mod-spacing-progressbar-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
 }
 
 :host([static-color='white']) .fill {
-    background: var(
-        --mod-progressbar-fill-color-white,
-        var(--spectrum-progressbar-fill-color-white)
-    );
+    background: var(--mod-progressbar-fill-color-white, var(--spectrum-progressbar-fill-color-white));
 }
 
 :host([static-color='white']) .fill,
 :host([static-color='white']) .label,
 :host([static-color='white']) .percentage {
-    color: var(
-        --mod-progressbar-label-and-value-white,
-        var(--spectrum-progressbar-label-and-value-white)
-    );
+    color: var(--mod-progressbar-label-and-value-white, var(--spectrum-progressbar-label-and-value-white));
 }
 
 :host([static-color='white']) .track {
@@ -193,45 +120,21 @@ governing permissions and limitations under the License.
 
 @keyframes indeterminate-loop-ltr {
     0% {
-        transform: translate(
-            calc(
-                var(
-                        --mod-progressbar-fill-size-indeterminate,
-                        var(--spectrum-progressbar-fill-size-indeterminate)
-                    ) * -1
-            )
-        );
+        transform: translate(calc(var(--mod-progressbar-fill-size-indeterminate, var(--spectrum-progressbar-fill-size-indeterminate)) * -1));
     }
 
     to {
-        transform: translate(
-            var(
-                --mod-progressbar-size-default,
-                var(--spectrum-progressbar-size-default)
-            )
-        );
+        transform: translate(var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default)));
     }
 }
 
 @keyframes indeterminate-loop-rtl {
     0% {
-        transform: translate(
-            var(
-                --mod-progressbar-size-default,
-                var(--spectrum-progressbar-fill-size-indeterminate)
-            )
-        );
+        transform: translate(var(--mod-progressbar-size-default, var(--spectrum-progressbar-fill-size-indeterminate)));
     }
 
     to {
-        transform: translate(
-            calc(
-                var(
-                        --mod-progressbar-size-default,
-                        var(--spectrum-progressbar-size-default)
-                    ) * -1
-            )
-        );
+        transform: translate(calc(var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default)) * -1));
     }
 }
 

--- a/packages/progress-circle/src/spectrum-progress-circle.css
+++ b/packages/progress-circle/src/spectrum-progress-circle.css
@@ -24,24 +24,12 @@ governing permissions and limitations under the License.
 
 :host {
     --spectrum-progress-circle-track-border-color: var(--spectrum-gray-300);
-    --spectrum-progress-circle-fill-border-color: var(
-        --spectrum-accent-content-color-default
-    );
-    --spectrum-progress-circle-track-border-color-over-background: var(
-        --spectrum-transparent-white-300
-    );
-    --spectrum-progress-circle-fill-border-color-over-background: var(
-        --spectrum-transparent-white-900
-    );
+    --spectrum-progress-circle-fill-border-color: var(--spectrum-accent-content-color-default);
+    --spectrum-progress-circle-track-border-color-over-background: var(--spectrum-transparent-white-300);
+    --spectrum-progress-circle-fill-border-color-over-background: var(--spectrum-transparent-white-900);
     --spectrum-progress-circle-track-border-style: solid;
-    inline-size: var(
-        --mod-progress-circle-size,
-        var(--spectrum-progress-circle-size)
-    );
-    block-size: var(
-        --mod-progress-circle-size,
-        var(--spectrum-progress-circle-size)
-    );
+    inline-size: var(--mod-progress-circle-size, var(--spectrum-progress-circle-size));
+    block-size: var(--mod-progress-circle-size, var(--spectrum-progress-circle-size));
     position: var(--mod-progress-circle-position, relative);
     direction: ltr;
     display: inline-block;
@@ -51,53 +39,27 @@ governing permissions and limitations under the License.
 
 :host([size='s']) {
     --spectrum-progress-circle-size: var(--spectrum-progress-circle-size-small);
-    --spectrum-progress-circle-thickness: var(
-        --spectrum-progress-circle-thickness-small
-    );
+    --spectrum-progress-circle-thickness: var(--spectrum-progress-circle-thickness-small);
 }
 
 :host {
-    --spectrum-progress-circle-size: var(
-        --spectrum-progress-circle-size-medium
-    );
-    --spectrum-progress-circle-thickness: var(
-        --spectrum-progress-circle-thickness-medium
-    );
+    --spectrum-progress-circle-size: var(--spectrum-progress-circle-size-medium);
+    --spectrum-progress-circle-thickness: var(--spectrum-progress-circle-thickness-medium);
 }
 
 :host([size='l']) {
     --spectrum-progress-circle-size: var(--spectrum-progress-circle-size-large);
-    --spectrum-progress-circle-thickness: var(
-        --spectrum-progress-circle-thickness-large
-    );
+    --spectrum-progress-circle-thickness: var(--spectrum-progress-circle-thickness-large);
 }
 
 .track {
     box-sizing: border-box;
-    inline-size: var(
-        --mod-progress-circle-size,
-        var(--spectrum-progress-circle-size)
-    );
-    block-size: var(
-        --mod-progress-circle-size,
-        var(--spectrum-progress-circle-size)
-    );
-    border-style: var(
-        --mod-progress-circle-track-border-style,
-        var(--spectrum-progress-circle-track-border-style)
-    );
-    border-width: var(
-        --mod-progress-circle-thickness,
-        var(--spectrum-progress-circle-thickness)
-    );
-    border-radius: var(
-        --mod-progress-circle-size,
-        var(--spectrum-progress-circle-size)
-    );
-    border-color: var(
-        --mod-progress-circle-track-border-color,
-        var(--spectrum-progress-circle-track-border-color)
-    );
+    inline-size: var(--mod-progress-circle-size, var(--spectrum-progress-circle-size));
+    block-size: var(--mod-progress-circle-size, var(--spectrum-progress-circle-size));
+    border-style: var(--mod-progress-circle-track-border-style, var(--spectrum-progress-circle-track-border-style));
+    border-width: var(--mod-progress-circle-thickness, var(--spectrum-progress-circle-thickness));
+    border-radius: var(--mod-progress-circle-size, var(--spectrum-progress-circle-size));
+    border-color: var(--mod-progress-circle-track-border-color, var(--spectrum-progress-circle-track-border-color));
 }
 
 .fills {
@@ -110,47 +72,20 @@ governing permissions and limitations under the License.
 
 .fill {
     box-sizing: border-box;
-    inline-size: var(
-        --mod-progress-circle-size,
-        var(--spectrum-progress-circle-size)
-    );
-    block-size: var(
-        --mod-progress-circle-size,
-        var(--spectrum-progress-circle-size)
-    );
+    inline-size: var(--mod-progress-circle-size, var(--spectrum-progress-circle-size));
+    block-size: var(--mod-progress-circle-size, var(--spectrum-progress-circle-size));
     border-style: solid;
-    border-width: var(
-        --mod-progress-circle-thickness,
-        var(--spectrum-progress-circle-thickness)
-    );
-    border-radius: var(
-        --mod-progress-circle-size,
-        var(--spectrum-progress-circle-size)
-    );
-    border-color: var(
-        --highcontrast-progress-circle-fill-border-color,
-        var(
-            --mod-progress-circle-fill-border-color,
-            var(--spectrum-progress-circle-fill-border-color)
-        )
-    );
+    border-width: var(--mod-progress-circle-thickness, var(--spectrum-progress-circle-thickness));
+    border-radius: var(--mod-progress-circle-size, var(--spectrum-progress-circle-size));
+    border-color: var(--highcontrast-progress-circle-fill-border-color, var(--mod-progress-circle-fill-border-color, var(--spectrum-progress-circle-fill-border-color)));
 }
 
 :host([static-color='white']) .track {
-    border-color: var(
-        --mod-progress-circle-track-border-color-over-background,
-        var(--spectrum-progress-circle-track-border-color-over-background)
-    );
+    border-color: var(--mod-progress-circle-track-border-color-over-background, var(--spectrum-progress-circle-track-border-color-over-background));
 }
 
 :host([static-color='white']) .fill {
-    border-color: var(
-        --highcontrast-progress-circle-fill-border-color-over-background,
-        var(
-            --mod-progress-circle-fill-border-color-over-background,
-            var(--spectrum-progress-circle-fill-border-color-over-background)
-        )
-    );
+    border-color: var(--highcontrast-progress-circle-fill-border-color-over-background, var(--mod-progress-circle-fill-border-color-over-background, var(--spectrum-progress-circle-fill-border-color-over-background)));
 }
 
 .fillMask1,
@@ -179,8 +114,7 @@ governing permissions and limitations under the License.
 :host([indeterminate]) .fills {
     will-change: transform;
     transform-origin: center;
-    animation: 1s cubic-bezier(0.25, 0.78, 0.48, 0.89) infinite
-        spectrum-fills-rotate;
+    animation: 1s cubic-bezier(0.25, 0.78, 0.48, 0.89) infinite spectrum-fills-rotate;
     transform: translateZ(0);
 }
 

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -49,86 +49,35 @@ governing permissions and limitations under the License.
 }
 
 :host(:active) #button:before {
-    border-color: var(
-        --highcontrast-radio-button-border-color-down,
-        var(
-            --mod-radio-button-border-color-down,
-            var(--spectrum-radio-button-border-color-down)
-        )
-    );
+    border-color: var(--highcontrast-radio-button-border-color-down, var(--mod-radio-button-border-color-down, var(--spectrum-radio-button-border-color-down)));
 }
 
 :host(:active[checked]) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-button-checked-border-color-down,
-        var(
-            --mod-radio-button-checked-border-color-down,
-            var(--spectrum-radio-button-checked-border-color-down)
-        )
-    );
+    border-color: var(--highcontrast-radio-button-checked-border-color-down, var(--mod-radio-button-checked-border-color-down, var(--spectrum-radio-button-checked-border-color-down)));
 }
 
 :host(:active) #label {
-    color: var(
-        --highcontrast-radio-neutral-content-color-down,
-        var(
-            --mod-radio-neutral-content-color-down,
-            var(--spectrum-radio-neutral-content-color-down)
-        )
-    );
+    color: var(--highcontrast-radio-neutral-content-color-down, var(--mod-radio-neutral-content-color-down, var(--spectrum-radio-neutral-content-color-down)));
 }
 
 :host(:focus-visible) #button:before {
-    border-color: var(
-        --highcontrast-radio-button-border-color-focus,
-        var(
-            --mod-radio-button-border-color-focus,
-            var(--spectrum-radio-button-border-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-radio-button-border-color-focus, var(--mod-radio-button-border-color-focus, var(--spectrum-radio-button-border-color-focus)));
 }
 
 :host(:focus-visible) #button:after {
     border-style: solid;
-    border-color: var(
-        --highcontrast-radio-focus-indicator-color,
-        var(
-            --mod-radio-focus-indicator-color,
-            var(--spectrum-radio-focus-indicator-color)
-        )
-    );
-    border-width: var(
-        --mod-radio-focus-indicator-thickness,
-        var(--spectrum-radio-focus-indicator-thickness)
-    );
-    inline-size: calc(
-        var(--spectrum-radio-button-control-size) +
-            var(--spectrum-radio-focus-indicator-gap) * 2
-    );
-    block-size: calc(
-        var(--spectrum-radio-button-control-size) +
-            var(--spectrum-radio-focus-indicator-gap) * 2
-    );
+    border-color: var(--highcontrast-radio-focus-indicator-color, var(--mod-radio-focus-indicator-color, var(--spectrum-radio-focus-indicator-color)));
+    border-width: var(--mod-radio-focus-indicator-thickness, var(--spectrum-radio-focus-indicator-thickness));
+    inline-size: calc(var(--spectrum-radio-button-control-size) + var(--spectrum-radio-focus-indicator-gap) * 2);
+    block-size: calc(var(--spectrum-radio-button-control-size) + var(--spectrum-radio-focus-indicator-gap) * 2);
 }
 
 :host(:focus-visible[checked]) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-button-checked-border-color-focus,
-        var(
-            --mod-radio-button-checked-border-color-focus,
-            var(--spectrum-radio-button-checked-border-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-radio-button-checked-border-color-focus, var(--mod-radio-button-checked-border-color-focus, var(--spectrum-radio-button-checked-border-color-focus)));
 }
 
 :host(:focus-visible) #label {
-    color: var(
-        --highcontrast-radio-neutral-content-color-focus,
-        var(
-            --mod-radio-neutral-content-color-focus,
-            var(--spectrum-radio-neutral-content-color-focus)
-        )
-    );
+    color: var(--highcontrast-radio-neutral-content-color-focus, var(--mod-radio-neutral-content-color-focus, var(--spectrum-radio-neutral-content-color-focus)));
 }
 
 :host([readonly]) #input:read-only {
@@ -146,117 +95,54 @@ governing permissions and limitations under the License.
 :host([readonly][checked][disabled]) #input ~ #label,
 :host([readonly][disabled]) #input ~ #label,
 :host([readonly]) #label {
-    color: var(
-        --highcontrast-radio-neutral-content-color,
-        var(
-            --mod-radio-neutral-content-color,
-            var(--spectrum-radio-neutral-content-color)
-        )
-    );
+    color: var(--highcontrast-radio-neutral-content-color, var(--mod-radio-neutral-content-color, var(--spectrum-radio-neutral-content-color)));
     margin-inline-start: 0;
 }
 
 :host([emphasized][checked]) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-emphasized-accent-color,
-        var(
-            --mod-radio-emphasized-accent-color,
-            var(--spectrum-radio-emphasized-accent-color)
-        )
-    );
+    border-color: var(--highcontrast-radio-emphasized-accent-color, var(--mod-radio-emphasized-accent-color, var(--spectrum-radio-emphasized-accent-color)));
 }
 
 @media (hover: hover) {
     :host(:hover) #button:before {
-        border-color: var(
-            --highcontrast-radio-button-border-color-hover,
-            var(
-                --mod-radio-button-border-color-hover,
-                var(--spectrum-radio-button-border-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-radio-button-border-color-hover, var(--mod-radio-button-border-color-hover, var(--spectrum-radio-button-border-color-hover)));
     }
 
     :host([checked]:hover) #input + #button:before {
-        border-color: var(
-            --highcontrast-radio-button-checked-border-color-hover,
-            var(
-                --mod-radio-button-checked-border-color-hover,
-                var(--spectrum-radio-button-checked-border-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-radio-button-checked-border-color-hover, var(--mod-radio-button-checked-border-color-hover, var(--spectrum-radio-button-checked-border-color-hover)));
     }
 
     :host(:hover) #label {
-        color: var(
-            --highcontrast-radio-neutral-content-color-hover,
-            var(
-                --mod-radio-neutral-content-color-hover,
-                var(--spectrum-radio-neutral-content-color-hover)
-            )
-        );
+        color: var(--highcontrast-radio-neutral-content-color-hover, var(--mod-radio-neutral-content-color-hover, var(--spectrum-radio-neutral-content-color-hover)));
     }
 
     :host([emphasized][checked]:hover) #input + #button:before {
-        border-color: var(
-            --highcontrast-radio-emphasized-accent-color-hover,
-            var(
-                --mod-radio-emphasized-accent-color-hover,
-                var(--spectrum-radio-emphasized-accent-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-radio-emphasized-accent-color-hover, var(--mod-radio-emphasized-accent-color-hover, var(--spectrum-radio-emphasized-accent-color-hover)));
     }
 }
 
 :host([emphasized]:active[checked]) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-emphasized-accent-color-down,
-        var(
-            --mod-radio-emphasized-accent-color-down,
-            var(--spectrum-radio-emphasized-accent-color-down)
-        )
-    );
+    border-color: var(--highcontrast-radio-emphasized-accent-color-down, var(--mod-radio-emphasized-accent-color-down, var(--spectrum-radio-emphasized-accent-color-down)));
 }
 
 :host([emphasized]:focus-visible[checked]) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-emphasized-accent-color-focus,
-        var(
-            --mod-radio-emphasized-accent-color-focus,
-            var(--spectrum-radio-emphasized-accent-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-radio-emphasized-accent-color-focus, var(--mod-radio-emphasized-accent-color-focus, var(--spectrum-radio-emphasized-accent-color-focus)));
 }
 
 :host([checked][disabled]) #input + #button:before,
 :host([disabled]) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-disabled-border-color,
-        var(
-            --mod-radio-disabled-border-color,
-            var(--spectrum-radio-disabled-border-color)
-        )
-    );
+    border-color: var(--highcontrast-radio-disabled-border-color, var(--mod-radio-disabled-border-color, var(--spectrum-radio-disabled-border-color)));
 }
 
 :host([checked][disabled]) #input ~ #label,
 :host([disabled]) #input ~ #label {
-    color: var(
-        --highcontrast-radio-disabled-content-color,
-        var(
-            --mod-radio-disabled-content-color,
-            var(--spectrum-radio-disabled-content-color)
-        )
-    );
+    color: var(--highcontrast-radio-disabled-content-color, var(--mod-radio-disabled-content-color, var(--spectrum-radio-disabled-content-color)));
 }
 
 #input {
     font-family: inherit;
     font-size: 100%;
-    line-height: var(
-        --mod-radio-line-height,
-        var(--spectrum-radio-line-height)
-    );
+    line-height: var(--mod-radio-line-height, var(--spectrum-radio-line-height));
     box-sizing: border-box;
     inline-size: 100%;
     block-size: 100%;
@@ -274,95 +160,42 @@ governing permissions and limitations under the License.
 }
 
 :host([checked]) #input + #button:before {
-    border-width: calc(
-        var(--spectrum-radio-button-control-size) / 2 -
-            var(--spectrum-radio-button-selection-indicator) / 2
-    );
-    border-color: var(
-        --highcontrast-radio-button-checked-border-color-default,
-        var(
-            --mod-radio-button-checked-border-color-default,
-            var(--spectrum-radio-button-checked-border-color-default)
-        )
-    );
+    border-width: calc(var(--spectrum-radio-button-control-size) / 2 - var(--spectrum-radio-button-selection-indicator) / 2);
+    border-color: var(--highcontrast-radio-button-checked-border-color-default, var(--mod-radio-button-checked-border-color-default, var(--spectrum-radio-button-checked-border-color-default)));
 }
 
 #input:focus-visible + #button:after {
-    border-width: var(
-        --mod-radio-focus-indicator-thickness,
-        var(--spectrum-radio-focus-indicator-thickness)
-    );
-    border-color: var(
-        --highcontrast-radio-focus-indicator-color,
-        var(
-            --mod-radio-focus-indicator-color,
-            var(--spectrum-radio-focus-indicator-color)
-        )
-    );
-    inline-size: calc(
-        var(--spectrum-radio-button-control-size) +
-            var(--spectrum-radio-focus-indicator-gap) * 2
-    );
-    block-size: calc(
-        var(--spectrum-radio-button-control-size) +
-            var(--spectrum-radio-focus-indicator-gap) * 2
-    );
+    border-width: var(--mod-radio-focus-indicator-thickness, var(--spectrum-radio-focus-indicator-thickness));
+    border-color: var(--highcontrast-radio-focus-indicator-color, var(--mod-radio-focus-indicator-color, var(--spectrum-radio-focus-indicator-color)));
+    inline-size: calc(var(--spectrum-radio-button-control-size) + var(--spectrum-radio-focus-indicator-gap) * 2);
+    block-size: calc(var(--spectrum-radio-button-control-size) + var(--spectrum-radio-focus-indicator-gap) * 2);
     border-style: solid;
 }
 
 #label {
     text-align: start;
     font-size: var(--mod-radio-font-size, var(--spectrum-radio-font-size));
-    color: var(
-        --highcontrast-radio-neutral-content-color,
-        var(
-            --mod-radio-neutral-content-color,
-            var(--spectrum-radio-neutral-content-color)
-        )
-    );
-    line-height: var(
-        --mod-radio-line-height,
-        var(--spectrum-radio-line-height)
-    );
-    transition: color
-        var(
-            --mod-radio-animation-duration,
-            var(--spectrum-radio-animation-duration)
-        )
-        ease-in-out;
+    color: var(--highcontrast-radio-neutral-content-color, var(--mod-radio-neutral-content-color, var(--spectrum-radio-neutral-content-color)));
+    line-height: var(--mod-radio-line-height, var(--spectrum-radio-line-height));
+    transition: color var(--mod-radio-animation-duration, var(--spectrum-radio-animation-duration)) ease-in-out;
     margin-block-start: var(--spectrum-radio-label-top-to-text);
     margin-block-end: var(--spectrum-radio-label-bottom-to-text);
-    margin-inline-start: var(
-        --mod-radio-text-to-control,
-        var(--spectrum-radio-text-to-control)
-    );
+    margin-inline-start: var(--mod-radio-text-to-control, var(--spectrum-radio-text-to-control));
 }
 
 #label:lang(ja),
 #label:lang(ko),
 #label:lang(zh) {
-    line-height: var(
-        --mod-radio-line-height-cjk,
-        var(--spectrum-radio-line-height-cjk)
-    );
+    line-height: var(--mod-radio-line-height-cjk, var(--spectrum-radio-line-height-cjk));
 }
 
 #button {
     box-sizing: border-box;
-    inline-size: var(
-        --mod-radio-button-control-size,
-        var(--spectrum-radio-button-control-size)
-    );
-    block-size: var(
-        --mod-radio-button-control-size,
-        var(--spectrum-radio-button-control-size)
-    );
+    inline-size: var(--mod-radio-button-control-size, var(--spectrum-radio-button-control-size));
+    block-size: var(--mod-radio-button-control-size, var(--spectrum-radio-button-control-size));
     flex-grow: 0;
     flex-shrink: 0;
-    margin-block-start: var(
-        --mod-radio-button-top-to-control,
-        var(--spectrum-radio-button-top-to-control)
-    );
+    margin-block-start: var(--mod-radio-button-top-to-control, var(--spectrum-radio-button-top-to-control));
     position: relative;
 }
 
@@ -370,45 +203,14 @@ governing permissions and limitations under the License.
     z-index: 0;
     content: '';
     box-sizing: border-box;
-    inline-size: var(
-        --mod-radio-button-control-size,
-        var(--spectrum-radio-button-control-size)
-    );
-    block-size: var(
-        --mod-radio-button-control-size,
-        var(--spectrum-radio-button-control-size)
-    );
-    background-color: var(
-        --highcontrast-radio-button-background-color,
-        var(
-            --mod-radio-button-background-color,
-            var(--spectrum-radio-button-background-color)
-        )
-    );
-    border-width: var(
-        --mod-radio-border-width,
-        var(--spectrum-radio-border-width)
-    );
-    border-color: var(
-        --highcontrast-radio-button-border-color-default,
-        var(
-            --mod-radio-button-border-color-default,
-            var(--spectrum-radio-button-border-color-default)
-        )
-    );
+    inline-size: var(--mod-radio-button-control-size, var(--spectrum-radio-button-control-size));
+    block-size: var(--mod-radio-button-control-size, var(--spectrum-radio-button-control-size));
+    background-color: var(--highcontrast-radio-button-background-color, var(--mod-radio-button-background-color, var(--spectrum-radio-button-background-color)));
+    border-width: var(--mod-radio-border-width, var(--spectrum-radio-border-width));
+    border-color: var(--highcontrast-radio-button-border-color-default, var(--mod-radio-button-border-color-default, var(--spectrum-radio-button-border-color-default)));
     transition:
-        border
-            var(
-                --mod-radio-animation-duration,
-                var(--spectrum-radio-animation-duration)
-            )
-            ease-in-out,
-        box-shadow
-            var(
-                --mod-radio-animation-duration,
-                var(--spectrum-radio-animation-duration)
-            )
-            ease-in-out;
+        border var(--mod-radio-animation-duration, var(--spectrum-radio-animation-duration)) ease-in-out,
+        box-shadow var(--mod-radio-animation-duration, var(--spectrum-radio-animation-duration)) ease-in-out;
     border-style: solid;
     border-radius: 50%;
     display: block;
@@ -418,18 +220,8 @@ governing permissions and limitations under the License.
 #button:after {
     content: '';
     transition:
-        opacity
-            var(
-                --mod-radio-animation-duration,
-                var(--spectrum-radio-animation-duration)
-            )
-            ease-out,
-        margin
-            var(
-                --mod-radio-animation-duration,
-                var(--spectrum-radio-animation-duration)
-            )
-            ease-out;
+        opacity var(--mod-radio-animation-duration, var(--spectrum-radio-animation-duration)) ease-out,
+        margin var(--mod-radio-animation-duration, var(--spectrum-radio-animation-duration)) ease-out;
     border-radius: 50%;
     display: block;
     position: absolute;

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -15,148 +15,57 @@ governing permissions and limitations under the License.
     --spectrum-search-inline-size: var(--spectrum-field-width);
     --spectrum-search-block-size: var(--spectrum-component-height-100);
     --spectrum-search-button-inline-size: var(--spectrum-search-block-size);
-    --spectrum-search-min-inline-size: calc(
-        var(--spectrum-search-field-minimum-width-multiplier) *
-            var(--spectrum-search-block-size)
-    );
+    --spectrum-search-min-inline-size: calc(var(--spectrum-search-field-minimum-width-multiplier) * var(--spectrum-search-block-size));
     --spectrum-search-icon-size: var(--spectrum-workflow-icon-size-100);
     --spectrum-search-text-to-icon: var(--spectrum-text-to-visual-100);
     --spectrum-search-to-help-text: var(--spectrum-help-text-to-component);
     --spectrum-search-top-to-text: var(--spectrum-component-top-to-text-100);
-    --spectrum-search-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --spectrum-search-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
+    --spectrum-search-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
+    --spectrum-search-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
     --spectrum-search-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
-    --spectrum-search-focus-indicator-color: var(
-        --spectrum-focus-indicator-color
-    );
+    --spectrum-search-focus-indicator-color: var(--spectrum-focus-indicator-color);
     --spectrum-search-font-family: var(--spectrum-sans-font-family-stack);
     --spectrum-search-font-weight: var(--spectrum-regular-font-weight);
     --spectrum-search-font-style: var(--spectrum-default-font-style);
     --spectrum-search-line-height: var(--spectrum-line-height-100);
-    --spectrum-search-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
+    --spectrum-search-color-default: var(--spectrum-neutral-content-color-default);
     --spectrum-search-color-hover: var(--spectrum-neutral-content-color-hover);
     --spectrum-search-color-focus: var(--spectrum-neutral-content-color-focus);
-    --spectrum-search-color-focus-hover: var(
-        --spectrum-neutral-content-color-focus-hover
-    );
-    --spectrum-search-color-key-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
+    --spectrum-search-color-focus-hover: var(--spectrum-neutral-content-color-focus-hover);
+    --spectrum-search-color-key-focus: var(--spectrum-neutral-content-color-key-focus);
     --spectrum-search-border-width: var(--spectrum-border-width-100);
     --spectrum-search-color-disabled: var(--spectrum-disabled-content-color);
-    --spectrum-search-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --spectrum-search-border-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --mod-textfield-font-family: var(
-        --mod-search-font-family,
-        var(--spectrum-search-font-family)
-    );
-    --mod-textfield-font-weight: var(
-        --mod-search-font-weight,
-        var(--spectrum-search-font-weight)
-    );
-    --mod-textfield-corner-radius: var(
-        --mod-search-border-radius,
-        var(--spectrum-search-border-radius)
-    );
-    --mod-textfield-border-width: var(
-        --mod-search-border-width,
-        var(--spectrum-search-border-width)
-    );
-    --mod-textfield-focus-indicator-gap: var(
-        --mod-search-focus-indicator-gap,
-        var(--spectrum-search-focus-indicator-gap)
-    );
-    --mod-textfield-focus-indicator-width: var(
-        --mod-search-focus-indicator-thickness,
-        var(--spectrum-search-focus-indicator-thickness)
-    );
-    --mod-textfield-focus-indicator-color: var(
-        --mod-search-focus-indicator-color,
-        var(--spectrum-search-focus-indicator-color)
-    );
-    --mod-textfield-text-color-default: var(
-        --mod-search-color-default,
-        var(--spectrum-search-color-default)
-    );
-    --mod-textfield-text-color-hover: var(
-        --mod-search-color-hover,
-        var(--spectrum-search-color-hover)
-    );
-    --mod-textfield-text-color-focus: var(
-        --mod-search-color-focus,
-        var(--spectrum-search-color-focus)
-    );
-    --mod-textfield-text-color-focus-hover: var(
-        --mod-search-color-focus-hover,
-        var(--spectrum-search-color-focus-hover)
-    );
-    --mod-textfield-text-color-keyboard-focus: var(
-        --mod-search-color-key-focus,
-        var(--spectrum-search-color-key-focus)
-    );
-    --mod-textfield-text-color-disabled: var(
-        --mod-search-color-disabled,
-        var(--spectrum-search-color-disabled)
-    );
-    --mod-textfield-border-color: var(
-        --mod-search-border-color-default,
-        var(--spectrum-search-border-color-default)
-    );
-    --mod-textfield-border-color-hover: var(
-        --mod-search-border-color-hover,
-        var(--spectrum-search-border-color-hover)
-    );
-    --mod-textfield-border-color-focus: var(
-        --mod-search-border-color-focus,
-        var(--spectrum-search-border-color-focus)
-    );
-    --mod-textfield-border-color-focus-hover: var(
-        --mod-search-border-color-focus-hover,
-        var(--spectrum-search-border-color-focus-hover)
-    );
-    --mod-textfield-border-color-keyboard-focus: var(
-        --mod-search-border-color-key-focus,
-        var(--spectrum-search-border-color-key-focus)
-    );
-    --mod-textfield-border-color-disabled: var(
-        --mod-search-border-color-disabled,
-        var(--spectrum-search-border-color-disabled)
-    );
-    --mod-textfield-background-color: var(
-        --mod-search-background-color,
-        var(--spectrum-search-background-color)
-    );
-    --mod-textfield-background-color-disabled: var(
-        --mod-search-background-color-disabled,
-        var(--spectrum-search-background-color-disabled)
-    );
-    inline-size: var(
-        --mod-search-inline-size,
-        var(--spectrum-search-inline-size)
-    );
-    min-inline-size: var(
-        --mod-search-min-inline-size,
-        var(--spectrum-search-min-inline-size)
-    );
+    --spectrum-search-background-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-search-border-color-disabled: var(--spectrum-disabled-background-color);
+    --mod-textfield-font-family: var(--mod-search-font-family, var(--spectrum-search-font-family));
+    --mod-textfield-font-weight: var(--mod-search-font-weight, var(--spectrum-search-font-weight));
+    --mod-textfield-corner-radius: var(--mod-search-border-radius, var(--spectrum-search-border-radius));
+    --mod-textfield-border-width: var(--mod-search-border-width, var(--spectrum-search-border-width));
+    --mod-textfield-focus-indicator-gap: var(--mod-search-focus-indicator-gap, var(--spectrum-search-focus-indicator-gap));
+    --mod-textfield-focus-indicator-width: var(--mod-search-focus-indicator-thickness, var(--spectrum-search-focus-indicator-thickness));
+    --mod-textfield-focus-indicator-color: var(--mod-search-focus-indicator-color, var(--spectrum-search-focus-indicator-color));
+    --mod-textfield-text-color-default: var(--mod-search-color-default, var(--spectrum-search-color-default));
+    --mod-textfield-text-color-hover: var(--mod-search-color-hover, var(--spectrum-search-color-hover));
+    --mod-textfield-text-color-focus: var(--mod-search-color-focus, var(--spectrum-search-color-focus));
+    --mod-textfield-text-color-focus-hover: var(--mod-search-color-focus-hover, var(--spectrum-search-color-focus-hover));
+    --mod-textfield-text-color-keyboard-focus: var(--mod-search-color-key-focus, var(--spectrum-search-color-key-focus));
+    --mod-textfield-text-color-disabled: var(--mod-search-color-disabled, var(--spectrum-search-color-disabled));
+    --mod-textfield-border-color: var(--mod-search-border-color-default, var(--spectrum-search-border-color-default));
+    --mod-textfield-border-color-hover: var(--mod-search-border-color-hover, var(--spectrum-search-border-color-hover));
+    --mod-textfield-border-color-focus: var(--mod-search-border-color-focus, var(--spectrum-search-border-color-focus));
+    --mod-textfield-border-color-focus-hover: var(--mod-search-border-color-focus-hover, var(--spectrum-search-border-color-focus-hover));
+    --mod-textfield-border-color-keyboard-focus: var(--mod-search-border-color-key-focus, var(--spectrum-search-border-color-key-focus));
+    --mod-textfield-border-color-disabled: var(--mod-search-border-color-disabled, var(--spectrum-search-border-color-disabled));
+    --mod-textfield-background-color: var(--mod-search-background-color, var(--spectrum-search-background-color));
+    --mod-textfield-background-color-disabled: var(--mod-search-background-color-disabled, var(--spectrum-search-background-color-disabled));
+    inline-size: var(--mod-search-inline-size, var(--spectrum-search-inline-size));
+    min-inline-size: var(--mod-search-min-inline-size, var(--spectrum-search-min-inline-size));
     display: inline-block;
     position: relative;
 }
 
 #textfield .spectrum-HelpText {
-    margin-block-start: var(
-        --mod-search-to-help-text,
-        var(--spectrum-search-to-help-text)
-    );
+    margin-block-start: var(--mod-search-to-help-text, var(--spectrum-search-to-help-text));
 }
 
 :host([size='s']) #textfield {
@@ -200,10 +109,7 @@ governing permissions and limitations under the License.
 
 #button,
 #button .spectrum-ClearButton-fill {
-    border-radius: var(
-        --mod-search-border-radius,
-        var(--spectrum-search-border-radius)
-    );
+    border-radius: var(--mod-search-border-radius, var(--spectrum-search-border-radius));
 }
 
 #textfield.is-disabled #button {
@@ -215,10 +121,7 @@ governing permissions and limitations under the License.
 }
 
 .icon-search {
-    --spectrum-search-color: var(
-        --highcontrast-search-color-default,
-        var(--mod-search-color-default, var(--spectrum-search-color-default))
-    );
+    --spectrum-search-color: var(--highcontrast-search-color-default, var(--mod-search-color-default, var(--spectrum-search-color-default)));
     color: var(--spectrum-search-color);
     margin-block: auto;
     display: block;
@@ -227,55 +130,28 @@ governing permissions and limitations under the License.
 }
 
 #textfield.is-focused .icon-search {
-    --spectrum-search-color: var(
-        --highcontrast-search-color-focus,
-        var(--mod-search-color-focus, var(--spectrum-search-color-focus))
-    );
+    --spectrum-search-color: var(--highcontrast-search-color-focus, var(--mod-search-color-focus, var(--spectrum-search-color-focus)));
 }
 
 #textfield.is-keyboardFocused .icon-search {
-    --spectrum-search-color: var(
-        --highcontrast-search-color-focus,
-        var(
-            --mod-search-color-key-focus,
-            var(--spectrum-search-color-key-focus)
-        )
-    );
+    --spectrum-search-color: var(--highcontrast-search-color-focus, var(--mod-search-color-key-focus, var(--spectrum-search-color-key-focus)));
 }
 
 #textfield.is-disabled .icon-search {
-    --spectrum-search-color: var(
-        --highcontrast-search-color-disabled,
-        var(--mod-search-color-disabled, var(--spectrum-search-color-disabled))
-    );
+    --spectrum-search-color: var(--highcontrast-search-color-disabled, var(--mod-search-color-disabled, var(--spectrum-search-color-disabled)));
 }
 
 @media (hover: hover) {
     #textfield:hover .icon-search {
-        --spectrum-search-color: var(
-            --highcontrast-search-color-hover,
-            var(--mod-search-color-hover, var(--spectrum-search-color-hover))
-        );
+        --spectrum-search-color: var(--highcontrast-search-color-hover, var(--mod-search-color-hover, var(--spectrum-search-color-hover)));
     }
 
     #textfield.is-focused:hover .icon-search {
-        --spectrum-search-color: var(
-            --highcontrast-search-color-focus,
-            var(
-                --mod-search-color-focus-hover,
-                var(--spectrum-search-color-focus-hover)
-            )
-        );
+        --spectrum-search-color: var(--highcontrast-search-color-focus, var(--mod-search-color-focus-hover, var(--spectrum-search-color-focus-hover)));
     }
 
     #textfield.is-disabled:hover .icon-search {
-        --spectrum-search-color: var(
-            --highcontrast-search-color-disabled,
-            var(
-                --mod-search-color-disabled,
-                var(--spectrum-search-color-disabled)
-            )
-        );
+        --spectrum-search-color: var(--highcontrast-search-color-disabled, var(--mod-search-color-disabled, var(--spectrum-search-color-disabled)));
     }
 }
 
@@ -283,18 +159,9 @@ governing permissions and limitations under the License.
     appearance: none;
     block-size: var(--mod-search-block-size, var(--spectrum-search-block-size));
     font-style: var(--mod-search-font-style, var(--spectrum-search-font-style));
-    line-height: var(
-        --mod-search-line-height,
-        var(--spectrum-search-line-height)
-    );
-    padding-block-start: calc(
-        var(--mod-search-top-to-text, var(--spectrum-search-top-to-text)) -
-            var(--mod-search-border-width, var(--spectrum-search-border-width))
-    );
-    padding-block-end: calc(
-        var(--mod-search-bottom-to-text, var(--spectrum-search-bottom-to-text)) -
-            var(--mod-search-border-width, var(--spectrum-search-border-width))
-    );
+    line-height: var(--mod-search-line-height, var(--spectrum-search-line-height));
+    padding-block-start: calc(var(--mod-search-top-to-text, var(--spectrum-search-top-to-text)) - var(--mod-search-border-width, var(--spectrum-search-border-width)));
+    padding-block-end: calc(var(--mod-search-bottom-to-text, var(--spectrum-search-bottom-to-text)) - var(--mod-search-border-width, var(--spectrum-search-border-width)));
 }
 
 .input::-webkit-search-cancel-button,
@@ -303,51 +170,25 @@ governing permissions and limitations under the License.
 }
 
 :host(:not([quiet])) #textfield .icon-search {
-    inset-inline-start: var(
-        --mod-search-edge-to-visual,
-        var(--spectrum-search-edge-to-visual)
-    );
+    inset-inline-start: var(--mod-search-edge-to-visual, var(--spectrum-search-edge-to-visual));
 }
 
 :host(:not([quiet])) #textfield .input {
-    padding-inline-start: calc(
-        var(--mod-search-edge-to-visual, var(--spectrum-search-edge-to-visual)) -
-            var(--mod-search-border-width, var(--spectrum-search-border-width)) +
-            var(--mod-search-icon-size, var(--spectrum-search-icon-size)) +
-            var(--mod-search-text-to-icon, var(--spectrum-search-text-to-icon))
-    );
-    padding-inline-end: var(
-        --mod-search-button-inline-size,
-        var(--spectrum-search-button-inline-size)
-    );
+    padding-inline-start: calc(var(--mod-search-edge-to-visual, var(--spectrum-search-edge-to-visual)) - var(--mod-search-border-width, var(--spectrum-search-border-width)) + var(--mod-search-icon-size, var(--spectrum-search-icon-size)) + var(--mod-search-text-to-icon, var(--spectrum-search-text-to-icon)));
+    padding-inline-end: var(--mod-search-button-inline-size, var(--spectrum-search-button-inline-size));
 }
 
 :host([quiet]) {
     --spectrum-search-background-color: transparent;
     --spectrum-search-background-color-disabled: transparent;
-    --spectrum-search-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
+    --spectrum-search-border-color-disabled: var(--spectrum-disabled-border-color);
     --mod-search-border-radius: 0;
     --mod-search-edge-to-visual: var(--spectrum-field-edge-to-visual-quiet);
 }
 
 :host([quiet]) .input {
-    border-radius: var(
-        --mod-search-border-radius,
-        var(--spectrum-search-border-radius)
-    );
-    padding-block-start: var(
-        --mod-search-top-to-text,
-        var(--spectrum-search-top-to-text)
-    );
-    padding-inline-start: calc(
-        var(--mod-search-edge-to-visual, var(--spectrum-search-edge-to-visual)) +
-            var(--mod-search-icon-size, var(--spectrum-search-icon-size)) +
-            var(--mod-search-text-to-icon, var(--spectrum-search-text-to-icon))
-    );
-    padding-inline-end: var(
-        --mod-search-button-inline-size,
-        var(--spectrum-search-button-inline-size)
-    );
+    border-radius: var(--mod-search-border-radius, var(--spectrum-search-border-radius));
+    padding-block-start: var(--mod-search-top-to-text, var(--spectrum-search-top-to-text));
+    padding-inline-start: calc(var(--mod-search-edge-to-visual, var(--spectrum-search-edge-to-visual)) + var(--mod-search-icon-size, var(--spectrum-search-icon-size)) + var(--mod-search-text-to-icon, var(--spectrum-search-text-to-icon)));
+    padding-inline-end: var(--mod-search-button-inline-size, var(--spectrum-search-button-inline-size));
 }

--- a/packages/sidenav/src/spectrum-sidenav-heading.css
+++ b/packages/sidenav/src/spectrum-sidenav-heading.css
@@ -26,38 +26,12 @@ governing permissions and limitations under the License.
 }
 
 #heading {
-    padding-inline: var(
-        --mod-sidenav-inline-padding,
-        var(--spectrum-sidenav-inline-padding)
-    );
-    color: var(
-        --mod-sidenav-header-color,
-        var(--spectrum-sidenav-header-color)
-    );
-    font-size: var(
-        --mod-sidenav-header-font-size,
-        var(--spectrum-sidenav-header-font-size)
-    );
-    font-weight: var(
-        --mod-sidenav-header-font-weight,
-        var(--spectrum-sidenav-header-font-weight)
-    );
-    font-style: var(
-        --mod-sidenav-header-font-style,
-        var(--spectrum-sidenav-header-font-style)
-    );
-    line-height: var(
-        --mod-sidenav-header-line-height,
-        var(--spectrum-sidenav-header-line-height)
-    );
-    margin-block-start: calc(
-        var(
-                --mod-sidenav-heading-top-margin,
-                var(--spectrum-sidenav-heading-top-margin)
-            ) - var(--mod-sidenav-gap, var(--spectrum-sidenav-gap))
-    );
-    margin-block-end: var(
-        --mod-sidenav-heading-bottom-margin,
-        var(--spectrum-sidenav-heading-bottom-margin)
-    );
+    padding-inline: var(--mod-sidenav-inline-padding, var(--spectrum-sidenav-inline-padding));
+    color: var(--mod-sidenav-header-color, var(--spectrum-sidenav-header-color));
+    font-size: var(--mod-sidenav-header-font-size, var(--spectrum-sidenav-header-font-size));
+    font-weight: var(--mod-sidenav-header-font-weight, var(--spectrum-sidenav-header-font-weight));
+    font-style: var(--mod-sidenav-header-font-style, var(--spectrum-sidenav-header-font-style));
+    line-height: var(--mod-sidenav-header-line-height, var(--spectrum-sidenav-header-line-height));
+    margin-block-start: calc(var(--mod-sidenav-heading-top-margin, var(--spectrum-sidenav-heading-top-margin)) - var(--mod-sidenav-gap, var(--spectrum-sidenav-gap)));
+    margin-block-end: var(--mod-sidenav-heading-bottom-margin, var(--spectrum-sidenav-heading-bottom-margin));
 }

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -49,75 +49,30 @@ governing permissions and limitations under the License.
 }
 
 :host([disabled]) #item-link {
-    background-color: var(
-        --highcontrast-sidenav-background-disabled,
-        var(
-            --mod-sidenav-background-disabled,
-            var(--spectrum-sidenav-background-disabled)
-        )
-    );
-    color: var(
-        --highcontrast-sidenav-content-disabled-color,
-        var(
-            --mod-sidenav-content-disabled-color,
-            var(--spectrum-sidenav-content-disabled-color)
-        )
-    );
+    background-color: var(--highcontrast-sidenav-background-disabled, var(--mod-sidenav-background-disabled, var(--spectrum-sidenav-background-disabled)));
+    color: var(--highcontrast-sidenav-content-disabled-color, var(--mod-sidenav-content-disabled-color, var(--spectrum-sidenav-content-disabled-color)));
     cursor: default;
     pointer-events: none;
 }
 
 :host([selected]) #item-link {
-    background-color: var(
-        --highcontrast-sidenav-item-background-default-selected,
-        var(
-            --mod-sidenav-item-background-default-selected,
-            var(--spectrum-sidenav-item-background-default-selected)
-        )
-    );
-    color: var(
-        --highcontrast-sidenav-content-color-default-selected,
-        var(
-            --mod-sidenav-content-color-default-selected,
-            var(--spectrum-sidenav-content-color-default-selected)
-        )
-    );
+    background-color: var(--highcontrast-sidenav-item-background-default-selected, var(--mod-sidenav-item-background-default-selected, var(--spectrum-sidenav-item-background-default-selected)));
+    color: var(--highcontrast-sidenav-content-color-default-selected, var(--mod-sidenav-content-color-default-selected, var(--spectrum-sidenav-content-color-default-selected)));
 }
 
 :host([selected]) #item-link:active {
-    background-color: var(
-        --highcontrast-sidenav-item-background-down-selected,
-        var(
-            --mod-sidenav-item-background-down-selected,
-            var(--spectrum-sidenav-item-background-down-selected)
-        )
-    );
-    color: var(
-        --mod-sidenav-content-color-down-selected,
-        var(--spectrum-sidenav-content-color-down-selected)
-    );
+    background-color: var(--highcontrast-sidenav-item-background-down-selected, var(--mod-sidenav-item-background-down-selected, var(--spectrum-sidenav-item-background-down-selected)));
+    color: var(--mod-sidenav-content-color-down-selected, var(--spectrum-sidenav-content-color-down-selected));
 }
 
 :host([selected]) #item-link.is-keyboardFocused,
 :host([selected]) #item-link:focus-visible {
-    background-color: var(
-        --highcontrast-sidenav-background-key-focus-selected,
-        var(
-            --mod-sidenav-background-key-focus-selected,
-            var(--spectrum-sidenav-background-key-focus-selected)
-        )
-    );
-    color: var(
-        --mod-sidenav-content-color-key-focus-selected,
-        var(--spectrum-sidenav-content-color-key-focus-selected)
-    );
+    background-color: var(--highcontrast-sidenav-background-key-focus-selected, var(--mod-sidenav-background-key-focus-selected, var(--spectrum-sidenav-background-key-focus-selected)));
+    color: var(--mod-sidenav-content-color-key-focus-selected, var(--spectrum-sidenav-content-color-key-focus-selected));
 }
 
 #item-link {
-    padding-inline: var(
-        --mod-sidenav-inline-padding,
-        var(--spectrum-sidenav-inline-padding)
-    );
+    padding-inline: var(--mod-sidenav-inline-padding, var(--spectrum-sidenav-inline-padding));
     box-sizing: border-box;
     word-break: break-word;
     hyphens: auto;
@@ -125,57 +80,18 @@ governing permissions and limitations under the License.
     transition:
         background-color var(--spectrum-animation-duration-100) ease-out,
         color var(--spectrum-animation-duration-100) ease-out;
-    border-radius: var(
-        --mod-sidenav-border-radius,
-        var(--spectrum-sidenav-border-radius)
-    );
-    background-color: var(
-        --highcontrast-sidenav-background-default,
-        var(
-            --mod-sidenav-background-default,
-            var(--spectrum-sidenav-background-default)
-        )
-    );
-    color: var(
-        --highcontrast-sidenav-content-color-default,
-        var(
-            --mod-sidenav-content-color-default,
-            var(--spectrum-sidenav-content-color-default)
-        )
-    );
+    border-radius: var(--mod-sidenav-border-radius, var(--spectrum-sidenav-border-radius));
+    background-color: var(--highcontrast-sidenav-background-default, var(--mod-sidenav-background-default, var(--spectrum-sidenav-background-default)));
+    color: var(--highcontrast-sidenav-content-color-default, var(--mod-sidenav-content-color-default, var(--spectrum-sidenav-content-color-default)));
     inline-size: var(--mod-sidenav-width, var(--spectrum-sidenav-width));
-    min-inline-size: var(
-        --mod-sidenav-min-width,
-        var(--spectrum-sidenav-min-width)
-    );
-    max-inline-size: var(
-        --mod-sidenav-max-width,
-        var(--spectrum-sidenav-max-width)
-    );
-    min-block-size: var(
-        --mod-sidenav-min-height,
-        var(--spectrum-sidenav-min-height)
-    );
-    font-family: var(
-        --mod-sidenav-text-font-family,
-        var(--spectrum-sidenav-text-font-family)
-    );
-    font-size: var(
-        --mod-sidenav-text-font-size,
-        var(--spectrum-sidenav-text-font-size)
-    );
-    font-weight: var(
-        --mod-sidenav-text-font-weight,
-        var(--spectrum-sidenav-text-font-weight)
-    );
-    font-style: var(
-        --mod-sidenav-text-font-style,
-        var(--spectrum-sidenav-text-font-style)
-    );
-    line-height: var(
-        --mod-sidenav-text-line-height,
-        var(--spectrum-sidenav-text-line-height)
-    );
+    min-inline-size: var(--mod-sidenav-min-width, var(--spectrum-sidenav-min-width));
+    max-inline-size: var(--mod-sidenav-max-width, var(--spectrum-sidenav-max-width));
+    min-block-size: var(--mod-sidenav-min-height, var(--spectrum-sidenav-min-height));
+    font-family: var(--mod-sidenav-text-font-family, var(--spectrum-sidenav-text-font-family));
+    font-size: var(--mod-sidenav-text-font-size, var(--spectrum-sidenav-text-font-size));
+    font-weight: var(--mod-sidenav-text-font-weight, var(--spectrum-sidenav-text-font-weight));
+    font-style: var(--mod-sidenav-text-font-style, var(--spectrum-sidenav-text-font-style));
+    line-height: var(--mod-sidenav-text-line-height, var(--spectrum-sidenav-text-line-height));
     justify-content: start;
     margin-block-end: var(--mod-sidenav-gap, var(--spectrum-sidenav-gap));
     -webkit-text-decoration: none;
@@ -185,168 +101,64 @@ governing permissions and limitations under the License.
 }
 
 #item-link #link-text {
-    margin-block-start: var(
-        --mod-sidenav-top-to-label,
-        var(--spectrum-sidenav-top-to-label)
-    );
-    margin-block-end: var(
-        --mod-sidenav-bottom-to-label,
-        var(--spectrum-sidenav-bottom-to-label)
-    );
+    margin-block-start: var(--mod-sidenav-top-to-label, var(--spectrum-sidenav-top-to-label));
+    margin-block-end: var(--mod-sidenav-bottom-to-label, var(--spectrum-sidenav-bottom-to-label));
 }
 
 #item-link ::slotted([slot='icon']) {
-    inline-size: var(
-        --mod-sidenav-icon-size,
-        var(--spectrum-sidenav-icon-size)
-    );
+    inline-size: var(--mod-sidenav-icon-size, var(--spectrum-sidenav-icon-size));
     block-size: var(--mod-sidenav-icon-size, var(--spectrum-sidenav-icon-size));
     flex-shrink: 0;
-    margin-block-start: var(
-        --mod-sidenav-top-to-icon,
-        var(--spectrum-sidenav-top-to-icon)
-    );
-    margin-inline-end: var(
-        --mod-sidenav-icon-spacing,
-        var(--spectrum-sidenav-icon-spacing)
-    );
+    margin-block-start: var(--mod-sidenav-top-to-icon, var(--spectrum-sidenav-top-to-icon));
+    margin-inline-end: var(--mod-sidenav-icon-spacing, var(--spectrum-sidenav-icon-spacing));
 }
 
 @media (hover: hover) {
     :host([selected]) #item-link:hover {
-        background-color: var(
-            --highcontrast-sidenav-background-hover-selected,
-            var(
-                --mod-sidenav-background-hover-selected,
-                var(--spectrum-sidenav-background-hover-selected)
-            )
-        );
-        color: var(
-            --mod-sidenav-content-color-hover-selected,
-            var(--spectrum-sidenav-content-color-hover-selected)
-        );
+        background-color: var(--highcontrast-sidenav-background-hover-selected, var(--mod-sidenav-background-hover-selected, var(--spectrum-sidenav-background-hover-selected)));
+        color: var(--mod-sidenav-content-color-hover-selected, var(--spectrum-sidenav-content-color-hover-selected));
     }
 
     #item-link:hover {
-        background-color: var(
-            --highcontrast-sidenav-background-hover,
-            var(
-                --mod-sidenav-background-hover,
-                var(--spectrum-sidenav-background-hover)
-            )
-        );
-        color: var(
-            --highcontrast-sidenav-content-color-hover,
-            var(
-                --mod-sidenav-content-color-hover,
-                var(--spectrum-sidenav-content-color-hover)
-            )
-        );
+        background-color: var(--highcontrast-sidenav-background-hover, var(--mod-sidenav-background-hover, var(--spectrum-sidenav-background-hover)));
+        color: var(--highcontrast-sidenav-content-color-hover, var(--mod-sidenav-content-color-hover, var(--spectrum-sidenav-content-color-hover)));
     }
 }
 
 #item-link:active {
-    background-color: var(
-        --highcontrast-sidenav-item-background-down,
-        var(
-            --mod-sidenav-item-background-down,
-            var(--spectrum-sidenav-item-background-down)
-        )
-    );
-    color: var(
-        --highcontrast-sidenav-content-color-down,
-        var(
-            --mod-sidenav-content-color-down,
-            var(--spectrum-sidenav-content-color-down)
-        )
-    );
+    background-color: var(--highcontrast-sidenav-item-background-down, var(--mod-sidenav-item-background-down, var(--spectrum-sidenav-item-background-down)));
+    color: var(--highcontrast-sidenav-content-color-down, var(--mod-sidenav-content-color-down, var(--spectrum-sidenav-content-color-down)));
 }
 
 #item-link.is-keyboardFocused,
 #item-link:focus-visible {
-    outline: var(
-            --highcontrast-sidenav-focus-ring-color,
-            var(
-                --mod-sidenav-focus-ring-color,
-                var(--spectrum-sidenav-focus-ring-color)
-            )
-        )
-        solid
-        var(
-            --mod-sidenav-focus-ring-size,
-            var(--spectrum-sidenav-focus-ring-size)
-        );
-    outline-offset: var(
-        --mod-sidenav-focus-ring-gap,
-        var(--spectrum-sidenav-focus-ring-gap)
-    );
-    background-color: var(
-        --highcontrast-sidenav-background-key-focus,
-        var(
-            --mod-sidenav-background-key-focus,
-            var(--spectrum-sidenav-background-key-focus)
-        )
-    );
-    color: var(
-        --highcontrast-sidenav-content-color-key-focus,
-        var(
-            --mod-sidenav-content-color-key-focus,
-            var(--spectrum-sidenav-content-color-key-focus)
-        )
-    );
+    outline: var(--highcontrast-sidenav-focus-ring-color, var(--mod-sidenav-focus-ring-color, var(--spectrum-sidenav-focus-ring-color))) solid var(--mod-sidenav-focus-ring-size, var(--spectrum-sidenav-focus-ring-size));
+    outline-offset: var(--mod-sidenav-focus-ring-gap, var(--spectrum-sidenav-focus-ring-gap));
+    background-color: var(--highcontrast-sidenav-background-key-focus, var(--mod-sidenav-background-key-focus, var(--spectrum-sidenav-background-key-focus)));
+    color: var(--highcontrast-sidenav-content-color-key-focus, var(--mod-sidenav-content-color-key-focus, var(--spectrum-sidenav-content-color-key-focus)));
 }
 
 #item-link[data-level] {
-    font-family: var(
-        --mod-sidenav-top-level-font-family,
-        var(--spectrum-sidenav-top-level-font-family)
-    );
-    font-weight: var(
-        --mod-sidenav-top-level-font-weight,
-        var(--spectrum-sidenav-top-level-font-weight)
-    );
-    font-style: var(
-        --mod-sidenav-top-level-font-style,
-        var(--spectrum-sidenav-top-level-font-style)
-    );
-    font-size: var(
-        --mod-sidenav-top-level-font-size,
-        var(--spectrum-sidenav-top-level-font-size)
-    );
-    line-height: var(
-        --mod-sidenav-top-level-line-height,
-        var(--spectrum-sidenav-top-level-line-height)
-    );
+    font-family: var(--mod-sidenav-top-level-font-family, var(--spectrum-sidenav-top-level-font-family));
+    font-weight: var(--mod-sidenav-top-level-font-weight, var(--spectrum-sidenav-top-level-font-weight));
+    font-style: var(--mod-sidenav-top-level-font-style, var(--spectrum-sidenav-top-level-font-style));
+    font-size: var(--mod-sidenav-top-level-font-size, var(--spectrum-sidenav-top-level-font-size));
+    line-height: var(--mod-sidenav-top-level-line-height, var(--spectrum-sidenav-top-level-line-height));
 }
 
 #item-link:not([data-level='0']) {
-    font-weight: var(
-        --mod-sidenav-text-font-weight,
-        var(--spectrum-sidenav-text-font-weight)
-    );
-    padding-inline-start: var(
-        --mod-sidenav-start-to-content-second-level,
-        var(--spectrum-sidenav-start-to-content-second-level)
-    );
+    font-weight: var(--mod-sidenav-text-font-weight, var(--spectrum-sidenav-text-font-weight));
+    padding-inline-start: var(--mod-sidenav-start-to-content-second-level, var(--spectrum-sidenav-start-to-content-second-level));
 }
 
 #item-link[data-level='2'] {
-    padding-inline-start: var(
-        --mod-sidenav-start-to-content-third-level,
-        var(--spectrum-sidenav-start-to-content-third-level)
-    );
+    padding-inline-start: var(--mod-sidenav-start-to-content-third-level, var(--spectrum-sidenav-start-to-content-third-level));
 }
 
 .spectrum-SideNav--hasIcon#item-link:not([data-level='0']) {
-    padding-inline-start: var(
-        --mod-sidenav-start-to-content-with-icon-second-level,
-        var(--spectrum-sidenav-start-to-content-with-icon-second-level)
-    );
+    padding-inline-start: var(--mod-sidenav-start-to-content-with-icon-second-level, var(--spectrum-sidenav-start-to-content-with-icon-second-level));
 }
 
 .spectrum-SideNav--hasIcon#item-link[data-level='2'] {
-    padding-inline-start: var(
-        --mod-sidenav-start-to-content-with-icon-third-level,
-        var(--spectrum-sidenav-start-to-content-with-icon-third-level)
-    );
+    padding-inline-start: var(--mod-sidenav-start-to-content-with-icon-third-level, var(--spectrum-sidenav-start-to-content-with-icon-third-level));
 }

--- a/packages/slider/src/spectrum-slider.css
+++ b/packages/slider/src/spectrum-slider.css
@@ -15,75 +15,37 @@ governing permissions and limitations under the License.
     --spectrum-slider-font-size: var(--spectrum-font-size-75);
     --spectrum-slider-handle-size: var(--spectrum-slider-handle-size-medium);
     --spectrum-slider-control-height: var(--spectrum-component-height-100);
-    --spectrum-slider-handle-border-width-down: var(
-        --spectrum-slider-handle-border-width-down-medium
-    );
-    --spectrum-slider-label-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --spectrum-slider-control-to-field-label: var(
-        --spectrum-slider-control-to-field-label-medium
-    );
+    --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-medium);
+    --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-75);
+    --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-medium);
     --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
     --spectrum-slider-value-inline-size: 18px;
     --spectrum-slider-cjk-line-height: var(--spectrum-cjk-line-height-100);
     --spectrum-slider-min-size: var(--spectrum-spacing-900);
     --spectrum-slider-label-margin-start: var(--spectrum-spacing-300);
     --spectrum-slider-handle-border-width: var(--spectrum-border-width-200);
-    --spectrum-slider-handle-margin-left: calc(
-        var(--spectrum-slider-handle-size) / -2
-    );
-    --spectrum-slider-controls-margin: calc(
-        var(--spectrum-slider-handle-size) / 2
-    );
-    --spectrum-slider-track-margin-offset: calc(
-        var(--spectrum-slider-controls-margin) * -1
-    );
-    --spectrum-slider-track-middle-handleoffset: calc(
-        var(--spectrum-slider-handle-gap) + var(--spectrum-slider-handle-size) /
-            2
-    );
-    --spectrum-slider-input-top-size: calc(
-        var(--spectrum-slider-handle-size) / -2 / 4
-    );
-    --spectrum-slider-track-fill-thickness: var(
-        --spectrum-slider-track-thickness
-    );
+    --spectrum-slider-handle-margin-left: calc(var(--spectrum-slider-handle-size) / -2);
+    --spectrum-slider-controls-margin: calc(var(--spectrum-slider-handle-size) / 2);
+    --spectrum-slider-track-margin-offset: calc(var(--spectrum-slider-controls-margin) * -1);
+    --spectrum-slider-track-middle-handleoffset: calc(var(--spectrum-slider-handle-gap) + var(--spectrum-slider-handle-size) / 2);
+    --spectrum-slider-input-top-size: calc(var(--spectrum-slider-handle-size) / -2 / 4);
+    --spectrum-slider-track-fill-thickness: var(--spectrum-slider-track-thickness);
     --spectrum-slider-tick-mark-width: var(--spectrum-border-width-200);
     --spectrum-slider-tick-mark-border-radius: 2px;
     --spectrum-slider-tick-handle-background-color: var(--spectrum-gray-100);
-    --spectrum-slider-track-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --spectrum-slider-track-fill-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --spectrum-slider-handle-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
-    --spectrum-slider-label-text-color: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-slider-tick-label-color: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-slider-label-text-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
-    --spectrum-slider-tick-mark-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --spectrum-slider-track-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-slider-track-fill-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-slider-handle-border-color-disabled: var(--spectrum-disabled-border-color);
+    --spectrum-slider-label-text-color: var(--spectrum-neutral-content-color-default);
+    --spectrum-slider-tick-label-color: var(--spectrum-neutral-content-color-default);
+    --spectrum-slider-label-text-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-slider-tick-mark-color-disabled: var(--spectrum-disabled-background-color);
     --spectrum-slider-ramp-handle-border-color-active: var(--spectrum-gray-100);
-    --spectrum-slider-input-left: calc(
-        var(--spectrum-slider-handle-margin-left) / 4
-    );
+    --spectrum-slider-input-left: calc(var(--spectrum-slider-handle-margin-left) / 4);
     --spectrum-slider-track-handleoffset: var(--spectrum-slider-handle-gap);
     --spectrum-slider-range-track-reset: 0;
     z-index: 0;
-    min-inline-size: var(
-        --mod-slider-min-size,
-        var(--spectrum-slider-min-size)
-    );
+    min-inline-size: var(--mod-slider-min-size, var(--spectrum-slider-min-size));
     -webkit-user-select: none;
     user-select: none;
     display: block;
@@ -95,30 +57,17 @@ governing permissions and limitations under the License.
     --spectrum-logical-rotation: matrix(-1, 0, 0, 1, 0, 0);
 }
 
-:host:not(.spectrum-Slider--sideLabel)
-    #label-container
-    + #track:has(.spectrum-Slider-ramp) {
-    margin-block-start: calc(
-        var(
-                --mod-slider-ramp-track-height,
-                var(--spectrum-slider-ramp-track-height)
-            ) / 2
-    );
+:host:not(.spectrum-Slider--sideLabel) #label-container + #track:has(.spectrum-Slider-ramp) {
+    margin-block-start: calc(var(--mod-slider-ramp-track-height, var(--spectrum-slider-ramp-track-height)) / 2);
 }
 
 :host([size='s']) {
     --spectrum-slider-font-size: var(--spectrum-font-size-75);
     --spectrum-slider-handle-size: var(--spectrum-slider-handle-size-small);
     --spectrum-slider-control-height: var(--spectrum-component-height-75);
-    --spectrum-slider-handle-border-width-down: var(
-        --spectrum-slider-handle-border-width-down-small
-    );
-    --spectrum-slider-label-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --spectrum-slider-control-to-field-label: var(
-        --spectrum-slider-control-to-field-label-small
-    );
+    --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-small);
+    --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-75);
+    --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-small);
     --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-100);
 }
 
@@ -126,34 +75,20 @@ governing permissions and limitations under the License.
     --spectrum-slider-font-size: var(--spectrum-font-size-100);
     --spectrum-slider-handle-size: var(--spectrum-slider-handle-size-large);
     --spectrum-slider-control-height: var(--spectrum-component-height-200);
-    --spectrum-slider-handle-border-width-down: var(
-        --spectrum-slider-handle-border-width-down-large
-    );
-    --spectrum-slider-label-top-to-text: var(
-        --spectrum-component-top-to-text-100
-    );
-    --spectrum-slider-control-to-field-label: var(
-        --spectrum-slider-control-to-field-label-large
-    );
+    --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-large);
+    --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-100);
+    --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-large);
     --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
     --spectrum-slider-value-inline-size: 18px;
 }
 
 :host([size='xl']) {
     --spectrum-slider-font-size: var(--spectrum-font-size-200);
-    --spectrum-slider-handle-size: var(
-        --spectrum-slider-handle-size-extra-large
-    );
+    --spectrum-slider-handle-size: var(--spectrum-slider-handle-size-extra-large);
     --spectrum-slider-control-height: var(--spectrum-component-height-300);
-    --spectrum-slider-handle-border-width-down: var(
-        --spectrum-slider-handle-border-width-down-extra-large
-    );
-    --spectrum-slider-label-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --spectrum-slider-control-to-field-label: var(
-        --spectrum-slider-control-to-field-label-extra-large
-    );
+    --spectrum-slider-handle-border-width-down: var(--spectrum-slider-handle-border-width-down-extra-large);
+    --spectrum-slider-label-top-to-text: var(--spectrum-component-top-to-text-200);
+    --spectrum-slider-control-to-field-label: var(--spectrum-slider-control-to-field-label-extra-large);
     --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
     --spectrum-slider-value-inline-size: 22px;
 }
@@ -168,10 +103,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Slider--sideLabel #label-container #label {
-    margin-inline-end: var(
-        --mod-slider-value-side-padding-inline,
-        var(--spectrum-slider-value-side-padding-inline)
-    );
+    margin-inline-end: var(--mod-slider-value-side-padding-inline, var(--spectrum-slider-value-side-padding-inline));
 }
 
 .spectrum-Slider--sideLabel #label-container + #track {
@@ -179,44 +111,23 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Slider--sideLabel #controls {
-    margin-inline-end: var(
-        --mod-slider-controls-margin,
-        var(--spectrum-slider-controls-margin)
-    );
+    margin-inline-end: var(--mod-slider-controls-margin, var(--spectrum-slider-controls-margin));
 }
 
 .spectrum-Slider--sideLabel #value {
-    inline-size: var(
-        --mod-slider-value-inline-size,
-        var(--spectrum-slider-value-inline-size)
-    );
+    inline-size: var(--mod-slider-value-inline-size, var(--spectrum-slider-value-inline-size));
     text-align: start;
-    margin-inline-start: var(
-        --mod-slider-value-side-padding-inline,
-        var(--spectrum-slider-value-side-padding-inline)
-    );
+    margin-inline-start: var(--mod-slider-value-side-padding-inline, var(--spectrum-slider-value-side-padding-inline));
 }
 
 #controls {
     box-sizing: border-box;
     cursor: pointer;
     z-index: auto;
-    inline-size: calc(
-        100% -
-            var(
-                --mod-slider-controls-margin,
-                var(--spectrum-slider-controls-margin)
-            ) * 2
-    );
-    block-size: var(
-        --mod-slider-control-height,
-        var(--spectrum-slider-control-height)
-    );
+    inline-size: calc(100% - var(--mod-slider-controls-margin, var(--spectrum-slider-controls-margin)) * 2);
+    block-size: var(--mod-slider-control-height, var(--spectrum-slider-control-height));
     vertical-align: top;
-    margin-inline-start: var(
-        --mod-slider-controls-margin,
-        var(--spectrum-slider-controls-margin)
-    );
+    margin-inline-start: var(--mod-slider-controls-margin, var(--spectrum-slider-controls-margin));
     display: inline-block;
     position: relative;
 }
@@ -227,46 +138,25 @@ governing permissions and limitations under the License.
 }
 
 #label-container + #track {
-    margin-block-start: calc(
-        var(--spectrum-slider-control-to-field-label) * -1
-    );
+    margin-block-start: calc(var(--spectrum-slider-control-to-field-label) * -1);
 }
 
 :host([tick-labels]) {
-    margin-block-end: var(
-        --mod-slider-control-height,
-        var(--spectrum-slider-control-height)
-    );
+    margin-block-end: var(--mod-slider-control-height, var(--spectrum-slider-control-height));
 }
 
 .fill,
 .track {
-    block-size: var(
-        --mod-slider-track-fill-thickness,
-        var(--spectrum-slider-track-fill-thickness)
-    );
+    block-size: var(--mod-slider-track-fill-thickness, var(--spectrum-slider-track-fill-thickness));
     box-sizing: border-box;
     z-index: 1;
     pointer-events: none;
-    margin-inline-start: var(
-        --mod-slider-track-margin-offset,
-        var(--spectrum-slider-track-margin-offset)
-    );
+    margin-inline-start: var(--mod-slider-track-margin-offset, var(--spectrum-slider-track-margin-offset));
     padding-block: 0;
     padding-inline-start: 0;
-    padding-inline-end: var(
-        --mod-slider-handle-gap,
-        var(--spectrum-slider-handle-gap)
-    );
+    padding-inline-end: var(--mod-slider-handle-gap, var(--spectrum-slider-handle-gap));
     position: absolute;
-    inset-block-start: calc(
-        var(--mod-slider-control-height, var(--spectrum-slider-control-height)) /
-            2 -
-            var(
-                --mod-slider-track-fill-thickness,
-                var(--spectrum-slider-track-fill-thickness)
-            ) / 2
-    );
+    inset-block-start: calc(var(--mod-slider-control-height, var(--spectrum-slider-control-height)) / 2 - var(--mod-slider-track-fill-thickness, var(--spectrum-slider-track-fill-thickness)) / 2);
     inset-inline: 0 auto;
 }
 
@@ -282,88 +172,42 @@ governing permissions and limitations under the License.
 }
 
 .track:first-of-type:before {
-    border-start-start-radius: var(
-        --mod-slider-track-corner-radius,
-        var(--spectrum-slider-track-corner-radius)
-    );
-    border-end-start-radius: var(
-        --mod-slider-track-corner-radius,
-        var(--spectrum-slider-track-corner-radius)
-    );
+    border-start-start-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
+    border-end-start-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
 }
 
 .track:last-of-type:before {
-    border-start-end-radius: var(
-        --mod-slider-track-corner-radius,
-        var(--spectrum-slider-track-corner-radius)
-    );
-    border-end-end-radius: var(
-        --mod-slider-track-corner-radius,
-        var(--spectrum-slider-track-corner-radius)
-    );
+    border-start-end-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
+    border-end-end-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
 }
 
 .track ~ .track {
-    margin-inline-start: var(
-        --mod-slider-range-track-reset,
-        var(--spectrum-slider-range-track-reset)
-    );
-    margin-inline-end: var(
-        --mod-slider-track-margin-offset,
-        var(--spectrum-slider-track-margin-offset)
-    );
+    margin-inline-start: var(--mod-slider-range-track-reset, var(--spectrum-slider-range-track-reset));
+    margin-inline-end: var(--mod-slider-track-margin-offset, var(--spectrum-slider-track-margin-offset));
     padding-block: 0;
-    padding-inline-start: var(
-        --mod-slider-track-handleoffset,
-        var(--spectrum-slider-track-handleoffset)
-    );
+    padding-inline-start: var(--mod-slider-track-handleoffset, var(--spectrum-slider-track-handleoffset));
     padding-inline-end: 0;
     inset-inline-start: auto;
-    inset-inline-end: var(
-        --mod-slider-range-track-reset,
-        var(--spectrum-slider-range-track-reset)
-    );
+    inset-inline-end: var(--mod-slider-range-track-reset, var(--spectrum-slider-range-track-reset));
 }
 
 :host([variant='range']) .track ~ .track {
-    padding-inline: var(
-            --mod-slider-track-middle-handleoffset,
-            var(--spectrum-slider-track-middle-handleoffset)
-        )
-        var(
-            --mod-slider-track-middle-handleoffset,
-            var(--spectrum-slider-track-middle-handleoffset)
-        );
-    margin-inline: var(
-        --mod-slider-range-track-reset,
-        var(--spectrum-slider-range-track-reset)
-    );
+    padding-inline: var(--mod-slider-track-middle-handleoffset, var(--spectrum-slider-track-middle-handleoffset)) var(--mod-slider-track-middle-handleoffset, var(--spectrum-slider-track-middle-handleoffset));
+    margin-inline: var(--mod-slider-range-track-reset, var(--spectrum-slider-range-track-reset));
     inset-inline: auto;
 }
 
 .fill {
     margin-inline-start: 0;
     padding-block: 0;
-    padding-inline-start: calc(
-        var(
-                --mod-slider-controls-margin,
-                var(--spectrum-slider-controls-margin)
-            ) +
-            var(--spectrum-slider-handle-gap, var(--spectrum-slider-handle-gap))
-    );
+    padding-inline-start: calc(var(--mod-slider-controls-margin, var(--spectrum-slider-controls-margin)) + var(--spectrum-slider-handle-gap, var(--spectrum-slider-handle-gap)));
     padding-inline-end: 0;
 }
 
 .offset {
     padding-block: 0;
     padding-inline-start: 0;
-    padding-inline-end: calc(
-        var(
-                --mod-slider-controls-margin,
-                var(--spectrum-slider-controls-margin)
-            ) +
-            var(--spectrum-slider-handle-gap, var(--spectrum-slider-handle-gap))
-    );
+    padding-inline-end: calc(var(--mod-slider-controls-margin, var(--spectrum-slider-controls-margin)) + var(--spectrum-slider-handle-gap, var(--spectrum-slider-handle-gap)));
 }
 
 :host([variant='range']) #value {
@@ -372,72 +216,36 @@ governing permissions and limitations under the License.
 }
 
 :host([variant='range']) .track:first-of-type {
-    margin-inline-start: var(
-        --mod-slider-track-margin-offset,
-        var(--spectrum-slider-track-margin-offset)
-    );
+    margin-inline-start: var(--mod-slider-track-margin-offset, var(--spectrum-slider-track-margin-offset));
     padding-inline-start: 0;
-    padding-inline-end: var(
-        --mod-slider-track-handleoffset,
-        var(--spectrum-slider-track-handleoffset)
-    );
-    inset-inline-start: var(
-        --mod-slider-range-track-reset,
-        var(--spectrum-slider-range-track-reset)
-    );
+    padding-inline-end: var(--mod-slider-track-handleoffset, var(--spectrum-slider-track-handleoffset));
+    inset-inline-start: var(--mod-slider-range-track-reset, var(--spectrum-slider-range-track-reset));
     inset-inline-end: auto;
 }
 
 :host([variant='range']) .track:first-of-type:before {
-    border-start-start-radius: var(
-        --mod-slider-track-corner-radius,
-        var(--spectrum-slider-track-corner-radius)
-    );
-    border-end-start-radius: var(
-        --mod-slider-track-corner-radius,
-        var(--spectrum-slider-track-corner-radius)
-    );
+    border-start-start-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
+    border-end-start-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
 }
 
 :host([variant='range']) .track:last-of-type {
-    margin-inline-end: var(
-        --mod-slider-track-margin-offset,
-        var(--spectrum-slider-track-margin-offset)
-    );
+    margin-inline-end: var(--mod-slider-track-margin-offset, var(--spectrum-slider-track-margin-offset));
     padding-inline-start: var(--spectrum-slider-track-handleoffset);
     padding-inline-end: 0;
     inset-inline-start: auto;
-    inset-inline-end: var(
-        --mod-slider-range-track-reset,
-        var(--spectrum-slider-range-track-reset)
-    );
+    inset-inline-end: var(--mod-slider-range-track-reset, var(--spectrum-slider-range-track-reset));
 }
 
 :host([variant='range']) .track:last-of-type:before {
-    border-start-end-radius: var(
-        --mod-slider-track-corner-radius,
-        var(--spectrum-slider-track-corner-radius)
-    );
-    border-end-end-radius: var(
-        --mod-slider-track-corner-radius,
-        var(--spectrum-slider-track-corner-radius)
-    );
+    border-start-end-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
+    border-end-end-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
 }
 
 #ramp {
-    block-size: var(
-        --mod-slider-ramp-track-height,
-        var(--spectrum-slider-ramp-track-height)
-    );
+    block-size: var(--mod-slider-ramp-track-height, var(--spectrum-slider-ramp-track-height));
     position: absolute;
-    inset-inline-start: var(
-        --spectrum-slider-track-margin-offset,
-        var(--spectrum-slider-track-margin-offset)
-    );
-    inset-inline-end: var(
-        --spectrum-slider-track-margin-offset,
-        var(--spectrum-slider-track-margin-offset)
-    );
+    inset-inline-start: var(--spectrum-slider-track-margin-offset, var(--spectrum-slider-track-margin-offset));
+    inset-inline-end: var(--spectrum-slider-track-margin-offset, var(--spectrum-slider-track-margin-offset));
 }
 
 #ramp svg {
@@ -449,53 +257,24 @@ governing permissions and limitations under the License.
 .handle {
     z-index: 2;
     box-sizing: border-box;
-    inline-size: var(
-        --mod-slider-handle-size,
-        var(--spectrum-slider-handle-size)
-    );
-    block-size: var(
-        --mod-slider-handle-size,
-        var(--spectrum-slider-handle-size)
-    );
+    inline-size: var(--mod-slider-handle-size, var(--spectrum-slider-handle-size));
+    block-size: var(--mod-slider-handle-size, var(--spectrum-slider-handle-size));
     margin-block: 0;
-    margin-inline: calc(
-            var(--mod-slider-handle-size, var(--spectrum-slider-handle-size)) /
-                -2
-        )
-        0;
-    border-width: var(
-        --mod-slider-handle-border-width,
-        var(--spectrum-slider-handle-border-width)
-    );
-    border-radius: var(
-        --mod-slider-handle-border-radius,
-        var(--spectrum-slider-handle-border-radius)
-    );
-    transition: border-width
-        var(
-            --mod-animation-duration-100,
-            var(--spectrum-animation-duration-100)
-        )
-        ease-in-out;
+    margin-inline: calc(var(--mod-slider-handle-size, var(--spectrum-slider-handle-size)) / -2) 0;
+    border-width: var(--mod-slider-handle-border-width, var(--spectrum-slider-handle-border-width));
+    border-radius: var(--mod-slider-handle-border-radius, var(--spectrum-slider-handle-border-radius));
+    transition: border-width var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;
     border-style: solid;
     outline: none;
     display: inline-block;
     position: absolute;
-    inset-block-start: calc(
-        var(--mod-slider-control-height, var(--spectrum-slider-control-height)) /
-            2 -
-            var(--mod-slider-handle-size, var(--spectrum-slider-handle-size)) /
-            2
-    );
+    inset-block-start: calc(var(--mod-slider-control-height, var(--spectrum-slider-control-height)) / 2 - var(--mod-slider-handle-size, var(--spectrum-slider-handle-size)) / 2);
     inset-inline-start: 0;
 }
 
 .handle.dragging,
 .handle:active {
-    border-width: var(
-        --mod-slider-handle-border-width-down,
-        var(--spectrum-slider-handle-border-width-down)
-    );
+    border-width: var(--mod-slider-handle-border-width-down, var(--spectrum-slider-handle-border-width-down));
 }
 
 .handle.dragging,
@@ -508,32 +287,11 @@ governing permissions and limitations under the License.
 .handle:before {
     content: '';
     transition:
-        box-shadow
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-out,
-        inline-size
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-out,
-        block-size
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-out;
-    inline-size: var(
-        --mod-slider-handle-size,
-        var(--spectrum-slider-handle-size)
-    );
-    block-size: var(
-        --mod-slider-handle-size,
-        var(--spectrum-slider-handle-size)
-    );
+        box-shadow var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out,
+        inline-size var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out,
+        block-size var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out;
+    inline-size: var(--mod-slider-handle-size, var(--spectrum-slider-handle-size));
+    block-size: var(--mod-slider-handle-size, var(--spectrum-slider-handle-size));
     border-radius: 100%;
     display: block;
     position: absolute;
@@ -548,27 +306,13 @@ governing permissions and limitations under the License.
 }
 
 .handle.handle-highlight:before {
-    inline-size: calc(
-        var(--mod-slider-handle-size, var(--spectrum-slider-handle-size)) +
-            var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) *
-            2
-    );
-    block-size: calc(
-        var(--mod-slider-handle-size, var(--spectrum-slider-handle-size)) +
-            var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) *
-            2
-    );
+    inline-size: calc(var(--mod-slider-handle-size, var(--spectrum-slider-handle-size)) + var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * 2);
+    block-size: calc(var(--mod-slider-handle-size, var(--spectrum-slider-handle-size)) + var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * 2);
 }
 
 .input {
-    inline-size: var(
-        --mod-slider-handle-size,
-        var(--spectrum-slider-handle-size)
-    );
-    block-size: var(
-        --mod-slider-handle-size,
-        var(--spectrum-slider-handle-size)
-    );
+    inline-size: var(--mod-slider-handle-size, var(--spectrum-slider-handle-size));
+    block-size: var(--mod-slider-handle-size, var(--spectrum-slider-handle-size));
     opacity: 0;
     cursor: default;
     appearance: none;
@@ -577,14 +321,8 @@ governing permissions and limitations under the License.
     margin: 0;
     padding: 0;
     position: absolute;
-    inset-block-start: var(
-        --mod-slider-input-top-size,
-        var(--spectrum-slider-input-top-size)
-    );
-    inset-inline-start: var(
-        --mod-slider-input-left,
-        var(--spectrum-slider-input-left)
-    );
+    inset-block-start: var(--mod-slider-input-top-size, var(--spectrum-slider-input-top-size));
+    inset-inline-start: var(--mod-slider-input-left, var(--spectrum-slider-input-left));
     overflow: hidden;
 }
 
@@ -598,10 +336,7 @@ governing permissions and limitations under the License.
     line-height: var(--mod-line-height-100, var(--spectrum-line-height-100));
     justify-content: space-between;
     align-items: center;
-    margin-block-start: var(
-        --mod-slider-label-top-to-text,
-        var(--spectrum-slider-label-top-to-text)
-    );
+    margin-block-start: var(--mod-slider-label-top-to-text, var(--spectrum-slider-label-top-to-text));
     display: flex;
     position: relative;
 }
@@ -609,10 +344,7 @@ governing permissions and limitations under the License.
 #label-container:lang(ja),
 #label-container:lang(ko),
 #label-container:lang(zh) {
-    line-height: var(
-        --mod-slider-cjk-line-height,
-        var(--spectrum-slider-cjk-line-height)
-    );
+    line-height: var(--mod-slider-cjk-line-height, var(--spectrum-slider-cjk-line-height));
 }
 
 #label {
@@ -625,112 +357,57 @@ governing permissions and limitations under the License.
     font-feature-settings: 'tnum';
     text-align: end;
     flex-grow: 0;
-    margin-inline-start: var(
-        --mod-slider-label-margin-start,
-        var(--spectrum-slider-label-margin-start)
-    );
+    margin-inline-start: var(--mod-slider-label-margin-start, var(--spectrum-slider-label-margin-start));
     padding-inline-end: 0;
 }
 
 :host([variant='tick']) .handle {
-    background-color: var(
-        --mod-slider-tick-handle-background-color,
-        var(--spectrum-slider-tick-handle-background-color)
-    );
+    background-color: var(--mod-slider-tick-handle-background-color, var(--spectrum-slider-tick-handle-background-color));
 }
 
 :host([variant='tick']) #controls {
-    margin-block-start: calc(
-        var(--spectrum-text-to-visual-75) -
-            var(
-                --mod-slider-tick-mark-height,
-                var(--spectrum-slider-tick-mark-height)
-            ) / 2 -
-            var(
-                --mod-slider-track-thickness,
-                var(--spectrum-slider-track-thickness)
-            ) / 2
-    );
+    margin-block-start: calc(var(--spectrum-text-to-visual-75) - var(--mod-slider-tick-mark-height, var(--spectrum-slider-tick-mark-height)) / 2 - var(--mod-slider-track-thickness, var(--spectrum-slider-track-thickness)) / 2);
 }
 
 :host([variant='tick']) .tickLabel {
-    margin-block-start: calc(
-        var(
-                --mod-slider-tick-mark-height,
-                var(--spectrum-slider-tick-mark-height)
-            ) + var(--spectrum-text-to-visual-75)
-    );
+    margin-block-start: calc(var(--mod-slider-tick-mark-height, var(--spectrum-slider-tick-mark-height)) + var(--spectrum-text-to-visual-75));
 }
 
 .ticks {
     z-index: 0;
-    margin-inline: var(
-        --mod-slider-track-margin-offset,
-        var(--spectrum-slider-track-margin-offset)
-    );
+    margin-inline: var(--mod-slider-track-margin-offset, var(--spectrum-slider-track-margin-offset));
     justify-content: space-between;
     display: flex;
 }
 
 .ticks ~ .handleContainer .handle {
-    background: var(
-        --mod-slider-ticks-handle-background-color,
-        var(--spectrum-slider-ticks-handle-background-color)
-    );
+    background: var(--mod-slider-ticks-handle-background-color, var(--spectrum-slider-ticks-handle-background-color));
 }
 
 .tick {
     position: relative;
-    inset-block-start: calc(
-        var(--mod-slider-track-thickness, var(--spectrum-slider-control-height)) /
-            2 -
-            var(
-                --mod-slider-tick-mark-height,
-                var(--spectrum-slider-tick-mark-height)
-            ) / 2
-    );
+    inset-block-start: calc(var(--mod-slider-track-thickness, var(--spectrum-slider-control-height)) / 2 - var(--mod-slider-tick-mark-height, var(--spectrum-slider-tick-mark-height)) / 2);
 }
 
 .tick,
 .tick:after {
-    inline-size: var(
-        --mod-slider-tick-mark-width,
-        var(--spectrum-slider-tick-mark-width)
-    );
+    inline-size: var(--mod-slider-tick-mark-width, var(--spectrum-slider-tick-mark-width));
 }
 
 .tick:after {
     content: '';
-    block-size: var(
-        --mod-slider-tick-mark-height,
-        var(--spectrum-slider-tick-mark-height)
-    );
-    border-radius: var(
-        --mod-slider-tick-mark-border-radius,
-        var(--spectrum-slider-tick-mark-border-radius)
-    );
+    block-size: var(--mod-slider-tick-mark-height, var(--spectrum-slider-tick-mark-height));
+    border-radius: var(--mod-slider-tick-mark-border-radius, var(--spectrum-slider-tick-mark-border-radius));
     display: block;
     position: absolute;
     inset-block-start: 0;
-    inset-inline-start: calc(
-        50% -
-            var(
-                --mod-slider-tick-mark-width,
-                var(--spectrum-slider-tick-mark-width)
-            ) / 2
-    );
+    inset-inline-start: calc(50% - var(--mod-slider-tick-mark-width, var(--spectrum-slider-tick-mark-width)) / 2);
 }
 
 .tick .tickLabel {
     font-size: var(--mod-font-size-75, var(--spectrum-font-size-75));
     line-height: var(--mod-line-height-100, var(--spectrum-line-height-100));
-    color: var(
-        --highcontrast-slider-label-text-color,
-        var(
-            --mod-slider-tick-label-color,
-            var(--spectrum-slider-tick-label-color)
-        )
-    );
+    color: var(--highcontrast-slider-label-text-color, var(--mod-slider-tick-label-color, var(--spectrum-slider-tick-label-color)));
     justify-content: center;
     align-items: center;
     display: flex;
@@ -744,12 +421,7 @@ governing permissions and limitations under the License.
 }
 
 .tick:first-of-type {
-    inset-inline-start: calc(
-        var(
-                --mod-slider-tick-mark-width,
-                var(--spectrum-slider-tick-mark-width)
-            ) / -2
-    );
+    inset-inline-start: calc(var(--mod-slider-tick-mark-width, var(--spectrum-slider-tick-mark-width)) / -2);
 }
 
 .tick:first-of-type .tickLabel {
@@ -757,12 +429,7 @@ governing permissions and limitations under the License.
 }
 
 .tick:last-of-type {
-    inset-inline-end: calc(
-        var(
-                --mod-slider-tick-mark-width,
-                var(--spectrum-slider-tick-mark-width)
-            ) / -2
-    );
+    inset-inline-end: calc(var(--mod-slider-tick-mark-width, var(--spectrum-slider-tick-mark-width)) / -2);
 }
 
 .tick:last-of-type .tickLabel {
@@ -778,123 +445,52 @@ governing permissions and limitations under the License.
 }
 
 .trackContainer {
-    block-size: var(
-        --mod-slider-control-height,
-        var(--spectrum-slider-control-height)
-    );
+    block-size: var(--mod-slider-control-height, var(--spectrum-slider-control-height));
     overflow: hidden;
 }
 
 .track:before {
-    background: var(
-        --highcontrast-slider-track-color-static,
-        var(--mod-slider-track-color, var(--spectrum-slider-track-color))
-    );
+    background: var(--highcontrast-slider-track-color-static, var(--mod-slider-track-color, var(--spectrum-slider-track-color)));
 }
 
 .track:not(:has(~ .spectrum-Slider-fill)):before {
-    background: var(
-        --highcontrast-slider-track-color,
-        var(--mod-slider-track-color, var(--spectrum-slider-track-color))
-    );
+    background: var(--highcontrast-slider-track-color, var(--mod-slider-track-color, var(--spectrum-slider-track-color)));
 }
 
 #label-container {
-    color: var(
-        --highcontrast-slider-label-text-color,
-        var(
-            --mod-slider-label-text-color,
-            var(--spectrum-slider-label-text-color)
-        )
-    );
+    color: var(--highcontrast-slider-label-text-color, var(--mod-slider-label-text-color, var(--spectrum-slider-label-text-color)));
 }
 
 :host([variant='filled']) .track:first-child:before,
 .fill:before {
-    background: var(
-        --highcontrast-slider-filled-track-fill-color,
-        var(
-            --mod-slider-track-fill-color,
-            var(--spectrum-slider-track-fill-color)
-        )
-    );
+    background: var(--highcontrast-slider-filled-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
 }
 
 #ramp path {
-    fill: var(
-        --highcontrast-slider-ramp-track-color,
-        var(
-            --mod-slider-ramp-track-color,
-            var(--spectrum-slider-ramp-track-color)
-        )
-    );
+    fill: var(--highcontrast-slider-ramp-track-color, var(--mod-slider-ramp-track-color, var(--spectrum-slider-ramp-track-color)));
 }
 
 .handle {
-    border-color: var(
-        --highcontrast-slider-handle-border-color,
-        var(
-            --mod-slider-handle-border-color,
-            var(--spectrum-slider-handle-border-color)
-        )
-    );
-    background: var(
-        --highcontrast-slider-handle-background-color,
-        var(
-            --mod-slider-handle-background-color,
-            var(--spectrum-slider-handle-background-color)
-        )
-    );
+    border-color: var(--highcontrast-slider-handle-border-color, var(--mod-slider-handle-border-color, var(--spectrum-slider-handle-border-color)));
+    background: var(--highcontrast-slider-handle-background-color, var(--mod-slider-handle-background-color, var(--spectrum-slider-handle-background-color)));
 }
 
 .handle.handle-highlight {
-    border-color: var(
-        --highcontrast-slider-handle-border-color-key-focus,
-        var(
-            --mod-slider-handle-border-color-key-focus,
-            var(--spectrum-slider-handle-border-color-key-focus)
-        )
-    );
+    border-color: var(--highcontrast-slider-handle-border-color-key-focus, var(--mod-slider-handle-border-color-key-focus, var(--spectrum-slider-handle-border-color-key-focus)));
 }
 
 .handle.handle-highlight:before {
-    box-shadow: 0 0 0 var(--spectrum-focus-indicator-thickness)
-        var(
-            --highcontrast-slider-handle-focus-ring-color-key-focus,
-            var(
-                --mod-slider-handle-focus-ring-color-key-focus,
-                var(--spectrum-slider-handle-focus-ring-color-key-focus)
-            )
-        );
+    box-shadow: 0 0 0 var(--spectrum-focus-indicator-thickness) var(--highcontrast-slider-handle-focus-ring-color-key-focus, var(--mod-slider-handle-focus-ring-color-key-focus, var(--spectrum-slider-handle-focus-ring-color-key-focus)));
 }
 
 .handle.dragging,
 .handle:active {
-    border-color: var(
-        --highcontrast-slider-handle-border-color-down,
-        var(
-            --mod-slider-handle-border-color-down,
-            var(--spectrum-slider-handle-border-color-down)
-        )
-    );
+    border-color: var(--highcontrast-slider-handle-border-color-down, var(--mod-slider-handle-border-color-down, var(--spectrum-slider-handle-border-color-down)));
 }
 
 :host([variant='ramp']) .handle {
-    box-shadow: 0 0 0 var(--spectrum-slider-handle-gap)
-        var(
-            --highcontrast-slider-ramp-handle-border-color-active,
-            var(
-                --mod-sectrum-slider-ramp-handle-border-color-active,
-                var(--spectrum-slider-ramp-handle-border-color-active)
-            )
-        );
-    background: var(
-        --mod-slider-ramp-handle-background-color,
-        var(
-            --highcontrast-slider-ramp-handle-background-color,
-            var(--spectrum-slider-ramp-handle-background-color)
-        )
-    );
+    box-shadow: 0 0 0 var(--spectrum-slider-handle-gap) var(--highcontrast-slider-ramp-handle-border-color-active, var(--mod-sectrum-slider-ramp-handle-border-color-active, var(--spectrum-slider-ramp-handle-border-color-active)));
+    background: var(--mod-slider-ramp-handle-background-color, var(--highcontrast-slider-ramp-handle-background-color, var(--spectrum-slider-ramp-handle-background-color)));
 }
 
 .input {
@@ -902,40 +498,16 @@ governing permissions and limitations under the License.
 }
 
 .tick:after {
-    background-color: var(
-        --highcontrast-slider-tick-mark-color,
-        var(
-            --mod-slider-tick-mark-color,
-            var(--spectrum-slider-tick-mark-color)
-        )
-    );
+    background-color: var(--highcontrast-slider-tick-mark-color, var(--mod-slider-tick-mark-color, var(--spectrum-slider-tick-mark-color)));
 }
 
 .handle.dragging {
-    border-color: var(
-        --highcontrast-slider-handle-border-color-down,
-        var(
-            --mod-slider-handle-border-color-down,
-            var(--spectrum-slider-handle-border-color-down)
-        )
-    );
-    background: var(
-        --highcontrast-slider-handle-background-color,
-        var(
-            --mod-slider-handle-background-color,
-            var(--spectrum-slider-handle-background-color)
-        )
-    );
+    border-color: var(--highcontrast-slider-handle-border-color-down, var(--mod-slider-handle-border-color-down, var(--spectrum-slider-handle-border-color-down)));
+    background: var(--highcontrast-slider-handle-background-color, var(--mod-slider-handle-background-color, var(--spectrum-slider-handle-background-color)));
 }
 
 :host([variant='range']) .track:not(:first-of-type, :last-of-type):before {
-    background: var(
-        --highcontrast-slider-filled-track-fill-color,
-        var(
-            --mod-slider-track-fill-color,
-            var(--spectrum-slider-track-fill-color)
-        )
-    );
+    background: var(--highcontrast-slider-filled-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
 }
 
 :host([disabled]),
@@ -945,124 +517,51 @@ governing permissions and limitations under the License.
 
 :host([disabled]) #label-container,
 :host([disabled]) .tickLabel {
-    color: var(
-        --highcontrast-slider-label-text-color-disabled,
-        var(
-            --mod-slider-label-text-color-disabled,
-            var(--spectrum-slider-label-text-color-disabled)
-        )
-    );
+    color: var(--highcontrast-slider-label-text-color-disabled, var(--mod-slider-label-text-color-disabled, var(--spectrum-slider-label-text-color-disabled)));
 }
 
 :host([disabled]) .handle {
-    border-color: var(
-        --highcontrast-slider-handle-border-color-disabled,
-        var(
-            --mod-slider-handle-border-color-disabled,
-            var(--spectrum-slider-handle-border-color-disabled)
-        )
-    );
-    background: var(
-        --highcontrast-slider-handle-disabled-background-color,
-        var(
-            --mod-slider-handle-disabled-background-color,
-            var(--spectrum-slider-handle-disabled-background-color)
-        )
-    );
+    border-color: var(--highcontrast-slider-handle-border-color-disabled, var(--mod-slider-handle-border-color-disabled, var(--spectrum-slider-handle-border-color-disabled)));
+    background: var(--highcontrast-slider-handle-disabled-background-color, var(--mod-slider-handle-disabled-background-color, var(--spectrum-slider-handle-disabled-background-color)));
     cursor: default;
     pointer-events: none;
 }
 
 :host([disabled]) .handle:active {
-    border-color: var(
-        --mod-disabled-border-color,
-        var(--spectrum-disabled-border-color)
-    );
-    background: var(
-        --highcontrast-slider-handle-background-color-disabled,
-        var(
-            --mod-slider-handle-background-color-disabled,
-            var(--spectrum-slider-handle-background-color-disabled)
-        )
-    );
+    border-color: var(--mod-disabled-border-color, var(--spectrum-disabled-border-color));
+    background: var(--highcontrast-slider-handle-background-color-disabled, var(--mod-slider-handle-background-color-disabled, var(--spectrum-slider-handle-background-color-disabled)));
 }
 
 @media (hover: hover) {
     .handle:hover {
-        border-color: var(
-            --highcontrast-slider-handle-border-color-hover,
-            var(
-                --mod-slider-handle-border-color-hover,
-                var(--spectrum-slider-handle-border-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-slider-handle-border-color-hover, var(--mod-slider-handle-border-color-hover, var(--spectrum-slider-handle-border-color-hover)));
     }
 
     :host([disabled]) .handle:hover {
-        border-color: var(
-            --mod-disabled-border-color,
-            var(--spectrum-disabled-border-color)
-        );
-        background: var(
-            --highcontrast-slider-handle-background-color-disabled,
-            var(
-                --mod-slider-handle-background-color-disabled,
-                var(--spectrum-slider-handle-background-color-disabled)
-            )
-        );
+        border-color: var(--mod-disabled-border-color, var(--spectrum-disabled-border-color));
+        background: var(--highcontrast-slider-handle-background-color-disabled, var(--mod-slider-handle-background-color-disabled, var(--spectrum-slider-handle-background-color-disabled)));
     }
 }
 
 :host([disabled]) .track:before {
-    background: var(
-        --highcontrast-slider-track-color-disabled,
-        var(
-            --mod-slider-track-color-disabled,
-            var(--spectrum-slider-track-color-disabled)
-        )
-    );
+    background: var(--highcontrast-slider-track-color-disabled, var(--mod-slider-track-color-disabled, var(--spectrum-slider-track-color-disabled)));
 }
 
 :host([disabled]) .fill:before,
 :host([disabled][variant='filled']) .track:first-child:before {
-    background: var(
-        --highcontrast-slider-track-fill-color-disabled,
-        var(
-            --mod-slider-track-fill-color-disabled,
-            var(--spectrum-slider-track-fill-color-disabled)
-        )
-    );
+    background: var(--highcontrast-slider-track-fill-color-disabled, var(--mod-slider-track-fill-color-disabled, var(--spectrum-slider-track-fill-color-disabled)));
 }
 
 :host([disabled]) #ramp path {
-    fill: var(
-        --highcontrast-slider-ramp-track-color-disabled,
-        var(
-            --mod-slider-ramp-track-color-disabled,
-            var(--spectrum-slider-ramp-track-color-disabled)
-        )
-    );
+    fill: var(--highcontrast-slider-ramp-track-color-disabled, var(--mod-slider-ramp-track-color-disabled, var(--spectrum-slider-ramp-track-color-disabled)));
 }
 
 :host([disabled]) .tick:after {
-    background-color: var(
-        --highcontrast-slider-tick-mark-color-disabled,
-        var(
-            --mod-slider-tick-mark-color-disabled,
-            var(--spectrum-slider-tick-mark-color-disabled)
-        )
-    );
+    background-color: var(--highcontrast-slider-tick-mark-color-disabled, var(--mod-slider-tick-mark-color-disabled, var(--spectrum-slider-tick-mark-color-disabled)));
 }
 
-:host([disabled][variant='range'])
-    .track:not(:first-of-type, :last-of-type):before {
-    background: var(
-        --highcontrast-slider-track-color-disabled,
-        var(
-            --mod-slider-track-color-disabled,
-            var(--spectrum-slider-track-color-disabled)
-        )
-    );
+:host([disabled][variant='range']) .track:not(:first-of-type, :last-of-type):before {
+    background: var(--highcontrast-slider-track-color-disabled, var(--mod-slider-track-color-disabled, var(--spectrum-slider-track-color-disabled)));
 }
 
 @media (forced-colors: active) {
@@ -1096,25 +595,11 @@ governing permissions and limitations under the License.
         forced-color-adjust: none;
     }
 
-    :host([focus-within])
-        .js-focus-within:not(
-            .is-disabled,
-            .spectrum-Slider--filled,
-            .spectrum-Slider--range
-        )
-        #controls,
-    :host:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range)
-        #controls.handle-highlight,
-    :host:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range)
-        #controls:active,
-    :host:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range)
-        #controls:focus-within,
-    :host([focus-within]):not(
-            .is-disabled,
-            .spectrum-Slider--filled,
-            .spectrum-Slider--range
-        ).js-focus-within
-        #controls {
+    :host([focus-within]) .js-focus-within:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range) #controls,
+    :host:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range) #controls.handle-highlight,
+    :host:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range) #controls:active,
+    :host:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range) #controls:focus-within,
+    :host([focus-within]):not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range).js-focus-within #controls {
         --highcontrast-slider-track-color: Highlight;
         --highcontrast-slider-handle-border-color: Highlight;
         --highcontrast-slider-ramp-track-color: Highlight;
@@ -1122,12 +607,7 @@ governing permissions and limitations under the License.
     }
 
     @media (hover: hover) {
-        :host:not(
-                .is-disabled,
-                .spectrum-Slider--filled,
-                .spectrum-Slider--range
-            )
-            #controls:hover {
+        :host:not(.is-disabled, .spectrum-Slider--filled, .spectrum-Slider--range) #controls:hover {
             --highcontrast-slider-track-color: Highlight;
             --highcontrast-slider-handle-border-color: Highlight;
             --highcontrast-slider-ramp-track-color: Highlight;

--- a/packages/split-view/src/spectrum-split-view.css
+++ b/packages/split-view/src/spectrum-split-view.css
@@ -18,98 +18,36 @@ governing permissions and limitations under the License.
 
 ::slotted(*) {
     block-size: 100%;
-    background-color: var(
-        --mod-splitview-background-color,
-        var(--spectrum-splitview-background-color)
-    );
-    color: var(
-        --mod-splitview-content-color,
-        var(--spectrum-splitview-content-color)
-    );
+    background-color: var(--mod-splitview-background-color, var(--spectrum-splitview-background-color));
+    color: var(--mod-splitview-content-color, var(--spectrum-splitview-content-color));
 }
 
 #gripper {
     content: '';
-    border-radius: var(
-        --mod-splitview-gripper-border-radius,
-        var(--spectrum-splitview-gripper-border-radius)
-    );
+    border-radius: var(--mod-splitview-gripper-border-radius, var(--spectrum-splitview-gripper-border-radius));
     border-style: solid;
-    border-color: var(
-        --highcontrast-splitview-handle-background-color,
-        var(
-            --mod-splitview-handle-background-color,
-            var(--spectrum-splitview-handle-background-color)
-        )
-    );
+    border-color: var(--highcontrast-splitview-handle-background-color, var(--mod-splitview-handle-background-color, var(--spectrum-splitview-handle-background-color)));
     touch-action: none;
-    inline-size: var(
-        --mod-splitview-gripper-width,
-        var(--spectrum-splitview-gripper-width)
-    );
-    block-size: var(
-        --mod-splitview-gripper-height,
-        var(--spectrum-splitview-gripper-height)
-    );
-    border-block-width: var(
-        --mod-splitview-gripper-border-width-vertical,
-        var(--spectrum-splitview-gripper-border-width-vertical)
-    );
-    border-inline-width: var(
-        --mod-splitview-gripper-border-width-horizontal,
-        var(--spectrum-splitview-gripper-border-width-horizontal)
-    );
+    inline-size: var(--mod-splitview-gripper-width, var(--spectrum-splitview-gripper-width));
+    block-size: var(--mod-splitview-gripper-height, var(--spectrum-splitview-gripper-height));
+    border-block-width: var(--mod-splitview-gripper-border-width-vertical, var(--spectrum-splitview-gripper-border-width-vertical));
+    border-inline-width: var(--mod-splitview-gripper-border-width-horizontal, var(--spectrum-splitview-gripper-border-width-horizontal));
     display: block;
     position: absolute;
     inset-block-start: 50%;
-    inset-inline-start: calc(
-        (
-                var(
-                        --mod-splitview-gripper-width,
-                        var(--spectrum-splitview-gripper-width)
-                    ) +
-                    (
-                        2 *
-                            var(
-                                --mod-splitview-gripper-border-width-vertical,
-                                var(
-                                    --spectrum-splitview-gripper-border-width-vertical
-                                )
-                            )
-                    ) -
-                    var(
-                        --mod-splitview-gripper-width,
-                        var(--spectrum-splitview-gripper-width)
-                    )
-            ) / 2 * -1
-    );
+    inset-inline-start: calc((var(--mod-splitview-gripper-width, var(--spectrum-splitview-gripper-width)) + (2 * var(--mod-splitview-gripper-border-width-vertical, var(--spectrum-splitview-gripper-border-width-vertical))) - var(--mod-splitview-gripper-width, var(--spectrum-splitview-gripper-width))) / 2 * -1);
     transform: translateY(-50%);
 }
 
 #gripper:before {
-    background-color: var(
-        --highcontrast-splitview-handle-background-color,
-        var(
-            --mod-splitview-handle-background-color,
-            var(--spectrum-splitview-handle-background-color)
-        )
-    );
+    background-color: var(--highcontrast-splitview-handle-background-color, var(--mod-splitview-handle-background-color, var(--spectrum-splitview-handle-background-color)));
 }
 
 #splitter {
-    background-color: var(
-        --highcontrast-splitview-handle-background-color,
-        var(
-            --mod-splitview-handle-background-color,
-            var(--spectrum-splitview-handle-background-color)
-        )
-    );
+    background-color: var(--highcontrast-splitview-handle-background-color, var(--mod-splitview-handle-background-color, var(--spectrum-splitview-handle-background-color)));
     -webkit-user-select: none;
     user-select: none;
-    inline-size: var(
-        --mod-splitview-handle-width,
-        var(--spectrum-splitview-handle-width)
-    );
+    inline-size: var(--mod-splitview-handle-width, var(--spectrum-splitview-handle-width));
     block-size: 100%;
     z-index: 1;
     position: relative;
@@ -118,20 +56,11 @@ governing permissions and limitations under the License.
 #splitter.is-collapsed-end #gripper:before,
 #splitter.is-collapsed-start #gripper:before {
     content: '';
-    inline-size: var(
-        --mod-splitview-handle-width,
-        var(--spectrum-splitview-handle-width)
-    );
+    inline-size: var(--mod-splitview-handle-width, var(--spectrum-splitview-handle-width));
     block-size: 100%;
     position: absolute;
     inset-block-start: 0;
-    inset-inline-start: calc(
-        50% -
-            var(
-                --mod-splitview-handle-width,
-                var(--spectrum-splitview-handle-width)
-            ) / 2
-    );
+    inset-inline-start: calc(50% - var(--mod-splitview-handle-width, var(--spectrum-splitview-handle-width)) / 2);
 }
 
 #splitter.is-collapsed-start #gripper {
@@ -143,98 +72,44 @@ governing permissions and limitations under the License.
 }
 
 :host([resizable]) #splitter.is-hovered {
-    background-color: var(
-        --highcontrast-splitview-handle-background-color-hover,
-        var(
-            --mod-splitview-handle-background-color-hover,
-            var(--spectrum-splitview-handle-background-color-hover)
-        )
-    );
+    background-color: var(--highcontrast-splitview-handle-background-color-hover, var(--mod-splitview-handle-background-color-hover, var(--spectrum-splitview-handle-background-color-hover)));
 }
 
 :host([resizable]) #splitter.is-hovered #gripper {
-    border-color: var(
-        --highcontrast-splitview-handle-background-color-hover,
-        var(
-            --mod-splitview-handle-background-color-hover,
-            var(--spectrum-splitview-handle-background-color-hover)
-        )
-    );
+    border-color: var(--highcontrast-splitview-handle-background-color-hover, var(--mod-splitview-handle-background-color-hover, var(--spectrum-splitview-handle-background-color-hover)));
 }
 
 :host([resizable]) #splitter.is-hovered #gripper:before {
-    background-color: var(
-        --highcontrast-splitview-handle-background-color-hover,
-        var(
-            --mod-splitview-handle-background-color-hover,
-            var(--spectrum-splitview-handle-background-color-hover)
-        )
-    );
+    background-color: var(--highcontrast-splitview-handle-background-color-hover, var(--mod-splitview-handle-background-color-hover, var(--spectrum-splitview-handle-background-color-hover)));
 }
 
 @media (hover: hover) {
     :host([resizable]) #splitter:hover {
-        background-color: var(
-            --highcontrast-splitview-handle-background-color-hover,
-            var(
-                --mod-splitview-handle-background-color-hover,
-                var(--spectrum-splitview-handle-background-color-hover)
-            )
-        );
+        background-color: var(--highcontrast-splitview-handle-background-color-hover, var(--mod-splitview-handle-background-color-hover, var(--spectrum-splitview-handle-background-color-hover)));
     }
 
     :host([resizable]) #splitter:hover #gripper {
-        border-color: var(
-            --highcontrast-splitview-handle-background-color-hover,
-            var(
-                --mod-splitview-handle-background-color-hover,
-                var(--spectrum-splitview-handle-background-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-splitview-handle-background-color-hover, var(--mod-splitview-handle-background-color-hover, var(--spectrum-splitview-handle-background-color-hover)));
     }
 
     :host([resizable]) #splitter:hover #gripper:before {
-        background-color: var(
-            --highcontrast-splitview-handle-background-color-hover,
-            var(
-                --mod-splitview-handle-background-color-hover,
-                var(--spectrum-splitview-handle-background-color-hover)
-            )
-        );
+        background-color: var(--highcontrast-splitview-handle-background-color-hover, var(--mod-splitview-handle-background-color-hover, var(--spectrum-splitview-handle-background-color-hover)));
     }
 }
 
 :host([resizable]) #splitter.is-active,
 :host([resizable]) #splitter:active {
-    background-color: var(
-        --highcontrast-splitview-handle-background-color-down,
-        var(
-            --mod-splitview-handle-background-color-down,
-            var(--spectrum-splitview-handle-background-color-down)
-        )
-    );
+    background-color: var(--highcontrast-splitview-handle-background-color-down, var(--mod-splitview-handle-background-color-down, var(--spectrum-splitview-handle-background-color-down)));
 }
 
 :host([resizable]) #splitter.is-active #gripper,
 :host([resizable]) #splitter:active #gripper {
-    border-color: var(
-        --highcontrast-splitview-handle-background-color-down,
-        var(
-            --mod-splitview-handle-background-color-down,
-            var(--spectrum-splitview-handle-background-color-down)
-        )
-    );
+    border-color: var(--highcontrast-splitview-handle-background-color-down, var(--mod-splitview-handle-background-color-down, var(--spectrum-splitview-handle-background-color-down)));
 }
 
 :host([resizable]) #splitter.is-active #gripper:before,
 :host([resizable]) #splitter:active #gripper:before {
-    background-color: var(
-        --highcontrast-splitview-handle-background-color-down,
-        var(
-            --mod-splitview-handle-background-color-down,
-            var(--spectrum-splitview-handle-background-color-down)
-        )
-    );
+    background-color: var(--highcontrast-splitview-handle-background-color-down, var(--mod-splitview-handle-background-color-down, var(--spectrum-splitview-handle-background-color-down)));
 }
 
 :host([resizable]) #splitter:focus {
@@ -242,42 +117,17 @@ governing permissions and limitations under the License.
 }
 
 :host([resizable]) #splitter:focus-visible {
-    background-color: var(
-        --highcontrast-splitview-handle-background-color-focus,
-        var(
-            --mod-splitview-handle-background-color-focus,
-            var(--spectrum-splitview-handle-background-color-focus)
-        )
-    );
+    background-color: var(--highcontrast-splitview-handle-background-color-focus, var(--mod-splitview-handle-background-color-focus, var(--spectrum-splitview-handle-background-color-focus)));
     outline: none;
 }
 
 :host([resizable]) #splitter:focus-visible #gripper {
-    border-color: var(
-        --highcontrast-splitview-handle-background-color-focus,
-        var(
-            --mod-splitview-handle-background-color-focus,
-            var(--spectrum-splitview-handle-background-color-focus)
-        )
-    );
-    box-shadow: 0 0 0 1px
-        var(
-            --highcontrast-splitview-handle-background-color-focus,
-            var(
-                --mod-splitview-handle-background-color-focus,
-                var(--spectrum-splitview-handle-background-color-focus)
-            )
-        );
+    border-color: var(--highcontrast-splitview-handle-background-color-focus, var(--mod-splitview-handle-background-color-focus, var(--spectrum-splitview-handle-background-color-focus)));
+    box-shadow: 0 0 0 1px var(--highcontrast-splitview-handle-background-color-focus, var(--mod-splitview-handle-background-color-focus, var(--spectrum-splitview-handle-background-color-focus)));
 }
 
 :host([resizable]) #splitter:focus-visible #gripper:before {
-    background-color: var(
-        --highcontrast-splitview-handle-background-color-focus,
-        var(
-            --mod-splitview-handle-background-color-focus,
-            var(--spectrum-splitview-handle-background-color-focus)
-        )
-    );
+    background-color: var(--highcontrast-splitview-handle-background-color-focus, var(--mod-splitview-handle-background-color-focus, var(--spectrum-splitview-handle-background-color-focus)));
 }
 
 :host([vertical]) {
@@ -286,122 +136,44 @@ governing permissions and limitations under the License.
 
 :host([vertical]) ::slotted(*) {
     block-size: auto;
-    inline-size: var(
-        --mod-splitview-vertical-width,
-        var(--spectrum-splitview-vertical-width)
-    );
+    inline-size: var(--mod-splitview-vertical-width, var(--spectrum-splitview-vertical-width));
 }
 
 :host([vertical]) #gripper {
-    transform: translate(
-        calc(
-            var(
-                    --mod-splitview-vertical-gripper-width,
-                    var(--spectrum-splitview-vertical-gripper-width)
-                ) * -1
-        )
-    );
-    inline-size: var(
-        --mod-splitview-gripper-height,
-        var(--spectrum-splitview-gripper-height)
-    );
-    block-size: var(
-        --mod-splitview-gripper-width,
-        var(--spectrum-splitview-gripper-width)
-    );
-    border-block-width: var(
-        --mod-splitview-gripper-border-width-horizontal,
-        var(--spectrum-splitview-gripper-border-width-horizontal)
-    );
-    border-inline-width: var(
-        --mod-splitview-gripper-border-width-vertical,
-        var(--spectrum-splitview-gripper-border-width-vertical)
-    );
-    inset-block-start: calc(
-        (
-                var(
-                        --mod-splitview-gripper-width,
-                        var(--spectrum-splitview-gripper-width)
-                    ) +
-                    (
-                        2 *
-                            var(
-                                --mod-splitview-gripper-border-width-vertical,
-                                var(
-                                    --spectrum-splitview-gripper-border-width-vertical
-                                )
-                            )
-                    ) -
-                    var(
-                        --mod-splitview-gripper-width,
-                        var(--spectrum-splitview-gripper-width)
-                    )
-            ) / 2 * -1
-    );
-    inset-inline-start: var(
-        --mod-splitview-vertical-gripper-width,
-        var(--spectrum-splitview-vertical-gripper-width)
-    );
+    transform: translate(calc(var(--mod-splitview-vertical-gripper-width, var(--spectrum-splitview-vertical-gripper-width)) * -1));
+    inline-size: var(--mod-splitview-gripper-height, var(--spectrum-splitview-gripper-height));
+    block-size: var(--mod-splitview-gripper-width, var(--spectrum-splitview-gripper-width));
+    border-block-width: var(--mod-splitview-gripper-border-width-horizontal, var(--spectrum-splitview-gripper-border-width-horizontal));
+    border-inline-width: var(--mod-splitview-gripper-border-width-vertical, var(--spectrum-splitview-gripper-border-width-vertical));
+    inset-block-start: calc((var(--mod-splitview-gripper-width, var(--spectrum-splitview-gripper-width)) + (2 * var(--mod-splitview-gripper-border-width-vertical, var(--spectrum-splitview-gripper-border-width-vertical))) - var(--mod-splitview-gripper-width, var(--spectrum-splitview-gripper-width))) / 2 * -1);
+    inset-inline-start: var(--mod-splitview-vertical-gripper-width, var(--spectrum-splitview-vertical-gripper-width));
 }
 
 :host([vertical]) #splitter {
-    inline-size: var(
-        --mod-splitview-vertical-width,
-        var(--spectrum-splitview-vertical-width)
-    );
-    block-size: var(
-        --mod-splitview-handle-width,
-        var(--spectrum-splitview-handle-width)
-    );
+    inline-size: var(--mod-splitview-vertical-width, var(--spectrum-splitview-vertical-width));
+    block-size: var(--mod-splitview-handle-width, var(--spectrum-splitview-handle-width));
 }
 
 :host([vertical]) #splitter.is-collapsed-end #gripper,
 :host([vertical]) #splitter.is-collapsed-start #gripper {
-    inset-inline-start: var(
-        --mod-splitview-vertical-gripper-width,
-        var(--spectrum-splitview-vertical-gripper-width)
-    );
+    inset-inline-start: var(--mod-splitview-vertical-gripper-width, var(--spectrum-splitview-vertical-gripper-width));
 }
 
 :host([vertical]) #splitter.is-collapsed-end #gripper:before,
 :host([vertical]) #splitter.is-collapsed-start #gripper:before {
-    inline-size: var(
-        --mod-splitview-vertical-gripper-outer-width,
-        var(--spectrum-splitview-vertical-gripper-outer-width)
-    );
-    block-size: var(
-        --mod-splitview-handle-width,
-        var(--spectrum-splitview-handle-width)
-    );
-    inset-block-start: calc(
-        var(
-                --mod-splitview-vertical-gripper-width,
-                var(--spectrum-splitview-vertical-gripper-width)
-            ) -
-            var(
-                --mod-splitview-handle-width,
-                var(--spectrum-splitview-handle-width)
-            ) / 2
-    );
-    inset-inline-start: var(
-        --mod-splitview-vertical-gripper-reset,
-        var(--spectrum-splitview-vertical-gripper-reset)
-    );
+    inline-size: var(--mod-splitview-vertical-gripper-outer-width, var(--spectrum-splitview-vertical-gripper-outer-width));
+    block-size: var(--mod-splitview-handle-width, var(--spectrum-splitview-handle-width));
+    inset-block-start: calc(var(--mod-splitview-vertical-gripper-width, var(--spectrum-splitview-vertical-gripper-width)) - var(--mod-splitview-handle-width, var(--spectrum-splitview-handle-width)) / 2);
+    inset-inline-start: var(--mod-splitview-vertical-gripper-reset, var(--spectrum-splitview-vertical-gripper-reset));
 }
 
 :host([vertical]) #splitter.is-collapsed-start #gripper {
-    inset-block-start: var(
-        --mod-splitview-vertical-gripper-reset,
-        var(--spectrum-splitview-vertical-gripper-reset)
-    );
+    inset-block-start: var(--mod-splitview-vertical-gripper-reset, var(--spectrum-splitview-vertical-gripper-reset));
 }
 
 :host([vertical]) #splitter.is-collapsed-end #gripper {
     inset-block-start: auto;
-    inset-block-end: var(
-        --mod-splitview-vertical-gripper-reset,
-        var(--spectrum-splitview-vertical-gripper-reset)
-    );
+    inset-block-end: var(--mod-splitview-vertical-gripper-reset, var(--spectrum-splitview-vertical-gripper-reset));
 }
 
 @media (forced-colors: active) {

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -12,40 +12,16 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([dir]) {
-    min-block-size: var(
-        --mod-statuslight-height,
-        var(--spectrum-statuslight-height)
-    );
+    min-block-size: var(--mod-statuslight-height, var(--spectrum-statuslight-height));
     box-sizing: border-box;
-    font-size: var(
-        --mod-statuslight-font-size,
-        var(--spectrum-statuslight-font-size)
-    );
-    font-weight: var(
-        --mod-statuslight-font-weight,
-        var(--spectrum-statuslight-font-weight)
-    );
-    line-height: var(
-        --mod-statuslight-line-height,
-        var(--spectrum-statuslight-line-height)
-    );
-    color: var(
-        --highcontrast-statuslight-content-color-default,
-        var(
-            --mod-statuslight-content-color-default,
-            var(--spectrum-statuslight-content-color-default)
-        )
-    );
+    font-size: var(--mod-statuslight-font-size, var(--spectrum-statuslight-font-size));
+    font-weight: var(--mod-statuslight-font-weight, var(--spectrum-statuslight-font-weight));
+    line-height: var(--mod-statuslight-line-height, var(--spectrum-statuslight-line-height));
+    color: var(--highcontrast-statuslight-content-color-default, var(--mod-statuslight-content-color-default, var(--spectrum-statuslight-content-color-default)));
     flex-direction: row;
     align-items: flex-start;
-    padding-block-start: var(
-        --mod-statuslight-spacing-top-to-label,
-        var(--spectrum-statuslight-spacing-top-to-label)
-    );
-    padding-block-end: var(
-        --mod-statuslight-spacing-bottom-to-label,
-        var(--spectrum-statuslight-spacing-bottom-to-label)
-    );
+    padding-block-start: var(--mod-statuslight-spacing-top-to-label, var(--spectrum-statuslight-spacing-top-to-label));
+    padding-block-end: var(--mod-statuslight-spacing-bottom-to-label, var(--spectrum-statuslight-spacing-bottom-to-label));
     padding-inline: 0;
     display: flex;
 }
@@ -53,195 +29,105 @@ governing permissions and limitations under the License.
 :host(:lang(ja)),
 :host(:lang(ko)),
 :host(:lang(zh)) {
-    line-height: var(
-        --mod-statuslight-line-height-cjk,
-        var(--spectrum-statuslight-line-height-cjk)
-    );
+    line-height: var(--mod-statuslight-line-height-cjk, var(--spectrum-statuslight-line-height-cjk));
 }
 
 :host:before {
-    --spectrum-statuslight-spacing-computed-top-to-dot: calc(
-        var(
-                --mod-statuslight-spacing-top-to-dot,
-                var(--spectrum-statuslight-spacing-top-to-dot)
-            ) -
-            var(
-                --mod-statuslight-spacing-top-to-label,
-                var(--spectrum-statuslight-spacing-top-to-label)
-            )
-    );
+    --spectrum-statuslight-spacing-computed-top-to-dot: calc(var(--mod-statuslight-spacing-top-to-dot, var(--spectrum-statuslight-spacing-top-to-dot)) - var(--mod-statuslight-spacing-top-to-label, var(--spectrum-statuslight-spacing-top-to-label)));
     content: '';
-    inline-size: var(
-        --mod-statuslight-dot-size,
-        var(--spectrum-statuslight-dot-size)
-    );
-    block-size: var(
-        --mod-statuslight-dot-size,
-        var(--spectrum-statuslight-dot-size)
-    );
-    border-radius: var(
-        --mod-statuslight-corner-radius,
-        var(--spectrum-statuslight-corner-radius)
-    );
+    inline-size: var(--mod-statuslight-dot-size, var(--spectrum-statuslight-dot-size));
+    block-size: var(--mod-statuslight-dot-size, var(--spectrum-statuslight-dot-size));
+    border-radius: var(--mod-statuslight-corner-radius, var(--spectrum-statuslight-corner-radius));
     flex-grow: 0;
     flex-shrink: 0;
     margin-block-start: var(--spectrum-statuslight-spacing-computed-top-to-dot);
-    margin-inline-end: var(
-        --mod-statuslight-spacing-dot-to-label,
-        var(--spectrum-statuslight-spacing-dot-to-label)
-    );
+    margin-inline-end: var(--mod-statuslight-spacing-dot-to-label, var(--spectrum-statuslight-spacing-dot-to-label));
     display: inline-block;
 }
 
 :host([variant='neutral']) {
-    color: var(
-        --highcontrast-statuslight-subdued-content-color-default,
-        var(
-            --mod-statuslight-subdued-content-color-default,
-            var(--spectrum-statuslight-subdued-content-color-default)
-        )
-    );
+    color: var(--highcontrast-statuslight-subdued-content-color-default, var(--mod-statuslight-subdued-content-color-default, var(--spectrum-statuslight-subdued-content-color-default)));
     font-style: italic;
 }
 
 :host([variant='neutral']):before {
-    background-color: var(
-        --mod-statuslight-semantic-neutral-color,
-        var(--spectrum-statuslight-semantic-neutral-color)
-    );
+    background-color: var(--mod-statuslight-semantic-neutral-color, var(--spectrum-statuslight-semantic-neutral-color));
 }
 
 .spectrum-StatusLight--accent:before {
-    background-color: var(
-        --mod-statuslight-semantic-accent-color,
-        var(--spectrum-statuslight-semantic-accent-color)
-    );
+    background-color: var(--mod-statuslight-semantic-accent-color, var(--spectrum-statuslight-semantic-accent-color));
 }
 
 :host([variant='info']):before {
-    background-color: var(
-        --mod-statuslight-semantic-info-color,
-        var(--spectrum-statuslight-semantic-info-color)
-    );
+    background-color: var(--mod-statuslight-semantic-info-color, var(--spectrum-statuslight-semantic-info-color));
 }
 
 :host([variant='negative']):before {
-    background-color: var(
-        --mod-statuslight-semantic-negative-color,
-        var(--spectrum-statuslight-semantic-negative-color)
-    );
+    background-color: var(--mod-statuslight-semantic-negative-color, var(--spectrum-statuslight-semantic-negative-color));
 }
 
 :host([variant='notice']):before {
-    background-color: var(
-        --mod-statuslight-semantic-notice-color,
-        var(--spectrum-statuslight-semantic-notice-color)
-    );
+    background-color: var(--mod-statuslight-semantic-notice-color, var(--spectrum-statuslight-semantic-notice-color));
 }
 
 :host([variant='positive']):before {
-    background-color: var(
-        --mod-statuslight-semantic-positive-color,
-        var(--spectrum-statuslight-semantic-positive-color)
-    );
+    background-color: var(--mod-statuslight-semantic-positive-color, var(--spectrum-statuslight-semantic-positive-color));
 }
 
 .spectrum-StatusLight--gray:before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-gray-color,
-        var(--spectrum-statuslight-nonsemantic-gray-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-gray-color, var(--spectrum-statuslight-nonsemantic-gray-color));
 }
 
 .spectrum-StatusLight--red:before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-red-color,
-        var(--spectrum-statuslight-nonsemantic-red-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-red-color, var(--spectrum-statuslight-nonsemantic-red-color));
 }
 
 .spectrum-StatusLight--orange:before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-orange-color,
-        var(--spectrum-statuslight-nonsemantic-orange-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-orange-color, var(--spectrum-statuslight-nonsemantic-orange-color));
 }
 
 :host([variant='yellow']):before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-yellow-color,
-        var(--spectrum-statuslight-nonsemantic-yellow-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-yellow-color, var(--spectrum-statuslight-nonsemantic-yellow-color));
 }
 
 :host([variant='chartreuse']):before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-chartreuse-color,
-        var(--spectrum-statuslight-nonsemantic-chartreuse-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-chartreuse-color, var(--spectrum-statuslight-nonsemantic-chartreuse-color));
 }
 
 :host([variant='celery']):before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-celery-color,
-        var(--spectrum-statuslight-nonsemantic-celery-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-celery-color, var(--spectrum-statuslight-nonsemantic-celery-color));
 }
 
 .spectrum-StatusLight--green:before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-green-color,
-        var(--spectrum-statuslight-nonsemantic-green-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-green-color, var(--spectrum-statuslight-nonsemantic-green-color));
 }
 
 :host([variant='seafoam']):before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-seafoam-color,
-        var(--spectrum-statuslight-nonsemantic-seafoam-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-seafoam-color, var(--spectrum-statuslight-nonsemantic-seafoam-color));
 }
 
 .spectrum-StatusLight--cyan:before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-cyan-color,
-        var(--spectrum-statuslight-nonsemantic-cyan-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-cyan-color, var(--spectrum-statuslight-nonsemantic-cyan-color));
 }
 
 .spectrum-StatusLight--blue:before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-blue-color,
-        var(--spectrum-statuslight-nonsemantic-blue-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-blue-color, var(--spectrum-statuslight-nonsemantic-blue-color));
 }
 
 :host([variant='indigo']):before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-indigo-color,
-        var(--spectrum-statuslight-nonsemantic-indigo-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-indigo-color, var(--spectrum-statuslight-nonsemantic-indigo-color));
 }
 
 :host([variant='purple']):before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-purple-color,
-        var(--spectrum-statuslight-nonsemantic-purple-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-purple-color, var(--spectrum-statuslight-nonsemantic-purple-color));
 }
 
 :host([variant='fuchsia']):before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-fuchsia-color,
-        var(--spectrum-statuslight-nonsemantic-fuchsia-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-fuchsia-color, var(--spectrum-statuslight-nonsemantic-fuchsia-color));
 }
 
 :host([variant='magenta']):before {
-    background-color: var(
-        --mod-statuslight-nonsemantic-magenta-color,
-        var(--spectrum-statuslight-nonsemantic-magenta-color)
-    );
+    background-color: var(--mod-statuslight-nonsemantic-magenta-color, var(--spectrum-statuslight-nonsemantic-magenta-color));
 }
 
 @media (forced-colors: active) {
@@ -253,10 +139,6 @@ governing permissions and limitations under the License.
 
     :host:before {
         forced-color-adjust: none;
-        border: var(
-                --mod-statuslight-border-width,
-                var(--spectrum-statuslight-border-width)
-            )
-            solid ButtonText;
+        border: var(--mod-statuslight-border-width, var(--spectrum-statuslight-border-width)) solid ButtonText;
     }
 }

--- a/packages/swatch/src/spectrum-swatch-group.css
+++ b/packages/swatch/src/spectrum-swatch-group.css
@@ -14,24 +14,15 @@ governing permissions and limitations under the License.
 :host {
     justify-content: flex-start;
     align-items: flex-start;
-    gap: var(
-        --mod-swatchgroup-spacing-regular,
-        var(--spectrum-swatchgroup-spacing-regular)
-    );
+    gap: var(--mod-swatchgroup-spacing-regular, var(--spectrum-swatchgroup-spacing-regular));
     flex-flow: wrap;
     display: inline-flex;
 }
 
 :host([density='compact']) {
-    gap: var(
-        --mod-swatchgroup-spacing-compact,
-        var(--spectrum-swatchgroup-spacing-compact)
-    );
+    gap: var(--mod-swatchgroup-spacing-compact, var(--spectrum-swatchgroup-spacing-compact));
 }
 
 :host([density='spacious']) {
-    gap: var(
-        --mod-swatchgroup-spacing-spacious,
-        var(--spectrum-swatchgroup-spacing-spacious)
-    );
+    gap: var(--mod-swatchgroup-spacing-spacious, var(--spectrum-swatchgroup-spacing-spacious));
 }

--- a/packages/swatch/src/spectrum-swatch.css
+++ b/packages/swatch/src/spectrum-swatch.css
@@ -44,88 +44,25 @@ governing permissions and limitations under the License.
 }
 
 .disabledIcon {
-    inline-size: var(
-        --mod-swatch-disabled-icon-size,
-        var(--spectrum-swatch-disabled-icon-size)
-    );
-    block-size: var(
-        --mod-swatch-disabled-icon-size,
-        var(--spectrum-swatch-disabled-icon-size)
-    );
+    inline-size: var(--mod-swatch-disabled-icon-size, var(--spectrum-swatch-disabled-icon-size));
+    block-size: var(--mod-swatch-disabled-icon-size, var(--spectrum-swatch-disabled-icon-size));
 }
 
 :host,
 :host:before {
-    border-radius: var(
-        --mod-swatch-border-radius,
-        var(--spectrum-swatch-border-radius)
-    );
+    border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
 }
 
 :host([selected]) {
-    background-color: var(
-        --highcontrast-swatch-background-color-selected,
-        var(
-            --mod-swatch-inner-border-color-selected,
-            var(--spectrum-swatch-inner-border-color-selected)
-        )
-    );
+    background-color: var(--highcontrast-swatch-background-color-selected, var(--mod-swatch-inner-border-color-selected, var(--spectrum-swatch-inner-border-color-selected)));
 }
 
 :host([selected]) .fill {
     clip-path: polygon(
-        calc(
-                var(
-                        --mod-swatch-border-thickness-selected,
-                        var(--spectrum-swatch-border-thickness-selected)
-                    ) * 2
-            )
-            calc(
-                var(
-                        --mod-swatch-border-thickness-selected,
-                        var(--spectrum-swatch-border-thickness-selected)
-                    ) * 2
-            ),
-        calc(
-                100% -
-                    var(
-                        --mod-swatch-border-thickness-selected,
-                        var(--spectrum-swatch-border-thickness-selected)
-                    ) * 2
-            )
-            calc(
-                var(
-                        --mod-swatch-border-thickness-selected,
-                        var(--spectrum-swatch-border-thickness-selected)
-                    ) * 2
-            ),
-        calc(
-                100% -
-                    var(
-                        --mod-swatch-border-thickness-selected,
-                        var(--spectrum-swatch-border-thickness-selected)
-                    ) * 2
-            )
-            calc(
-                100% -
-                    var(
-                        --mod-swatch-border-thickness-selected,
-                        var(--spectrum-swatch-border-thickness-selected)
-                    ) * 2
-            ),
-        calc(
-                var(
-                        --mod-swatch-border-thickness-selected,
-                        var(--spectrum-swatch-border-thickness-selected)
-                    ) * 2
-            )
-            calc(
-                100% -
-                    var(
-                        --mod-swatch-border-thickness-selected,
-                        var(--spectrum-swatch-border-thickness-selected)
-                    ) * 2
-            )
+        calc(var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2) calc(var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2),
+        calc(100% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2) calc(var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2),
+        calc(100% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2) calc(100% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2),
+        calc(var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2) calc(100% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2)
     );
     border-radius: 0;
 }
@@ -160,19 +97,10 @@ governing permissions and limitations under the License.
 }
 
 :host([nothing]) .fill:after {
-    inline-size: var(
-        --mod-swatch-slash-thickness,
-        var(--spectrum-swatch-slash-thickness)
-    );
+    inline-size: var(--mod-swatch-slash-thickness, var(--spectrum-swatch-slash-thickness));
     content: '';
     block-size: 200%;
-    background: var(
-        --highcontrast-swatch-fill-foreground-color,
-        var(
-            --mod-swatch-slash-icon-color,
-            var(--spectrum-swatch-slash-icon-color)
-        )
-    );
+    background: var(--highcontrast-swatch-fill-foreground-color, var(--mod-swatch-slash-icon-color, var(--spectrum-swatch-slash-icon-color)));
     position: absolute;
     transform: rotate(-45deg);
 }
@@ -188,18 +116,9 @@ governing permissions and limitations under the License.
 
 :host:before {
     content: '';
-    border-width: var(
-        --mod-swatch-border-thickness-selected,
-        var(--spectrum-swatch-border-thickness-selected)
-    );
+    border-width: var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected));
     border-style: solid;
-    border-color: var(
-        --highcontrast-swatch-border-color-selected,
-        var(
-            --mod-swatch-border-color-selected,
-            var(--spectrum-swatch-border-color-selected)
-        )
-    );
+    border-color: var(--highcontrast-swatch-border-color-selected, var(--mod-swatch-border-color-selected, var(--spectrum-swatch-border-color-selected)));
     opacity: 0;
     pointer-events: none;
     position: absolute;
@@ -208,35 +127,13 @@ governing permissions and limitations under the License.
 
 :host:after {
     content: '';
-    inset: calc(
-        var(
-                --mod-swatch-focus-indicator-gap,
-                var(--spectrum-swatch-focus-indicator-gap)
-            ) * -2
-    );
+    inset: calc(var(--mod-swatch-focus-indicator-gap, var(--spectrum-swatch-focus-indicator-gap)) * -2);
     opacity: 0;
-    border-width: var(
-        --mod-swatch-focus-indicator-thickness,
-        var(--spectrum-swatch-focus-indicator-thickness)
-    );
+    border-width: var(--mod-swatch-focus-indicator-thickness, var(--spectrum-swatch-focus-indicator-thickness));
     border-style: solid;
-    border-color: var(
-        --highcontrast-swatch-focus-indicator-color,
-        var(
-            --mod-swatch-focus-indicator-color,
-            var(--spectrum-swatch-focus-indicator-color)
-        )
-    );
-    border-radius: var(
-        --mod-swatch-focus-indicator-border-radius,
-        var(--spectrum-swatch-focus-indicator-border-radius)
-    );
-    transition: opacity
-        var(
-            --mod-animation-duration-100,
-            var(--spectrum-animation-duration-100)
-        )
-        ease-in-out;
+    border-color: var(--highcontrast-swatch-focus-indicator-color, var(--mod-swatch-focus-indicator-color, var(--spectrum-swatch-focus-indicator-color)));
+    border-radius: var(--mod-swatch-focus-indicator-border-radius, var(--spectrum-swatch-focus-indicator-border-radius));
+    transition: opacity var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;
     position: absolute;
 }
 
@@ -248,10 +145,7 @@ governing permissions and limitations under the License.
     inline-size: 100%;
     block-size: 100%;
     box-sizing: border-box;
-    border-radius: var(
-        --mod-swatch-border-radius,
-        var(--spectrum-swatch-border-radius)
-    );
+    border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
     justify-content: center;
     align-items: center;
     display: flex;
@@ -262,19 +156,8 @@ governing permissions and limitations under the License.
 .fill:before {
     content: '';
     z-index: 0;
-    box-shadow: inset 0 0 0
-        var(
-            --mod-swatch-border-thickness,
-            var(--spectrum-swatch-border-thickness)
-        )
-        var(
-            --highcontrast-swatch-border-color,
-            var(--mod-swatch-border-color, var(--spectrum-swatch-border-color))
-        );
-    border-radius: var(
-        --mod-swatch-border-radius,
-        var(--spectrum-swatch-border-radius)
-    );
+    box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color, var(--spectrum-swatch-border-color)));
+    border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
     position: absolute;
     inset: 0;
 }
@@ -290,18 +173,7 @@ governing permissions and limitations under the License.
 }
 
 :host([border='light']) .fill:before {
-    box-shadow: inset 0 0 0
-        var(
-            --mod-swatch-border-thickness,
-            var(--spectrum-swatch-border-thickness)
-        )
-        var(
-            --highcontrast-swatch-border-color-light,
-            var(
-                --mod-swatch-border-color-light,
-                var(--spectrum-swatch-border-color-light)
-            )
-        );
+    box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color-light, var(--mod-swatch-border-color-light, var(--spectrum-swatch-border-color-light)));
 }
 
 .mixedValueIcon {
@@ -314,39 +186,18 @@ governing permissions and limitations under the License.
 .disabledIcon {
     z-index: 1;
     pointer-events: none;
-    color: var(
-        --highcontrast-swatch-disabled-icon-color,
-        var(
-            --mod-swatch-disabled-icon-color,
-            var(--spectrum-swatch-disabled-icon-color)
-        )
-    );
-    stroke: var(
-        --highcontrast-swatch-disabled-icon-color,
-        var(
-            --mod-swatch-disabled-icon-color,
-            var(--spectrum-swatch-disabled-icon-color)
-        )
-    );
+    color: var(--highcontrast-swatch-disabled-icon-color, var(--mod-swatch-disabled-icon-color, var(--spectrum-swatch-disabled-icon-color)));
+    stroke: var(--highcontrast-swatch-disabled-icon-color, var(--mod-swatch-disabled-icon-color, var(--spectrum-swatch-disabled-icon-color)));
     display: none;
     position: relative;
 }
 
 .disabledIcon path:first-child {
-    fill: var(
-        --highcontrast-swatch-disabled-icon-color,
-        var(
-            --mod-swatch-disabled-icon-color,
-            var(--spectrum-swatch-disabled-icon-color)
-        )
-    );
+    fill: var(--highcontrast-swatch-disabled-icon-color, var(--mod-swatch-disabled-icon-color, var(--spectrum-swatch-disabled-icon-color)));
 }
 
 .disabledIcon path:last-child {
-    fill: var(
-        --mod-swatch-icon-border-color,
-        var(--spectrum-swatch-icon-border-color)
-    );
+    fill: var(--mod-swatch-icon-border-color, var(--spectrum-swatch-icon-border-color));
 }
 
 :host([shape='rectangle']) {
@@ -374,16 +225,7 @@ governing permissions and limitations under the License.
 }
 
 :host([rounding='full'][selected]:not([shape='rectangle'])) .fill {
-    clip-path: circle(
-        calc(
-                50% -
-                    var(
-                        --mod-swatch-border-thickness-selected,
-                        var(--spectrum-swatch-border-thickness-selected)
-                    ) * 2
-            )
-            at 50% 50%
-    );
+    clip-path: circle(calc(50% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2) at 50% 50%);
 }
 
 ::slotted([slot='image']) {
@@ -391,16 +233,6 @@ governing permissions and limitations under the License.
     inline-size: 100%;
     block-size: 100%;
     transition:
-        width
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-in-out,
-        height
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-in-out;
+        width var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out,
+        height var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;
 }

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -12,10 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-switch-focus-indicator-thickness: var(
-        --mod-focus-indicator-thickness,
-        var(--spectrum-focus-indicator-thickness)
-    );
+    --spectrum-switch-focus-indicator-thickness: var(--mod-focus-indicator-thickness, var(--spectrum-focus-indicator-thickness));
     min-block-size: var(--mod-switch-height, var(--spectrum-switch-min-height));
     max-inline-size: 100%;
     vertical-align: top;
@@ -39,28 +36,12 @@ governing permissions and limitations under the License.
 }
 
 :host([checked]) #input + #switch:before {
-    transform: translateX(
-        calc(
-            var(
-                    --mod-switch-control-width,
-                    var(--spectrum-switch-control-width)
-                ) - 100%
-        )
-    );
+    transform: translateX(calc(var(--mod-switch-control-width, var(--spectrum-switch-control-width)) - 100%));
 }
 
 :host([checked]) #input + #switch:dir(rtl):before,
 :host([dir='rtl'][checked]) #input + #switch:before {
-    transform: translateX(
-        calc(
-            (
-                    var(
-                            --mod-switch-control-width,
-                            var(--spectrum-switch-control-width)
-                        ) - 100%
-                ) * -1
-        )
-    );
+    transform: translateX(calc((var(--mod-switch-control-width, var(--spectrum-switch-control-width)) - 100%) * -1));
 }
 
 :host([disabled]) #input,
@@ -69,77 +50,29 @@ governing permissions and limitations under the License.
 }
 
 #input:focus-visible + #switch:after {
-    margin: calc(
-        var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -1
-    );
+    margin: calc(var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -1);
 }
 
 #label {
-    color: var(
-        --highcontrast-switch-label-color-default,
-        var(
-            --mod-switch-label-color-default,
-            var(--spectrum-switch-label-color-default)
-        )
-    );
-    margin-inline: var(
-        --mod-switch-control-label-spacing,
-        var(--spectrum-switch-control-label-spacing)
-    );
+    color: var(--highcontrast-switch-label-color-default, var(--mod-switch-label-color-default, var(--spectrum-switch-label-color-default)));
+    margin-inline: var(--mod-switch-control-label-spacing, var(--spectrum-switch-control-label-spacing));
     font-size: var(--mod-switch-font-size, var(--spectrum-switch-font-size));
     line-height: var(--mod-line-height-100, var(--spectrum-line-height-100));
-    transition: color
-        var(
-            --mod-animation-duration-200,
-            var(--spectrum-animation-duration-200)
-        )
-        ease-in-out;
-    margin-block-start: var(
-        --mod-switch-spacing-top-to-label,
-        var(--spectrum-switch-spacing-top-to-label)
-    );
+    transition: color var(--mod-animation-duration-200, var(--spectrum-animation-duration-200)) ease-in-out;
+    margin-block-start: var(--mod-switch-spacing-top-to-label, var(--spectrum-switch-spacing-top-to-label));
     margin-block-end: 0;
 }
 
 #switch {
     box-sizing: border-box;
-    inline-size: var(
-        --mod-switch-control-width,
-        var(--spectrum-switch-control-width)
-    );
-    margin-block: calc(
-        var(--mod-switch-height, var(--spectrum-switch-min-height)) -
-            var(
-                --mod-switch-control-height,
-                var(--spectrum-switch-control-height)
-            ) -
-            var(
-                --mod-switch-spacing-top-to-control,
-                var(--spectrum-switch-spacing-top-to-control)
-            )
-    );
+    inline-size: var(--mod-switch-control-width, var(--spectrum-switch-control-width));
+    margin-block: calc(var(--mod-switch-height, var(--spectrum-switch-min-height)) - var(--mod-switch-control-height, var(--spectrum-switch-control-height)) - var(--mod-switch-spacing-top-to-control, var(--spectrum-switch-spacing-top-to-control)));
     vertical-align: middle;
     transition:
-        background
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-in-out,
-        border
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-in-out;
-    block-size: var(
-        --mod-switch-control-height,
-        var(--spectrum-switch-control-height)
-    );
-    border-radius: calc(
-        var(--mod-switch-control-height, var(--spectrum-switch-control-height)) /
-            2
-    );
+        background var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out,
+        border var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;
+    block-size: var(--mod-switch-control-height, var(--spectrum-switch-control-height));
+    border-radius: calc(var(--mod-switch-control-height, var(--spectrum-switch-control-height)) / 2);
     flex-grow: 0;
     flex-shrink: 0;
     margin-inline: 0;
@@ -151,43 +84,14 @@ governing permissions and limitations under the License.
 #switch:before {
     box-sizing: border-box;
     transition:
-        background
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-in-out,
-        border
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-in-out,
-        transform
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-in-out,
-        box-shadow
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-in-out;
-    inline-size: var(
-        --mod-switch-control-height,
-        var(--spectrum-switch-control-height)
-    );
-    block-size: var(
-        --mod-switch-control-height,
-        var(--spectrum-switch-control-height)
-    );
+        background var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out,
+        border var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out,
+        transform var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out,
+        box-shadow var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-in-out;
+    inline-size: var(--mod-switch-control-height, var(--spectrum-switch-control-height));
+    block-size: var(--mod-switch-control-height, var(--spectrum-switch-control-height));
     border-width: var(--mod-border-width-200, var(--spectrum-border-width-200));
-    border-radius: calc(
-        var(--mod-switch-control-height, var(--spectrum-switch-control-height)) /
-            2
-    );
+    border-radius: calc(var(--mod-switch-control-height, var(--spectrum-switch-control-height)) / 2);
     border-style: solid;
 }
 
@@ -201,395 +105,160 @@ governing permissions and limitations under the License.
 }
 
 #switch:after {
-    border-radius: calc(
-        var(--mod-switch-control-height, var(--spectrum-switch-control-height)) /
-            2 +
-            var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) *
-            2
-    );
+    border-radius: calc(var(--mod-switch-control-height, var(--spectrum-switch-control-height)) / 2 + var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * 2);
     transition:
-        opacity
-            var(
-                --mod-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-out,
-        margin
-            var(
-                --spectrum-animation-duration-100,
-                var(--spectrum-animation-duration-100)
-            )
-            ease-out;
+        opacity var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out,
+        margin var(--spectrum-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out;
     margin: 0;
     inset-block-end: 0;
     inset-inline-end: 0;
 }
 
 #switch {
-    background-color: var(
-        --highcontrast-switch-background-color,
-        var(
-            --mod-switch-background-color,
-            var(--spectrum-switch-background-color)
-        )
-    );
+    background-color: var(--highcontrast-switch-background-color, var(--mod-switch-background-color, var(--spectrum-switch-background-color)));
 }
 
 #switch:before {
-    background-color: var(
-        --highcontrast-switch-handle-background-color,
-        var(
-            --mod-switch-handle-background-color,
-            var(--spectrum-switch-handle-background-color)
-        )
-    );
-    border-color: var(
-        --highcontrast-switch-handle-border-color-default,
-        var(
-            --mod-switch-handle-border-color-default,
-            var(--spectrum-switch-handle-border-color-default)
-        )
-    );
+    background-color: var(--highcontrast-switch-handle-background-color, var(--mod-switch-handle-background-color, var(--spectrum-switch-handle-background-color)));
+    border-color: var(--highcontrast-switch-handle-border-color-default, var(--mod-switch-handle-border-color-default, var(--spectrum-switch-handle-border-color-default)));
 }
 
 :host(:active) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-down,
-        var(
-            --mod-switch-handle-border-color-down,
-            var(--spectrum-switch-handle-border-color-down)
-        )
-    );
+    border-color: var(--highcontrast-switch-handle-border-color-down, var(--mod-switch-handle-border-color-down, var(--spectrum-switch-handle-border-color-down)));
 }
 
 :host(:active) #input ~ #label {
-    color: var(
-        --highcontrast-switch-label-color-down,
-        var(
-            --mod-switch-label-color-down,
-            var(--spectrum-switch-label-color-down)
-        )
-    );
+    color: var(--highcontrast-switch-label-color-down, var(--mod-switch-label-color-down, var(--spectrum-switch-label-color-down)));
 }
 
 :host(:active[checked]) #input:enabled + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-selected-down,
-        var(
-            --mod-switch-background-color-selected-down,
-            var(--spectrum-switch-background-color-selected-down)
-        )
-    );
+    background-color: var(--highcontrast-switch-background-color-selected-down, var(--mod-switch-background-color-selected-down, var(--spectrum-switch-background-color-selected-down)));
 }
 
 :host(:active[checked]) #input:enabled + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-selected-down,
-        var(
-            --mod-switch-handle-border-color-selected-down,
-            var(--spectrum-switch-handle-border-color-selected-down)
-        )
-    );
+    border-color: var(--highcontrast-switch-handle-border-color-selected-down, var(--mod-switch-handle-border-color-selected-down, var(--spectrum-switch-handle-border-color-selected-down)));
 }
 
 #input:focus-visible + #switch:after {
-    box-shadow: 0 0 0
-        var(
-            --mod-switch-focus-indicator-thickness,
-            var(
-                --mod-focus-indicator-thickness,
-                var(--spectrum-switch-focus-indicator-thickness)
-            )
-        )
-        var(
-            --highcontrast-switch-focus-indicator-color,
-            var(
-                --mod-switch-focus-indicator-color,
-                var(--spectrum-switch-focus-indicator-color)
-            )
-        );
+    box-shadow: 0 0 0 var(--mod-switch-focus-indicator-thickness, var(--mod-focus-indicator-thickness, var(--spectrum-switch-focus-indicator-thickness))) var(--highcontrast-switch-focus-indicator-color, var(--mod-switch-focus-indicator-color, var(--spectrum-switch-focus-indicator-color)));
 }
 
 #input:focus-visible + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-focus,
-        var(
-            --mod-switch-handle-border-color-focus,
-            var(--spectrum-switch-handle-border-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-switch-handle-border-color-focus, var(--mod-switch-handle-border-color-focus, var(--spectrum-switch-handle-border-color-focus)));
 }
 
 :host([checked]) #input:focus-visible + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-selected-focus,
-        var(
-            --mod-switch-background-color-selected-focus,
-            var(--spectrum-switch-background-color-selected-focus)
-        )
-    );
+    background-color: var(--highcontrast-switch-background-color-selected-focus, var(--mod-switch-background-color-selected-focus, var(--spectrum-switch-background-color-selected-focus)));
 }
 
 :host([checked]) #input:focus-visible + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-selected-focus,
-        var(
-            --mod-switch-handle-border-color-selected-focus,
-            var(--spectrum-switch-handle-border-color-selected-focus)
-        )
-    );
+    border-color: var(--highcontrast-switch-handle-border-color-selected-focus, var(--mod-switch-handle-border-color-selected-focus, var(--spectrum-switch-handle-border-color-selected-focus)));
 }
 
 #input:focus-visible ~ #label {
-    color: var(
-        --highcontrast-switch-label-color-focus,
-        var(
-            --mod-switch-label-color-focus,
-            var(--spectrum-switch-label-color-focus)
-        )
-    );
+    color: var(--highcontrast-switch-label-color-focus, var(--mod-switch-label-color-focus, var(--spectrum-switch-label-color-focus)));
 }
 
 @media (hover: hover) {
     :host(:hover) #input + #switch:before {
-        border-color: var(
-            --highcontrast-switch-handle-border-color-hover,
-            var(
-                --mod-switch-handle-border-color-hover,
-                var(--spectrum-switch-handle-border-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-switch-handle-border-color-hover, var(--mod-switch-handle-border-color-hover, var(--spectrum-switch-handle-border-color-hover)));
         box-shadow: none;
     }
 
     :host(:hover) #input ~ #label {
-        color: var(
-            --highcontrast-switch-label-color-hover,
-            var(
-                --mod-switch-label-color-hover,
-                var(--spectrum-switch-label-color-hover)
-            )
-        );
+        color: var(--highcontrast-switch-label-color-hover, var(--mod-switch-label-color-hover, var(--spectrum-switch-label-color-hover)));
     }
 
     :host([checked]:hover) #input:enabled + #switch {
-        background-color: var(
-            --highcontrast-switch-background-color-selected-hover,
-            var(
-                --mod-switch-background-color-selected-hover,
-                var(--spectrum-switch-background-color-selected-hover)
-            )
-        );
+        background-color: var(--highcontrast-switch-background-color-selected-hover, var(--mod-switch-background-color-selected-hover, var(--spectrum-switch-background-color-selected-hover)));
     }
 
     :host([checked]:hover) #input:enabled + #switch:before {
-        border-color: var(
-            --highcontrast-switch-handle-border-color-selected-hover,
-            var(
-                --mod-switch-handle-border-color-selected-hover,
-                var(--spectrum-switch-handle-border-color-selected-hover)
-            )
-        );
+        border-color: var(--highcontrast-switch-handle-border-color-selected-hover, var(--mod-switch-handle-border-color-selected-hover, var(--spectrum-switch-handle-border-color-selected-hover)));
     }
 
     :host([disabled]:hover) #input + #switch,
     :host([disabled]:hover) #input + #switch {
-        background-color: var(
-            --highcontrast-switch-background-color-disabled,
-            var(
-                --mod-switch-background-color-disabled,
-                var(--spectrum-switch-background-color-disabled)
-            )
-        );
+        background-color: var(--highcontrast-switch-background-color-disabled, var(--mod-switch-background-color-disabled, var(--spectrum-switch-background-color-disabled)));
     }
 
     :host([disabled]:hover) #input + #switch:before,
     :host([disabled]:hover) #input + #switch:before {
-        border-color: var(
-            --highcontrast-switch-handle-border-color-disabled,
-            var(
-                --mod-switch-handle-border-color-disabled,
-                var(--spectrum-switch-handle-border-color-disabled)
-            )
-        );
+        border-color: var(--highcontrast-switch-handle-border-color-disabled, var(--mod-switch-handle-border-color-disabled, var(--spectrum-switch-handle-border-color-disabled)));
     }
 
     :host([disabled]:hover) #input ~ #label,
     :host([disabled]:hover) #input ~ #label {
-        color: var(
-            --highcontrast-switch-label-color-disabled,
-            var(
-                --mod-switch-label-color-disabled,
-                var(--spectrum-switch-label-color-disabled)
-            )
-        );
+        color: var(--highcontrast-switch-label-color-disabled, var(--mod-switch-label-color-disabled, var(--spectrum-switch-label-color-disabled)));
     }
 
     :host([disabled][checked]:hover) #input + #switch,
     :host([disabled][checked]:hover) #input + #switch {
-        background-color: var(
-            --highcontrast-switch-background-color-selected-disabled,
-            var(
-                --mod-switch-background-color-selected-disabled,
-                var(--spectrum-switch-background-color-selected-disabled)
-            )
-        );
+        background-color: var(--highcontrast-switch-background-color-selected-disabled, var(--mod-switch-background-color-selected-disabled, var(--spectrum-switch-background-color-selected-disabled)));
     }
 
     :host([disabled][checked]:hover) #input + #switch:before,
     :host([disabled][checked]:hover) #input + #switch:before {
-        border-color: var(
-            --highcontrast-switch-handle-border-color-disabled,
-            var(
-                --mod-switch-handle-border-color-disabled,
-                var(--spectrum-switch-handle-border-color-disabled)
-            )
-        );
+        border-color: var(--highcontrast-switch-handle-border-color-disabled, var(--mod-switch-handle-border-color-disabled, var(--spectrum-switch-handle-border-color-disabled)));
     }
 
     :host([disabled][checked]:hover) #input ~ #label,
     :host([disabled][checked]:hover) #input ~ #label {
-        color: var(
-            --highcontrast-switch-label-color-disabled,
-            var(
-                --mod-switch-label-color-disabled,
-                var(--spectrum-switch-label-color-disabled)
-            )
-        );
+        color: var(--highcontrast-switch-label-color-disabled, var(--mod-switch-label-color-disabled, var(--spectrum-switch-label-color-disabled)));
     }
 
     :host(:hover) #input:focus-visible + #switch:after {
-        box-shadow: 0 0 0
-            var(
-                --mod-switch-focus-indicator-thickness,
-                var(
-                    --mod-focus-indicator-thickness,
-                    var(--spectrum-switch-focus-indicator-thickness)
-                )
-            )
-            var(
-                --highcontrast-switch-focus-indicator-color,
-                var(
-                    --mod-switch-focus-indicator-color,
-                    var(--spectrum-switch-focus-indicator-color)
-                )
-            );
+        box-shadow: 0 0 0 var(--mod-switch-focus-indicator-thickness, var(--mod-focus-indicator-thickness, var(--spectrum-switch-focus-indicator-thickness))) var(--highcontrast-switch-focus-indicator-color, var(--mod-switch-focus-indicator-color, var(--spectrum-switch-focus-indicator-color)));
     }
 
     :host(:hover) #input:focus-visible + #switch:before {
-        border-color: var(
-            --highcontrast-switch-handle-border-color-focus,
-            var(
-                --mod-switch-handle-border-color-focus,
-                var(--spectrum-switch-handle-border-color-focus)
-            )
-        );
+        border-color: var(--highcontrast-switch-handle-border-color-focus, var(--mod-switch-handle-border-color-focus, var(--spectrum-switch-handle-border-color-focus)));
     }
 
     :host([checked]:hover) #input:focus-visible + #switch {
-        background-color: var(
-            --highcontrast-switch-background-color-selected-focus,
-            var(
-                --mod-switch-background-color-selected-focus,
-                var(--spectrum-switch-background-color-selected-focus)
-            )
-        );
+        background-color: var(--highcontrast-switch-background-color-selected-focus, var(--mod-switch-background-color-selected-focus, var(--spectrum-switch-background-color-selected-focus)));
     }
 
     :host([checked]:hover) #input:focus-visible + #switch:before {
-        border-color: var(
-            --highcontrast-switch-handle-border-color-selected-focus,
-            var(
-                --mod-switch-handle-border-color-selected-focus,
-                var(--spectrum-switch-handle-border-color-selected-focus)
-            )
-        );
+        border-color: var(--highcontrast-switch-handle-border-color-selected-focus, var(--mod-switch-handle-border-color-selected-focus, var(--spectrum-switch-handle-border-color-selected-focus)));
     }
 
     :host(:hover) #input:focus-visible ~ #label {
-        color: var(
-            --highcontrast-switch-label-color-focus,
-            var(
-                --mod-switch-label-color-focus,
-                var(--spectrum-switch-label-color-focus)
-            )
-        );
+        color: var(--highcontrast-switch-label-color-focus, var(--mod-switch-label-color-focus, var(--spectrum-switch-label-color-focus)));
     }
 }
 
 :host([checked]) #input + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-selected-default,
-        var(
-            --mod-switch-background-color-selected-default,
-            var(--spectrum-switch-background-color-selected-default)
-        )
-    );
+    background-color: var(--highcontrast-switch-background-color-selected-default, var(--mod-switch-background-color-selected-default, var(--spectrum-switch-background-color-selected-default)));
 }
 
 :host([checked]) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-selected-default,
-        var(
-            --mod-switch-handle-border-color-selected-default,
-            var(--spectrum-switch-handle-border-color-selected-default)
-        )
-    );
+    border-color: var(--highcontrast-switch-handle-border-color-selected-default, var(--mod-switch-handle-border-color-selected-default, var(--spectrum-switch-handle-border-color-selected-default)));
 }
 
 :host([disabled]) #input + #switch,
 :host([disabled]) #input + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-disabled,
-        var(
-            --mod-switch-background-color-disabled,
-            var(--spectrum-switch-background-color-disabled)
-        )
-    );
+    background-color: var(--highcontrast-switch-background-color-disabled, var(--mod-switch-background-color-disabled, var(--spectrum-switch-background-color-disabled)));
 }
 
 :host([disabled]) #input + #switch:before,
 :host([disabled]) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-disabled,
-        var(
-            --mod-switch-handle-border-color-disabled,
-            var(--spectrum-switch-handle-border-color-disabled)
-        )
-    );
+    border-color: var(--highcontrast-switch-handle-border-color-disabled, var(--mod-switch-handle-border-color-disabled, var(--spectrum-switch-handle-border-color-disabled)));
 }
 
 :host([disabled][checked]) #input + #switch,
 :host([disabled][checked]) #input + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-selected-disabled,
-        var(
-            --mod-switch-background-color-selected-disabled,
-            var(--spectrum-switch-background-color-selected-disabled)
-        )
-    );
+    background-color: var(--highcontrast-switch-background-color-selected-disabled, var(--mod-switch-background-color-selected-disabled, var(--spectrum-switch-background-color-selected-disabled)));
 }
 
 :host([disabled][checked]) #input + #switch:before,
 :host([disabled][checked]) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-disabled,
-        var(
-            --mod-switch-handle-border-color-disabled,
-            var(--spectrum-switch-handle-border-color-disabled)
-        )
-    );
+    border-color: var(--highcontrast-switch-handle-border-color-disabled, var(--mod-switch-handle-border-color-disabled, var(--spectrum-switch-handle-border-color-disabled)));
 }
 
 :host([disabled]) #input ~ #label,
 :host([disabled]) #input ~ #label {
-    color: var(
-        --highcontrast-switch-label-color-disabled,
-        var(
-            --mod-switch-label-color-disabled,
-            var(--spectrum-switch-label-color-disabled)
-        )
-    );
+    color: var(--highcontrast-switch-label-color-disabled, var(--mod-switch-label-color-disabled, var(--spectrum-switch-label-color-disabled)));
 }
 
 @media (forced-colors: active) {

--- a/packages/table/src/spectrum-table-body.css
+++ b/packages/table/src/spectrum-table-body.css
@@ -12,28 +12,16 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    border-radius: var(
-        --mod-table-border-radius,
-        var(--spectrum-table-border-radius)
-    );
+    border-radius: var(--mod-table-border-radius, var(--spectrum-table-border-radius));
     border: none;
     position: relative;
 }
 
 :host([drop-target]) {
     --spectrum-table-border-color: transparent;
-    outline-width: var(
-        --mod-table-focus-indicator-thickness,
-        var(--spectrum-table-focus-indicator-thickness)
-    );
+    outline-width: var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness));
     outline-style: solid;
-    outline-color: var(
-        --highcontrast-table-focus-indicator-color,
-        var(
-            --mod-table-drop-zone-outline-color,
-            var(--spectrum-table-drop-zone-outline-color)
-        )
-    );
+    outline-color: var(--highcontrast-table-focus-indicator-color, var(--mod-table-drop-zone-outline-color, var(--spectrum-table-drop-zone-outline-color)));
 }
 
 :host {

--- a/packages/table/src/spectrum-table-cell.css
+++ b/packages/table/src/spectrum-table-cell.css
@@ -26,59 +26,21 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    border-block-start: var(
-            --mod-table-border-width,
-            var(--spectrum-table-border-width)
-        )
-        solid
-        var(
-            --highcontrast-table-divider-color,
-            var(--mod-table-divider-color, var(--spectrum-table-divider-color))
-        );
+    border-block-start: var(--mod-table-border-width, var(--spectrum-table-border-width)) solid var(--highcontrast-table-divider-color, var(--mod-table-divider-color, var(--spectrum-table-divider-color)));
 }
 
 :host {
     box-sizing: border-box;
-    font-size: var(
-        --mod-table-row-font-size,
-        var(--spectrum-table-row-font-size)
-    );
-    font-weight: var(
-        --mod-table-row-font-weight,
-        var(--spectrum-table-row-font-weight)
-    );
-    line-height: var(
-        --mod-table-row-line-height,
-        var(--spectrum-table-row-line-height)
-    );
-    vertical-align: var(
-        --mod-table-default-vertical-align,
-        var(--spectrum-table-default-vertical-align)
-    );
-    color: var(
-        --highcontrast-table-row-text-color,
-        var(--mod-table-row-text-color, var(--spectrum-table-row-text-color))
-    );
+    font-size: var(--mod-table-row-font-size, var(--spectrum-table-row-font-size));
+    font-weight: var(--mod-table-row-font-weight, var(--spectrum-table-row-font-weight));
+    line-height: var(--mod-table-row-line-height, var(--spectrum-table-row-line-height));
+    vertical-align: var(--mod-table-default-vertical-align, var(--spectrum-table-default-vertical-align));
+    color: var(--highcontrast-table-row-text-color, var(--mod-table-row-text-color, var(--spectrum-table-row-text-color)));
     background-color: var(--spectrum-table-cell-background-color);
-    block-size: var(
-        --mod-table-min-row-height,
-        var(--spectrum-table-min-row-height)
-    );
-    padding-block-start: calc(
-        var(--mod-table-row-top-to-text, var(--spectrum-table-row-top-to-text)) -
-            var(--mod-table-border-width, var(--spectrum-table-border-width))
-    );
-    padding-block-end: var(
-        --mod-table-row-bottom-to-text,
-        var(--spectrum-table-row-bottom-to-text)
-    );
-    padding-inline: calc(
-        var(--mod-table-edge-to-content, var(--spectrum-table-edge-to-content)) -
-            var(
-                --mod-table-outer-border-inline-width,
-                var(--spectrum-table-outer-border-inline-width)
-            )
-    );
+    block-size: var(--mod-table-min-row-height, var(--spectrum-table-min-row-height));
+    padding-block-start: calc(var(--mod-table-row-top-to-text, var(--spectrum-table-row-top-to-text)) - var(--mod-table-border-width, var(--spectrum-table-border-width)));
+    padding-block-end: var(--mod-table-row-bottom-to-text, var(--spectrum-table-row-bottom-to-text));
+    padding-inline: calc(var(--mod-table-edge-to-content, var(--spectrum-table-edge-to-content)) - var(--mod-table-outer-border-inline-width, var(--spectrum-table-outer-border-inline-width)));
 }
 
 :host {
@@ -87,45 +49,15 @@ governing permissions and limitations under the License.
 
 :host([focused]),
 :host(:focus-visible) {
-    outline-width: var(
-        --mod-table-focus-indicator-thickness,
-        var(--spectrum-table-focus-indicator-thickness)
-    );
+    outline-width: var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness));
     outline-style: solid;
-    outline-color: var(
-        --highcontrast-table-cell-focus-indicator-color,
-        var(
-            --highcontrast-table-focus-indicator-color,
-            var(
-                --mod-table-focus-indicator-color,
-                var(--spectrum-table-focus-indicator-color)
-            )
-        )
-    );
-    outline-offset: calc(
-        var(
-                --mod-table-focus-indicator-thickness,
-                var(--spectrum-table-focus-indicator-thickness)
-            ) * -1
-    );
-    outline-offset: calc(
-        var(
-                --mod-table-focus-indicator-thickness,
-                var(--spectrum-table-focus-indicator-thickness)
-            ) * -1 - var(--highcontrast-table-cell-focus-extra-offset, 0px)
-    );
+    outline-color: var(--highcontrast-table-cell-focus-indicator-color, var(--highcontrast-table-focus-indicator-color, var(--mod-table-focus-indicator-color, var(--spectrum-table-focus-indicator-color))));
+    outline-offset: calc(var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness)) * -1);
+    outline-offset: calc(var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness)) * -1 - var(--highcontrast-table-cell-focus-extra-offset, 0px));
 }
 
 .divider {
-    border-inline-end: var(
-            --mod-table-border-width,
-            var(--spectrum-table-border-width)
-        )
-        solid
-        var(
-            --highcontrast-table-divider-color,
-            var(--mod-table-divider-color, var(--spectrum-table-divider-color))
-        );
+    border-inline-end: var(--mod-table-border-width, var(--spectrum-table-border-width)) solid var(--highcontrast-table-divider-color, var(--mod-table-divider-color, var(--spectrum-table-divider-color)));
 }
 
 :host {
@@ -134,8 +66,5 @@ governing permissions and limitations under the License.
 
 .spectrum-Table-cell--collapsible {
     padding-block: 0;
-    padding-inline-start: calc(
-        var(--spectrum-table-row-tier, 0px) *
-            var(--spectrum-table-collapsible-tier-indent)
-    );
+    padding-inline-start: calc(var(--spectrum-table-row-tier, 0px) * var(--spectrum-table-collapsible-tier-indent));
 }

--- a/packages/table/src/spectrum-table-checkbox-cell.css
+++ b/packages/table/src/spectrum-table-checkbox-cell.css
@@ -18,70 +18,22 @@ governing permissions and limitations under the License.
 }
 
 :host([head-cell]) {
-    --spectrum-table-icon-color: var(
-        --highcontrast-table-icon-color,
-        var(
-            --mod-table-icon-color-default,
-            var(--spectrum-table-icon-color-default)
-        )
-    );
+    --spectrum-table-icon-color: var(--highcontrast-table-icon-color, var(--mod-table-icon-color-default, var(--spectrum-table-icon-color-default)));
     box-sizing: border-box;
     text-align: start;
-    vertical-align: var(
-        --mod-table-header-vertical-align,
-        var(--spectrum-table-header-vertical-align)
-    );
-    font-family: var(
-        --mod-table-header-font-family,
-        var(--spectrum-table-row-font-family)
-    );
-    font-size: var(
-        --mod-table-header-font-size,
-        var(--spectrum-table-row-font-size)
-    );
-    font-weight: var(
-        --mod-table-header-font-weight,
-        var(--spectrum-table-header-font-weight)
-    );
-    line-height: var(
-        --mod-table-header-line-height,
-        var(--spectrum-table-row-line-height)
-    );
+    vertical-align: var(--mod-table-header-vertical-align, var(--spectrum-table-header-vertical-align));
+    font-family: var(--mod-table-header-font-family, var(--spectrum-table-row-font-family));
+    font-size: var(--mod-table-header-font-size, var(--spectrum-table-row-font-size));
+    font-weight: var(--mod-table-header-font-weight, var(--spectrum-table-header-font-weight));
+    line-height: var(--mod-table-header-line-height, var(--spectrum-table-row-line-height));
     text-transform: none;
     text-transform: var(--mod-table-header-text-transform, none);
-    block-size: var(
-        --mod-table-min-header-height,
-        var(--spectrum-table-min-header-height)
-    );
-    padding-block: var(
-            --mod-table-header-top-to-text,
-            var(--spectrum-table-header-top-to-text)
-        )
-        var(
-            --mod-table-header-bottom-to-text,
-            var(--spectrum-table-header-bottom-to-text)
-        );
-    padding-inline: var(
-        --mod-table-cell-inline-space,
-        var(--spectrum-table-cell-inline-space)
-    );
-    color: var(
-        --mod-table-header-text-color,
-        var(--spectrum-table-header-text-color)
-    );
-    background-color: var(
-        --mod-table-header-background-color,
-        var(--spectrum-table-header-background-color)
-    );
-    transition: color
-        var(
-            --highcontrast-table-transition-duration,
-            var(
-                --mod-table-transition-duration,
-                var(--spectrum-table-transition-duration)
-            )
-        )
-        ease-in-out;
+    block-size: var(--mod-table-min-header-height, var(--spectrum-table-min-header-height));
+    padding-block: var(--mod-table-header-top-to-text, var(--spectrum-table-header-top-to-text)) var(--mod-table-header-bottom-to-text, var(--spectrum-table-header-bottom-to-text));
+    padding-inline: var(--mod-table-cell-inline-space, var(--spectrum-table-cell-inline-space));
+    color: var(--mod-table-header-text-color, var(--spectrum-table-header-text-color));
+    background-color: var(--mod-table-header-background-color, var(--spectrum-table-header-background-color));
+    transition: color var(--highcontrast-table-transition-duration, var(--mod-table-transition-duration, var(--spectrum-table-transition-duration))) ease-in-out;
     cursor: auto;
     cursor: var(--mod-table-cursor-header-default, initial);
     border-radius: 0;
@@ -89,59 +41,21 @@ governing permissions and limitations under the License.
 }
 
 :host(:not([head-cell])) {
-    border-block-start: var(
-            --mod-table-border-width,
-            var(--spectrum-table-border-width)
-        )
-        solid
-        var(
-            --highcontrast-table-divider-color,
-            var(--mod-table-divider-color, var(--spectrum-table-divider-color))
-        );
+    border-block-start: var(--mod-table-border-width, var(--spectrum-table-border-width)) solid var(--highcontrast-table-divider-color, var(--mod-table-divider-color, var(--spectrum-table-divider-color)));
 }
 
 :host(:not([head-cell])) {
     box-sizing: border-box;
-    font-size: var(
-        --mod-table-row-font-size,
-        var(--spectrum-table-row-font-size)
-    );
-    font-weight: var(
-        --mod-table-row-font-weight,
-        var(--spectrum-table-row-font-weight)
-    );
-    line-height: var(
-        --mod-table-row-line-height,
-        var(--spectrum-table-row-line-height)
-    );
-    vertical-align: var(
-        --mod-table-default-vertical-align,
-        var(--spectrum-table-default-vertical-align)
-    );
-    color: var(
-        --highcontrast-table-row-text-color,
-        var(--mod-table-row-text-color, var(--spectrum-table-row-text-color))
-    );
+    font-size: var(--mod-table-row-font-size, var(--spectrum-table-row-font-size));
+    font-weight: var(--mod-table-row-font-weight, var(--spectrum-table-row-font-weight));
+    line-height: var(--mod-table-row-line-height, var(--spectrum-table-row-line-height));
+    vertical-align: var(--mod-table-default-vertical-align, var(--spectrum-table-default-vertical-align));
+    color: var(--highcontrast-table-row-text-color, var(--mod-table-row-text-color, var(--spectrum-table-row-text-color)));
     background-color: var(--spectrum-table-cell-background-color);
-    block-size: var(
-        --mod-table-min-row-height,
-        var(--spectrum-table-min-row-height)
-    );
-    padding-block-start: calc(
-        var(--mod-table-row-top-to-text, var(--spectrum-table-row-top-to-text)) -
-            var(--mod-table-border-width, var(--spectrum-table-border-width))
-    );
-    padding-block-end: var(
-        --mod-table-row-bottom-to-text,
-        var(--spectrum-table-row-bottom-to-text)
-    );
-    padding-inline: calc(
-        var(--mod-table-edge-to-content, var(--spectrum-table-edge-to-content)) -
-            var(
-                --mod-table-outer-border-inline-width,
-                var(--spectrum-table-outer-border-inline-width)
-            )
-    );
+    block-size: var(--mod-table-min-row-height, var(--spectrum-table-min-row-height));
+    padding-block-start: calc(var(--mod-table-row-top-to-text, var(--spectrum-table-row-top-to-text)) - var(--mod-table-border-width, var(--spectrum-table-border-width)));
+    padding-block-end: var(--mod-table-row-bottom-to-text, var(--spectrum-table-row-bottom-to-text));
+    padding-inline: calc(var(--mod-table-edge-to-content, var(--spectrum-table-edge-to-content)) - var(--mod-table-outer-border-inline-width, var(--spectrum-table-outer-border-inline-width)));
 }
 
 :host(:not([head-cell])),
@@ -153,48 +67,17 @@ governing permissions and limitations under the License.
 :host(:not([head-cell]):focus-visible),
 :host([head-cell][focused]),
 :host([head-cell]:focus-visible) {
-    outline-width: var(
-        --mod-table-focus-indicator-thickness,
-        var(--spectrum-table-focus-indicator-thickness)
-    );
+    outline-width: var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness));
     outline-style: solid;
-    outline-color: var(
-        --highcontrast-table-cell-focus-indicator-color,
-        var(
-            --highcontrast-table-focus-indicator-color,
-            var(
-                --mod-table-focus-indicator-color,
-                var(--spectrum-table-focus-indicator-color)
-            )
-        )
-    );
-    outline-offset: calc(
-        var(
-                --mod-table-focus-indicator-thickness,
-                var(--spectrum-table-focus-indicator-thickness)
-            ) * -1
-    );
-    outline-offset: calc(
-        var(
-                --mod-table-focus-indicator-thickness,
-                var(--spectrum-table-focus-indicator-thickness)
-            ) * -1 - var(--highcontrast-table-cell-focus-extra-offset, 0px)
-    );
+    outline-color: var(--highcontrast-table-cell-focus-indicator-color, var(--highcontrast-table-focus-indicator-color, var(--mod-table-focus-indicator-color, var(--spectrum-table-focus-indicator-color))));
+    outline-offset: calc(var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness)) * -1);
+    outline-offset: calc(var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness)) * -1 - var(--highcontrast-table-cell-focus-extra-offset, 0px));
 }
 
 :host(:host) {
     inline-size: var(--spectrum-checkbox-control-size-small);
     padding-block: 0;
-    padding-inline-end: calc(
-        var(
-                --mod-table-checkbox-to-text,
-                var(--spectrum-table-checkbox-to-text)
-            ) -
-            var(
-                --mod-table-edge-to-content,
-                var(--spectrum-table-edge-to-content)
-            )
-    );
+    padding-inline-end: calc(var(--mod-table-checkbox-to-text, var(--spectrum-table-checkbox-to-text)) - var(--mod-table-edge-to-content, var(--spectrum-table-edge-to-content)));
 }
 
 :host(:host) sp-checkbox {
@@ -203,31 +86,13 @@ governing permissions and limitations under the License.
 }
 
 :host(:host:not([head-cell])) sp-checkbox {
-    margin-block-start: calc(
-        var(
-                --mod-table-row-checkbox-block-spacing,
-                var(--spectrum-table-row-checkbox-block-spacing)
-            ) -
-            var(--mod-table-border-width, var(--spectrum-table-border-width))
-    );
-    margin-block-end: var(
-        --mod-table-row-checkbox-block-spacing,
-        var(--spectrum-table-row-checkbox-block-spacing)
-    );
+    margin-block-start: calc(var(--mod-table-row-checkbox-block-spacing, var(--spectrum-table-row-checkbox-block-spacing)) - var(--mod-table-border-width, var(--spectrum-table-border-width)));
+    margin-block-end: var(--mod-table-row-checkbox-block-spacing, var(--spectrum-table-row-checkbox-block-spacing));
 }
 
 :host(:host[head-cell]) sp-checkbox {
-    margin-block-start: calc(
-        var(
-                --mod-table-header-checkbox-block-spacing,
-                var(--spectrum-table-header-checkbox-block-spacing)
-            ) -
-            var(--mod-table-border-width, var(--spectrum-table-border-width))
-    );
-    margin-block-end: var(
-        --mod-table-header-checkbox-block-spacing,
-        var(--spectrum-table-header-checkbox-block-spacing)
-    );
+    margin-block-start: calc(var(--mod-table-header-checkbox-block-spacing, var(--spectrum-table-header-checkbox-block-spacing)) - var(--mod-table-border-width, var(--spectrum-table-border-width)));
+    margin-block-end: var(--mod-table-header-checkbox-block-spacing, var(--spectrum-table-header-checkbox-block-spacing));
 }
 
 :host(:not([head-cell])),

--- a/packages/table/src/spectrum-table-head-cell.css
+++ b/packages/table/src/spectrum-table-head-cell.css
@@ -13,88 +13,29 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .sortedIcon {
     vertical-align: initial;
-    transition: transform
-        var(
-            --highcontrast-table-transition-duration,
-            var(
-                --mod-table-transition-duration,
-                var(--spectrum-table-transition-duration)
-            )
-        )
-        ease-in-out;
+    transition: transform var(--highcontrast-table-transition-duration, var(--mod-table-transition-duration, var(--spectrum-table-transition-duration))) ease-in-out;
     margin-inline-start: var(--mod-table-sort-icon-inline-start-spacing, 0);
-    margin-inline-end: var(
-        --mod-table-sort-icon-inline-end-spacing,
-        var(--mod-table-icon-to-text, var(--spectrum-table-icon-to-text))
-    );
+    margin-inline-end: var(--mod-table-sort-icon-inline-end-spacing, var(--mod-table-icon-to-text, var(--spectrum-table-icon-to-text)));
     display: none;
 }
 
 :host {
-    --spectrum-table-icon-color: var(
-        --highcontrast-table-icon-color,
-        var(
-            --mod-table-icon-color-default,
-            var(--spectrum-table-icon-color-default)
-        )
-    );
+    --spectrum-table-icon-color: var(--highcontrast-table-icon-color, var(--mod-table-icon-color-default, var(--spectrum-table-icon-color-default)));
     box-sizing: border-box;
     text-align: start;
-    vertical-align: var(
-        --mod-table-header-vertical-align,
-        var(--spectrum-table-header-vertical-align)
-    );
-    font-family: var(
-        --mod-table-header-font-family,
-        var(--spectrum-table-row-font-family)
-    );
-    font-size: var(
-        --mod-table-header-font-size,
-        var(--spectrum-table-row-font-size)
-    );
-    font-weight: var(
-        --mod-table-header-font-weight,
-        var(--spectrum-table-header-font-weight)
-    );
-    line-height: var(
-        --mod-table-header-line-height,
-        var(--spectrum-table-row-line-height)
-    );
+    vertical-align: var(--mod-table-header-vertical-align, var(--spectrum-table-header-vertical-align));
+    font-family: var(--mod-table-header-font-family, var(--spectrum-table-row-font-family));
+    font-size: var(--mod-table-header-font-size, var(--spectrum-table-row-font-size));
+    font-weight: var(--mod-table-header-font-weight, var(--spectrum-table-header-font-weight));
+    line-height: var(--mod-table-header-line-height, var(--spectrum-table-row-line-height));
     text-transform: none;
     text-transform: var(--mod-table-header-text-transform, none);
-    block-size: var(
-        --mod-table-min-header-height,
-        var(--spectrum-table-min-header-height)
-    );
-    padding-block: var(
-            --mod-table-header-top-to-text,
-            var(--spectrum-table-header-top-to-text)
-        )
-        var(
-            --mod-table-header-bottom-to-text,
-            var(--spectrum-table-header-bottom-to-text)
-        );
-    padding-inline: var(
-        --mod-table-cell-inline-space,
-        var(--spectrum-table-cell-inline-space)
-    );
-    color: var(
-        --mod-table-header-text-color,
-        var(--spectrum-table-header-text-color)
-    );
-    background-color: var(
-        --mod-table-header-background-color,
-        var(--spectrum-table-header-background-color)
-    );
-    transition: color
-        var(
-            --highcontrast-table-transition-duration,
-            var(
-                --mod-table-transition-duration,
-                var(--spectrum-table-transition-duration)
-            )
-        )
-        ease-in-out;
+    block-size: var(--mod-table-min-header-height, var(--spectrum-table-min-header-height));
+    padding-block: var(--mod-table-header-top-to-text, var(--spectrum-table-header-top-to-text)) var(--mod-table-header-bottom-to-text, var(--spectrum-table-header-bottom-to-text));
+    padding-inline: var(--mod-table-cell-inline-space, var(--spectrum-table-cell-inline-space));
+    color: var(--mod-table-header-text-color, var(--spectrum-table-header-text-color));
+    background-color: var(--mod-table-header-background-color, var(--spectrum-table-header-background-color));
+    transition: color var(--highcontrast-table-transition-duration, var(--mod-table-transition-duration, var(--spectrum-table-transition-duration))) ease-in-out;
     cursor: auto;
     cursor: var(--mod-table-cursor-header-default, initial);
     border-radius: 0;
@@ -112,34 +53,16 @@ governing permissions and limitations under the License.
 }
 
 :host([sortable][active]) {
-    --spectrum-table-icon-color: var(
-        --highcontrast-table-icon-color-focus,
-        var(
-            --mod-table-icon-color-active,
-            var(--spectrum-table-icon-color-active)
-        )
-    );
+    --spectrum-table-icon-color: var(--highcontrast-table-icon-color-focus, var(--mod-table-icon-color-active, var(--spectrum-table-icon-color-active)));
 }
 
 :host([sortable]:focus) {
-    --spectrum-table-icon-color: var(
-        --highcontrast-table-icon-color-focus,
-        var(
-            --mod-table-icon-color-focus,
-            var(--spectrum-table-icon-color-focus)
-        )
-    );
+    --spectrum-table-icon-color: var(--highcontrast-table-icon-color-focus, var(--mod-table-icon-color-focus, var(--spectrum-table-icon-color-focus)));
 }
 
 :host([sortable]) .is-keyboardFocused,
 :host([sortable]:focus-visible) {
-    --spectrum-table-icon-color: var(
-        --highcontrast-table-icon-color-focus,
-        var(
-            --mod-table-icon-color-key-focus,
-            var(--spectrum-table-icon-color-key-focus)
-        )
-    );
+    --spectrum-table-icon-color: var(--highcontrast-table-icon-color-focus, var(--mod-table-icon-color-key-focus, var(--spectrum-table-icon-color-key-focus)));
 }
 
 :host([sort-direction='asc']) .sortedIcon,
@@ -157,47 +80,16 @@ governing permissions and limitations under the License.
 
 :host([focused]),
 :host(:focus-visible) {
-    outline-width: var(
-        --mod-table-focus-indicator-thickness,
-        var(--spectrum-table-focus-indicator-thickness)
-    );
+    outline-width: var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness));
     outline-style: solid;
-    outline-color: var(
-        --highcontrast-table-cell-focus-indicator-color,
-        var(
-            --highcontrast-table-focus-indicator-color,
-            var(
-                --mod-table-focus-indicator-color,
-                var(--spectrum-table-focus-indicator-color)
-            )
-        )
-    );
-    outline-offset: calc(
-        var(
-                --mod-table-focus-indicator-thickness,
-                var(--spectrum-table-focus-indicator-thickness)
-            ) * -1
-    );
-    outline-offset: calc(
-        var(
-                --mod-table-focus-indicator-thickness,
-                var(--spectrum-table-focus-indicator-thickness)
-            ) * -1 - var(--highcontrast-table-cell-focus-extra-offset, 0px)
-    );
+    outline-color: var(--highcontrast-table-cell-focus-indicator-color, var(--highcontrast-table-focus-indicator-color, var(--mod-table-focus-indicator-color, var(--spectrum-table-focus-indicator-color))));
+    outline-offset: calc(var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness)) * -1);
+    outline-offset: calc(var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness)) * -1 - var(--highcontrast-table-cell-focus-extra-offset, 0px));
 }
 
 :host .spectrum-Table-checkboxCell .spectrum-Table-checkbox {
-    margin-block-start: calc(
-        var(
-                --mod-table-header-checkbox-block-spacing,
-                var(--spectrum-table-header-checkbox-block-spacing)
-            ) -
-            var(--mod-table-border-width, var(--spectrum-table-border-width))
-    );
-    margin-block-end: var(
-        --mod-table-header-checkbox-block-spacing,
-        var(--spectrum-table-header-checkbox-block-spacing)
-    );
+    margin-block-start: calc(var(--mod-table-header-checkbox-block-spacing, var(--spectrum-table-header-checkbox-block-spacing)) - var(--mod-table-border-width, var(--spectrum-table-border-width)));
+    margin-block-end: var(--mod-table-header-checkbox-block-spacing, var(--spectrum-table-header-checkbox-block-spacing));
 }
 
 :host {
@@ -205,35 +97,15 @@ governing permissions and limitations under the License.
 }
 
 :host .spectrum-Table-scroller {
-    border-block-end: var(
-            --mod-table-border-width,
-            var(--spectrum-table-border-width)
-        )
-        solid
-        var(
-            --highcontrast-table-border-color,
-            var(--mod-table-border-color, var(--spectrum-table-border-color))
-        );
+    border-block-end: var(--mod-table-border-width, var(--spectrum-table-border-width)) solid var(--highcontrast-table-border-color, var(--mod-table-border-color, var(--spectrum-table-border-color)));
 }
 
 @media (hover: hover) {
     :host([sortable]:hover) {
-        --spectrum-table-icon-color: var(
-            --highcontrast-table-icon-color-focus,
-            var(
-                --mod-table-icon-color-hover,
-                var(--spectrum-table-icon-color-hover)
-            )
-        );
+        --spectrum-table-icon-color: var(--highcontrast-table-icon-color-focus, var(--mod-table-icon-color-hover, var(--spectrum-table-icon-color-hover)));
     }
 
     :host([sortable]:focus):hover {
-        --spectrum-table-icon-color: var(
-            --highcontrast-table-icon-color-focus,
-            var(
-                --mod-table-icon-color-focus-hover,
-                var(--spectrum-table-icon-color-focus-hover)
-            )
-        );
+        --spectrum-table-icon-color: var(--highcontrast-table-icon-color-focus, var(--mod-table-icon-color-focus-hover, var(--spectrum-table-icon-color-focus-hover)));
     }
 }

--- a/packages/table/src/spectrum-table-row.css
+++ b/packages/table/src/spectrum-table-row.css
@@ -13,9 +13,7 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {
     :host([focused]) .spectrum-Table-checkbox .spectrum-Checkbox-box:before,
-    :host(:focus-visible)
-        .spectrum-Table-checkbox
-        .spectrum-Checkbox-box:before {
+    :host(:focus-visible) .spectrum-Table-checkbox .spectrum-Checkbox-box:before {
         outline: var(--highcontrast-table-row-text-color-hover) 1px solid;
     }
 
@@ -28,16 +26,11 @@ governing permissions and limitations under the License.
     :host([drop-target]) .spectrum-Table-body,
     :host([drop-target]),
     :host([selected]) {
-        --highcontrast-table-cell-focus-indicator-color: var(
-            --highcontrast-table-selected-row-text-color
-        );
+        --highcontrast-table-cell-focus-indicator-color: var(--highcontrast-table-selected-row-text-color);
         --highcontrast-table-cell-focus-extra-offset: 1px;
     }
 
-    :host([drop-target])
-        .spectrum-Table-body
-        .spectrum-Table-checkbox
-        .spectrum-Checkbox-box:before,
+    :host([drop-target]) .spectrum-Table-body .spectrum-Table-checkbox .spectrum-Checkbox-box:before,
     :host([drop-target]) .spectrum-Table-checkbox .spectrum-Checkbox-box:before,
     :host([selected]) .spectrum-Table-checkbox .spectrum-Checkbox-box:before {
         outline: var(--highcontrast-table-selected-row-text-color) 1px solid;
@@ -45,91 +38,39 @@ governing permissions and limitations under the License.
 }
 
 :host(:first-child) .spectrum-Table-body ::slotted(*) {
-    border-block-start: var(
-            --mod-table-border-width,
-            var(--spectrum-table-border-width)
-        )
-        solid
-        var(
-            --highcontrast-table-border-color,
-            var(--mod-table-border-color, var(--spectrum-table-border-color))
-        );
+    border-block-start: var(--mod-table-border-width, var(--spectrum-table-border-width)) solid var(--highcontrast-table-border-color, var(--mod-table-border-color, var(--spectrum-table-border-color)));
 }
 
 :host(:last-child) .spectrum-Table-body ::slotted(*) {
-    border-block-end: var(
-            --mod-table-border-width,
-            var(--spectrum-table-border-width)
-        )
-        solid
-        var(
-            --highcontrast-table-border-color,
-            var(--mod-table-border-color, var(--spectrum-table-border-color))
-        );
+    border-block-end: var(--mod-table-border-width, var(--spectrum-table-border-width)) solid var(--highcontrast-table-border-color, var(--mod-table-border-color, var(--spectrum-table-border-color)));
 }
 
 :host .spectrum-Table-body ::slotted(:first-child) {
-    border-inline-start: var(
-            --mod-table-outer-border-inline-width,
-            var(--spectrum-table-outer-border-inline-width)
-        )
-        solid
-        var(
-            --highcontrast-table-border-color,
-            var(--mod-table-border-color, var(--spectrum-table-border-color))
-        );
+    border-inline-start: var(--mod-table-outer-border-inline-width, var(--spectrum-table-outer-border-inline-width)) solid var(--highcontrast-table-border-color, var(--mod-table-border-color, var(--spectrum-table-border-color)));
 }
 
 :host .spectrum-Table-body ::slotted(:last-child) {
-    border-inline-end: var(
-            --mod-table-outer-border-inline-width,
-            var(--spectrum-table-outer-border-inline-width)
-        )
-        solid
-        var(
-            --highcontrast-table-border-color,
-            var(--mod-table-border-color, var(--spectrum-table-border-color))
-        );
+    border-inline-end: var(--mod-table-outer-border-inline-width, var(--spectrum-table-outer-border-inline-width)) solid var(--highcontrast-table-border-color, var(--mod-table-border-color, var(--spectrum-table-border-color)));
 }
 
 :host(:first-child) ::slotted(:first-child) {
-    border-start-start-radius: var(
-        --mod-table-border-radius,
-        var(--spectrum-table-border-radius)
-    );
+    border-start-start-radius: var(--mod-table-border-radius, var(--spectrum-table-border-radius));
 }
 
 :host(:first-child) ::slotted(:last-child) {
-    border-start-end-radius: var(
-        --mod-table-border-radius,
-        var(--spectrum-table-border-radius)
-    );
+    border-start-end-radius: var(--mod-table-border-radius, var(--spectrum-table-border-radius));
 }
 
 :host(:last-child) ::slotted(:first-child) {
-    border-end-start-radius: var(
-        --mod-table-border-radius,
-        var(--spectrum-table-border-radius)
-    );
+    border-end-start-radius: var(--mod-table-border-radius, var(--spectrum-table-border-radius));
 }
 
 :host(:last-child) ::slotted(:last-child) {
-    border-end-end-radius: var(
-        --mod-table-border-radius,
-        var(--spectrum-table-border-radius)
-    );
+    border-end-end-radius: var(--mod-table-border-radius, var(--spectrum-table-border-radius));
 }
 
 :host {
-    transition: background-color
-        var(
-            --highcontrast-table-transition-duration,
-            var(
-                --mod-table-transition-duration,
-                var(--spectrum-table-transition-duration)
-            )
-        )
-        ease-in-out;
+    transition: background-color var(--highcontrast-table-transition-duration, var(--mod-table-transition-duration, var(--spectrum-table-transition-duration))) ease-in-out;
     cursor: pointer;
     cursor: var(--mod-table-cursor-row-default, pointer);
     border-block-start: none;
@@ -137,25 +78,13 @@ governing permissions and limitations under the License.
 }
 
 :host(:first-child) {
-    border-start-start-radius: var(
-        --mod-table-border-radius,
-        var(--spectrum-table-border-radius)
-    );
-    border-start-end-radius: var(
-        --mod-table-border-radius,
-        var(--spectrum-table-border-radius)
-    );
+    border-start-start-radius: var(--mod-table-border-radius, var(--spectrum-table-border-radius));
+    border-start-end-radius: var(--mod-table-border-radius, var(--spectrum-table-border-radius));
 }
 
 :host(:last-child) {
-    border-end-end-radius: var(
-        --mod-table-border-radius,
-        var(--spectrum-table-border-radius)
-    );
-    border-end-start-radius: var(
-        --mod-table-border-radius,
-        var(--spectrum-table-border-radius)
-    );
+    border-end-end-radius: var(--mod-table-border-radius, var(--spectrum-table-border-radius));
+    border-end-start-radius: var(--mod-table-border-radius, var(--spectrum-table-border-radius));
 }
 
 :host(:focus) {
@@ -164,215 +93,79 @@ governing permissions and limitations under the License.
 
 :host([focused]),
 :host(:focus-visible) {
-    --highcontrast-table-row-text-color: var(
-        --highcontrast-table-row-text-color-hover
-    );
-    --highcontrast-table-icon-color: var(
-        --highcontrast-table-row-text-color-hover
-    );
-    --spectrum-table-cell-background-color: var(
-        --highcontrast-table-row-background-color-hover,
-        var(
-            --mod-table-row-background-color-hover,
-            var(--spectrum-table-row-background-color-hover)
-        )
-    );
+    --highcontrast-table-row-text-color: var(--highcontrast-table-row-text-color-hover);
+    --highcontrast-table-icon-color: var(--highcontrast-table-row-text-color-hover);
+    --spectrum-table-cell-background-color: var(--highcontrast-table-row-background-color-hover, var(--mod-table-row-background-color-hover, var(--spectrum-table-row-background-color-hover)));
 }
 
 :host:active {
-    --highcontrast-table-row-text-color: var(
-        --highcontrast-table-row-text-color-hover
-    );
-    --highcontrast-table-icon-color: var(
-        --highcontrast-table-row-text-color-hover
-    );
-    --spectrum-table-cell-background-color: var(
-        --highcontrast-table-row-background-color-hover,
-        var(
-            --mod-table-row-active-color,
-            var(--spectrum-table-row-active-color)
-        )
-    );
+    --highcontrast-table-row-text-color: var(--highcontrast-table-row-text-color-hover);
+    --highcontrast-table-icon-color: var(--highcontrast-table-row-text-color-hover);
+    --spectrum-table-cell-background-color: var(--highcontrast-table-row-background-color-hover, var(--mod-table-row-active-color, var(--spectrum-table-row-active-color)));
 }
 
 :host([selected]) {
-    --highcontrast-table-row-text-color: var(
-        --highcontrast-table-selected-row-text-color
-    );
-    --highcontrast-table-icon-color: var(
-        --highcontrast-table-selected-row-text-color
-    );
-    --spectrum-table-cell-background-color: var(
-        --highcontrast-table-selected-row-background-color,
-        var(--spectrum-table-selected-cell-background-color)
-    );
+    --highcontrast-table-row-text-color: var(--highcontrast-table-selected-row-text-color);
+    --highcontrast-table-icon-color: var(--highcontrast-table-selected-row-text-color);
+    --spectrum-table-cell-background-color: var(--highcontrast-table-selected-row-background-color, var(--spectrum-table-selected-cell-background-color));
 }
 
 :host([selected][focused]),
 :host([selected]:focus-visible) {
-    --highcontrast-table-row-text-color: var(
-        --highcontrast-table-selected-row-text-color-focus
-    );
-    --highcontrast-table-icon-color: var(
-        --highcontrast-table-selected-row-text-color-focus
-    );
-    --spectrum-table-cell-background-color: var(
-        --highcontrast-table-selected-row-background-color-focus,
-        var(--spectrum-table-selected-cell-background-color-focus)
-    );
+    --highcontrast-table-row-text-color: var(--highcontrast-table-selected-row-text-color-focus);
+    --highcontrast-table-icon-color: var(--highcontrast-table-selected-row-text-color-focus);
+    --spectrum-table-cell-background-color: var(--highcontrast-table-selected-row-background-color-focus, var(--spectrum-table-selected-cell-background-color-focus));
 }
 
 :host([drop-target]) .spectrum-Table-body,
 :host([drop-target]) {
-    --highcontrast-table-row-text-color: var(
-        --highcontrast-table-selected-row-text-color
-    );
-    --highcontrast-table-icon-color: var(
-        --highcontrast-table-selected-row-text-color
-    );
-    --spectrum-table-cell-background-color: var(
-        --highcontrast-table-selected-row-background-color,
-        var(
-            --mod-table-drop-zone-background-color,
-            var(--spectrum-table-drop-zone-background-color)
-        )
-    );
+    --highcontrast-table-row-text-color: var(--highcontrast-table-selected-row-text-color);
+    --highcontrast-table-icon-color: var(--highcontrast-table-selected-row-text-color);
+    --spectrum-table-cell-background-color: var(--highcontrast-table-selected-row-background-color, var(--mod-table-drop-zone-background-color, var(--spectrum-table-drop-zone-background-color)));
 }
 
 :host([drop-target]) {
-    --spectrum-table-border-color: var(
-        --highcontrast-table-focus-indicator-color,
-        transparent
-    );
-    outline-width: var(
-        --mod-table-focus-indicator-thickness,
-        var(--spectrum-table-focus-indicator-thickness)
-    );
+    --spectrum-table-border-color: var(--highcontrast-table-focus-indicator-color, transparent);
+    outline-width: var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness));
     outline-style: solid;
-    outline-color: var(
-        --highcontrast-table-focus-indicator-color,
-        var(
-            --mod-table-drop-zone-outline-color,
-            var(--spectrum-table-drop-zone-outline-color)
-        )
-    );
-    outline-offset: calc(
-        var(
-                --mod-table-focus-indicator-thickness,
-                var(--spectrum-table-focus-indicator-thickness)
-            ) * -1
-    );
+    outline-color: var(--highcontrast-table-focus-indicator-color, var(--mod-table-drop-zone-outline-color, var(--spectrum-table-drop-zone-outline-color)));
+    outline-offset: calc(var(--mod-table-focus-indicator-thickness, var(--spectrum-table-focus-indicator-thickness)) * -1);
 }
 
 :host([drop-target]) ::slotted(*) {
-    border-block-start-color: var(
-        --highcontrast-table-focus-indicator-color,
-        var(
-            --mod-table-drop-zone-outline-color,
-            var(--spectrum-table-drop-zone-outline-color)
-        )
-    );
+    border-block-start-color: var(--highcontrast-table-focus-indicator-color, var(--mod-table-drop-zone-outline-color, var(--spectrum-table-drop-zone-outline-color)));
 }
 
 .spectrum-Table-row--summary {
-    --spectrum-table-cell-background-color: var(
-        --highcontrast-table-row-background-color,
-        var(
-            --mod-table-summary-row-background-color,
-            var(--spectrum-table-summary-row-background-color)
-        )
-    );
+    --spectrum-table-cell-background-color: var(--highcontrast-table-row-background-color, var(--mod-table-summary-row-background-color, var(--spectrum-table-summary-row-background-color)));
 }
 
 .spectrum-Table-row--summary ::slotted(*) {
-    font-weight: var(
-        --mod-table-summary-row-font-weight,
-        var(--spectrum-table-summary-row-font-weight)
-    );
-    font-size: var(
-        --mod-table-summary-row-font-size,
-        var(--spectrum-table-row-font-size)
-    );
-    font-family: var(
-        --mod-table-summary-row-font-family,
-        var(--spectrum-table-row-font-family)
-    );
-    font-style: var(
-        --mod-table-summary-row-font-style,
-        var(--spectrum-table-row-font-style)
-    );
-    line-height: var(
-        --mod-table-summary-row-line-height,
-        var(--spectrum-table-row-line-height)
-    );
-    color: var(
-        --highcontrast-table-row-text-color,
-        var(
-            --mod-table-summary-row-text-color,
-            var(--spectrum-table-row-text-color)
-        )
-    );
+    font-weight: var(--mod-table-summary-row-font-weight, var(--spectrum-table-summary-row-font-weight));
+    font-size: var(--mod-table-summary-row-font-size, var(--spectrum-table-row-font-size));
+    font-family: var(--mod-table-summary-row-font-family, var(--spectrum-table-row-font-family));
+    font-style: var(--mod-table-summary-row-font-style, var(--spectrum-table-row-font-style));
+    line-height: var(--mod-table-summary-row-line-height, var(--spectrum-table-row-line-height));
+    color: var(--highcontrast-table-row-text-color, var(--mod-table-summary-row-text-color, var(--spectrum-table-row-text-color)));
 }
 
 .spectrum-Table-row--sectionHeader {
-    --spectrum-table-cell-background-color: var(
-        --highcontrast-table-section-header-background-color,
-        var(
-            --mod-table-section-header-background-color,
-            var(--spectrum-table-section-header-background-color)
-        )
-    );
+    --spectrum-table-cell-background-color: var(--highcontrast-table-section-header-background-color, var(--mod-table-section-header-background-color, var(--spectrum-table-section-header-background-color)));
     cursor: auto;
     cursor: var(--mod-table-cursor-section-header, initial);
 }
 
 .spectrum-Table-row--sectionHeader ::slotted(*) {
-    font-weight: var(
-        --mod-table-section-header-font-weight,
-        var(--spectrum-table-section-header-font-weight)
-    );
+    font-weight: var(--mod-table-section-header-font-weight, var(--spectrum-table-section-header-font-weight));
     text-align: start;
-    block-size: var(
-        --mod-table-section-header-min-height,
-        var(--spectrum-table-section-header-min-height)
-    );
-    font-size: var(
-        --mod-table-section-header-font-size,
-        var(--spectrum-table-row-font-size)
-    );
-    font-family: var(
-        --mod-table-section-header-font-family,
-        var(--spectrum-table-row-font-family)
-    );
-    font-style: var(
-        --mod-table-section-header-font-style,
-        var(--spectrum-table-row-font-style)
-    );
-    line-height: var(
-        --mod-table-section-header-line-height,
-        var(--spectrum-table-row-line-height)
-    );
-    color: var(
-        --highcontrast-table-section-header-text-color,
-        var(
-            --mod-table-section-header-text-color,
-            var(--spectrum-table-row-text-color)
-        )
-    );
-    padding-block-start: calc(
-        var(
-                --mod-table-section-header-block-start-spacing,
-                var(--spectrum-table-section-header-block-start-spacing)
-            ) -
-            var(--mod-table-border-width, var(--spectrum-table-border-width))
-    );
-    padding-block-end: calc(
-        var(
-                --mod-table-section-header-block-end-spacing,
-                var(--spectrum-table-section-header-block-end-spacing)
-            ) -
-            var(--mod-table-border-width, var(--spectrum-table-border-width))
-    );
+    block-size: var(--mod-table-section-header-min-height, var(--spectrum-table-section-header-min-height));
+    font-size: var(--mod-table-section-header-font-size, var(--spectrum-table-row-font-size));
+    font-family: var(--mod-table-section-header-font-family, var(--spectrum-table-row-font-family));
+    font-style: var(--mod-table-section-header-font-style, var(--spectrum-table-row-font-style));
+    line-height: var(--mod-table-section-header-line-height, var(--spectrum-table-row-line-height));
+    color: var(--highcontrast-table-section-header-text-color, var(--mod-table-section-header-text-color, var(--spectrum-table-row-text-color)));
+    padding-block-start: calc(var(--mod-table-section-header-block-start-spacing, var(--spectrum-table-section-header-block-start-spacing)) - var(--mod-table-border-width, var(--spectrum-table-border-width)));
+    padding-block-end: calc(var(--mod-table-section-header-block-end-spacing, var(--spectrum-table-section-header-block-end-spacing)) - var(--mod-table-border-width, var(--spectrum-table-border-width)));
 }
 
 :host {
@@ -429,20 +222,8 @@ governing permissions and limitations under the License.
     padding-inline-end: 0;
 }
 
-.spectrum-Table-row--collapsible.is-last-tier
-    .spectrum-Table-cell--collapsible {
-    padding-inline-start: calc(
-        var(--spectrum-table-row-tier) *
-            var(--spectrum-table-collapsible-tier-indent) +
-            var(
-                --mod-table-disclosure-icon-size,
-                var(--spectrum-table-disclosure-icon-size)
-            ) +
-            var(
-                --mod-table-collapsible-disclosure-inline-spacing,
-                var(--spectrum-table-collapsible-disclosure-inline-spacing)
-            ) * 2
-    );
+.spectrum-Table-row--collapsible.is-last-tier .spectrum-Table-cell--collapsible {
+    padding-inline-start: calc(var(--spectrum-table-row-tier) * var(--spectrum-table-collapsible-tier-indent) + var(--mod-table-disclosure-icon-size, var(--spectrum-table-disclosure-icon-size)) + var(--mod-table-collapsible-disclosure-inline-spacing, var(--spectrum-table-collapsible-disclosure-inline-spacing)) * 2);
 }
 
 .spectrum-Table-row--collapsible.is-last-tier .spectrum-Table-disclosureIcon {
@@ -450,25 +231,8 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Table-row--collapsible .spectrum-Table-disclosureIcon {
-    margin-inline: var(
-        --mod-table-collapsible-disclosure-inline-spacing,
-        var(--spectrum-table-collapsible-disclosure-inline-spacing)
-    );
-    margin-block-start: max(
-        0px,
-        calc(
-            (
-                    var(
-                            --mod-table-min-row-height,
-                            var(--spectrum-table-min-row-height)
-                        ) -
-                        var(
-                            --mod-table-disclosure-icon-size,
-                            var(--spectrum-table-disclosure-icon-size)
-                        )
-                ) / 2
-        )
-    );
+    margin-inline: var(--mod-table-collapsible-disclosure-inline-spacing, var(--spectrum-table-collapsible-disclosure-inline-spacing));
+    margin-block-start: max(0px, calc((var(--mod-table-min-row-height, var(--spectrum-table-min-row-height)) - var(--mod-table-disclosure-icon-size, var(--spectrum-table-disclosure-icon-size))) / 2));
 }
 
 :host([hidden]) .spectrum-Table-row--collapsible {
@@ -477,81 +241,30 @@ governing permissions and limitations under the License.
 
 @media (hover: hover) {
     :host(:hover) {
-        --highcontrast-table-row-text-color: var(
-            --highcontrast-table-row-text-color-hover
-        );
-        --highcontrast-table-icon-color: var(
-            --highcontrast-table-row-text-color-hover
-        );
-        --spectrum-table-cell-background-color: var(
-            --highcontrast-table-row-background-color-hover,
-            var(
-                --mod-table-row-background-color-hover,
-                var(--spectrum-table-row-background-color-hover)
-            )
-        );
+        --highcontrast-table-row-text-color: var(--highcontrast-table-row-text-color-hover);
+        --highcontrast-table-icon-color: var(--highcontrast-table-row-text-color-hover);
+        --spectrum-table-cell-background-color: var(--highcontrast-table-row-background-color-hover, var(--mod-table-row-background-color-hover, var(--spectrum-table-row-background-color-hover)));
     }
 
     :host([selected]:hover) {
-        --highcontrast-table-row-text-color: var(
-            --highcontrast-table-selected-row-text-color-focus
-        );
-        --highcontrast-table-icon-color: var(
-            --highcontrast-table-selected-row-text-color-focus
-        );
-        --spectrum-table-cell-background-color: var(
-            --highcontrast-table-selected-row-background-color-focus,
-            var(--spectrum-table-selected-cell-background-color-focus)
-        );
+        --highcontrast-table-row-text-color: var(--highcontrast-table-selected-row-text-color-focus);
+        --highcontrast-table-icon-color: var(--highcontrast-table-selected-row-text-color-focus);
+        --spectrum-table-cell-background-color: var(--highcontrast-table-selected-row-background-color-focus, var(--spectrum-table-selected-cell-background-color-focus));
     }
 
     .spectrum-Table-row--sectionHeader:hover {
-        --highcontrast-table-row-text-color: var(
-            --highcontrast-table-section-header-text-color
-        );
-        --spectrum-table-cell-background-color: var(
-            --highcontrast-table-section-header-background-color,
-            var(
-                --mod-table-section-header-background-color,
-                var(--spectrum-table-section-header-background-color)
-            )
-        );
+        --highcontrast-table-row-text-color: var(--highcontrast-table-section-header-text-color);
+        --spectrum-table-cell-background-color: var(--highcontrast-table-section-header-background-color, var(--mod-table-section-header-background-color, var(--spectrum-table-section-header-background-color)));
     }
 }
 
 .spectrum-Table-row--thumbnail {
-    --table-thumbnail-cell-block-spacing: var(
-        --mod-table-thumbnail-block-spacing,
-        var(--spectrum-table-thumbnail-block-spacing)
-    );
-    --table-thumbnail-inner-content-block-spacing: max(
-        0px,
-        calc(
-            (
-                    var(
-                            --mod-table-thumbnail-size,
-                            var(--spectrum-table-thumbnail-size)
-                        ) -
-                        (
-                            var(
-                                    --mod-table-row-line-height,
-                                    var(--spectrum-table-row-line-height)
-                                ) *
-                                var(
-                                    --mod-table-header-font-size,
-                                    var(--spectrum-table-row-font-size)
-                                )
-                        )
-                ) / 2
-        )
-    );
+    --table-thumbnail-cell-block-spacing: var(--mod-table-thumbnail-block-spacing, var(--spectrum-table-thumbnail-block-spacing));
+    --table-thumbnail-inner-content-block-spacing: max(0px, calc((var(--mod-table-thumbnail-size, var(--spectrum-table-thumbnail-size)) - (var(--mod-table-row-line-height, var(--spectrum-table-row-line-height)) * var(--mod-table-header-font-size, var(--spectrum-table-row-font-size)))) / 2));
 }
 
 .spectrum-Table-row--thumbnail ::slotted(*) {
-    padding-block: calc(
-        var(--table-thumbnail-cell-block-spacing) +
-            var(--table-thumbnail-inner-content-block-spacing)
-    );
+    padding-block: calc(var(--table-thumbnail-cell-block-spacing) + var(--table-thumbnail-inner-content-block-spacing));
 }
 
 .spectrum-Table-row--thumbnail .spectrum-Table-cell--thumbnail {
@@ -559,26 +272,6 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Table-row--thumbnail.spectrum-Table-row--collapsible {
-    --table-thumbnail-inner-minimum-block-spacing: max(
-        0px,
-        calc(
-            (
-                    var(
-                            --mod-table-disclosure-icon-size,
-                            var(--spectrum-table-disclosure-icon-size)
-                        ) -
-                        var(
-                            --mod-table-thumbnail-size,
-                            var(--spectrum-table-thumbnail-size)
-                        )
-                ) / 2
-        )
-    );
-    --table-thumbnail-cell-block-spacing: max(
-        var(
-            --mod-table-thumbnail-block-spacing,
-            var(--spectrum-table-thumbnail-block-spacing)
-        ),
-        var(--table-thumbnail-inner-minimum-block-spacing)
-    );
+    --table-thumbnail-inner-minimum-block-spacing: max(0px, calc((var(--mod-table-disclosure-icon-size, var(--spectrum-table-disclosure-icon-size)) - var(--mod-table-thumbnail-size, var(--spectrum-table-thumbnail-size))) / 2));
+    --table-thumbnail-cell-block-spacing: max(var(--mod-table-thumbnail-block-spacing, var(--spectrum-table-thumbnail-block-spacing)), var(--table-thumbnail-inner-minimum-block-spacing));
 }

--- a/packages/table/src/spectrum-table.css
+++ b/packages/table/src/spectrum-table.css
@@ -42,33 +42,10 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    --mod-thumbnail-size: var(
-        --mod-table-thumbnail-size,
-        var(--spectrum-table-thumbnail-size)
-    );
-    --spectrum-table-cell-background-color: var(
-        --highcontrast-table-row-background-color,
-        var(
-            --mod-table-row-background-color,
-            var(--spectrum-table-row-background-color)
-        )
-    );
-    --spectrum-table-selected-cell-background-color: var(
-        --highcontrast-table-selected-row-background-color,
-        var(
-            --mod-table-selected-row-background-color-non-emphasized,
-            var(--spectrum-table-selected-row-background-color-non-emphasized)
-        )
-    );
-    --spectrum-table-selected-cell-background-color-focus: var(
-        --highcontrast-table-selected-row-background-color-focus,
-        var(
-            --mod-table-selected-row-background-color-non-emphasized-focus,
-            var(
-                --spectrum-table-selected-row-background-color-non-emphasized-focus
-            )
-        )
-    );
+    --mod-thumbnail-size: var(--mod-table-thumbnail-size, var(--spectrum-table-thumbnail-size));
+    --spectrum-table-cell-background-color: var(--highcontrast-table-row-background-color, var(--mod-table-row-background-color, var(--spectrum-table-row-background-color)));
+    --spectrum-table-selected-cell-background-color: var(--highcontrast-table-selected-row-background-color, var(--mod-table-selected-row-background-color-non-emphasized, var(--spectrum-table-selected-row-background-color-non-emphasized)));
+    --spectrum-table-selected-cell-background-color-focus: var(--highcontrast-table-selected-row-background-color-focus, var(--mod-table-selected-row-background-color-non-emphasized-focus, var(--spectrum-table-selected-row-background-color-non-emphasized-focus)));
 }
 
 :host:dir(rtl),
@@ -86,250 +63,85 @@ governing permissions and limitations under the License.
 }
 
 :host([density='compact']) {
-    --spectrum-table-min-row-height: var(
-        --mod-table-min-row-height--compact,
-        var(--spectrum-table-row-height-medium-compact)
-    );
-    --spectrum-table-row-top-to-text: var(
-        --mod-table-row-top-to-text--compact,
-        var(--spectrum-table-row-top-to-text-medium-compact)
-    );
-    --spectrum-table-row-bottom-to-text: var(
-        --mod-table-row-bottom-to-text--compact,
-        var(--spectrum-table-row-bottom-to-text-medium-compact)
-    );
-    --spectrum-table-row-checkbox-block-spacing: var(
-        --mod-table-row-checkbox-block-spacing--compact,
-        var(--spectrum-table-row-checkbox-to-top-medium-compact)
-    );
-    --spectrum-table-thumbnail-block-spacing: var(
-        --mod-table-thumbnail-block-spacing-compact,
-        var(--spectrum-table-thumbnail-to-top-minimum-medium-compact)
-    );
-    --spectrum-table-thumbnail-size: var(
-        --mod-table-thumbnail-size-compact,
-        var(--spectrum-thumbnail-size-200)
-    );
+    --spectrum-table-min-row-height: var(--mod-table-min-row-height--compact, var(--spectrum-table-row-height-medium-compact));
+    --spectrum-table-row-top-to-text: var(--mod-table-row-top-to-text--compact, var(--spectrum-table-row-top-to-text-medium-compact));
+    --spectrum-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--compact, var(--spectrum-table-row-bottom-to-text-medium-compact));
+    --spectrum-table-row-checkbox-block-spacing: var(--mod-table-row-checkbox-block-spacing--compact, var(--spectrum-table-row-checkbox-to-top-medium-compact));
+    --spectrum-table-thumbnail-block-spacing: var(--mod-table-thumbnail-block-spacing-compact, var(--spectrum-table-thumbnail-to-top-minimum-medium-compact));
+    --spectrum-table-thumbnail-size: var(--mod-table-thumbnail-size-compact, var(--spectrum-thumbnail-size-200));
 }
 
 :host([density='compact'][size='s']) {
-    --spectrum-table-min-row-height: var(
-        --mod-table-min-row-height--compact,
-        var(--spectrum-table-row-height-small-compact)
-    );
-    --spectrum-table-row-top-to-text: var(
-        --mod-table-row-top-to-text--compact,
-        var(--spectrum-table-row-top-to-text-small-compact)
-    );
-    --spectrum-table-row-bottom-to-text: var(
-        --mod-table-row-bottom-to-text--compact,
-        var(--spectrum-table-row-bottom-to-text-small-compact)
-    );
-    --spectrum-table-row-checkbox-block-spacing: var(
-        --mod-table-row-checkbox-block-spacing--compact,
-        var(--spectrum-table-row-checkbox-to-top-small-compact)
-    );
-    --spectrum-table-thumbnail-block-spacing: var(
-        --mod-table-thumbnail-block-spacing-compact,
-        var(--spectrum-table-thumbnail-to-top-minimum-small-compact)
-    );
-    --spectrum-table-thumbnail-size: var(
-        --mod-table-thumbnail-size-compact,
-        var(--spectrum-thumbnail-size-50)
-    );
+    --spectrum-table-min-row-height: var(--mod-table-min-row-height--compact, var(--spectrum-table-row-height-small-compact));
+    --spectrum-table-row-top-to-text: var(--mod-table-row-top-to-text--compact, var(--spectrum-table-row-top-to-text-small-compact));
+    --spectrum-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--compact, var(--spectrum-table-row-bottom-to-text-small-compact));
+    --spectrum-table-row-checkbox-block-spacing: var(--mod-table-row-checkbox-block-spacing--compact, var(--spectrum-table-row-checkbox-to-top-small-compact));
+    --spectrum-table-thumbnail-block-spacing: var(--mod-table-thumbnail-block-spacing-compact, var(--spectrum-table-thumbnail-to-top-minimum-small-compact));
+    --spectrum-table-thumbnail-size: var(--mod-table-thumbnail-size-compact, var(--spectrum-thumbnail-size-50));
 }
 
 :host([density='compact'][size='l']) {
-    --spectrum-table-min-row-height: var(
-        --mod-table-min-row-height--compact,
-        var(--spectrum-table-row-height-large-compact)
-    );
-    --spectrum-table-row-top-to-text: var(
-        --mod-table-row-top-to-text--compact,
-        var(--spectrum-table-row-top-to-text-large-compact)
-    );
-    --spectrum-table-row-bottom-to-text: var(
-        --mod-table-row-bottom-to-text--compact,
-        var(--spectrum-table-row-bottom-to-text-large-compact)
-    );
-    --spectrum-table-row-checkbox-block-spacing: var(
-        --mod-table-row-checkbox-block-spacing--compact,
-        var(--spectrum-table-row-checkbox-to-top-large-compact)
-    );
-    --spectrum-table-thumbnail-block-spacing: var(
-        --mod-table-thumbnail-block-spacing-compact,
-        var(--spectrum-table-thumbnail-to-top-minimum-large-compact)
-    );
-    --spectrum-table-thumbnail-size: var(
-        --mod-table-thumbnail-size-compact,
-        var(--spectrum-thumbnail-size-300)
-    );
+    --spectrum-table-min-row-height: var(--mod-table-min-row-height--compact, var(--spectrum-table-row-height-large-compact));
+    --spectrum-table-row-top-to-text: var(--mod-table-row-top-to-text--compact, var(--spectrum-table-row-top-to-text-large-compact));
+    --spectrum-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--compact, var(--spectrum-table-row-bottom-to-text-large-compact));
+    --spectrum-table-row-checkbox-block-spacing: var(--mod-table-row-checkbox-block-spacing--compact, var(--spectrum-table-row-checkbox-to-top-large-compact));
+    --spectrum-table-thumbnail-block-spacing: var(--mod-table-thumbnail-block-spacing-compact, var(--spectrum-table-thumbnail-to-top-minimum-large-compact));
+    --spectrum-table-thumbnail-size: var(--mod-table-thumbnail-size-compact, var(--spectrum-thumbnail-size-300));
 }
 
 :host([density='compact'][size='xl']) {
-    --spectrum-table-min-row-height: var(
-        --mod-table-min-row-height--compact,
-        var(--spectrum-table-row-height-extra-large-compact)
-    );
-    --spectrum-table-row-top-to-text: var(
-        --mod-table-row-top-to-text--compact,
-        var(--spectrum-table-row-top-to-text-extra-large-compact)
-    );
-    --spectrum-table-row-bottom-to-text: var(
-        --mod-table-row-bottom-to-text--compact,
-        var(--spectrum-table-row-bottom-to-text-extra-large-compact)
-    );
-    --spectrum-table-row-checkbox-block-spacing: var(
-        --mod-table-row-checkbox-block-spacing--compact,
-        var(--spectrum-table-row-checkbox-to-top-extra-large-compact)
-    );
-    --spectrum-table-thumbnail-block-spacing: var(
-        --mod-table-thumbnail-block-spacing-compact,
-        var(--spectrum-table-thumbnail-to-top-minimum-extra-large-compact)
-    );
-    --spectrum-table-thumbnail-size: var(
-        --mod-table-thumbnail-size-compact,
-        var(--spectrum-thumbnail-size-500)
-    );
+    --spectrum-table-min-row-height: var(--mod-table-min-row-height--compact, var(--spectrum-table-row-height-extra-large-compact));
+    --spectrum-table-row-top-to-text: var(--mod-table-row-top-to-text--compact, var(--spectrum-table-row-top-to-text-extra-large-compact));
+    --spectrum-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--compact, var(--spectrum-table-row-bottom-to-text-extra-large-compact));
+    --spectrum-table-row-checkbox-block-spacing: var(--mod-table-row-checkbox-block-spacing--compact, var(--spectrum-table-row-checkbox-to-top-extra-large-compact));
+    --spectrum-table-thumbnail-block-spacing: var(--mod-table-thumbnail-block-spacing-compact, var(--spectrum-table-thumbnail-to-top-minimum-extra-large-compact));
+    --spectrum-table-thumbnail-size: var(--mod-table-thumbnail-size-compact, var(--spectrum-thumbnail-size-500));
 }
 
 :host([density='spacious']) {
-    --spectrum-table-min-row-height: var(
-        --mod-table-min-row-height--spacious,
-        var(--spectrum-table-row-height-medium-spacious)
-    );
-    --spectrum-table-row-top-to-text: var(
-        --mod-table-row-top-to-text--spacious,
-        var(--spectrum-table-row-top-to-text-medium-spacious)
-    );
-    --spectrum-table-row-bottom-to-text: var(
-        --mod-table-row-bottom-to-text--spacious,
-        var(--spectrum-table-row-bottom-to-text-medium-spacious)
-    );
-    --spectrum-table-row-checkbox-block-spacing: var(
-        --mod-table-row-checkbox-block-spacing--spacious,
-        var(--spectrum-table-row-checkbox-to-top-medium-spacious)
-    );
-    --spectrum-table-thumbnail-block-spacing: var(
-        --mod-table-thumbnail-block-spacing-spacious,
-        var(--spectrum-table-thumbnail-to-top-minimum-medium-spacious)
-    );
-    --spectrum-table-thumbnail-size: var(
-        --mod-table-thumbnail-size-spacious,
-        var(--spectrum-thumbnail-size-500)
-    );
+    --spectrum-table-min-row-height: var(--mod-table-min-row-height--spacious, var(--spectrum-table-row-height-medium-spacious));
+    --spectrum-table-row-top-to-text: var(--mod-table-row-top-to-text--spacious, var(--spectrum-table-row-top-to-text-medium-spacious));
+    --spectrum-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--spacious, var(--spectrum-table-row-bottom-to-text-medium-spacious));
+    --spectrum-table-row-checkbox-block-spacing: var(--mod-table-row-checkbox-block-spacing--spacious, var(--spectrum-table-row-checkbox-to-top-medium-spacious));
+    --spectrum-table-thumbnail-block-spacing: var(--mod-table-thumbnail-block-spacing-spacious, var(--spectrum-table-thumbnail-to-top-minimum-medium-spacious));
+    --spectrum-table-thumbnail-size: var(--mod-table-thumbnail-size-spacious, var(--spectrum-thumbnail-size-500));
 }
 
 :host([density='spacious'][size='s']) {
-    --spectrum-table-min-row-height: var(
-        --mod-table-min-row-height--spacious,
-        var(--spectrum-table-row-height-small-spacious)
-    );
-    --spectrum-table-row-top-to-text: var(
-        --mod-table-row-top-to-text--spacious,
-        var(--spectrum-table-row-top-to-text-small-spacious)
-    );
-    --spectrum-table-row-bottom-to-text: var(
-        --mod-table-row-bottom-to-text--spacious,
-        var(--spectrum-table-row-bottom-to-text-small-spacious)
-    );
-    --spectrum-table-row-checkbox-block-spacing: var(
-        --mod-table-row-checkbox-block-spacing--spacious,
-        var(--spectrum-table-row-checkbox-to-top-small-spacious)
-    );
-    --spectrum-table-thumbnail-block-spacing: var(
-        --mod-table-thumbnail-block-spacing-spacious,
-        var(--spectrum-table-thumbnail-to-top-minimum-small-spacious)
-    );
-    --spectrum-table-thumbnail-size: var(
-        --mod-table-thumbnail-size-spacious,
-        var(--spectrum-thumbnail-size-300)
-    );
+    --spectrum-table-min-row-height: var(--mod-table-min-row-height--spacious, var(--spectrum-table-row-height-small-spacious));
+    --spectrum-table-row-top-to-text: var(--mod-table-row-top-to-text--spacious, var(--spectrum-table-row-top-to-text-small-spacious));
+    --spectrum-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--spacious, var(--spectrum-table-row-bottom-to-text-small-spacious));
+    --spectrum-table-row-checkbox-block-spacing: var(--mod-table-row-checkbox-block-spacing--spacious, var(--spectrum-table-row-checkbox-to-top-small-spacious));
+    --spectrum-table-thumbnail-block-spacing: var(--mod-table-thumbnail-block-spacing-spacious, var(--spectrum-table-thumbnail-to-top-minimum-small-spacious));
+    --spectrum-table-thumbnail-size: var(--mod-table-thumbnail-size-spacious, var(--spectrum-thumbnail-size-300));
 }
 
 :host([density='spacious'][size='l']) {
-    --spectrum-table-min-row-height: var(
-        --mod-table-min-row-height--spacious,
-        var(--spectrum-table-row-height-large-spacious)
-    );
-    --spectrum-table-row-top-to-text: var(
-        --mod-table-row-top-to-text--spacious,
-        var(--spectrum-table-row-top-to-text-large-spacious)
-    );
-    --spectrum-table-row-bottom-to-text: var(
-        --mod-table-row-bottom-to-text--spacious,
-        var(--spectrum-table-row-bottom-to-text-large-spacious)
-    );
-    --spectrum-table-row-checkbox-block-spacing: var(
-        --mod-table-row-checkbox-block-spacing--spacious,
-        var(--spectrum-table-row-checkbox-to-top-large-spacious)
-    );
-    --spectrum-table-thumbnail-block-spacing: var(
-        --mod-table-thumbnail-block-spacing-spacious,
-        var(--spectrum-table-thumbnail-to-top-minimum-large-spacious)
-    );
-    --spectrum-table-thumbnail-size: var(
-        --mod-table-thumbnail-size-spacious,
-        var(--spectrum-thumbnail-size-700)
-    );
+    --spectrum-table-min-row-height: var(--mod-table-min-row-height--spacious, var(--spectrum-table-row-height-large-spacious));
+    --spectrum-table-row-top-to-text: var(--mod-table-row-top-to-text--spacious, var(--spectrum-table-row-top-to-text-large-spacious));
+    --spectrum-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--spacious, var(--spectrum-table-row-bottom-to-text-large-spacious));
+    --spectrum-table-row-checkbox-block-spacing: var(--mod-table-row-checkbox-block-spacing--spacious, var(--spectrum-table-row-checkbox-to-top-large-spacious));
+    --spectrum-table-thumbnail-block-spacing: var(--mod-table-thumbnail-block-spacing-spacious, var(--spectrum-table-thumbnail-to-top-minimum-large-spacious));
+    --spectrum-table-thumbnail-size: var(--mod-table-thumbnail-size-spacious, var(--spectrum-thumbnail-size-700));
 }
 
 :host([density='spacious'][size='xl']) {
-    --spectrum-table-min-row-height: var(
-        --mod-table-min-row-height--spacious,
-        var(--spectrum-table-row-height-extra-large-spacious)
-    );
-    --spectrum-table-row-top-to-text: var(
-        --mod-table-row-top-to-text--spacious,
-        var(--spectrum-table-row-top-to-text-extra-large-spacious)
-    );
-    --spectrum-table-row-bottom-to-text: var(
-        --mod-table-row-bottom-to-text--spacious,
-        var(--spectrum-table-row-bottom-to-text-extra-large-spacious)
-    );
-    --spectrum-table-row-checkbox-block-spacing: var(
-        --mod-table-row-checkbox-block-spacing--spacious,
-        var(--spectrum-table-row-checkbox-to-top-extra-large-spacious)
-    );
-    --spectrum-table-thumbnail-block-spacing: var(
-        --mod-table-thumbnail-block-spacing-spacious,
-        var(--spectrum-table-thumbnail-to-top-minimum-extra-large-spacious)
-    );
-    --spectrum-table-thumbnail-size: var(
-        --mod-table-thumbnail-size-spacious,
-        var(--spectrum-thumbnail-size-800)
-    );
+    --spectrum-table-min-row-height: var(--mod-table-min-row-height--spacious, var(--spectrum-table-row-height-extra-large-spacious));
+    --spectrum-table-row-top-to-text: var(--mod-table-row-top-to-text--spacious, var(--spectrum-table-row-top-to-text-extra-large-spacious));
+    --spectrum-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--spacious, var(--spectrum-table-row-bottom-to-text-extra-large-spacious));
+    --spectrum-table-row-checkbox-block-spacing: var(--mod-table-row-checkbox-block-spacing--spacious, var(--spectrum-table-row-checkbox-to-top-extra-large-spacious));
+    --spectrum-table-thumbnail-block-spacing: var(--mod-table-thumbnail-block-spacing-spacious, var(--spectrum-table-thumbnail-to-top-minimum-extra-large-spacious));
+    --spectrum-table-thumbnail-size: var(--mod-table-thumbnail-size-spacious, var(--spectrum-thumbnail-size-800));
 }
 
 :host([emphasized]) {
-    --spectrum-table-selected-cell-background-color: var(
-        --highcontrast-table-selected-row-background-color,
-        var(
-            --mod-table-selected-row-background-color,
-            var(--spectrum-table-selected-row-background-color)
-        )
-    );
-    --spectrum-table-selected-cell-background-color-focus: var(
-        --highcontrast-table-selected-row-background-color-focus,
-        var(
-            --mod-table-selected-row-background-color-focus,
-            var(--spectrum-table-selected-row-background-color-focus)
-        )
-    );
+    --spectrum-table-selected-cell-background-color: var(--highcontrast-table-selected-row-background-color, var(--mod-table-selected-row-background-color, var(--spectrum-table-selected-row-background-color)));
+    --spectrum-table-selected-cell-background-color-focus: var(--highcontrast-table-selected-row-background-color-focus, var(--mod-table-selected-row-background-color-focus, var(--spectrum-table-selected-row-background-color-focus)));
 }
 
 :host([quiet]) {
     --spectrum-table-border-radius: var(--mod-table-border-radius--quiet, 0px);
-    --spectrum-table-outer-border-inline-width: var(
-        --mod-table-outer-border-inline-width--quiet,
-        0px
-    );
-    --spectrum-table-header-background-color: var(
-        --mod-table-header-background-color--quiet,
-        var(--spectrum-transparent-white-100)
-    );
-    --spectrum-table-row-background-color: var(
-        --mod-table-row-background-color--quiet,
-        var(--spectrum-transparent-white-100)
-    );
+    --spectrum-table-outer-border-inline-width: var(--mod-table-outer-border-inline-width--quiet, 0px);
+    --spectrum-table-header-background-color: var(--mod-table-header-background-color--quiet, var(--spectrum-transparent-white-100));
+    --spectrum-table-row-background-color: var(--mod-table-row-background-color--quiet, var(--spectrum-transparent-white-100));
 }

--- a/packages/tabs/src/spectrum-tab.css
+++ b/packages/tabs/src/spectrum-tab.css
@@ -13,22 +13,11 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     box-sizing: border-box;
-    block-size: calc(
-        var(--mod-tabs-item-height, var(--spectrum-tabs-item-height)) -
-            var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size))
-    );
+    block-size: calc(var(--mod-tabs-item-height, var(--spectrum-tabs-item-height)) - var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size)));
     z-index: 1;
     white-space: nowrap;
-    color: var(
-        --highcontrast-tabs-color,
-        var(--mod-tabs-color, var(--spectrum-tabs-color))
-    );
-    transition: color
-        var(
-            --mod-tabs-animation-duration,
-            var(--spectrum-tabs-animation-duration)
-        )
-        ease-out;
+    color: var(--highcontrast-tabs-color, var(--mod-tabs-color, var(--spectrum-tabs-color)));
+    transition: color var(--mod-tabs-animation-duration, var(--spectrum-tabs-animation-duration)) ease-out;
     cursor: pointer;
     outline: none;
     -webkit-text-decoration: none;
@@ -39,82 +28,40 @@ governing permissions and limitations under the License.
 ::slotted([slot='icon']) {
     block-size: var(--mod-tabs-icon-size, var(--spectrum-tabs-icon-size));
     inline-size: var(--mod-tabs-icon-size, var(--spectrum-tabs-icon-size));
-    margin-block-start: var(
-        --mod-tabs-top-to-icon,
-        var(--spectrum-tabs-top-to-icon)
-    );
+    margin-block-start: var(--mod-tabs-top-to-icon, var(--spectrum-tabs-top-to-icon));
 }
 
 [name='icon'] + #item-label {
-    margin-inline-start: var(
-        --mod-tabs-icon-to-text,
-        var(--spectrum-tabs-icon-to-text)
-    );
+    margin-inline-start: var(--mod-tabs-icon-to-text, var(--spectrum-tabs-icon-to-text));
 }
 
 :host:before {
     content: '';
     box-sizing: border-box;
-    block-size: calc(
-        100% - var(--mod-tabs-top-to-text, var(--spectrum-tabs-top-to-text))
-    );
-    inline-size: calc(
-        100% +
-            var(
-                --mod-tabs-focus-indicator-gap,
-                var(--spectrum-tabs-focus-indicator-gap)
-            ) * 2
-    );
-    border: var(
-            --mod-tabs-focus-indicator-width,
-            var(--spectrum-tabs-focus-indicator-width)
-        )
-        solid transparent;
-    border-radius: var(
-        --mod-tabs-focus-indicator-border-radius,
-        var(--spectrum-tabs-focus-indicator-border-radius)
-    );
+    block-size: calc(100% - var(--mod-tabs-top-to-text, var(--spectrum-tabs-top-to-text)));
+    inline-size: calc(100% + var(--mod-tabs-focus-indicator-gap, var(--spectrum-tabs-focus-indicator-gap)) * 2);
+    border: var(--mod-tabs-focus-indicator-width, var(--spectrum-tabs-focus-indicator-width)) solid transparent;
+    border-radius: var(--mod-tabs-focus-indicator-border-radius, var(--spectrum-tabs-focus-indicator-border-radius));
     pointer-events: none;
     position: absolute;
-    inset-block-start: calc(
-        var(--mod-tabs-top-to-text, var(--spectrum-tabs-top-to-text)) / 2
-    );
-    inset-inline-start: calc(
-        var(
-                --mod-tabs-focus-indicator-gap,
-                var(--spectrum-tabs-focus-indicator-gap)
-            ) * -1
-    );
-    inset-inline-end: calc(
-        var(
-                --mod-tabs-focus-indicator-gap,
-                var(--spectrum-tabs-focus-indicator-gap)
-            ) * -1
-    );
+    inset-block-start: calc(var(--mod-tabs-top-to-text, var(--spectrum-tabs-top-to-text)) / 2);
+    inset-inline-start: calc(var(--mod-tabs-focus-indicator-gap, var(--spectrum-tabs-focus-indicator-gap)) * -1);
+    inset-inline-end: calc(var(--mod-tabs-focus-indicator-gap, var(--spectrum-tabs-focus-indicator-gap)) * -1);
 }
 
 @media (hover: hover) {
     :host(:hover) {
-        color: var(
-            --highcontrast-tabs-color-hover,
-            var(--mod-tabs-color-hover, var(--spectrum-tabs-color-hover))
-        );
+        color: var(--highcontrast-tabs-color-hover, var(--mod-tabs-color-hover, var(--spectrum-tabs-color-hover)));
     }
 }
 
 :host([selected]) {
-    color: var(
-        --highcontrast-tabs-color-selected,
-        var(--mod-tabs-color-selected, var(--spectrum-tabs-color-selected))
-    );
+    color: var(--highcontrast-tabs-color-selected, var(--mod-tabs-color-selected, var(--spectrum-tabs-color-selected)));
 }
 
 :host([disabled]) {
     cursor: default;
-    color: var(
-        --highcontrast-tabs-color-disabled,
-        var(--mod-tabs-color-disabled, var(--spectrum-tabs-color-disabled))
-    );
+    color: var(--highcontrast-tabs-color-disabled, var(--mod-tabs-color-disabled, var(--spectrum-tabs-color-disabled)));
 }
 
 :host([disabled]) #item-label {
@@ -122,20 +69,11 @@ governing permissions and limitations under the License.
 }
 
 :host(:focus-visible) {
-    color: var(
-        --highcontrast-tabs-color-key-focus,
-        var(--mod-tabs-color-key-focus, var(--spectrum-tabs-color-key-focus))
-    );
+    color: var(--highcontrast-tabs-color-key-focus, var(--mod-tabs-color-key-focus, var(--spectrum-tabs-color-key-focus)));
 }
 
 :host(:focus-visible):before {
-    border-color: var(
-        --highcontrast-tabs-focus-indicator-color,
-        var(
-            --mod-tabs-focus-indicator-color,
-            var(--spectrum-tabs-focus-indicator-color)
-        )
-    );
+    border-color: var(--highcontrast-tabs-focus-indicator-color, var(--mod-tabs-focus-indicator-color, var(--spectrum-tabs-focus-indicator-color)));
 }
 
 #item-label {
@@ -146,14 +84,8 @@ governing permissions and limitations under the License.
     font-size: var(--mod-tabs-font-size, var(--spectrum-tabs-font-size));
     font-weight: var(--mod-tabs-font-weight, var(--spectrum-tabs-font-weight));
     line-height: var(--mod-tabs-line-height, var(--spectrum-tabs-line-height));
-    margin-block-start: var(
-        --mod-tabs-top-to-text,
-        var(--spectrum-tabs-top-to-text)
-    );
-    margin-block-end: var(
-        --mod-tabs-bottom-to-text,
-        var(--spectrum-tabs-bottom-to-text)
-    );
+    margin-block-start: var(--mod-tabs-top-to-text, var(--spectrum-tabs-top-to-text));
+    margin-block-end: var(--mod-tabs-bottom-to-text, var(--spectrum-tabs-bottom-to-text));
     -webkit-text-decoration: none;
     text-decoration: none;
     display: inline-block;

--- a/packages/tabs/src/spectrum-tabs-sizes.css
+++ b/packages/tabs/src/spectrum-tabs-sizes.css
@@ -12,58 +12,22 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([size='s']) #list.spectrum-Tabs--compact {
-    --spectrum-tabs-item-height: var(
-        --mod-tabs-item-height-compact,
-        var(--spectrum-tab-item-compact-height-small)
-    );
-    --spectrum-tabs-top-to-text: var(
-        --mod-tabs-top-to-text-compact,
-        var(--spectrum-tab-item-top-to-text-compact-small)
-    );
-    --spectrum-tabs-bottom-to-text: var(
-        --mod-tabs-bottom-to-text-compact,
-        var(--spectrum-tab-item-top-to-text-compact-small)
-    );
-    --spectrum-tabs-top-to-icon: var(
-        --mod-tabs-top-to-icon-compact,
-        var(--spectrum-tab-item-top-to-workflow-icon-compact-small)
-    );
+    --spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-small));
+    --spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-small));
+    --spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-small));
+    --spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-small));
 }
 
 :host([size='l']) #list.spectrum-Tabs--compact {
-    --spectrum-tabs-item-height: var(
-        --mod-tabs-item-height-compact,
-        var(--spectrum-tab-item-compact-height-large)
-    );
-    --spectrum-tabs-top-to-text: var(
-        --mod-tabs-top-to-text-compact,
-        var(--spectrum-tab-item-top-to-text-compact-large)
-    );
-    --spectrum-tabs-bottom-to-text: var(
-        --mod-tabs-bottom-to-text-compact,
-        var(--spectrum-tab-item-top-to-text-compact-large)
-    );
-    --spectrum-tabs-top-to-icon: var(
-        --mod-tabs-top-to-icon-compact,
-        var(--spectrum-tab-item-top-to-workflow-icon-compact-large)
-    );
+    --spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-large));
+    --spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-large));
+    --spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-large));
+    --spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-large));
 }
 
 :host([size='xl']) #list.spectrum-Tabs--compact {
-    --spectrum-tabs-item-height: var(
-        --mod-tabs-item-height-compact,
-        var(--spectrum-tab-item-compact-height-extra-large)
-    );
-    --spectrum-tabs-top-to-text: var(
-        --mod-tabs-top-to-text-compact,
-        var(--spectrum-tab-item-top-to-text-compact-extra-large)
-    );
-    --spectrum-tabs-bottom-to-text: var(
-        --mod-tabs-bottom-to-text-compact,
-        var(--spectrum-tab-item-top-to-text-compact-extra-large)
-    );
-    --spectrum-tabs-top-to-icon: var(
-        --mod-tabs-top-to-icon-compact,
-        var(--spectrum-tab-item-top-to-workflow-icon-compact-extra-large)
-    );
+    --spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-extra-large));
+    --spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-extra-large));
+    --spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-extra-large));
+    --spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-extra-large));
 }

--- a/packages/tabs/src/spectrum-tabs.css
+++ b/packages/tabs/src/spectrum-tabs.css
@@ -14,23 +14,7 @@ governing permissions and limitations under the License.
 #list {
     z-index: 0;
     vertical-align: top;
-    background: linear-gradient(
-        to
-            var(
-                --mod-tabs-list-background-direction,
-                var(--spectrum-tabs-list-background-direction)
-            ),
-        var(
-                --highcontrast-tabs-divider-background-color,
-                var(
-                    --mod-tabs-divider-background-color,
-                    var(--spectrum-tabs-divider-background-color)
-                )
-            )
-            0 var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size)),
-        transparent
-            var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size))
-    );
+    background: linear-gradient(to var(--mod-tabs-list-background-direction, var(--spectrum-tabs-list-background-direction)), var(--highcontrast-tabs-divider-background-color, var(--mod-tabs-divider-background-color, var(--spectrum-tabs-divider-background-color))) 0 var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size)), transparent var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size)));
     margin: 0;
     padding-block: 0;
     display: flex;
@@ -38,59 +22,27 @@ governing permissions and limitations under the License.
 }
 
 :host([emphasized]) #list {
-    --mod-tabs-color-selected: var(
-        --mod-tabs-color-selected-emphasized,
-        var(--spectrum-tabs-color-selected)
-    );
-    --mod-tabs-color-hover: var(
-        --mod-tabs-color-hover-emphasized,
-        var(--spectrum-tabs-color-hover)
-    );
-    --mod-tabs-color-key-focus: var(
-        --mod-tabs-color-key-focus-emphasized,
-        var(--spectrum-tabs-color-key-focus)
-    );
-    --mod-tabs-selection-indicator-color: var(
-        --mod-tabs-selection-indicator-color-emphasized,
-        var(--spectrum-tabs-selection-indicator-color)
-    );
+    --mod-tabs-color-selected: var(--mod-tabs-color-selected-emphasized, var(--spectrum-tabs-color-selected));
+    --mod-tabs-color-hover: var(--mod-tabs-color-hover-emphasized, var(--spectrum-tabs-color-hover));
+    --mod-tabs-color-key-focus: var(--mod-tabs-color-key-focus-emphasized, var(--spectrum-tabs-color-key-focus));
+    --mod-tabs-selection-indicator-color: var(--mod-tabs-selection-indicator-color-emphasized, var(--spectrum-tabs-selection-indicator-color));
 }
 
 ::slotted([selected]:not([slot])) {
-    color: var(
-        --highcontrast-tabs-color-selected,
-        var(--mod-tabs-color-selected, var(--spectrum-tabs-color-selected))
-    );
+    color: var(--highcontrast-tabs-color-selected, var(--mod-tabs-color-selected, var(--spectrum-tabs-color-selected)));
 }
 
 ::slotted([disabled]:not([slot])) {
     cursor: default;
-    color: var(
-        --highcontrast-tabs-color-disabled,
-        var(--mod-tabs-color-disabled, var(--spectrum-tabs-color-disabled))
-    );
+    color: var(--highcontrast-tabs-color-disabled, var(--mod-tabs-color-disabled, var(--spectrum-tabs-color-disabled)));
 }
 
 #selection-indicator {
-    background-color: var(
-        --highcontrast-tabs-selection-indicator-color,
-        var(
-            --mod-tabs-selection-indicator-color,
-            var(--spectrum-tabs-selection-indicator-color)
-        )
-    );
+    background-color: var(--highcontrast-tabs-selection-indicator-color, var(--mod-tabs-selection-indicator-color, var(--spectrum-tabs-selection-indicator-color)));
     z-index: 0;
-    transition: transform
-        var(
-            --mod-tabs-animation-duration,
-            var(--spectrum-tabs-animation-duration)
-        )
-        var(--mod-tabs-animation-ease, var(--spectrum-tabs-animation-ease));
+    transition: transform var(--mod-tabs-animation-duration, var(--spectrum-tabs-animation-duration)) var(--mod-tabs-animation-ease, var(--spectrum-tabs-animation-ease));
     transform-origin: 0 0;
-    border-radius: var(
-        --mod-tabs-divider-border-radius,
-        var(--spectrum-tabs-divider-border-radius)
-    );
+    border-radius: var(--mod-tabs-divider-border-radius, var(--spectrum-tabs-divider-border-radius));
     position: absolute;
     inset-inline-start: 0;
 }
@@ -104,10 +56,7 @@ governing permissions and limitations under the License.
 }
 
 :host([direction^='horizontal']) ::slotted(:not(:first-child)) {
-    margin-inline-start: var(
-        --mod-tabs-item-horizontal-spacing,
-        var(--spectrum-tabs-item-horizontal-spacing)
-    );
+    margin-inline-start: var(--mod-tabs-item-horizontal-spacing, var(--spectrum-tabs-item-horizontal-spacing));
 }
 
 :host([direction^='horizontal']) #list #selection-indicator {
@@ -128,17 +77,11 @@ governing permissions and limitations under the License.
 }
 
 :host([quiet]) #selection-indicator {
-    padding-inline-start: var(
-        --mod-tabs-start-to-item-quiet,
-        var(--spectrum-tabs-start-to-item-quiet)
-    );
+    padding-inline-start: var(--mod-tabs-start-to-item-quiet, var(--spectrum-tabs-start-to-item-quiet));
 }
 
 :host([direction^='vertical']) #list {
-    --mod-tabs-list-background-direction: var(
-        --mod-tabs-list-background-direction-vertical,
-        right
-    );
+    --mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, right);
 }
 
 :host([direction^='vertical']) #list,
@@ -157,47 +100,27 @@ governing permissions and limitations under the License.
 :host([direction^='vertical-right']) #list ::slotted(:not([slot])) {
     block-size: var(--mod-tabs-item-height, var(--spectrum-tabs-item-height));
     line-height: var(--mod-tabs-item-height, var(--spectrum-tabs-item-height));
-    margin-block-end: var(
-        --mod-tabs-item-vertical-spacing,
-        var(--spectrum-tabs-item-vertical-spacing)
-    );
-    margin-inline-start: var(
-        --mod-tabs-start-to-edge,
-        var(--spectrum-tabs-start-to-edge)
-    );
-    margin-inline-end: var(
-        --mod-tabs-start-to-edge,
-        var(--spectrum-tabs-start-to-edge)
-    );
+    margin-block-end: var(--mod-tabs-item-vertical-spacing, var(--spectrum-tabs-item-vertical-spacing));
+    margin-inline-start: var(--mod-tabs-start-to-edge, var(--spectrum-tabs-start-to-edge));
+    margin-inline-end: var(--mod-tabs-start-to-edge, var(--spectrum-tabs-start-to-edge));
     padding-block: 0;
 }
 
 :host([direction^='vertical']) #list ::slotted(:not([slot])):before,
 :host([direction^='vertical-right']) #list ::slotted(:not([slot])):before {
-    inset-inline-start: calc(
-        var(
-                --mod-tabs-focus-indicator-gap,
-                var(--spectrum-tabs-focus-indicator-gap)
-            ) * -1
-    );
+    inset-inline-start: calc(var(--mod-tabs-focus-indicator-gap, var(--spectrum-tabs-focus-indicator-gap)) * -1);
 }
 
 :host([direction^='vertical']) #list #selection-indicator,
 :host([direction^='vertical-right']) #list #selection-indicator {
-    inline-size: var(
-        --mod-tabs-divider-size,
-        var(--spectrum-tabs-divider-size)
-    );
+    inline-size: var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size));
     position: absolute;
     inset-block-start: 0;
     inset-inline-start: 0;
 }
 
 :host([direction^='vertical-right']) #list {
-    --mod-tabs-list-background-direction: var(
-        --mod-tabs-list-background-direction-vertical-right,
-        left
-    );
+    --mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical-right, left);
 }
 
 :host([direction^='vertical-right']) #list #selection-indicator {
@@ -206,37 +129,19 @@ governing permissions and limitations under the License.
 
 :host([direction^='vertical']) #list:dir(rtl),
 :host([dir='rtl'][direction^='vertical']) #list {
-    --mod-tabs-list-background-direction: var(
-        --mod-tabs-list-background-direction-vertical,
-        left
-    );
+    --mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, left);
 }
 
 :host([direction^='vertical-right']) #list:dir(rtl),
 :host([dir='rtl'][direction^='vertical-right']) #list {
-    --mod-tabs-list-background-direction: var(
-        --mod-tabs-list-background-direction-vertical,
-        right
-    );
+    --mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, right);
 }
 
 :host([compact]) #list {
-    --spectrum-tabs-item-height: var(
-        --mod-tabs-item-height-compact,
-        var(--spectrum-tab-item-compact-height-medium)
-    );
-    --spectrum-tabs-top-to-text: var(
-        --mod-tabs-top-to-text-compact,
-        var(--spectrum-tab-item-top-to-text-compact-medium)
-    );
-    --spectrum-tabs-bottom-to-text: var(
-        --mod-tabs-bottom-to-text-compact,
-        var(--spectrum-tab-item-top-to-text-compact-medium)
-    );
-    --spectrum-tabs-top-to-icon: var(
-        --mod-tabs-top-to-icon-compact,
-        var(--spectrum-tab-item-top-to-workflow-icon-compact-medium)
-    );
+    --spectrum-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-medium));
+    --spectrum-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-medium));
+    --spectrum-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-medium));
+    --spectrum-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-medium));
 }
 
 @media (forced-colors: active) {
@@ -254,37 +159,15 @@ governing permissions and limitations under the License.
     }
 
     #list ::slotted([selected]:not([slot])):before {
-        background-color: var(
-            --highcontrast-tabs-focus-indicator-background-color
-        );
+        background-color: var(--highcontrast-tabs-focus-indicator-background-color);
     }
 
-    :host([direction^='vertical'][compact])
-        #list
-        #list
-        ::slotted(:not([slot])):before {
+    :host([direction^='vertical'][compact]) #list #list ::slotted(:not([slot])):before {
         block-size: 100%;
         inset-block-start: 0;
     }
 
     :host([quiet]) #list {
-        background: linear-gradient(
-            to
-                var(
-                    --mod-tabs-list-background-direction,
-                    var(--spectrum-tabs-list-background-direction)
-                ),
-            var(
-                    --highcontrast-tabs-divider-background-color,
-                    var(
-                        --mod-tabs-divider-background-color,
-                        var(--spectrum-tabs-divider-background-color)
-                    )
-                )
-                0
-                var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size)),
-            transparent
-                var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size))
-        );
+        background: linear-gradient(to var(--mod-tabs-list-background-direction, var(--spectrum-tabs-list-background-direction)), var(--highcontrast-tabs-divider-background-color, var(--mod-tabs-divider-background-color, var(--spectrum-tabs-divider-background-color))) 0 var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size)), transparent var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size)));
     }
 }

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -12,22 +12,10 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    border-color: var(
-        --highcontrast-tag-border-color,
-        var(--mod-tag-border-color, var(--spectrum-tag-border-color))
-    );
-    background-color: var(
-        --highcontrast-tag-background-color,
-        var(--mod-tag-background-color, var(--spectrum-tag-background-color))
-    );
-    color: var(
-        --highcontrast-tag-content-color,
-        var(--mod-tag-content-color, var(--spectrum-tag-content-color))
-    );
-    border-radius: var(
-        --mod-tag-corner-radius,
-        var(--spectrum-tag-corner-radius)
-    );
+    border-color: var(--highcontrast-tag-border-color, var(--mod-tag-border-color, var(--spectrum-tag-border-color)));
+    background-color: var(--highcontrast-tag-background-color, var(--mod-tag-background-color, var(--spectrum-tag-background-color)));
+    color: var(--highcontrast-tag-content-color, var(--mod-tag-content-color, var(--spectrum-tag-content-color)));
+    border-radius: var(--mod-tag-corner-radius, var(--spectrum-tag-corner-radius));
     border-width: var(--mod-tag-border-width, var(--spectrum-tag-border-width));
     block-size: var(--mod-tag-height, var(--spectrum-tag-height));
     box-sizing: border-box;
@@ -36,39 +24,14 @@ governing permissions and limitations under the License.
     -webkit-user-select: none;
     user-select: none;
     transition:
-        border-color
-            var(
-                --mod-tag-animation-duration,
-                var(--spectrum-tag-animation-duration)
-            )
-            ease-in-out,
-        color
-            var(
-                --mod-tag-animation-duration,
-                var(--spectrum-tag-animation-duration)
-            )
-            ease-in-out,
-        box-shadow
-            var(
-                --mod-tag-animation-duration,
-                var(--spectrum-tag-animation-duration)
-            )
-            ease-in-out,
-        background-color
-            var(
-                --mod-tag-animation-duration,
-                var(--spectrum-tag-animation-duration)
-            )
-            ease-in-out;
+        border-color var(--mod-tag-animation-duration, var(--spectrum-tag-animation-duration)) ease-in-out,
+        color var(--mod-tag-animation-duration, var(--spectrum-tag-animation-duration)) ease-in-out,
+        box-shadow var(--mod-tag-animation-duration, var(--spectrum-tag-animation-duration)) ease-in-out,
+        background-color var(--mod-tag-animation-duration, var(--spectrum-tag-animation-duration)) ease-in-out;
     border-style: solid;
     outline: none;
     align-items: center;
-    padding-inline-start: calc(
-        var(
-                --mod-tag-spacing-inline-start,
-                var(--spectrum-tag-spacing-inline-start)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
+    padding-inline-start: calc(var(--mod-tag-spacing-inline-start, var(--spectrum-tag-spacing-inline-start)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
     padding-inline-end: 0;
     display: inline-flex;
     position: relative;
@@ -78,41 +41,15 @@ governing permissions and limitations under the License.
     block-size: var(--mod-tag-icon-size, var(--spectrum-tag-icon-size));
     inline-size: var(--mod-tag-icon-size, var(--spectrum-tag-icon-size));
     flex-shrink: 0;
-    margin-block-start: calc(
-        var(
-                --mod-tag-icon-spacing-block-start,
-                var(--spectrum-tag-icon-spacing-block-start)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
-    margin-block-end: calc(
-        var(
-                --mod-tag-icon-spacing-block-end,
-                var(--spectrum-tag-icon-spacing-block-end)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
-    margin-inline-end: var(
-        --mod-tag-icon-spacing-inline-end,
-        var(--spectrum-tag-icon-spacing-inline-end)
-    );
+    margin-block-start: calc(var(--mod-tag-icon-spacing-block-start, var(--spectrum-tag-icon-spacing-block-start)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
+    margin-block-end: calc(var(--mod-tag-icon-spacing-block-end, var(--spectrum-tag-icon-spacing-block-end)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
+    margin-inline-end: var(--mod-tag-icon-spacing-inline-end, var(--spectrum-tag-icon-spacing-inline-end));
 }
 
 ::slotted([slot='avatar']) {
-    margin-block-start: calc(
-        var(
-                --mod-tag-avatar-spacing-block-start,
-                var(--spectrum-tag-avatar-spacing-block-start)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
-    margin-block-end: calc(
-        var(
-                --mod-tag-avatar-spacing-block-end,
-                var(--spectrum-tag-avatar-spacing-block-end)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
-    margin-inline-end: var(
-        --mod-tag-avatar-spacing-inline-end,
-        var(--spectrum-tag-avatar-spacing-inline-end)
-    );
+    margin-block-start: calc(var(--mod-tag-avatar-spacing-block-start, var(--spectrum-tag-avatar-spacing-block-start)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
+    margin-block-end: calc(var(--mod-tag-avatar-spacing-block-end, var(--spectrum-tag-avatar-spacing-block-end)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
+    margin-inline-end: var(--mod-tag-avatar-spacing-inline-end, var(--spectrum-tag-avatar-spacing-inline-end));
 }
 
 .clear-button {
@@ -121,559 +58,169 @@ governing permissions and limitations under the License.
     --spectrum-clearbutton-fill-background-color: transparent;
     box-sizing: border-box;
     color: currentColor;
-    margin-inline-start: calc(
-        var(
-                --mod-tag-clear-button-spacing-inline-start,
-                var(--spectrum-tag-clear-button-spacing-inline-start)
-            ) +
-            var(
-                --mod-tag-label-spacing-inline-end,
-                var(--spectrum-tag-label-spacing-inline-end)
-            ) * -1
-    );
-    margin-inline-end: calc(
-        var(
-                --mod-tag-clear-button-spacing-inline-end,
-                var(--spectrum-tag-clear-button-spacing-inline-end)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
-    padding-block-start: calc(
-        var(
-                --mod-tag-clear-button-spacing-block,
-                var(--spectrum-tag-clear-button-spacing-block)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
-    padding-block-end: calc(
-        var(
-                --mod-tag-clear-button-spacing-block,
-                var(--spectrum-tag-clear-button-spacing-block)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
+    margin-inline-start: calc(var(--mod-tag-clear-button-spacing-inline-start, var(--spectrum-tag-clear-button-spacing-inline-start)) + var(--mod-tag-label-spacing-inline-end, var(--spectrum-tag-label-spacing-inline-end)) * -1);
+    margin-inline-end: calc(var(--mod-tag-clear-button-spacing-inline-end, var(--spectrum-tag-clear-button-spacing-inline-end)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
+    padding-block-start: calc(var(--mod-tag-clear-button-spacing-block, var(--spectrum-tag-clear-button-spacing-block)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
+    padding-block-end: calc(var(--mod-tag-clear-button-spacing-block, var(--spectrum-tag-clear-button-spacing-block)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
 }
 
 .clear-button .spectrum-ClearButton-fill {
-    background-color: var(
-        --mod-clearbutton-fill-background-color,
-        var(--spectrum-clearbutton-fill-background-color)
-    );
-    inline-size: var(
-        --mod-clearbutton-fill-size,
-        var(--spectrum-clearbutton-fill-size)
-    );
-    block-size: var(
-        --mod-clearbutton-fill-size,
-        var(--spectrum-clearbutton-fill-size)
-    );
+    background-color: var(--mod-clearbutton-fill-background-color, var(--spectrum-clearbutton-fill-background-color));
+    inline-size: var(--mod-clearbutton-fill-size, var(--spectrum-clearbutton-fill-size));
+    block-size: var(--mod-clearbutton-fill-size, var(--spectrum-clearbutton-fill-size));
 }
 
 .label {
     block-size: 100%;
     box-sizing: border-box;
-    line-height: var(
-        --mod-tag-label-line-height,
-        var(--spectrum-tag-label-line-height)
-    );
-    font-weight: var(
-        --mod-tag-label-font-weight,
-        var(--spectrum-tag-label-font-weight)
-    );
+    line-height: var(--mod-tag-label-line-height, var(--spectrum-tag-label-line-height));
+    font-weight: var(--mod-tag-label-font-weight, var(--spectrum-tag-label-font-weight));
     font-size: var(--mod-tag-font-size, var(--spectrum-tag-font-size));
     cursor: default;
     white-space: nowrap;
     text-overflow: ellipsis;
     flex: auto;
-    margin-inline-end: calc(
-        var(
-                --mod-tag-label-spacing-inline-end,
-                var(--spectrum-tag-label-spacing-inline-end)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
-    padding-block-start: calc(
-        var(
-                --mod-tag-label-spacing-block,
-                var(--spectrum-tag-label-spacing-block)
-            ) - var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
+    margin-inline-end: calc(var(--mod-tag-label-spacing-inline-end, var(--spectrum-tag-label-spacing-inline-end)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
+    padding-block-start: calc(var(--mod-tag-label-spacing-block, var(--spectrum-tag-label-spacing-block)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
     overflow: hidden;
 }
 
 :host(:is(:active, [active])) {
-    border-color: var(
-        --highcontrast-tag-border-color-active,
-        var(
-            --mod-tag-border-color-active,
-            var(--spectrum-tag-border-color-active)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-active,
-        var(
-            --mod-tag-background-color-active,
-            var(--spectrum-tag-background-color-active)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-active,
-        var(
-            --mod-tag-content-color-active,
-            var(--spectrum-tag-content-color-active)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-active, var(--mod-tag-border-color-active, var(--spectrum-tag-border-color-active)));
+    background-color: var(--highcontrast-tag-background-color-active, var(--mod-tag-background-color-active, var(--spectrum-tag-background-color-active)));
+    color: var(--highcontrast-tag-content-color-active, var(--mod-tag-content-color-active, var(--spectrum-tag-content-color-active)));
 }
 
 :host([focused]),
 :host(:focus-visible) {
-    border-color: var(
-        --highcontrast-tag-border-color-focus,
-        var(
-            --mod-tag-border-color-focus,
-            var(--spectrum-tag-border-color-focus)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-focus,
-        var(
-            --mod-tag-background-color-focus,
-            var(--spectrum-tag-background-color-focus)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-focus,
-        var(
-            --mod-tag-content-color-focus,
-            var(--spectrum-tag-content-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-focus, var(--mod-tag-border-color-focus, var(--spectrum-tag-border-color-focus)));
+    background-color: var(--highcontrast-tag-background-color-focus, var(--mod-tag-background-color-focus, var(--spectrum-tag-background-color-focus)));
+    color: var(--highcontrast-tag-content-color-focus, var(--mod-tag-content-color-focus, var(--spectrum-tag-content-color-focus)));
 }
 
 :host([focused]):after,
 :host(:focus-visible):after {
     content: '';
-    border-color: var(
-        --highcontrast-tag-focus-ring-color,
-        var(--mod-tag-focus-ring-color, var(--spectrum-tag-focus-ring-color))
-    );
-    border-radius: calc(
-        var(--mod-tag-corner-radius, var(--spectrum-tag-corner-radius)) +
-            var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) +
-            var(--mod-tag-border-width, var(--spectrum-tag-border-width))
-    );
-    border-width: var(
-        --mod-tag-focus-ring-thickness,
-        var(--spectrum-tag-focus-ring-thickness)
-    );
+    border-color: var(--highcontrast-tag-focus-ring-color, var(--mod-tag-focus-ring-color, var(--spectrum-tag-focus-ring-color)));
+    border-radius: calc(var(--mod-tag-corner-radius, var(--spectrum-tag-corner-radius)) + var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) + var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
+    border-width: var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness));
     pointer-events: none;
     border-style: solid;
     display: inline-block;
     position: absolute;
-    inset-block-start: calc(
-        var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * -1 -
-            var(--mod-tag-border-width, var(--spectrum-tag-border-width)) -
-            var(
-                --mod-tag-focus-ring-thickness,
-                var(--spectrum-tag-focus-ring-thickness)
-            )
-    );
-    inset-block-end: calc(
-        var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * -1 -
-            var(--mod-tag-border-width, var(--spectrum-tag-border-width)) -
-            var(
-                --mod-tag-focus-ring-thickness,
-                var(--spectrum-tag-focus-ring-thickness)
-            )
-    );
-    inset-inline-start: calc(
-        var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * -1 -
-            var(--mod-tag-border-width, var(--spectrum-tag-border-width)) -
-            var(
-                --mod-tag-focus-ring-thickness,
-                var(--spectrum-tag-focus-ring-thickness)
-            )
-    );
-    inset-inline-end: calc(
-        var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * -1 -
-            var(--mod-tag-border-width, var(--spectrum-tag-border-width)) -
-            var(
-                --mod-tag-focus-ring-thickness,
-                var(--spectrum-tag-focus-ring-thickness)
-            )
-    );
+    inset-block-start: calc(var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * -1 - var(--mod-tag-border-width, var(--spectrum-tag-border-width)) - var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)));
+    inset-block-end: calc(var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * -1 - var(--mod-tag-border-width, var(--spectrum-tag-border-width)) - var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)));
+    inset-inline-start: calc(var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * -1 - var(--mod-tag-border-width, var(--spectrum-tag-border-width)) - var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)));
+    inset-inline-end: calc(var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) * -1 - var(--mod-tag-border-width, var(--spectrum-tag-border-width)) - var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness)));
 }
 
 :host([selected]) {
-    border-color: var(
-        --highcontrast-tag-border-color-selected,
-        var(
-            --mod-tag-border-color-selected,
-            var(--spectrum-tag-border-color-selected)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-selected,
-        var(
-            --mod-tag-background-color-selected,
-            var(--spectrum-tag-background-color-selected)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-selected,
-        var(
-            --mod-tag-content-color-selected,
-            var(--spectrum-tag-content-color-selected)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-selected, var(--mod-tag-border-color-selected, var(--spectrum-tag-border-color-selected)));
+    background-color: var(--highcontrast-tag-background-color-selected, var(--mod-tag-background-color-selected, var(--spectrum-tag-background-color-selected)));
+    color: var(--highcontrast-tag-content-color-selected, var(--mod-tag-content-color-selected, var(--spectrum-tag-content-color-selected)));
 }
 
 :host([selected]:is(:active, [active])) {
-    border-color: var(
-        --highcontrast-tag-border-color-selected-active,
-        var(
-            --mod-tag-border-color-selected-active,
-            var(--spectrum-tag-border-color-selected-active)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-selected-active,
-        var(
-            --mod-tag-background-color-selected-active,
-            var(--spectrum-tag-background-color-selected-active)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-selected-active, var(--mod-tag-border-color-selected-active, var(--spectrum-tag-border-color-selected-active)));
+    background-color: var(--highcontrast-tag-background-color-selected-active, var(--mod-tag-background-color-selected-active, var(--spectrum-tag-background-color-selected-active)));
 }
 
 :host([selected][focused]),
 :host([selected]:focus-visible) {
-    border-color: var(
-        --highcontrast-tag-border-color-selected-focus,
-        var(
-            --mod-tag-border-color-selected-focus,
-            var(--spectrum-tag-border-color-selected-focus)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-selected-focus,
-        var(
-            --mod-tag-background-color-selected-focus,
-            var(--spectrum-tag-background-color-selected-focus)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-selected-focus, var(--mod-tag-border-color-selected-focus, var(--spectrum-tag-border-color-selected-focus)));
+    background-color: var(--highcontrast-tag-background-color-selected-focus, var(--mod-tag-background-color-selected-focus, var(--spectrum-tag-background-color-selected-focus)));
 }
 
 :host([invalid]) {
-    border-color: var(
-        --highcontrast-tag-border-color-invalid,
-        var(
-            --mod-tag-border-color-invalid,
-            var(--spectrum-tag-border-color-invalid)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-invalid,
-        var(
-            --mod-tag-content-color-invalid,
-            var(--spectrum-tag-content-color-invalid)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-invalid, var(--mod-tag-border-color-invalid, var(--spectrum-tag-border-color-invalid)));
+    color: var(--highcontrast-tag-content-color-invalid, var(--mod-tag-content-color-invalid, var(--spectrum-tag-content-color-invalid)));
 }
 
 :host([invalid]:is(:active, [active])) {
-    border-color: var(
-        --highcontrast-tag-border-color-invalid-active,
-        var(
-            --mod-tag-border-color-invalid-active,
-            var(--spectrum-tag-border-color-invalid-active)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-invalid-active,
-        var(
-            --mod-tag-content-color-invalid-active,
-            var(--spectrum-tag-content-color-invalid-active)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-invalid-active, var(--mod-tag-border-color-invalid-active, var(--spectrum-tag-border-color-invalid-active)));
+    color: var(--highcontrast-tag-content-color-invalid-active, var(--mod-tag-content-color-invalid-active, var(--spectrum-tag-content-color-invalid-active)));
 }
 
 :host([invalid][focused]),
 :host([invalid]:focus-visible) {
-    border-color: var(
-        --highcontrast-tag-border-color-invalid-focus,
-        var(
-            --mod-tag-border-color-invalid-focus,
-            var(--spectrum-tag-border-color-invalid-focus)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-invalid-focus,
-        var(
-            --mod-tag-content-color-invalid-focus,
-            var(--spectrum-tag-content-color-invalid-focus)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-invalid-focus, var(--mod-tag-border-color-invalid-focus, var(--spectrum-tag-border-color-invalid-focus)));
+    color: var(--highcontrast-tag-content-color-invalid-focus, var(--mod-tag-content-color-invalid-focus, var(--spectrum-tag-content-color-invalid-focus)));
 }
 
 :host([invalid][selected]) {
-    border-color: var(
-        --highcontrast-tag-border-color-invalid-selected,
-        var(
-            --mod-tag-border-color-invalid-selected,
-            var(--spectrum-tag-border-color-invalid-selected)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-invalid-selected,
-        var(
-            --mod-tag-background-color-invalid-selected,
-            var(--spectrum-tag-background-color-invalid-selected)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-invalid-selected,
-        var(
-            --mod-tag-content-color-invalid-selected,
-            var(--spectrum-tag-content-color-invalid-selected)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-invalid-selected, var(--mod-tag-border-color-invalid-selected, var(--spectrum-tag-border-color-invalid-selected)));
+    background-color: var(--highcontrast-tag-background-color-invalid-selected, var(--mod-tag-background-color-invalid-selected, var(--spectrum-tag-background-color-invalid-selected)));
+    color: var(--highcontrast-tag-content-color-invalid-selected, var(--mod-tag-content-color-invalid-selected, var(--spectrum-tag-content-color-invalid-selected)));
 }
 
 :host([invalid][selected]:is(:active, [active])) {
-    border-color: var(
-        --highcontrast-tag-border-color-invalid-selected-active,
-        var(
-            --mod-tag-border-color-invalid-selected-active,
-            var(--spectrum-tag-border-color-invalid-selected-active)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-invalid-selected-active,
-        var(
-            --mod-tag-background-color-invalid-selected-active,
-            var(--spectrum-tag-background-color-invalid-selected-active)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-invalid-selected-active, var(--mod-tag-border-color-invalid-selected-active, var(--spectrum-tag-border-color-invalid-selected-active)));
+    background-color: var(--highcontrast-tag-background-color-invalid-selected-active, var(--mod-tag-background-color-invalid-selected-active, var(--spectrum-tag-background-color-invalid-selected-active)));
 }
 
 :host([invalid][selected][focused]),
 :host([invalid][selected]:focus-visible) {
-    border-color: var(
-        --highcontrast-tag-border-color-invalid-selected-focus,
-        var(
-            --mod-tag-border-color-invalid-selected-focus,
-            var(--spectrum-tag-border-color-invalid-selected-focus)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-invalid-selected-focus,
-        var(
-            --mod-tag-background-color-invalid-selected-focus,
-            var(--spectrum-tag-background-color-invalid-selected-focus)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-invalid-selected-focus, var(--mod-tag-border-color-invalid-selected-focus, var(--spectrum-tag-border-color-invalid-selected-focus)));
+    background-color: var(--highcontrast-tag-background-color-invalid-selected-focus, var(--mod-tag-background-color-invalid-selected-focus, var(--spectrum-tag-background-color-invalid-selected-focus)));
 }
 
 :host([emphasized]) {
-    border-color: var(
-        --highcontrast-tag-border-color-emphasized,
-        var(
-            --mod-tag-border-color-emphasized,
-            var(--spectrum-tag-border-color-emphasized)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-emphasized,
-        var(
-            --mod-tag-background-color-emphasized,
-            var(--spectrum-tag-background-color-emphasized)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-emphasized,
-        var(
-            --mod-tag-content-color-emphasized,
-            var(--spectrum-tag-content-color-emphasized)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-emphasized, var(--mod-tag-border-color-emphasized, var(--spectrum-tag-border-color-emphasized)));
+    background-color: var(--highcontrast-tag-background-color-emphasized, var(--mod-tag-background-color-emphasized, var(--spectrum-tag-background-color-emphasized)));
+    color: var(--highcontrast-tag-content-color-emphasized, var(--mod-tag-content-color-emphasized, var(--spectrum-tag-content-color-emphasized)));
 }
 
 @media (hover: hover) {
     :host(:hover) {
-        border-color: var(
-            --highcontrast-tag-border-color-hover,
-            var(
-                --mod-tag-border-color-hover,
-                var(--spectrum-tag-border-color-hover)
-            )
-        );
-        background-color: var(
-            --highcontrast-tag-background-color-hover,
-            var(
-                --mod-tag-background-color-hover,
-                var(--spectrum-tag-background-color-hover)
-            )
-        );
-        color: var(
-            --highcontrast-tag-content-color-hover,
-            var(
-                --mod-tag-content-color-hover,
-                var(--spectrum-tag-content-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-tag-border-color-hover, var(--mod-tag-border-color-hover, var(--spectrum-tag-border-color-hover)));
+        background-color: var(--highcontrast-tag-background-color-hover, var(--mod-tag-background-color-hover, var(--spectrum-tag-background-color-hover)));
+        color: var(--highcontrast-tag-content-color-hover, var(--mod-tag-content-color-hover, var(--spectrum-tag-content-color-hover)));
     }
 
     :host([selected]:hover) {
-        border-color: var(
-            --highcontrast-tag-border-color-selected-hover,
-            var(
-                --mod-tag-border-color-selected-hover,
-                var(--spectrum-tag-border-color-selected-hover)
-            )
-        );
-        background-color: var(
-            --highcontrast-tag-background-color-selected-hover,
-            var(
-                --mod-tag-background-color-selected-hover,
-                var(--spectrum-tag-background-color-selected-hover)
-            )
-        );
-        color: var(
-            --highcontrast-tag-content-color-selected,
-            var(
-                --mod-tag-content-color-selected,
-                var(--spectrum-tag-content-color-selected)
-            )
-        );
+        border-color: var(--highcontrast-tag-border-color-selected-hover, var(--mod-tag-border-color-selected-hover, var(--spectrum-tag-border-color-selected-hover)));
+        background-color: var(--highcontrast-tag-background-color-selected-hover, var(--mod-tag-background-color-selected-hover, var(--spectrum-tag-background-color-selected-hover)));
+        color: var(--highcontrast-tag-content-color-selected, var(--mod-tag-content-color-selected, var(--spectrum-tag-content-color-selected)));
     }
 
     :host([invalid]:hover) {
-        border-color: var(
-            --highcontrast-tag-border-color-invalid-hover,
-            var(
-                --mod-tag-border-color-invalid-hover,
-                var(--spectrum-tag-border-color-invalid-hover)
-            )
-        );
-        color: var(
-            --highcontrast-tag-content-color-invalid-hover,
-            var(
-                --mod-tag-content-color-invalid-hover,
-                var(--spectrum-tag-content-color-invalid-hover)
-            )
-        );
+        border-color: var(--highcontrast-tag-border-color-invalid-hover, var(--mod-tag-border-color-invalid-hover, var(--spectrum-tag-border-color-invalid-hover)));
+        color: var(--highcontrast-tag-content-color-invalid-hover, var(--mod-tag-content-color-invalid-hover, var(--spectrum-tag-content-color-invalid-hover)));
     }
 
     :host([invalid][selected]:hover) {
-        border-color: var(
-            --highcontrast-tag-border-color-invalid-selected-hover,
-            var(
-                --mod-tag-border-color-invalid-selected-hover,
-                var(--spectrum-tag-border-color-invalid-selected-hover)
-            )
-        );
-        background-color: var(
-            --highcontrast-tag-background-color-invalid-selected-hover,
-            var(
-                --mod-tag-background-color-invalid-selected-hover,
-                var(--spectrum-tag-background-color-invalid-selected-hover)
-            )
-        );
-        color: var(
-            --highcontrast-tag-content-color-invalid-selected,
-            var(
-                --mod-tag-content-color-invalid-selected,
-                var(--spectrum-tag-content-color-invalid-selected)
-            )
-        );
+        border-color: var(--highcontrast-tag-border-color-invalid-selected-hover, var(--mod-tag-border-color-invalid-selected-hover, var(--spectrum-tag-border-color-invalid-selected-hover)));
+        background-color: var(--highcontrast-tag-background-color-invalid-selected-hover, var(--mod-tag-background-color-invalid-selected-hover, var(--spectrum-tag-background-color-invalid-selected-hover)));
+        color: var(--highcontrast-tag-content-color-invalid-selected, var(--mod-tag-content-color-invalid-selected, var(--spectrum-tag-content-color-invalid-selected)));
     }
 
     :host([emphasized]:hover) {
-        border-color: var(
-            --highcontrast-tag-border-color-emphasized-hover,
-            var(
-                --mod-tag-border-color-emphasized-hover,
-                var(--spectrum-tag-border-color-emphasized-hover)
-            )
-        );
-        background-color: var(
-            --highcontrast-tag-background-color-emphasized-hover,
-            var(
-                --mod-tag-background-color-emphasized-hover,
-                var(--spectrum-tag-background-color-emphasized-hover)
-            )
-        );
-        color: var(
-            --highcontrast-tag-content-color-emphasized,
-            var(
-                --mod-tag-content-color-emphasized,
-                var(--spectrum-tag-content-color-emphasized)
-            )
-        );
+        border-color: var(--highcontrast-tag-border-color-emphasized-hover, var(--mod-tag-border-color-emphasized-hover, var(--spectrum-tag-border-color-emphasized-hover)));
+        background-color: var(--highcontrast-tag-background-color-emphasized-hover, var(--mod-tag-background-color-emphasized-hover, var(--spectrum-tag-background-color-emphasized-hover)));
+        color: var(--highcontrast-tag-content-color-emphasized, var(--mod-tag-content-color-emphasized, var(--spectrum-tag-content-color-emphasized)));
     }
 }
 
 :host([emphasized]:is(:active, [active])) {
-    border-color: var(
-        --highcontrast-tag-border-color-emphasized-active,
-        var(
-            --mod-tag-border-color-emphasized-active,
-            var(--spectrum-tag-border-color-emphasized-active)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-emphasized-active,
-        var(
-            --mod-tag-background-color-emphasized-active,
-            var(--spectrum-tag-background-color-emphasized-active)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-emphasized-active, var(--mod-tag-border-color-emphasized-active, var(--spectrum-tag-border-color-emphasized-active)));
+    background-color: var(--highcontrast-tag-background-color-emphasized-active, var(--mod-tag-background-color-emphasized-active, var(--spectrum-tag-background-color-emphasized-active)));
 }
 
 :host([emphasized][focused]),
 :host([emphasized]:focus-visible) {
-    border-color: var(
-        --highcontrast-tag-border-color-emphasized-focus,
-        var(
-            --mod-tag-border-color-emphasized-focus,
-            var(--spectrum-tag-border-color-emphasized-focus)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-emphasized-focus,
-        var(
-            --mod-tag-background-color-emphasized-focus,
-            var(--spectrum-tag-background-color-emphasized-focus)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-emphasized-focus, var(--mod-tag-border-color-emphasized-focus, var(--spectrum-tag-border-color-emphasized-focus)));
+    background-color: var(--highcontrast-tag-background-color-emphasized-focus, var(--mod-tag-background-color-emphasized-focus, var(--spectrum-tag-background-color-emphasized-focus)));
 }
 
 :host([disabled]) {
-    border-color: var(
-        --highcontrast-tag-border-color-disabled,
-        var(
-            --mod-tag-border-color-disabled,
-            var(--spectrum-tag-border-color-disabled)
-        )
-    );
-    background-color: var(
-        --highcontrast-tag-background-color-disabled,
-        var(
-            --mod-tag-background-color-disabled,
-            var(--spectrum-tag-background-color-disabled)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-disabled,
-        var(
-            --mod-tag-content-color-disabled,
-            var(--spectrum-tag-content-color-disabled)
-        )
-    );
+    border-color: var(--highcontrast-tag-border-color-disabled, var(--mod-tag-border-color-disabled, var(--spectrum-tag-border-color-disabled)));
+    background-color: var(--highcontrast-tag-background-color-disabled, var(--mod-tag-background-color-disabled, var(--spectrum-tag-background-color-disabled)));
+    color: var(--highcontrast-tag-content-color-disabled, var(--mod-tag-content-color-disabled, var(--spectrum-tag-content-color-disabled)));
     pointer-events: none;
 }
 
 :host([disabled]) ::slotted([slot='avatar']) {
-    opacity: var(
-        --mod-avatar-opacity-disabled,
-        var(--spectrum-avatar-opacity-disabled)
-    );
+    opacity: var(--mod-avatar-opacity-disabled, var(--spectrum-avatar-opacity-disabled));
 }
 
 @media (forced-colors: active) {

--- a/packages/tags/src/spectrum-tags.css
+++ b/packages/tags/src/spectrum-tags.css
@@ -20,12 +20,6 @@ governing permissions and limitations under the License.
 }
 
 ::slotted(*) {
-    margin-block: var(
-        --mod-tag-group-item-margin-block,
-        var(--spectrum-tag-group-item-margin-block)
-    );
-    margin-inline: var(
-        --mod-tag-group-item-margin-inline,
-        var(--spectrum-tag-group-item-margin-inline)
-    );
+    margin-block: var(--mod-tag-group-item-margin-block, var(--spectrum-tag-group-item-margin-block));
+    margin-inline: var(--mod-tag-group-item-margin-inline, var(--spectrum-tag-group-item-margin-inline));
 }

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -13,334 +13,132 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     --spectrum-textfield-input-line-height: var(--spectrum-textfield-height);
-    --spectrum-texfield-animation-duration: var(
-        --spectrum-animation-duration-100
-    );
+    --spectrum-texfield-animation-duration: var(--spectrum-animation-duration-100);
     --spectrum-textfield-width: 240px;
-    --spectrum-textfield-min-width: var(
-        --spectrum-text-field-minimum-width-multiplier
-    );
+    --spectrum-textfield-min-width: var(--spectrum-text-field-minimum-width-multiplier);
     --spectrum-textfield-corner-radius: var(--spectrum-corner-radius-100);
-    --spectrum-textfield-spacing-inline-quiet: var(
-        --spectrum-field-edge-to-text-quiet
-    );
-    --spectrum-textfield-spacing-block-start: var(
-        --spectrum-component-top-to-text-100
-    );
-    --spectrum-textfield-spacing-block-end: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --spectrum-textfield-spacing-block-quiet: var(
-        --spectrum-field-edge-to-border-quiet
-    );
-    --spectrum-textfield-label-spacing-block: var(
-        --spectrum-field-label-to-component
-    );
-    --spectrum-textfield-helptext-spacing-block: var(
-        --spectrum-help-text-to-component
-    );
-    --spectrum-textfield-icon-spacing-inline-end-quiet-invalid: var(
-        --spectrum-field-edge-to-alert-icon-quiet
-    );
-    --spectrum-textfield-icon-spacing-inline-end-quiet-valid: var(
-        --spectrum-field-edge-to-validation-icon-quiet
-    );
+    --spectrum-textfield-spacing-inline-quiet: var(--spectrum-field-edge-to-text-quiet);
+    --spectrum-textfield-spacing-block-start: var(--spectrum-component-top-to-text-100);
+    --spectrum-textfield-spacing-block-end: var(--spectrum-component-bottom-to-text-100);
+    --spectrum-textfield-spacing-block-quiet: var(--spectrum-field-edge-to-border-quiet);
+    --spectrum-textfield-label-spacing-block: var(--spectrum-field-label-to-component);
+    --spectrum-textfield-helptext-spacing-block: var(--spectrum-help-text-to-component);
+    --spectrum-textfield-icon-spacing-inline-end-quiet-invalid: var(--spectrum-field-edge-to-alert-icon-quiet);
+    --spectrum-textfield-icon-spacing-inline-end-quiet-valid: var(--spectrum-field-edge-to-validation-icon-quiet);
     --spectrum-textfield-font-family: var(--spectrum-sans-font-family-stack);
     --spectrum-textfield-font-weight: var(--spectrum-regular-font-weight);
-    --spectrum-textfield-character-count-font-family: var(
-        --spectrum-sans-font-family-stack
-    );
-    --spectrum-textfield-character-count-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-textfield-character-count-spacing-inline: var(
-        --spectrum-spacing-200
-    );
-    --spectrum-textfield-character-count-spacing-inline-side: var(
-        --spectrum-side-label-character-count-to-field
-    );
-    --spectrum-textfield-focus-indicator-width: var(
-        --spectrum-focus-indicator-thickness
-    );
-    --spectrum-textfield-focus-indicator-gap: var(
-        --spectrum-focus-indicator-gap
-    );
-    --spectrum-textfield-text-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-textfield-text-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --spectrum-textfield-text-color-focus: var(
-        --spectrum-neutral-content-color-focus
-    );
-    --spectrum-textfield-text-color-focus-hover: var(
-        --spectrum-neutral-content-color-focus-hover
-    );
-    --spectrum-textfield-text-color-keyboard-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
-    --spectrum-textfield-text-color-readonly: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-textfield-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --spectrum-textfield-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
-    --spectrum-textfield-text-color-disabled: var(
-        --spectrum-disabled-content-color
-    );
-    --spectrum-textfield-border-color-invalid-default: var(
-        --spectrum-negative-border-color-default
-    );
-    --spectrum-textfield-border-color-invalid-hover: var(
-        --spectrum-negative-border-color-hover
-    );
-    --spectrum-textfield-border-color-invalid-focus: var(
-        --spectrum-negative-border-color-focus
-    );
-    --spectrum-textfield-border-color-invalid-focus-hover: var(
-        --spectrum-negative-border-color-focus-hover
-    );
-    --spectrum-textfield-border-color-invalid-keyboard-focus: var(
-        --spectrum-negative-border-color-key-focus
-    );
-    --spectrum-textfield-icon-color-invalid: var(
-        --spectrum-negative-visual-color
-    );
-    --spectrum-textfield-text-color-invalid: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-textfield-text-color-valid: var(
-        --spectrum-neutral-content-color-default
-    );
-    --spectrum-textfield-icon-color-valid: var(
-        --spectrum-positive-visual-color
-    );
-    --spectrum-textfield-focus-indicator-color: var(
-        --spectrum-focus-indicator-color
-    );
-    --spectrum-text-area-min-inline-size: var(
-        --spectrum-text-area-minimum-width
-    );
-    --spectrum-text-area-min-block-size: var(
-        --spectrum-text-area-minimum-height
-    );
+    --spectrum-textfield-character-count-font-family: var(--spectrum-sans-font-family-stack);
+    --spectrum-textfield-character-count-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-textfield-character-count-spacing-inline: var(--spectrum-spacing-200);
+    --spectrum-textfield-character-count-spacing-inline-side: var(--spectrum-side-label-character-count-to-field);
+    --spectrum-textfield-focus-indicator-width: var(--spectrum-focus-indicator-thickness);
+    --spectrum-textfield-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
+    --spectrum-textfield-text-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-textfield-text-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-textfield-text-color-focus: var(--spectrum-neutral-content-color-focus);
+    --spectrum-textfield-text-color-focus-hover: var(--spectrum-neutral-content-color-focus-hover);
+    --spectrum-textfield-text-color-keyboard-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-textfield-text-color-readonly: var(--spectrum-neutral-content-color-default);
+    --spectrum-textfield-background-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-textfield-border-color-disabled: var(--spectrum-disabled-border-color);
+    --spectrum-textfield-text-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-textfield-border-color-invalid-default: var(--spectrum-negative-border-color-default);
+    --spectrum-textfield-border-color-invalid-hover: var(--spectrum-negative-border-color-hover);
+    --spectrum-textfield-border-color-invalid-focus: var(--spectrum-negative-border-color-focus);
+    --spectrum-textfield-border-color-invalid-focus-hover: var(--spectrum-negative-border-color-focus-hover);
+    --spectrum-textfield-border-color-invalid-keyboard-focus: var(--spectrum-negative-border-color-key-focus);
+    --spectrum-textfield-icon-color-invalid: var(--spectrum-negative-visual-color);
+    --spectrum-textfield-text-color-invalid: var(--spectrum-neutral-content-color-default);
+    --spectrum-textfield-text-color-valid: var(--spectrum-neutral-content-color-default);
+    --spectrum-textfield-icon-color-valid: var(--spectrum-positive-visual-color);
+    --spectrum-textfield-focus-indicator-color: var(--spectrum-focus-indicator-color);
+    --spectrum-text-area-min-inline-size: var(--spectrum-text-area-minimum-width);
+    --spectrum-text-area-min-block-size: var(--spectrum-text-area-minimum-height);
 }
 
 #textfield,
 :host {
     --spectrum-textfield-height: var(--spectrum-component-height-100);
-    --spectrum-textfield-label-spacing-block-quiet: var(
-        --spectrum-field-label-to-component-quiet-medium
-    );
-    --spectrum-textfield-label-spacing-inline-side-label: var(
-        --spectrum-spacing-200
-    );
+    --spectrum-textfield-label-spacing-block-quiet: var(--spectrum-field-label-to-component-quiet-medium);
+    --spectrum-textfield-label-spacing-inline-side-label: var(--spectrum-spacing-200);
     --spectrum-textfield-placeholder-font-size: var(--spectrum-font-size-100);
-    --spectrum-textfield-spacing-inline: var(
-        --spectrum-component-edge-to-text-100
-    );
-    --spectrum-textfield-icon-size-invalid: var(
-        --spectrum-workflow-icon-size-100
-    );
-    --spectrum-textfield-icon-size-valid: var(
-        --spectrum-checkmark-icon-size-100
-    );
-    --spectrum-textfield-icon-spacing-inline-end-invalid: var(
-        --spectrum-field-edge-to-alert-icon-medium
-    );
-    --spectrum-textfield-icon-spacing-inline-end-valid: var(
-        --spectrum-field-edge-to-validation-icon-medium
-    );
-    --spectrum-textfield-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-medium
-    );
-    --spectrum-textfield-icon-spacing-block-valid: var(
-        --spectrum-field-top-to-validation-icon-medium
-    );
-    --spectrum-textfield-icon-spacing-inline-start-invalid: var(
-        --spectrum-field-text-to-alert-icon-medium
-    );
-    --spectrum-textfield-icon-spacing-inline-start-valid: var(
-        --spectrum-field-text-to-validation-icon-medium
-    );
-    --spectrum-textfield-character-count-font-size: var(
-        --spectrum-font-size-75
-    );
-    --spectrum-textfield-character-count-spacing-block: var(
-        --spectrum-component-bottom-to-text-75
-    );
-    --spectrum-textfield-character-count-spacing-block-quiet: var(
-        --spectrum-character-count-to-field-quiet-medium
-    );
-    --spectrum-textfield-character-count-spacing-block-side: var(
-        --spectrum-side-label-character-count-top-margin-medium
-    );
-    --spectrum-text-area-min-block-size-quiet: var(
-        --spectrum-component-height-100
-    );
+    --spectrum-textfield-spacing-inline: var(--spectrum-component-edge-to-text-100);
+    --spectrum-textfield-icon-size-invalid: var(--spectrum-workflow-icon-size-100);
+    --spectrum-textfield-icon-size-valid: var(--spectrum-checkmark-icon-size-100);
+    --spectrum-textfield-icon-spacing-inline-end-invalid: var(--spectrum-field-edge-to-alert-icon-medium);
+    --spectrum-textfield-icon-spacing-inline-end-valid: var(--spectrum-field-edge-to-validation-icon-medium);
+    --spectrum-textfield-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-medium);
+    --spectrum-textfield-icon-spacing-block-valid: var(--spectrum-field-top-to-validation-icon-medium);
+    --spectrum-textfield-icon-spacing-inline-start-invalid: var(--spectrum-field-text-to-alert-icon-medium);
+    --spectrum-textfield-icon-spacing-inline-start-valid: var(--spectrum-field-text-to-validation-icon-medium);
+    --spectrum-textfield-character-count-font-size: var(--spectrum-font-size-75);
+    --spectrum-textfield-character-count-spacing-block: var(--spectrum-component-bottom-to-text-75);
+    --spectrum-textfield-character-count-spacing-block-quiet: var(--spectrum-character-count-to-field-quiet-medium);
+    --spectrum-textfield-character-count-spacing-block-side: var(--spectrum-side-label-character-count-top-margin-medium);
+    --spectrum-text-area-min-block-size-quiet: var(--spectrum-component-height-100);
 }
 
 :host([size='s']) #textfield {
     --spectrum-textfield-height: var(--spectrum-component-height-75);
-    --spectrum-textfield-label-spacing-block-quiet: var(
-        --spectrum-field-label-to-component-quiet-small
-    );
-    --spectrum-textfield-label-spacing-inline-side-label: var(
-        --spectrum-spacing-100
-    );
+    --spectrum-textfield-label-spacing-block-quiet: var(--spectrum-field-label-to-component-quiet-small);
+    --spectrum-textfield-label-spacing-inline-side-label: var(--spectrum-spacing-100);
     --spectrum-textfield-placeholder-font-size: var(--spectrum-font-size-75);
-    --spectrum-textfield-spacing-inline: var(
-        --spectrum-component-edge-to-text-75
-    );
-    --spectrum-textfield-icon-size-invalid: var(
-        --spectrum-workflow-icon-size-75
-    );
-    --spectrum-textfield-icon-size-valid: var(
-        --spectrum-checkmark-icon-size-75
-    );
-    --spectrum-textfield-icon-spacing-inline-end-invalid: var(
-        --spectrum-field-edge-to-alert-icon-small
-    );
-    --spectrum-textfield-icon-spacing-inline-end-valid: var(
-        --spectrum-field-edge-to-validation-icon-small
-    );
-    --spectrum-textfield-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-small
-    );
-    --spectrum-textfield-icon-spacing-block-valid: var(
-        --spectrum-field-top-to-validation-icon-small
-    );
-    --spectrum-textfield-icon-spacing-inline-start-invalid: var(
-        --spectrum-field-text-to-alert-icon-small
-    );
-    --spectrum-textfield-icon-spacing-inline-start-valid: var(
-        --spectrum-field-text-to-validation-icon-small
-    );
-    --spectrum-textfield-character-count-font-size: var(
-        --spectrum-font-size-75
-    );
-    --spectrum-textfield-character-count-spacing-block: var(
-        --spectrum-component-bottom-to-text-75
-    );
-    --spectrum-textfield-character-count-spacing-block-quiet: var(
-        --spectrum-character-count-to-field-quiet-small
-    );
-    --spectrum-textfield-character-count-spacing-block-side: var(
-        --spectrum-side-label-character-count-top-margin-small
-    );
-    --spectrum-text-area-min-block-size-quiet: var(
-        --spectrum-component-height-75
-    );
+    --spectrum-textfield-spacing-inline: var(--spectrum-component-edge-to-text-75);
+    --spectrum-textfield-icon-size-invalid: var(--spectrum-workflow-icon-size-75);
+    --spectrum-textfield-icon-size-valid: var(--spectrum-checkmark-icon-size-75);
+    --spectrum-textfield-icon-spacing-inline-end-invalid: var(--spectrum-field-edge-to-alert-icon-small);
+    --spectrum-textfield-icon-spacing-inline-end-valid: var(--spectrum-field-edge-to-validation-icon-small);
+    --spectrum-textfield-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-small);
+    --spectrum-textfield-icon-spacing-block-valid: var(--spectrum-field-top-to-validation-icon-small);
+    --spectrum-textfield-icon-spacing-inline-start-invalid: var(--spectrum-field-text-to-alert-icon-small);
+    --spectrum-textfield-icon-spacing-inline-start-valid: var(--spectrum-field-text-to-validation-icon-small);
+    --spectrum-textfield-character-count-font-size: var(--spectrum-font-size-75);
+    --spectrum-textfield-character-count-spacing-block: var(--spectrum-component-bottom-to-text-75);
+    --spectrum-textfield-character-count-spacing-block-quiet: var(--spectrum-character-count-to-field-quiet-small);
+    --spectrum-textfield-character-count-spacing-block-side: var(--spectrum-side-label-character-count-top-margin-small);
+    --spectrum-text-area-min-block-size-quiet: var(--spectrum-component-height-75);
 }
 
 :host([size='l']) #textfield {
     --spectrum-textfield-height: var(--spectrum-component-height-200);
-    --spectrum-textfield-label-spacing-block-quiet: var(
-        --spectrum-field-label-to-component-quiet-large
-    );
-    --spectrum-textfield-label-spacing-inline-side-label: var(
-        --spectrum-spacing-200
-    );
+    --spectrum-textfield-label-spacing-block-quiet: var(--spectrum-field-label-to-component-quiet-large);
+    --spectrum-textfield-label-spacing-inline-side-label: var(--spectrum-spacing-200);
     --spectrum-textfield-placeholder-font-size: var(--spectrum-font-size-200);
-    --spectrum-textfield-spacing-inline: var(
-        --spectrum-component-edge-to-text-200
-    );
-    --spectrum-textfield-icon-size-invalid: var(
-        --spectrum-workflow-icon-size-200
-    );
-    --spectrum-textfield-icon-size-valid: var(
-        --spectrum-checkmark-icon-size-200
-    );
-    --spectrum-textfield-icon-spacing-inline-end-invalid: var(
-        --spectrum-field-edge-to-alert-icon-large
-    );
-    --spectrum-textfield-icon-spacing-inline-end-valid: var(
-        --spectrum-field-edge-to-validation-icon-large
-    );
-    --spectrum-textfield-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-large
-    );
-    --spectrum-textfield-icon-spacing-block-valid: var(
-        --spectrum-field-top-to-validation-icon-large
-    );
-    --spectrum-textfield-icon-spacing-inline-start-invalid: var(
-        --spectrum-field-text-to-alert-icon-large
-    );
-    --spectrum-textfield-icon-spacing-inline-start-valid: var(
-        --spectrum-field-text-to-validation-icon-large
-    );
-    --spectrum-textfield-character-count-font-size: var(
-        --spectrum-font-size-100
-    );
-    --spectrum-textfield-character-count-spacing-block: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --spectrum-textfield-character-count-spacing-block-quiet: var(
-        --spectrum-character-count-to-field-quiet-large
-    );
-    --spectrum-textfield-character-count-spacing-block-side: var(
-        --spectrum-side-label-character-count-top-margin-large
-    );
-    --spectrum-text-area-min-block-size-quiet: var(
-        --spectrum-component-height-200
-    );
+    --spectrum-textfield-spacing-inline: var(--spectrum-component-edge-to-text-200);
+    --spectrum-textfield-icon-size-invalid: var(--spectrum-workflow-icon-size-200);
+    --spectrum-textfield-icon-size-valid: var(--spectrum-checkmark-icon-size-200);
+    --spectrum-textfield-icon-spacing-inline-end-invalid: var(--spectrum-field-edge-to-alert-icon-large);
+    --spectrum-textfield-icon-spacing-inline-end-valid: var(--spectrum-field-edge-to-validation-icon-large);
+    --spectrum-textfield-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-large);
+    --spectrum-textfield-icon-spacing-block-valid: var(--spectrum-field-top-to-validation-icon-large);
+    --spectrum-textfield-icon-spacing-inline-start-invalid: var(--spectrum-field-text-to-alert-icon-large);
+    --spectrum-textfield-icon-spacing-inline-start-valid: var(--spectrum-field-text-to-validation-icon-large);
+    --spectrum-textfield-character-count-font-size: var(--spectrum-font-size-100);
+    --spectrum-textfield-character-count-spacing-block: var(--spectrum-component-bottom-to-text-100);
+    --spectrum-textfield-character-count-spacing-block-quiet: var(--spectrum-character-count-to-field-quiet-large);
+    --spectrum-textfield-character-count-spacing-block-side: var(--spectrum-side-label-character-count-top-margin-large);
+    --spectrum-text-area-min-block-size-quiet: var(--spectrum-component-height-200);
 }
 
 :host([size='xl']) #textfield {
     --spectrum-textfield-height: var(--spectrum-component-height-300);
-    --spectrum-textfield-label-spacing-block-quiet: var(
-        --spectrum-field-label-to-component-quiet-extra-large
-    );
-    --spectrum-textfield-label-spacing-inline-side-label: var(
-        --spectrum-spacing-200
-    );
+    --spectrum-textfield-label-spacing-block-quiet: var(--spectrum-field-label-to-component-quiet-extra-large);
+    --spectrum-textfield-label-spacing-inline-side-label: var(--spectrum-spacing-200);
     --spectrum-textfield-placeholder-font-size: var(--spectrum-font-size-300);
-    --spectrum-textfield-spacing-inline: var(
-        --spectrum-component-edge-to-text-200
-    );
-    --spectrum-textfield-icon-size-invalid: var(
-        --spectrum-workflow-icon-size-300
-    );
-    --spectrum-textfield-icon-size-valid: var(
-        --spectrum-checkmark-icon-size-300
-    );
-    --spectrum-textfield-icon-spacing-inline-end-invalid: var(
-        --spectrum-field-edge-to-alert-icon-extra-large
-    );
-    --spectrum-textfield-icon-spacing-inline-end-valid: var(
-        --spectrum-field-edge-to-validation-icon-extra-large
-    );
-    --spectrum-textfield-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-extra-large
-    );
-    --spectrum-textfield-icon-spacing-block-valid: var(
-        --spectrum-field-top-to-validation-icon-extra-large
-    );
-    --spectrum-textfield-icon-spacing-inline-start-invalid: var(
-        --spectrum-field-text-to-alert-icon-extra-large
-    );
-    --spectrum-textfield-icon-spacing-inline-start-valid: var(
-        --spectrum-field-text-to-validation-icon-extra-large
-    );
-    --spectrum-textfield-character-count-font-size: var(
-        --spectrum-font-size-200
-    );
-    --spectrum-textfield-character-count-spacing-block: var(
-        --spectrum-component-bottom-to-text-200
-    );
-    --spectrum-textfield-character-count-spacing-block-quiet: var(
-        --spectrum-character-count-to-field-quiet-extra-large
-    );
-    --spectrum-textfield-character-count-spacing-block-side: var(
-        --spectrum-side-label-character-count-top-margin-extra-large
-    );
-    --spectrum-text-area-min-block-size-quiet: var(
-        --spectrum-component-height-300
-    );
+    --spectrum-textfield-spacing-inline: var(--spectrum-component-edge-to-text-200);
+    --spectrum-textfield-icon-size-invalid: var(--spectrum-workflow-icon-size-300);
+    --spectrum-textfield-icon-size-valid: var(--spectrum-checkmark-icon-size-300);
+    --spectrum-textfield-icon-spacing-inline-end-invalid: var(--spectrum-field-edge-to-alert-icon-extra-large);
+    --spectrum-textfield-icon-spacing-inline-end-valid: var(--spectrum-field-edge-to-validation-icon-extra-large);
+    --spectrum-textfield-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-extra-large);
+    --spectrum-textfield-icon-spacing-block-valid: var(--spectrum-field-top-to-validation-icon-extra-large);
+    --spectrum-textfield-icon-spacing-inline-start-invalid: var(--spectrum-field-text-to-alert-icon-extra-large);
+    --spectrum-textfield-icon-spacing-inline-start-valid: var(--spectrum-field-text-to-validation-icon-extra-large);
+    --spectrum-textfield-character-count-font-size: var(--spectrum-font-size-200);
+    --spectrum-textfield-character-count-spacing-block: var(--spectrum-component-bottom-to-text-200);
+    --spectrum-textfield-character-count-spacing-block-quiet: var(--spectrum-character-count-to-field-quiet-extra-large);
+    --spectrum-textfield-character-count-spacing-block-side: var(--spectrum-side-label-character-count-top-margin-extra-large);
+    --spectrum-text-area-min-block-size-quiet: var(--spectrum-component-height-300);
 }
 
 #textfield {
@@ -358,60 +156,22 @@ governing permissions and limitations under the License.
     content: '';
     pointer-events: none;
     inline-size: 100%;
-    block-size: var(
-        --mod-textfield-focus-indicator-width,
-        var(--spectrum-textfield-focus-indicator-width)
-    );
+    block-size: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width));
     position: absolute;
-    inset-block-end: calc(
-        (
-                var(
-                        --mod-textfield-focus-indicator-gap,
-                        var(--spectrum-textfield-focus-indicator-gap)
-                    ) +
-                    var(
-                        --mod-textfield-focus-indicator-width,
-                        var(--spectrum-textfield-focus-indicator-width)
-                    )
-            ) * -1
-    );
+    inset-block-end: calc((var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap)) + var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width))) * -1);
     inset-inline-start: 0;
 }
 
 :host([quiet][focused]) #textfield:after {
-    background-color: var(
-        --highcontrast-textfield-focus-indicator-color,
-        var(
-            --mod-textfield-focus-indicator-color,
-            var(--spectrum-textfield-focus-indicator-color)
-        )
-    );
+    background-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
 }
 
 :host([quiet][invalid]) #textfield .input {
-    padding-inline-end: calc(
-        var(
-                --mod-textfield-icon-spacing-inline-start-invalid,
-                var(--spectrum-textfield-icon-spacing-inline-start-invalid)
-            ) +
-            var(
-                --mod-textfield-icon-size-invalid,
-                var(--spectrum-textfield-icon-size-invalid)
-            )
-    );
+    padding-inline-end: calc(var(--mod-textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid)) + var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid)));
 }
 
 :host([quiet][valid]) #textfield .input {
-    padding-inline-end: calc(
-        var(
-                --mod-textfield-icon-spacing-inline-start-valid,
-                var(--spectrum-textfield-icon-spacing-inline-start-valid)
-            ) +
-            var(
-                --mod-textfield-icon-size-valid,
-                var(--spectrum-textfield-icon-size-valid)
-            )
-    );
+    padding-inline-end: calc(var(--mod-textfield-icon-spacing-inline-start-valid, var(--spectrum-textfield-icon-spacing-inline-start-valid)) + var(--mod-textfield-icon-size-valid, var(--spectrum-textfield-icon-size-valid)));
 }
 
 :host([invalid]) #textfield .icon,
@@ -428,49 +188,19 @@ governing permissions and limitations under the License.
 }
 
 :host([valid]) #textfield .icon {
-    color: var(
-        --mod-textfield-icon-color-valid,
-        var(--spectrum-textfield-icon-color-valid)
-    );
-    inset-block-start: var(
-        --mod-textfield-icon-spacing-block-valid,
-        var(--spectrum-textfield-icon-spacing-block-valid)
-    );
-    inset-block-end: var(
-        --mod-textfield-icon-spacing-block-valid,
-        var(--spectrum-textfield-icon-spacing-block-valid)
-    );
-    inset-inline-end: var(
-        --mod-textfield-icon-spacing-inline-end-valid,
-        var(--spectrum-textfield-icon-spacing-inline-end-valid)
-    );
+    color: var(--mod-textfield-icon-color-valid, var(--spectrum-textfield-icon-color-valid));
+    inset-block-start: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
+    inset-block-end: var(--mod-textfield-icon-spacing-block-valid, var(--spectrum-textfield-icon-spacing-block-valid));
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-valid, var(--spectrum-textfield-icon-spacing-inline-end-valid));
 }
 
 :host([invalid]) #textfield .icon {
-    block-size: var(
-        --mod-textfield-icon-size-invalid,
-        var(--spectrum-textfield-icon-size-invalid)
-    );
-    inline-size: var(
-        --mod-textfield-icon-size-invalid,
-        var(--spectrum-textfield-icon-size-invalid)
-    );
-    color: var(
-        --mod-textfield-icon-color-invalid,
-        var(--spectrum-textfield-icon-color-invalid)
-    );
-    inset-block-start: var(
-        --mod-textfield-icon-spacing-block-invalid,
-        var(--spectrum-textfield-icon-spacing-block-invalid)
-    );
-    inset-block-end: var(
-        --mod-textfield-icon-spacing-block-invalid,
-        var(--spectrum-textfield-icon-spacing-block-invalid)
-    );
-    inset-inline-end: var(
-        --mod-textfield-icon-spacing-inline-end-invalid,
-        var(--spectrum-textfield-icon-spacing-inline-end-invalid)
-    );
+    block-size: var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid));
+    inline-size: var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid));
+    color: var(--mod-textfield-icon-color-invalid, var(--spectrum-textfield-icon-color-invalid));
+    inset-block-start: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
+    inset-block-end: var(--mod-textfield-icon-spacing-block-invalid, var(--spectrum-textfield-icon-spacing-block-invalid));
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-invalid, var(--spectrum-textfield-icon-spacing-inline-end-invalid));
 }
 
 :host([disabled]) #textfield .icon,
@@ -483,32 +213,20 @@ governing permissions and limitations under the License.
 }
 
 :host([quiet][valid]) .icon {
-    inset-inline-end: var(
-        --mod-textfield-icon-spacing-inline-end-quiet-valid,
-        var(--spectrum-textfield-icon-spacing-inline-end-quiet-valid)
-    );
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-valid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-valid));
 }
 
 :host([quiet][invalid]) .icon {
-    inset-inline-end: var(
-        --mod-textfield-icon-spacing-inline-end-quiet-invalid,
-        var(--spectrum-textfield-icon-spacing-inline-end-quiet-invalid)
-    );
+    inset-inline-end: var(--mod-textfield-icon-spacing-inline-end-quiet-invalid, var(--spectrum-textfield-icon-spacing-inline-end-quiet-invalid));
 }
 
 #textfield .spectrum-FieldLabel {
     grid-area: 1 / 1 / auto / span 1;
-    margin-block-end: var(
-        --mod-textfield-label-spacing-block,
-        var(--spectrum-textfield-label-spacing-block)
-    );
+    margin-block-end: var(--mod-textfield-label-spacing-block, var(--spectrum-textfield-label-spacing-block));
 }
 
 :host([quiet]) .spectrum-FieldLabel {
-    margin-block-end: var(
-        --mod-textfield-label-spacing-block-quiet,
-        var(--spectrum-textfield-label-spacing-block-quiet)
-    );
+    margin-block-end: var(--mod-textfield-label-spacing-block-quiet, var(--spectrum-textfield-label-spacing-block-quiet));
 }
 
 :host([disabled]) .spectrum-FieldLabel {
@@ -517,139 +235,48 @@ governing permissions and limitations under the License.
 
 #textfield .spectrum-HelpText {
     grid-area: 3 / 1 / auto / span 2;
-    margin-block-start: var(
-        --mod-textfield-helptext-spacing-block,
-        var(--spectrum-textfield-helptext-spacing-block)
-    );
+    margin-block-start: var(--mod-textfield-helptext-spacing-block, var(--spectrum-textfield-helptext-spacing-block));
 }
 
 .spectrum-Textfield-characterCount {
     inline-size: auto;
-    font-size: var(
-        --mod-textfield-character-count-font-size,
-        var(--spectrum-textfield-character-count-font-size)
-    );
-    font-family: var(
-        --mod-textfield-character-count-font-family,
-        var(--spectrum-textfield-character-count-font-family)
-    );
-    font-weight: var(
-        --mod-textfield-character-count-font-weight,
-        var(--spectrum-textfield-character-count-font-weight)
-    );
+    font-size: var(--mod-textfield-character-count-font-size, var(--spectrum-textfield-character-count-font-size));
+    font-family: var(--mod-textfield-character-count-font-family, var(--spectrum-textfield-character-count-font-family));
+    font-weight: var(--mod-textfield-character-count-font-weight, var(--spectrum-textfield-character-count-font-weight));
     grid-area: 1 / 2 / auto / span 1;
     justify-content: flex-end;
     align-items: flex-end;
-    margin-block-end: var(
-        --mod-textfield-character-count-spacing-block,
-        var(--spectrum-textfield-character-count-spacing-block)
-    );
-    margin-inline-start: var(
-        --mod-textfield-character-count-spacing-inline,
-        var(--spectrum-textfield-character-count-spacing-inline)
-    );
+    margin-block-end: var(--mod-textfield-character-count-spacing-block, var(--spectrum-textfield-character-count-spacing-block));
+    margin-inline-start: var(--mod-textfield-character-count-spacing-inline, var(--spectrum-textfield-character-count-spacing-inline));
     margin-inline-end: 0;
-    padding-inline-end: calc(
-        var(
-                --mod-textfield-corner-radius,
-                var(--spectrum-textfield-corner-radius)
-            ) / 2
-    );
+    padding-inline-end: calc(var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius)) / 2);
     display: inline-flex;
 }
 
 :host([quiet]) .spectrum-Textfield-characterCount {
-    margin-block-end: var(
-        --mod-textfield-character-count-spacing-block-quiet,
-        var(--spectrum-textfield-character-count-spacing-block-quiet)
-    );
+    margin-block-end: var(--mod-textfield-character-count-spacing-block-quiet, var(--spectrum-textfield-character-count-spacing-block-quiet));
 }
 
 .input {
     line-height: var(--spectrum-textfield-input-line-height);
     box-sizing: border-box;
     inline-size: 100%;
-    min-inline-size: var(
-        --mod-textfield-min-width,
-        var(--spectrum-textfield-min-width)
-    );
+    min-inline-size: var(--mod-textfield-min-width, var(--spectrum-textfield-min-width));
     block-size: var(--mod-textfield-height, var(--spectrum-textfield-height));
-    padding-block-start: calc(
-        var(
-                --mod-textfield-spacing-block-start,
-                var(--spectrum-textfield-spacing-block-start)
-            ) -
-            var(
-                --mod-textfield-border-width,
-                var(--spectrum-textfield-border-width)
-            )
-    );
-    padding-block-end: calc(
-        var(
-                --mod-textfield-spacing-block-end,
-                var(--spectrum-textfield-spacing-block-end)
-            ) -
-            var(
-                --mod-textfield-border-width,
-                var(--spectrum-textfield-border-width)
-            )
-    );
-    padding-inline: calc(
-        var(
-                --mod-textfield-spacing-inline,
-                var(--spectrum-textfield-spacing-inline)
-            ) -
-            var(
-                --mod-textfield-border-width,
-                var(--spectrum-textfield-border-width)
-            )
-    );
+    padding-block-start: calc(var(--mod-textfield-spacing-block-start, var(--spectrum-textfield-spacing-block-start)) - var(--mod-textfield-border-width, var(--spectrum-textfield-border-width)));
+    padding-block-end: calc(var(--mod-textfield-spacing-block-end, var(--spectrum-textfield-spacing-block-end)) - var(--mod-textfield-border-width, var(--spectrum-textfield-border-width)));
+    padding-inline: calc(var(--mod-textfield-spacing-inline, var(--spectrum-textfield-spacing-inline)) - var(--mod-textfield-border-width, var(--spectrum-textfield-border-width)));
     vertical-align: top;
-    background-color: var(
-        --mod-textfield-background-color,
-        var(--spectrum-textfield-background-color)
-    );
-    border-width: var(
-        --mod-textfield-border-width,
-        var(--spectrum-textfield-border-width)
-    );
+    background-color: var(--mod-textfield-background-color, var(--spectrum-textfield-background-color));
+    border-width: var(--mod-textfield-border-width, var(--spectrum-textfield-border-width));
     border-style: solid;
-    border-color: var(
-        --highcontrast-textfield-border-color,
-        var(
-            --mod-textfield-border-color,
-            var(--spectrum-textfield-border-color)
-        )
-    );
-    border-radius: var(
-        --mod-textfield-corner-radius,
-        var(--spectrum-textfield-corner-radius)
-    );
-    transition: border-color
-        var(
-            --mod-texfield-animation-duration,
-            var(--spectrum-texfield-animation-duration)
-        )
-        ease-in-out;
-    font-size: var(
-        --mod-textfield-placeholder-font-size,
-        var(--spectrum-textfield-placeholder-font-size)
-    );
-    font-family: var(
-        --mod-textfield-font-family,
-        var(--spectrum-textfield-font-family)
-    );
-    font-weight: var(
-        --mod-textfield-font-weight,
-        var(--spectrum-textfield-font-weight)
-    );
-    color: var(
-        --highcontrast-textfield-text-color-default,
-        var(
-            --mod-textfield-text-color-default,
-            var(--spectrum-textfield-text-color-default)
-        )
-    );
+    border-color: var(--highcontrast-textfield-border-color, var(--mod-textfield-border-color, var(--spectrum-textfield-border-color)));
+    border-radius: var(--mod-textfield-corner-radius, var(--spectrum-textfield-corner-radius));
+    transition: border-color var(--mod-texfield-animation-duration, var(--spectrum-texfield-animation-duration)) ease-in-out;
+    font-size: var(--mod-textfield-placeholder-font-size, var(--spectrum-textfield-placeholder-font-size));
+    font-family: var(--mod-textfield-font-family, var(--spectrum-textfield-font-family));
+    font-weight: var(--mod-textfield-font-weight, var(--spectrum-textfield-font-weight));
+    color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
     text-overflow: ellipsis;
     appearance: none;
     outline: none;
@@ -673,31 +300,11 @@ governing permissions and limitations under the License.
 
 .input::placeholder {
     opacity: 1;
-    font-size: var(
-        --mod-textfield-placeholder-font-size,
-        var(--spectrum-textfield-placeholder-font-size)
-    );
-    font-family: var(
-        --mod-textfield-font-family,
-        var(--spectrum-textfield-font-family)
-    );
-    font-weight: var(
-        --mod-textfield-font-weight,
-        var(--spectrum-textfield-font-weight)
-    );
-    color: var(
-        --highcontrast-textfield-text-color-default,
-        var(
-            --mod-textfield-text-color-default,
-            var(--spectrum-textfield-text-color-default)
-        )
-    );
-    transition: color
-        var(
-            --mod-texfield-animation-duration,
-            var(--spectrum-texfield-animation-duration)
-        )
-        ease-in-out;
+    font-size: var(--mod-textfield-placeholder-font-size, var(--spectrum-textfield-placeholder-font-size));
+    font-family: var(--mod-textfield-font-family, var(--spectrum-textfield-font-family));
+    font-weight: var(--mod-textfield-font-weight, var(--spectrum-textfield-font-weight));
+    color: var(--highcontrast-textfield-text-color-default, var(--mod-textfield-text-color-default, var(--spectrum-textfield-text-color-default)));
+    transition: color var(--mod-texfield-animation-duration, var(--spectrum-texfield-animation-duration)) ease-in-out;
 }
 
 .input:lang(ja)::placeholder,
@@ -708,154 +315,53 @@ governing permissions and limitations under the License.
 
 :host([focused]) .input,
 .input:focus {
-    border-color: var(
-        --highcontrast-textfield-border-color-focus,
-        var(
-            --mod-textfield-border-color-focus,
-            var(--spectrum-textfield-border-color-focus)
-        )
-    );
+    border-color: var(--highcontrast-textfield-border-color-focus, var(--mod-textfield-border-color-focus, var(--spectrum-textfield-border-color-focus)));
 }
 
 :host([focused]) .input,
 :host([focused]) .input::placeholder,
 .input:focus,
 .input:focus::placeholder {
-    color: var(
-        --mod-textfield-text-color-focus,
-        var(--spectrum-textfield-text-color-focus)
-    );
+    color: var(--mod-textfield-text-color-focus, var(--spectrum-textfield-text-color-focus));
 }
 
 :host([focused]) .input {
-    border-color: var(
-        --highcontrast-textfield-border-color-keyboard-focus,
-        var(
-            --mod-textfield-border-color-keyboard-focus,
-            var(--spectrum-textfield-border-color-keyboard-focus)
-        )
-    );
-    outline: var(
-            --mod-textfield-focus-indicator-width,
-            var(--spectrum-textfield-focus-indicator-width)
-        )
-        solid;
-    outline-color: var(
-        --highcontrast-textfield-focus-indicator-color,
-        var(
-            --mod-textfield-focus-indicator-color,
-            var(--spectrum-textfield-focus-indicator-color)
-        )
-    );
-    outline-offset: var(
-        --mod-textfield-focus-indicator-gap,
-        var(--spectrum-textfield-focus-indicator-gap)
-    );
+    border-color: var(--highcontrast-textfield-border-color-keyboard-focus, var(--mod-textfield-border-color-keyboard-focus, var(--spectrum-textfield-border-color-keyboard-focus)));
+    outline: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width)) solid;
+    outline-color: var(--highcontrast-textfield-focus-indicator-color, var(--mod-textfield-focus-indicator-color, var(--spectrum-textfield-focus-indicator-color)));
+    outline-offset: var(--mod-textfield-focus-indicator-gap, var(--spectrum-textfield-focus-indicator-gap));
 }
 
 :host([focused]) .input,
 :host([focused]) .input::placeholder {
-    color: var(
-        --highcontrast-textfield-text-color-keyboard-focus,
-        var(
-            --mod-textfield-text-color-keyboard-focus,
-            var(--spectrum-textfield-text-color-keyboard-focus)
-        )
-    );
+    color: var(--highcontrast-textfield-text-color-keyboard-focus, var(--mod-textfield-text-color-keyboard-focus, var(--spectrum-textfield-text-color-keyboard-focus)));
 }
 
 :host([valid]) .input {
-    color: var(
-        --highcontrast-textfield-text-color-valid,
-        var(
-            --mod-textfield-text-color-valid,
-            var(--spectrum-textfield-text-color-valid)
-        )
-    );
-    padding-inline-end: calc(
-        var(
-                --mod-textfield-icon-spacing-inline-start-valid,
-                var(--spectrum-textfield-icon-spacing-inline-start-valid)
-            ) +
-            var(
-                --mod-textfield-icon-size-valid,
-                var(--spectrum-textfield-icon-size-valid)
-            ) +
-            var(
-                --mod-textfield-icon-spacing-inline-end-valid,
-                var(--spectrum-textfield-icon-spacing-inline-end-valid)
-            ) -
-            var(
-                --mod-textfield-border-width,
-                var(--spectrum-textfield-border-width)
-            )
-    );
+    color: var(--highcontrast-textfield-text-color-valid, var(--mod-textfield-text-color-valid, var(--spectrum-textfield-text-color-valid)));
+    padding-inline-end: calc(var(--mod-textfield-icon-spacing-inline-start-valid, var(--spectrum-textfield-icon-spacing-inline-start-valid)) + var(--mod-textfield-icon-size-valid, var(--spectrum-textfield-icon-size-valid)) + var(--mod-textfield-icon-spacing-inline-end-valid, var(--spectrum-textfield-icon-spacing-inline-end-valid)) - var(--mod-textfield-border-width, var(--spectrum-textfield-border-width)));
 }
 
 :host([invalid]) .input {
-    color: var(
-        --highcontrast-textfield-text-color-invalid,
-        var(
-            --mod-textfield-text-color-invalid,
-            var(--spectrum-textfield-text-color-invalid)
-        )
-    );
-    border-color: var(
-        --highcontrast-textfield-border-color-invalid-default,
-        var(
-            --mod-textfield-border-color-invalid-default,
-            var(--spectrum-textfield-border-color-invalid-default)
-        )
-    );
-    padding-inline-end: calc(
-        var(
-                --mod-textfield-icon-spacing-inline-start-invalid,
-                var(--spectrum-textfield-icon-spacing-inline-start-invalid)
-            ) +
-            var(
-                --mod-textfield-icon-size-invalid,
-                var(--spectrum-textfield-icon-size-invalid)
-            ) +
-            var(
-                --mod-textfield-icon-spacing-inline-end-invalid,
-                var(--spectrum-textfield-icon-spacing-inline-end-invalid)
-            ) -
-            var(
-                --mod-textfield-border-width,
-                var(--spectrum-textfield-border-width)
-            )
-    );
+    color: var(--highcontrast-textfield-text-color-invalid, var(--mod-textfield-text-color-invalid, var(--spectrum-textfield-text-color-invalid)));
+    border-color: var(--highcontrast-textfield-border-color-invalid-default, var(--mod-textfield-border-color-invalid-default, var(--spectrum-textfield-border-color-invalid-default)));
+    padding-inline-end: calc(var(--mod-textfield-icon-spacing-inline-start-invalid, var(--spectrum-textfield-icon-spacing-inline-start-invalid)) + var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid)) + var(--mod-textfield-icon-spacing-inline-end-invalid, var(--spectrum-textfield-icon-spacing-inline-end-invalid)) - var(--mod-textfield-border-width, var(--spectrum-textfield-border-width)));
 }
 
 :host([invalid]) .input:focus,
 :host([invalid][focused]) .input,
 :host([invalid]:focus) .input {
-    border-color: var(
-        --highcontrast-textfield-border-color-invalid-focus,
-        var(
-            --mod-textfield-border-color-invalid-focus,
-            var(--spectrum-textfield-border-color-invalid-focus)
-        )
-    );
+    border-color: var(--highcontrast-textfield-border-color-invalid-focus, var(--mod-textfield-border-color-invalid-focus, var(--spectrum-textfield-border-color-invalid-focus)));
 }
 
 :host([invalid]) .input:focus-visible,
 :host([invalid][focused]) .input {
-    border-color: var(
-        --highcontrast-textfield-border-color-invalid-keyboard-focus,
-        var(
-            --mod-textfield-border-color-invalid-keyboard-focus,
-            var(--spectrum-textfield-border-color-invalid-keyboard-focus)
-        )
-    );
+    border-color: var(--highcontrast-textfield-border-color-invalid-keyboard-focus, var(--mod-textfield-border-color-invalid-keyboard-focus, var(--spectrum-textfield-border-color-invalid-keyboard-focus)));
 }
 
 .input:disabled,
 :host([disabled]) #textfield .input {
-    background-color: var(
-        --mod-textfield-background-color-disabled,
-        var(--spectrum-textfield-background-color-disabled)
-    );
+    background-color: var(--mod-textfield-background-color-disabled, var(--spectrum-textfield-background-color-disabled));
     resize: none;
     opacity: 1;
     border-color: #0000;
@@ -865,153 +371,87 @@ governing permissions and limitations under the License.
 .input:disabled::placeholder,
 :host([disabled]) #textfield .input,
 :host([disabled]) #textfield .input::placeholder {
-    color: var(
-        --highcontrast-textfield-text-color-disabled,
-        var(
-            --mod-textfield-text-color-disabled,
-            var(--spectrum-textfield-text-color-disabled)
-        )
-    );
+    color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
 }
 
 :host([quiet]) .input {
-    padding-block-start: var(
-        --mod-textfield-spacing-block-start,
-        var(--spectrum-textfield-spacing-block-start)
-    );
-    padding-inline: var(
-        --mod-textfield-spacing-inline-quiet,
-        var(--spectrum-textfield-spacing-inline-quiet)
-    );
+    padding-block-start: var(--mod-textfield-spacing-block-start, var(--spectrum-textfield-spacing-block-start));
+    padding-inline: var(--mod-textfield-spacing-inline-quiet, var(--spectrum-textfield-spacing-inline-quiet));
     background-color: initial;
     resize: none;
     border-block-start-width: 0;
     border-inline-width: 0;
     border-radius: 0;
     outline: none;
-    margin-block-end: var(
-        --mod-textfield-spacing-block-quiet,
-        var(--spectrum-textfield-spacing-block-quiet)
-    );
+    margin-block-end: var(--mod-textfield-spacing-block-quiet, var(--spectrum-textfield-spacing-block-quiet));
     overflow-y: hidden;
 }
 
 :host([quiet][disabled]) .input,
 .input:disabled {
     background-color: initial;
-    border-color: var(
-        --mod-textfield-border-color-disabled,
-        var(--spectrum-textfield-border-color-disabled)
-    );
+    border-color: var(--mod-textfield-border-color-disabled, var(--spectrum-textfield-border-color-disabled));
 }
 
 :host([quiet][disabled]) .input,
 :host([quiet][disabled]) .input::placeholder,
 .input:disabled,
 .input:disabled::placeholder {
-    color: var(
-        --highcontrast-textfield-text-color-disabled,
-        var(
-            --mod-textfield-text-color-disabled,
-            var(--spectrum-textfield-text-color-disabled)
-        )
-    );
+    color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
 }
 
 .input:read-only,
 :host([readonly]) #textfield .input {
     background-color: initial;
-    color: var(
-        --highcontrast-textfield-text-color-readonly,
-        var(
-            --mod-textfield-text-color-readonly,
-            var(--spectrum-textfield-text-color-readonly)
-        )
-    );
+    color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
     border-color: #0000;
     outline: none;
 }
 
 .input:read-only::placeholder,
 :host([readonly]) #textfield .input::placeholder {
-    color: var(
-        --highcontrast-textfield-text-color-readonly,
-        var(
-            --mod-textfield-text-color-readonly,
-            var(--spectrum-textfield-text-color-readonly)
-        )
-    );
+    color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
     background-color: initial;
 }
 
 @media (hover: hover) {
     .input:hover,
     #textfield:hover .input {
-        border-color: var(
-            --highcontrast-textfield-border-color-hover,
-            var(
-                --mod-textfield-border-color-hover,
-                var(--spectrum-textfield-border-color-hover)
-            )
-        );
+        border-color: var(--highcontrast-textfield-border-color-hover, var(--mod-textfield-border-color-hover, var(--spectrum-textfield-border-color-hover)));
     }
 
     .input:hover,
     .input:hover::placeholder,
     #textfield:hover .input,
     #textfield:hover .input::placeholder {
-        color: var(
-            --highcontrast-textfield-text-color-hover,
-            var(
-                --mod-textfield-text-color-hover,
-                var(--spectrum-textfield-text-color-hover)
-            )
-        );
+        color: var(--highcontrast-textfield-text-color-hover, var(--mod-textfield-text-color-hover, var(--spectrum-textfield-text-color-hover)));
     }
 
     :host([focused]) .input:hover,
     .input:focus:hover {
-        border-color: var(
-            --mod-textfield-border-color-focus-hover,
-            var(--spectrum-textfield-border-color-focus-hover)
-        );
+        border-color: var(--mod-textfield-border-color-focus-hover, var(--spectrum-textfield-border-color-focus-hover));
     }
 
     :host([focused]) .input:hover,
     :host([focused]) .input:hover::placeholder,
     .input:focus:hover,
     .input:focus:hover::placeholder {
-        color: var(
-            --mod-textfield-text-color-focus-hover,
-            var(--spectrum-textfield-text-color-focus-hover)
-        );
+        color: var(--mod-textfield-text-color-focus-hover, var(--spectrum-textfield-text-color-focus-hover));
     }
 
     :host([invalid]) .input:hover:not(.is-disabled),
     :host([invalid]:hover):not(.is-disabled) .input {
-        border-color: var(
-            --highcontrast-textfield-border-color-invalid-hover,
-            var(
-                --mod-textfield-border-color-invalid-hover,
-                var(--spectrum-textfield-border-color-invalid-hover)
-            )
-        );
+        border-color: var(--highcontrast-textfield-border-color-invalid-hover, var(--mod-textfield-border-color-invalid-hover, var(--spectrum-textfield-border-color-invalid-hover)));
     }
 
     :host([invalid]) .input:focus:hover,
     :host([invalid][focused]) .input:hover,
     :host([invalid]:focus) .input:hover {
-        border-color: var(
-            --mod-textfield-border-color-invalid-focus-hover,
-            var(--spectrum-textfield-border-color-invalid-focus-hover)
-        );
+        border-color: var(--mod-textfield-border-color-invalid-focus-hover, var(--spectrum-textfield-border-color-invalid-focus-hover));
     }
 
     :host([disabled]) #textfield:hover .input {
-        background-color: var(
-            --mod-textfield-background-color-disabled,
-            var(--spectrum-textfield-background-color-disabled)
-        );
+        background-color: var(--mod-textfield-background-color-disabled, var(--spectrum-textfield-background-color-disabled));
         resize: none;
         opacity: 1;
         border-color: #0000;
@@ -1020,31 +460,16 @@ governing permissions and limitations under the License.
     :host([quiet][disabled]:hover) .input,
     :host([disabled]) #textfield:hover .input,
     :host([disabled]) #textfield:hover .input::placeholder {
-        color: var(
-            --highcontrast-textfield-text-color-disabled,
-            var(
-                --mod-textfield-text-color-disabled,
-                var(--spectrum-textfield-text-color-disabled)
-            )
-        );
+        color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
     }
 
     :host([quiet][disabled]:hover) .input {
         background-color: initial;
-        border-color: var(
-            --mod-textfield-border-color-disabled,
-            var(--spectrum-textfield-border-color-disabled)
-        );
+        border-color: var(--mod-textfield-border-color-disabled, var(--spectrum-textfield-border-color-disabled));
     }
 
     :host([quiet][disabled]:hover) .input::placeholder {
-        color: var(
-            --highcontrast-textfield-text-color-disabled,
-            var(
-                --mod-textfield-text-color-disabled,
-                var(--spectrum-textfield-text-color-disabled)
-            )
-        );
+        color: var(--highcontrast-textfield-text-color-disabled, var(--mod-textfield-text-color-disabled, var(--spectrum-textfield-text-color-disabled)));
     }
 
     :host([readonly]) #textfield:hover .input {
@@ -1055,13 +480,7 @@ governing permissions and limitations under the License.
     :host([readonly]) #textfield:hover .input,
     :host([readonly]) #textfield:hover .input::placeholder {
         background-color: initial;
-        color: var(
-            --highcontrast-textfield-text-color-readonly,
-            var(
-                --mod-textfield-text-color-readonly,
-                var(--spectrum-textfield-text-color-readonly)
-            )
-        );
+        color: var(--highcontrast-textfield-text-color-readonly, var(--mod-textfield-text-color-readonly, var(--spectrum-textfield-text-color-readonly)));
     }
 }
 
@@ -1076,23 +495,14 @@ governing permissions and limitations under the License.
 
 .spectrum-Textfield--sideLabel .spectrum-FieldLabel {
     grid-area: 1 / 1 / span 2 / span 1;
-    margin-inline-end: var(
-        --mod-textfield-label-spacing-inline-side-label,
-        var(--spectrum-textfield-label-spacing-inline-side-label)
-    );
+    margin-inline-end: var(--mod-textfield-label-spacing-inline-side-label, var(--spectrum-textfield-label-spacing-inline-side-label));
 }
 
 .spectrum-Textfield--sideLabel .spectrum-Textfield-characterCount {
     grid-area: 1 / 3 / auto / span 1;
     align-items: flex-start;
-    margin-block-start: var(
-        --mod-textfield-character-count-spacing-block-side,
-        var(--spectrum-textfield-character-count-spacing-block-side)
-    );
-    margin-inline-start: var(
-        --mod-textfield-character-count-spacing-inline-side,
-        var(--spectrum-textfield-character-count-spacing-inline-side)
-    );
+    margin-block-start: var(--mod-textfield-character-count-spacing-block-side, var(--spectrum-textfield-character-count-spacing-block-side));
+    margin-inline-start: var(--mod-textfield-character-count-spacing-inline-side, var(--spectrum-textfield-character-count-spacing-inline-side));
 }
 
 .spectrum-Textfield--sideLabel .spectrum-HelpText {
@@ -1109,14 +519,8 @@ governing permissions and limitations under the License.
 }
 
 :host([multiline]) .input {
-    min-inline-size: var(
-        --mod-text-area-min-inline-size,
-        var(--spectrum-text-area-min-inline-size)
-    );
-    min-block-size: var(
-        --mod-text-area-min-block-size,
-        var(--spectrum-text-area-min-block-size)
-    );
+    min-inline-size: var(--mod-text-area-min-inline-size, var(--spectrum-text-area-min-inline-size));
+    min-block-size: var(--mod-text-area-min-block-size, var(--spectrum-text-area-min-block-size));
     resize: inherit;
 }
 
@@ -1129,10 +533,7 @@ governing permissions and limitations under the License.
 }
 
 :host([multiline][quiet]) .input {
-    min-block-size: var(
-        --mod-text-area-min-block-size-quiet,
-        var(--spectrum-text-area-min-block-size-quiet)
-    );
+    min-block-size: var(--mod-text-area-min-block-size-quiet, var(--spectrum-text-area-min-block-size-quiet));
     resize: none;
     overflow-y: hidden;
 }

--- a/packages/thumbnail/src/spectrum-thumbnail.css
+++ b/packages/thumbnail/src/spectrum-thumbnail.css
@@ -61,73 +61,20 @@ governing permissions and limitations under the License.
 }
 
 :host {
-    --spectrum-thumbnail-size: var(
-        --mod-thumbnail-size,
-        var(--spectrum-thumbnail-sized-size)
-    );
-    --spectrum-thumbnail-border-color: var(
-        --highcontrast-thumbnail-border-color,
-        var(
-            --mod-thumbnail-border-color,
-            rgba(
-                var(--spectrum-gray-800-rgb),
-                var(--spectrum-thumbnail-border-opacity)
-            )
-        )
-    );
-    --spectrum-thumbnail-border-color-selected: var(
-        --highcontrast-thumbnail-border-color-selected,
-        var(
-            --mod-thumbnail-border-color-selected,
-            var(--spectrum-accent-color-800)
-        )
-    );
-    --spectrum-thumbnail-border-width: var(
-        --mod-thumbnail-border-width,
-        var(--spectrum-border-width-100)
-    );
-    --spectrum-thumbnail-border-width-selected: var(
-        --mod-thumbnail-border-width-selected,
-        var(--spectrum-border-width-200)
-    );
-    --spectrum-thumbnail-border-radius-default: var(
-        --mod-thumbnail-border-radius,
-        var(--spectrum-thumbnail-border-radius)
-    );
-    --spectrum-thumbnail-layer-border-color-inner: var(
-        --highcontrast-thumbnail-layer-border-color-inner,
-        var(--mod-thumbnail-layer-border-color-inner, var(--spectrum-white))
-    );
-    --spectrum-thumbnail-layer-border-color-outer: var(
-        --highcontrast-thumbnail-layer-border-color-outer,
-        var(--mod-thumbnail-layer-border-color-outer, var(--spectrum-gray-500))
-    );
-    --spectrum-thumbnail-layer-border-width-inner: var(
-        --mod-thumbnail-layer-border-width-inner,
-        var(--spectrum-border-width-400)
-    );
-    --spectrum-thumbnail-layer-border-width-outer: var(
-        --mod-thumbnail-layer-border-width-outer,
-        var(--spectrum-border-width-100)
-    );
-    --spectrum-thumbnail-focus-indicator-thickness: var(
-        --mod-thumbnail-focus-indicator-thickness,
-        var(--spectrum-focus-indicator-thickness)
-    );
-    --spectrum-thumbnail-focus-indicator-gap: var(
-        --mod-thumbnail-focus-indicator-gap,
-        var(--spectrum-focus-indicator-gap)
-    );
-    --spectrum-thumbnail-focus-indicator-color: var(
-        --highcontrast-thumbnail-focus-indicator-color,
-        var(
-            --mod-thumbnail-focus-indicator-color,
-            var(--spectrum-focus-indicator-color)
-        )
-    );
-    --spectrum-thumbnail-color-opacity-disabled: var(
-        --spectrum-thumbnail-opacity-disabled
-    );
+    --spectrum-thumbnail-size: var(--mod-thumbnail-size, var(--spectrum-thumbnail-sized-size));
+    --spectrum-thumbnail-border-color: var(--highcontrast-thumbnail-border-color, var(--mod-thumbnail-border-color, rgba(var(--spectrum-gray-800-rgb), var(--spectrum-thumbnail-border-opacity))));
+    --spectrum-thumbnail-border-color-selected: var(--highcontrast-thumbnail-border-color-selected, var(--mod-thumbnail-border-color-selected, var(--spectrum-accent-color-800)));
+    --spectrum-thumbnail-border-width: var(--mod-thumbnail-border-width, var(--spectrum-border-width-100));
+    --spectrum-thumbnail-border-width-selected: var(--mod-thumbnail-border-width-selected, var(--spectrum-border-width-200));
+    --spectrum-thumbnail-border-radius-default: var(--mod-thumbnail-border-radius, var(--spectrum-thumbnail-border-radius));
+    --spectrum-thumbnail-layer-border-color-inner: var(--highcontrast-thumbnail-layer-border-color-inner, var(--mod-thumbnail-layer-border-color-inner, var(--spectrum-white)));
+    --spectrum-thumbnail-layer-border-color-outer: var(--highcontrast-thumbnail-layer-border-color-outer, var(--mod-thumbnail-layer-border-color-outer, var(--spectrum-gray-500)));
+    --spectrum-thumbnail-layer-border-width-inner: var(--mod-thumbnail-layer-border-width-inner, var(--spectrum-border-width-400));
+    --spectrum-thumbnail-layer-border-width-outer: var(--mod-thumbnail-layer-border-width-outer, var(--spectrum-border-width-100));
+    --spectrum-thumbnail-focus-indicator-thickness: var(--mod-thumbnail-focus-indicator-thickness, var(--spectrum-focus-indicator-thickness));
+    --spectrum-thumbnail-focus-indicator-gap: var(--mod-thumbnail-focus-indicator-gap, var(--spectrum-focus-indicator-gap));
+    --spectrum-thumbnail-focus-indicator-color: var(--highcontrast-thumbnail-focus-indicator-color, var(--mod-thumbnail-focus-indicator-color, var(--spectrum-focus-indicator-color)));
+    --spectrum-thumbnail-color-opacity-disabled: var(--spectrum-thumbnail-opacity-disabled);
     inline-size: var(--spectrum-thumbnail-size);
     block-size: var(--spectrum-thumbnail-size);
     z-index: 0;
@@ -148,16 +95,12 @@ governing permissions and limitations under the License.
     z-index: 2;
     inline-size: 100%;
     block-size: 100%;
-    box-shadow: inset 0 0 0 var(--spectrum-thumbnail-border-width)
-        var(--spectrum-thumbnail-border-color);
+    box-shadow: inset 0 0 0 var(--spectrum-thumbnail-border-width) var(--spectrum-thumbnail-border-color);
     position: absolute;
 }
 
 :host([disabled]) {
-    opacity: var(
-        --mod-thumbnail-color-opacity-disabled,
-        var(--spectrum-thumbnail-color-opacity-disabled)
-    );
+    opacity: var(--mod-thumbnail-color-opacity-disabled, var(--spectrum-thumbnail-color-opacity-disabled));
 }
 
 :host([focused]) {
@@ -171,30 +114,10 @@ governing permissions and limitations under the License.
     border-color: var(--spectrum-thumbnail-focus-indicator-color);
     border-radius: var(--spectrum-thumbnail-border-radius-default);
     position: absolute;
-    inset-block-start: calc(
-        (
-                var(--spectrum-thumbnail-focus-indicator-gap) +
-                    var(--spectrum-thumbnail-focus-indicator-thickness)
-            ) * -1
-    );
-    inset-block-end: calc(
-        (
-                var(--spectrum-thumbnail-focus-indicator-gap) +
-                    var(--spectrum-thumbnail-focus-indicator-thickness)
-            ) * -1
-    );
-    inset-inline-start: calc(
-        (
-                var(--spectrum-thumbnail-focus-indicator-gap) +
-                    var(--spectrum-thumbnail-focus-indicator-thickness)
-            ) * -1
-    );
-    inset-inline-end: calc(
-        (
-                var(--spectrum-thumbnail-focus-indicator-gap) +
-                    var(--spectrum-thumbnail-focus-indicator-thickness)
-            ) * -1
-    );
+    inset-block-start: calc((var(--spectrum-thumbnail-focus-indicator-gap) + var(--spectrum-thumbnail-focus-indicator-thickness)) * -1);
+    inset-block-end: calc((var(--spectrum-thumbnail-focus-indicator-gap) + var(--spectrum-thumbnail-focus-indicator-thickness)) * -1);
+    inset-inline-start: calc((var(--spectrum-thumbnail-focus-indicator-gap) + var(--spectrum-thumbnail-focus-indicator-thickness)) * -1);
+    inset-inline-end: calc((var(--spectrum-thumbnail-focus-indicator-gap) + var(--spectrum-thumbnail-focus-indicator-thickness)) * -1);
 }
 
 :host([focused]) .image-wrapper {
@@ -220,27 +143,15 @@ governing permissions and limitations under the License.
     outline-style: solid;
     outline-color: var(--spectrum-thumbnail-border-color-selected);
     outline-width: var(--spectrum-thumbnail-border-width-selected);
-    outline-offset: calc(
-        var(--spectrum-thumbnail-border-width-selected) -
-            var(--spectrum-thumbnail-layer-border-width-inner)
-    );
+    outline-offset: calc(var(--spectrum-thumbnail-border-width-selected) - var(--spectrum-thumbnail-layer-border-width-inner));
 }
 
 .layer-inner {
-    inline-size: calc(
-        var(--spectrum-thumbnail-size) -
-            var(--spectrum-thumbnail-layer-border-width-inner) * 2
-    );
-    block-size: calc(
-        var(--spectrum-thumbnail-size) -
-            var(--spectrum-thumbnail-layer-border-width-inner) * 2
-    );
+    inline-size: calc(var(--spectrum-thumbnail-size) - var(--spectrum-thumbnail-layer-border-width-inner) * 2);
+    block-size: calc(var(--spectrum-thumbnail-size) - var(--spectrum-thumbnail-layer-border-width-inner) * 2);
     outline-style: solid;
     outline-color: var(--spectrum-thumbnail-layer-border-color-inner);
-    outline-width: calc(
-        var(--spectrum-thumbnail-layer-border-width-inner) -
-            var(--spectrum-thumbnail-layer-border-width-outer)
-    );
+    outline-width: calc(var(--spectrum-thumbnail-layer-border-width-inner) - var(--spectrum-thumbnail-layer-border-width-outer));
     justify-content: center;
     align-items: center;
     display: flex;

--- a/packages/toast/src/spectrum-toast.css
+++ b/packages/toast/src/spectrum-toast.css
@@ -14,210 +14,92 @@ governing permissions and limitations under the License.
 @media (forced-colors: active) {
     :host {
         --highcontrast-toast-border-color: ButtonText;
-        border: var(
-                --mod-toast-border-width,
-                var(--spectrum-toast-border-width)
-            )
-            solid var(--highcontrast-toast-border-color, transparent);
+        border: var(--mod-toast-border-width, var(--spectrum-toast-border-width)) solid var(--highcontrast-toast-border-color, transparent);
     }
 }
 
 :host {
     box-sizing: border-box;
-    min-block-size: var(
-        --mod-toast-block-size,
-        var(--spectrum-toast-block-size)
-    );
-    max-inline-size: var(
-        --mod-toast-max-inline-size,
-        var(--spectrum-toast-max-inline-size)
-    );
-    border-radius: var(
-        --mod-toast-corner-radius,
-        var(--spectrum-toast-corner-radius)
-    );
+    min-block-size: var(--mod-toast-block-size, var(--spectrum-toast-block-size));
+    max-inline-size: var(--mod-toast-max-inline-size, var(--spectrum-toast-max-inline-size));
+    border-radius: var(--mod-toast-corner-radius, var(--spectrum-toast-corner-radius));
     font-size: var(--mod-toast-font-size, var(--spectrum-toast-font-size));
-    font-weight: var(
-        --mod-toast-font-weight,
-        var(--spectrum-toast-font-weight)
-    );
+    font-weight: var(--mod-toast-font-weight, var(--spectrum-toast-font-weight));
     -webkit-font-smoothing: antialiased;
-    background-color: var(
-        --highcontrast-toast-background-color-default,
-        var(
-            --mod-toast-background-color-default,
-            var(--spectrum-toast-background-color-default)
-        )
-    );
-    color: var(
-        --highcontrast-toast-background-color-default,
-        var(
-            --mod-toast-background-color-default,
-            var(--spectrum-toast-background-color-default)
-        )
-    );
+    background-color: var(--highcontrast-toast-background-color-default, var(--mod-toast-background-color-default, var(--spectrum-toast-background-color-default)));
+    color: var(--highcontrast-toast-background-color-default, var(--mod-toast-background-color-default, var(--spectrum-toast-background-color-default)));
     overflow-wrap: anywhere;
     flex-direction: row;
     align-items: stretch;
-    padding-inline-start: var(
-        --mod-toast-spacing-start-edge-to-text-and-icon,
-        var(--spectrum-toast-spacing-start-edge-to-text-and-icon)
-    );
+    padding-inline-start: var(--mod-toast-spacing-start-edge-to-text-and-icon, var(--spectrum-toast-spacing-start-edge-to-text-and-icon));
     display: inline-flex;
 }
 
 :host([variant='negative']) {
-    background-color: var(
-        --highcontrast-toast-negative-background-color-default,
-        var(
-            --mod-toast-negative-background-color-default,
-            var(--spectrum-toast-negative-background-color-default)
-        )
-    );
+    background-color: var(--highcontrast-toast-negative-background-color-default, var(--mod-toast-negative-background-color-default, var(--spectrum-toast-negative-background-color-default)));
 }
 
 :host([variant='negative']),
 :host([variant='negative']) .closeButton:focus-visible:not(:active) {
-    color: var(
-        --highcontrast-toast-negative-background-color-default,
-        var(
-            --mod-toast-negative-background-color-default,
-            var(--spectrum-toast-negative-background-color-default)
-        )
-    );
+    color: var(--highcontrast-toast-negative-background-color-default, var(--mod-toast-negative-background-color-default, var(--spectrum-toast-negative-background-color-default)));
 }
 
 :host([variant='info']) {
-    background-color: var(
-        --highcontrast-toast-informative-background-color-default,
-        var(
-            --mod-toast-informative-background-color-default,
-            var(--spectrum-toast-informative-background-color-default)
-        )
-    );
+    background-color: var(--highcontrast-toast-informative-background-color-default, var(--mod-toast-informative-background-color-default, var(--spectrum-toast-informative-background-color-default)));
 }
 
 :host([variant='info']),
 :host([variant='info']) .closeButton:focus-visible:not(:active) {
-    color: var(
-        --highcontrast-toast-informative-background-color-default,
-        var(
-            --mod-toast-informative-background-color-default,
-            var(--spectrum-toast-informative-background-color-default)
-        )
-    );
+    color: var(--highcontrast-toast-informative-background-color-default, var(--mod-toast-informative-background-color-default, var(--spectrum-toast-informative-background-color-default)));
 }
 
 :host([variant='positive']) {
-    background-color: var(
-        --highcontrast-toast-positive-background-color-default,
-        var(
-            --mod-toast-positive-background-color-default,
-            var(--spectrum-toast-positive-background-color-default)
-        )
-    );
+    background-color: var(--highcontrast-toast-positive-background-color-default, var(--mod-toast-positive-background-color-default, var(--spectrum-toast-positive-background-color-default)));
 }
 
 :host([variant='positive']),
 :host([variant='positive']) .closeButton:focus-visible:not(:active) {
-    color: var(
-        --highcontrast-toast-positive-background-color-default,
-        var(
-            --mod-toast-positive-background-color-default,
-            var(--spectrum-toast-positive-background-color-default)
-        )
-    );
+    color: var(--highcontrast-toast-positive-background-color-default, var(--mod-toast-positive-background-color-default, var(--spectrum-toast-positive-background-color-default)));
 }
 
 .type {
     flex-grow: 0;
     flex-shrink: 0;
-    margin-block-start: var(
-        --mod-toast-spacing-top-edge-to-icon,
-        var(--spectrum-toast-spacing-top-edge-to-icon)
-    );
+    margin-block-start: var(--mod-toast-spacing-top-edge-to-icon, var(--spectrum-toast-spacing-top-edge-to-icon));
     margin-inline-start: 0;
-    margin-inline-end: var(
-        --mod-toast-spacing-icon-to-text,
-        var(--spectrum-toast-spacing-icon-to-text)
-    );
+    margin-inline-end: var(--mod-toast-spacing-icon-to-text, var(--spectrum-toast-spacing-icon-to-text));
 }
 
 .content,
 .type {
-    color: var(
-        --highcontrast-toast-text-and-icon-color,
-        var(
-            --mod-toast-text-and-icon-color,
-            var(--spectrum-toast-text-and-icon-color)
-        )
-    );
+    color: var(--highcontrast-toast-text-and-icon-color, var(--mod-toast-text-and-icon-color, var(--spectrum-toast-text-and-icon-color)));
 }
 
 .content {
     box-sizing: border-box;
-    line-height: var(
-        --mod-toast-line-height,
-        var(--spectrum-toast-line-height)
-    );
+    line-height: var(--mod-toast-line-height, var(--spectrum-toast-line-height));
     text-align: start;
     flex: auto;
-    padding-block-start: calc(
-        var(
-                --mod-toast-spacing-top-edge-to-text,
-                var(--spectrum-toast-spacing-top-edge-to-text)
-            ) -
-            var(
-                --mod-toast-spacing-block-start,
-                var(--spectrum-toast-spacing-block-start)
-            )
-    );
-    padding-block-end: calc(
-        var(
-                --mod-toast-spacing-bottom-edge-to-text,
-                var(--spectrum-toast-spacing-bottom-edge-to-text)
-            ) -
-            var(
-                --mod-toast-spacing-block-end,
-                var(--spectrum-toast-spacing-block-end)
-            )
-    );
+    padding-block-start: calc(var(--mod-toast-spacing-top-edge-to-text, var(--spectrum-toast-spacing-top-edge-to-text)) - var(--mod-toast-spacing-block-start, var(--spectrum-toast-spacing-block-start)));
+    padding-block-end: calc(var(--mod-toast-spacing-bottom-edge-to-text, var(--spectrum-toast-spacing-bottom-edge-to-text)) - var(--mod-toast-spacing-block-end, var(--spectrum-toast-spacing-block-end)));
     padding-inline-start: 0;
-    padding-inline-end: var(
-        --mod-toast-spacing-text-to-action-button-horizontal,
-        var(--spectrum-toast-spacing-text-to-action-button-horizontal)
-    );
+    padding-inline-end: var(--mod-toast-spacing-text-to-action-button-horizontal, var(--spectrum-toast-spacing-text-to-action-button-horizontal));
     display: inline-block;
 }
 
 .content:lang(ja),
 .content:lang(ko),
 .content:lang(zh) {
-    line-height: var(
-        --mod-toast-line-height-cjk,
-        var(--spectrum-toast-line-height-cjk)
-    );
+    line-height: var(--mod-toast-line-height-cjk, var(--spectrum-toast-line-height-cjk));
 }
 
 .buttons {
-    border-inline-start-color: var(
-        --mod-toast-divider-color,
-        var(--spectrum-toast-divider-color)
-    );
+    border-inline-start-color: var(--mod-toast-divider-color, var(--spectrum-toast-divider-color));
     flex: none;
     align-items: flex-start;
-    margin-block-start: var(
-        --mod-toast-spacing-top-edge-to-divider,
-        var(--spectrum-toast-spacing-top-edge-to-divider)
-    );
-    margin-block-end: var(
-        --mod-toast-spacing-bottom-edge-to-divider,
-        var(--spectrum-toast-spacing-bottom-edge-to-divider)
-    );
-    padding-inline-end: var(
-        --mod-toast-spacing-close-button,
-        var(--spectrum-toast-spacing-close-button)
-    );
+    margin-block-start: var(--mod-toast-spacing-top-edge-to-divider, var(--spectrum-toast-spacing-top-edge-to-divider));
+    margin-block-end: var(--mod-toast-spacing-bottom-edge-to-divider, var(--spectrum-toast-spacing-bottom-edge-to-divider));
+    padding-inline-end: var(--mod-toast-spacing-close-button, var(--spectrum-toast-spacing-close-button));
     display: flex;
 }
 
@@ -230,38 +112,23 @@ governing permissions and limitations under the License.
     flex: auto;
     align-self: center;
     align-items: center;
-    padding-block-start: var(
-        --mod-toast-spacing-block-start,
-        var(--spectrum-toast-spacing-block-start)
-    );
-    padding-block-end: var(
-        --mod-toast-spacing-block-end,
-        var(--spectrum-toast-spacing-block-end)
-    );
+    padding-block-start: var(--mod-toast-spacing-block-start, var(--spectrum-toast-spacing-block-start));
+    padding-block-end: var(--mod-toast-spacing-block-end, var(--spectrum-toast-spacing-block-end));
     display: flex;
 }
 
 .body ::slotted([slot='action']) {
     margin-inline-start: auto;
-    margin-inline-end: var(
-        --mod-toast-spacing-text-and-action-button-to-divider,
-        var(--spectrum-toast-spacing-text-and-action-button-to-divider)
-    );
+    margin-inline-end: var(--mod-toast-spacing-text-and-action-button-to-divider, var(--spectrum-toast-spacing-text-and-action-button-to-divider));
 }
 
 .body ::slotted([slot='action']:dir(rtl)),
 :host([dir='rtl']) .body ::slotted([slot='action']) {
-    margin-inline-end: var(
-        --mod-toast-spacing-text-and-action-button-to-divider,
-        var(--spectrum-toast-spacing-text-and-action-button-to-divider)
-    );
+    margin-inline-end: var(--mod-toast-spacing-text-and-action-button-to-divider, var(--spectrum-toast-spacing-text-and-action-button-to-divider));
 }
 
 .body + .buttons {
     border-inline-start-style: solid;
     border-inline-start-width: 1px;
-    padding-inline-start: var(
-        --mod-toast-spacing-close-button,
-        var(--spectrum-toast-spacing-close-button)
-    );
+    padding-inline-start: var(--mod-toast-spacing-close-button, var(--spectrum-toast-spacing-close-button));
 }

--- a/packages/tooltip/src/spectrum-tooltip.css
+++ b/packages/tooltip/src/spectrum-tooltip.css
@@ -20,23 +20,9 @@ governing permissions and limitations under the License.
         opacity 0.13s ease-in-out,
         visibility 0s linear 0.13s;
     transition:
-        transform
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        opacity
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        visibility 0s linear
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            );
+        transform var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        opacity var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        visibility 0s linear var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s));
 }
 
 :host([open]) #tooltip {
@@ -44,10 +30,7 @@ governing permissions and limitations under the License.
     visibility: visible;
     opacity: 1;
     transition-delay: 0s;
-    transition-delay: var(
-        --mod-overlay-animation-duration-opened,
-        var(--spectrum-animation-duration-0, 0s)
-    );
+    transition-delay: var(--mod-overlay-animation-duration-opened, var(--spectrum-animation-duration-0, 0s));
 }
 
 @media (forced-colors: active) {
@@ -68,40 +51,16 @@ governing permissions and limitations under the License.
     box-sizing: border-box;
     vertical-align: top;
     inline-size: auto;
-    padding-inline: var(
-        --mod-tooltip-spacing-inline,
-        var(--spectrum-tooltip-spacing-inline)
-    );
-    border-radius: var(
-        --mod-tooltip-border-radius,
-        var(--spectrum-tooltip-border-radius)
-    );
+    padding-inline: var(--mod-tooltip-spacing-inline, var(--spectrum-tooltip-spacing-inline));
+    border-radius: var(--mod-tooltip-border-radius, var(--spectrum-tooltip-border-radius));
     block-size: auto;
     min-block-size: var(--mod-tooltip-height, var(--spectrum-tooltip-height));
-    max-inline-size: var(
-        --mod-tooltip-max-inline-size,
-        var(--spectrum-tooltip-max-inline-size)
-    );
-    background-color: var(
-        --highcontrast-tooltip-background-color-default,
-        var(
-            --mod-tooltip-background-color-default,
-            var(--spectrum-tooltip-background-color-default)
-        )
-    );
-    color: var(
-        --mod-tooltip-content-color,
-        var(--spectrum-tooltip-content-color)
-    );
+    max-inline-size: var(--mod-tooltip-max-inline-size, var(--spectrum-tooltip-max-inline-size));
+    background-color: var(--highcontrast-tooltip-background-color-default, var(--mod-tooltip-background-color-default, var(--spectrum-tooltip-background-color-default)));
+    color: var(--mod-tooltip-content-color, var(--spectrum-tooltip-content-color));
     font-size: var(--mod-tooltip-font-size, var(--spectrum-tooltip-font-size));
-    font-weight: var(
-        --mod-tooltip-font-weight,
-        var(--spectrum-tooltip-font-weight)
-    );
-    line-height: var(
-        --mod-tooltip-line-height,
-        var(--spectrum-tooltip-line-height)
-    );
+    font-weight: var(--mod-tooltip-font-weight, var(--spectrum-tooltip-font-weight));
+    line-height: var(--mod-tooltip-line-height, var(--spectrum-tooltip-line-height));
     word-break: break-word;
     -webkit-font-smoothing: antialiased;
     cursor: default;
@@ -116,10 +75,7 @@ governing permissions and limitations under the License.
 :host(:lang(ja)) #tooltip,
 :host(:lang(ko)) #tooltip,
 :host(:lang(zh)) #tooltip {
-    line-height: var(
-        --mod-tooltip-cjk-line-height,
-        var(--spectrum-tooltip-cjk-line-height)
-    );
+    line-height: var(--mod-tooltip-cjk-line-height, var(--spectrum-tooltip-cjk-line-height));
 }
 
 #tooltip p {
@@ -127,108 +83,38 @@ governing permissions and limitations under the License.
 }
 
 :host([variant='info']) #tooltip {
-    background-color: var(
-        --highcontrast-tooltip-background-color-informative,
-        var(
-            --mod-tooltip-background-color-informative,
-            var(--spectrum-tooltip-background-color-informative)
-        )
-    );
+    background-color: var(--highcontrast-tooltip-background-color-informative, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
 }
 
 :host([variant='positive']) #tooltip {
-    background-color: var(
-        --highcontrast-tooltip-background-color-positive,
-        var(
-            --mod-tooltip-background-color-positive,
-            var(--spectrum-tooltip-background-color-positive)
-        )
-    );
+    background-color: var(--highcontrast-tooltip-background-color-positive, var(--mod-tooltip-background-color-positive, var(--spectrum-tooltip-background-color-positive)));
 }
 
 :host([variant='negative']) #tooltip {
-    background-color: var(
-        --highcontrast-tooltip-background-color-negative,
-        var(
-            --mod-tooltip-background-color-negative,
-            var(--spectrum-tooltip-background-color-negative)
-        )
-    );
+    background-color: var(--highcontrast-tooltip-background-color-negative, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
 }
 
 #tip {
-    block-size: var(
-        --mod-tooltip-tip-square-size,
-        var(--spectrum-tooltip-tip-square-size)
-    );
-    inline-size: var(
-        --mod-tooltip-tip-square-size,
-        var(--spectrum-tooltip-tip-square-size)
-    );
+    block-size: var(--mod-tooltip-tip-square-size, var(--spectrum-tooltip-tip-square-size));
+    inline-size: var(--mod-tooltip-tip-square-size, var(--spectrum-tooltip-tip-square-size));
     inset-block-start: 100%;
-    background-color: var(
-        --highcontrast-tooltip-background-color-default,
-        var(
-            --mod-tooltip-background-color-default,
-            var(--spectrum-tooltip-background-color-default)
-        )
-    );
-    clip-path: polygon(
-        0
-            calc(
-                0% -
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            ),
-        50%
-            var(
-                --mod-tooltip-tip-height-percentage,
-                var(--spectrum-tooltip-tip-height-percentage)
-            ),
-        100%
-            calc(
-                0% -
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-    );
+    background-color: var(--highcontrast-tooltip-background-color-default, var(--mod-tooltip-background-color-default, var(--spectrum-tooltip-background-color-default)));
+    clip-path: polygon(0 calc(0% - var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))), 50% var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage)), 100% calc(0% - var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))));
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
 }
 
 :host([variant='info']) #tooltip #tip {
-    background-color: var(
-        --highcontrast-tooltip-background-color-informative,
-        var(
-            --mod-tooltip-background-color-informative,
-            var(--spectrum-tooltip-background-color-informative)
-        )
-    );
+    background-color: var(--highcontrast-tooltip-background-color-informative, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
 }
 
 :host([variant='positive']) #tooltip #tip {
-    background-color: var(
-        --highcontrast-tooltip-background-color-positive,
-        var(
-            --mod-tooltip-background-color-positive,
-            var(--spectrum-tooltip-background-color-positive)
-        )
-    );
+    background-color: var(--highcontrast-tooltip-background-color-positive, var(--mod-tooltip-background-color-positive, var(--spectrum-tooltip-background-color-positive)));
 }
 
 :host([variant='negative']) #tooltip #tip {
-    background-color: var(
-        --highcontrast-tooltip-background-color-negative,
-        var(
-            --mod-tooltip-background-color-negative,
-            var(--spectrum-tooltip-background-color-negative)
-        )
-    );
+    background-color: var(--highcontrast-tooltip-background-color-negative, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
 }
 
 :host([placement*='top']) #tooltip #tip,
@@ -244,32 +130,7 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--bottom-left #tip,
 .spectrum-Tooltip--bottom-right #tip,
 .spectrum-Tooltip--bottom-start #tip {
-    clip-path: polygon(
-        50%
-            calc(
-                100% -
-                    var(
-                        --mod-tooltip-tip-height-percentage,
-                        var(--spectrum-tooltip-tip-height-percentage)
-                    )
-            ),
-        0
-            calc(
-                100% +
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            ),
-        100%
-            calc(
-                100% +
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-    );
+    clip-path: polygon(50% calc(100% - var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage))), 0 calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))), 100% calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))));
     inset-block: auto 100%;
 }
 
@@ -286,58 +147,37 @@ governing permissions and limitations under the License.
 
 .spectrum-Tooltip--bottom-left #tip,
 .spectrum-Tooltip--top-left #tip {
-    inset-inline-start: var(
-        --mod-tooltip-pointer-corner-spacing,
-        var(--spectrum-tooltip-pointer-corner-spacing)
-    );
+    inset-inline-start: var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing));
 }
 
 .spectrum-Tooltip--bottom-right #tip,
 .spectrum-Tooltip--top-right #tip {
-    inset-inline: auto
-        var(
-            --mod-tooltip-pointer-corner-spacing,
-            var(--spectrum-tooltip-pointer-corner-spacing)
-        );
+    inset-inline: auto var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing));
 }
 
 .spectrum-Tooltip--bottom-start #tip,
 .spectrum-Tooltip--top-start #tip {
-    inset-inline: var(
-            --mod-tooltip-pointer-corner-spacing,
-            var(--spectrum-tooltip-pointer-corner-spacing)
-        )
-        auto;
+    inset-inline: var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing)) auto;
 }
 
 .spectrum-Tooltip--bottom-start #tip:dir(rtl),
 .spectrum-Tooltip--top-start #tip:dir(rtl),
 :host([dir='rtl']) .spectrum-Tooltip--bottom-start #tip,
 :host([dir='rtl']) .spectrum-Tooltip--top-start #tip {
-    right: var(
-        --mod-tooltip-pointer-corner-spacing,
-        var(--spectrum-tooltip-pointer-corner-spacing)
-    );
+    right: var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing));
     left: auto;
 }
 
 .spectrum-Tooltip--bottom-end #tip,
 .spectrum-Tooltip--top-end #tip {
-    inset-inline: auto
-        var(
-            --mod-tooltip-pointer-corner-spacing,
-            var(--spectrum-tooltip-pointer-corner-spacing)
-        );
+    inset-inline: auto var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing));
 }
 
 .spectrum-Tooltip--bottom-end #tip:dir(rtl),
 .spectrum-Tooltip--top-end #tip:dir(rtl),
 :host([dir='rtl']) .spectrum-Tooltip--bottom-end #tip,
 :host([dir='rtl']) .spectrum-Tooltip--top-end #tip {
-    left: var(
-        --mod-tooltip-pointer-corner-spacing,
-        var(--spectrum-tooltip-pointer-corner-spacing)
-    );
+    left: var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing));
     right: auto;
 }
 
@@ -375,32 +215,7 @@ governing permissions and limitations under the License.
 :host([placement*='right']) #tooltip #tip,
 .spectrum-Tooltip--right-bottom #tip,
 .spectrum-Tooltip--right-top #tip {
-    clip-path: polygon(
-        calc(
-                100% -
-                    var(
-                        --mod-tooltip-tip-height-percentage,
-                        var(--spectrum-tooltip-tip-height-percentage)
-                    )
-            )
-            50%,
-        calc(
-                100% +
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-            100%,
-        calc(
-                100% +
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-            0
-    );
+    clip-path: polygon(calc(100% - var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage))) 50%, calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 100%, calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 0);
     inset-inline: auto 100%;
 }
 
@@ -410,29 +225,7 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--start #tip,
 .spectrum-Tooltip--start-bottom #tip,
 .spectrum-Tooltip--start-top #tip {
-    clip-path: polygon(
-        calc(
-                0% -
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-            0,
-        calc(
-                0% -
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-            100%,
-        var(
-                --mod-tooltip-tip-height-percentage,
-                var(--spectrum-tooltip-tip-height-percentage)
-            )
-            50%
-    );
+    clip-path: polygon(calc(0% - var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 0, calc(0% - var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 100%, var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage)) 50%);
     inset-inline-start: 100%;
 }
 
@@ -440,20 +233,14 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--left-top #tip,
 .spectrum-Tooltip--right-top #tip,
 .spectrum-Tooltip--start-top #tip {
-    inset-block-start: var(
-        --mod-tooltip-pointer-corner-spacing,
-        var(--spectrum-tooltip-pointer-corner-spacing)
-    );
+    inset-block-start: var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing));
 }
 
 .spectrum-Tooltip--end-bottom #tip,
 .spectrum-Tooltip--left-bottom #tip,
 .spectrum-Tooltip--right-bottom #tip,
 .spectrum-Tooltip--start-bottom #tip {
-    inset-block-end: var(
-        --mod-tooltip-pointer-corner-spacing,
-        var(--spectrum-tooltip-pointer-corner-spacing)
-    );
+    inset-block-end: var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing));
 }
 
 .spectrum-Tooltip--end #tip:dir(rtl),
@@ -468,29 +255,7 @@ governing permissions and limitations under the License.
 :host([dir='rtl'][placement*='left']) #tooltip #tip,
 :host([dir='rtl']) .spectrum-Tooltip--left-bottom #tip,
 :host([dir='rtl']) .spectrum-Tooltip--left-top #tip {
-    clip-path: polygon(
-        calc(
-                0% -
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-            0,
-        calc(
-                0% -
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-            100%,
-        var(
-                --mod-tooltip-tip-height-percentage,
-                var(--spectrum-tooltip-tip-height-percentage)
-            )
-            50%
-    );
+    clip-path: polygon(calc(0% - var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 0, calc(0% - var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 100%, var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage)) 50%);
     left: 100%;
     right: auto;
 }
@@ -507,77 +272,25 @@ governing permissions and limitations under the License.
 :host([dir='rtl']) .spectrum-Tooltip--start #tip,
 :host([dir='rtl']) .spectrum-Tooltip--start-bottom #tip,
 :host([dir='rtl']) .spectrum-Tooltip--start-top #tip {
-    clip-path: polygon(
-        var(
-                --mod-tooltip-tip-height-percentage,
-                var(--spectrum-tooltip-tip-height-percentage)
-            )
-            50%,
-        calc(
-                100% +
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-            100%,
-        calc(
-                100% +
-                    var(
-                        --mod-tooltip-tip-antialiasing-inset,
-                        var(--spectrum-tooltip-tip-antialiasing-inset)
-                    )
-            )
-            0
-    );
+    clip-path: polygon(var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage)) 50%, calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 100%, calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 0);
     left: auto;
     right: 100%;
 }
 
 ::slotted([slot='icon']) {
-    inline-size: var(
-        --mod-tooltip-icon-width,
-        var(--spectrum-tooltip-icon-width)
-    );
-    block-size: var(
-        --mod-tooltip-icon-height,
-        var(--spectrum-tooltip-icon-height)
-    );
+    inline-size: var(--mod-tooltip-icon-width, var(--spectrum-tooltip-icon-width));
+    block-size: var(--mod-tooltip-icon-height, var(--spectrum-tooltip-icon-height));
     flex-shrink: 0;
     align-self: flex-start;
-    margin-block-start: var(
-        --mod-tooltip-icon-spacing-block-start,
-        var(--spectrum-tooltip-icon-spacing-block-start)
-    );
-    margin-inline-start: calc(
-        var(
-                --mod-tooltip-icon-spacing-inline-start,
-                var(--spectrum-tooltip-icon-spacing-inline-start)
-            ) -
-            var(
-                --mod-tooltip-spacing-inline,
-                var(--spectrum-tooltip-spacing-inline)
-            )
-    );
-    margin-inline-end: var(
-        --mod-tooltip-icon-spacing-inline-end,
-        var(--spectrum-tooltip-icon-spacing-inline-end)
-    );
+    margin-block-start: var(--mod-tooltip-icon-spacing-block-start, var(--spectrum-tooltip-icon-spacing-block-start));
+    margin-inline-start: calc(var(--mod-tooltip-icon-spacing-inline-start, var(--spectrum-tooltip-icon-spacing-inline-start)) - var(--mod-tooltip-spacing-inline, var(--spectrum-tooltip-spacing-inline)));
+    margin-inline-end: var(--mod-tooltip-icon-spacing-inline-end, var(--spectrum-tooltip-icon-spacing-inline-end));
 }
 
 #label {
-    line-height: var(
-        --mod-tooltip-line-height,
-        var(--spectrum-tooltip-line-height)
-    );
-    margin-block-start: var(
-        --mod-tooltip-spacing-block-start,
-        var(--spectrum-tooltip-spacing-block-start)
-    );
-    margin-block-end: var(
-        --mod-tooltip-spacing-block-end,
-        var(--spectrum-tooltip-spacing-block-end)
-    );
+    line-height: var(--mod-tooltip-line-height, var(--spectrum-tooltip-line-height));
+    margin-block-start: var(--mod-tooltip-spacing-block-start, var(--spectrum-tooltip-spacing-block-start));
+    margin-block-end: var(--mod-tooltip-spacing-block-end, var(--spectrum-tooltip-spacing-block-end));
 }
 
 #tooltip,
@@ -586,12 +299,7 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--top-left,
 .spectrum-Tooltip--top-right,
 .spectrum-Tooltip--top-start {
-    margin-block-end: calc(
-        var(
-                --mod-tooltip-tip-block-size,
-                var(--spectrum-tooltip-tip-block-size)
-            ) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin))
-    );
+    margin-block-end: calc(var(--mod-tooltip-tip-block-size, var(--spectrum-tooltip-tip-block-size)) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin)));
 }
 
 :host([open]) .spectrum-Tooltip--top-end,
@@ -600,14 +308,7 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Tooltip--top-start,
 :host([placement*='top'][open]) #tooltip,
 :host([open]) #tooltip {
-    transform: translateY(
-        calc(
-            var(
-                    --mod-tooltip-animation-distance,
-                    var(--spectrum-tooltip-animation-distance)
-                ) * -1
-        )
-    );
+    transform: translateY(calc(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)) * -1));
 }
 
 :host([placement*='bottom']) #tooltip,
@@ -615,12 +316,7 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--bottom-left,
 .spectrum-Tooltip--bottom-right,
 .spectrum-Tooltip--bottom-start {
-    margin-block-start: calc(
-        var(
-                --mod-tooltip-tip-block-size,
-                var(--spectrum-tooltip-tip-block-size)
-            ) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin))
-    );
+    margin-block-start: calc(var(--mod-tooltip-tip-block-size, var(--spectrum-tooltip-tip-block-size)) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin)));
 }
 
 :host([open]) .spectrum-Tooltip--bottom-end,
@@ -628,82 +324,43 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Tooltip--bottom-right,
 :host([open]) .spectrum-Tooltip--bottom-start,
 :host([placement*='bottom'][open]) #tooltip {
-    transform: translateY(
-        var(
-            --mod-tooltip-animation-distance,
-            var(--spectrum-tooltip-animation-distance)
-        )
-    );
+    transform: translateY(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)));
 }
 
 :host([placement*='right']) #tooltip,
 .spectrum-Tooltip--right-bottom,
 .spectrum-Tooltip--right-top {
-    margin-left: calc(
-        var(
-                --mod-tooltip-tip-block-size,
-                var(--spectrum-tooltip-tip-block-size)
-            ) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin))
-    );
+    margin-left: calc(var(--mod-tooltip-tip-block-size, var(--spectrum-tooltip-tip-block-size)) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin)));
 }
 
 :host([open]) .spectrum-Tooltip--right-bottom,
 :host([open]) .spectrum-Tooltip--right-top,
 :host([placement*='right'][open]) #tooltip {
-    transform: translateX(
-        var(
-            --mod-tooltip-animation-distance,
-            var(--spectrum-tooltip-animation-distance)
-        )
-    );
+    transform: translateX(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)));
 }
 
 :host([placement*='left']) #tooltip,
 .spectrum-Tooltip--left-bottom,
 .spectrum-Tooltip--left-top {
-    margin-right: calc(
-        var(
-                --mod-tooltip-tip-block-size,
-                var(--spectrum-tooltip-tip-block-size)
-            ) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin))
-    );
+    margin-right: calc(var(--mod-tooltip-tip-block-size, var(--spectrum-tooltip-tip-block-size)) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin)));
 }
 
 :host([open]) .spectrum-Tooltip--left-bottom,
 :host([open]) .spectrum-Tooltip--left-top,
 :host([placement*='left'][open]) #tooltip {
-    transform: translateX(
-        calc(
-            var(
-                    --mod-tooltip-animation-distance,
-                    var(--spectrum-tooltip-animation-distance)
-                ) * -1
-        )
-    );
+    transform: translateX(calc(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)) * -1));
 }
 
 .spectrum-Tooltip--start,
 .spectrum-Tooltip--start-bottom,
 .spectrum-Tooltip--start-top {
-    margin-inline-end: calc(
-        var(
-                --mod-tooltip-tip-block-size,
-                var(--spectrum-tooltip-tip-block-size)
-            ) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin))
-    );
+    margin-inline-end: calc(var(--mod-tooltip-tip-block-size, var(--spectrum-tooltip-tip-block-size)) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin)));
 }
 
 :host([open]) .spectrum-Tooltip--start-bottom,
 :host([open]) .spectrum-Tooltip--start-top,
 :host([open]) .spectrum-Tooltip--start {
-    transform: translateX(
-        calc(
-            var(
-                    --mod-tooltip-animation-distance,
-                    var(--spectrum-tooltip-animation-distance)
-                ) * -1
-        )
-    );
+    transform: translateX(calc(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)) * -1));
 }
 
 :host([open]) .spectrum-Tooltip--start-bottom:dir(rtl),
@@ -712,34 +369,19 @@ governing permissions and limitations under the License.
 :host([dir='rtl'][open]) .spectrum-Tooltip--start-bottom,
 :host([dir='rtl'][open]) .spectrum-Tooltip--start-top,
 :host([dir='rtl'][open]) .spectrum-Tooltip--start {
-    transform: translateX(
-        var(
-            --mod-tooltip-animation-distance,
-            var(--spectrum-tooltip-animation-distance)
-        )
-    );
+    transform: translateX(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)));
 }
 
 .spectrum-Tooltip--end,
 .spectrum-Tooltip--end-bottom,
 .spectrum-Tooltip--end-top {
-    margin-inline-start: calc(
-        var(
-                --mod-tooltip-tip-block-size,
-                var(--spectrum-tooltip-tip-block-size)
-            ) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin))
-    );
+    margin-inline-start: calc(var(--mod-tooltip-tip-block-size, var(--spectrum-tooltip-tip-block-size)) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin)));
 }
 
 :host([open]) .spectrum-Tooltip--end-bottom,
 :host([open]) .spectrum-Tooltip--end-top,
 :host([open]) .spectrum-Tooltip--end {
-    transform: translateX(
-        var(
-            --mod-tooltip-animation-distance,
-            var(--spectrum-tooltip-animation-distance)
-        )
-    );
+    transform: translateX(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)));
 }
 
 :host([open]) .spectrum-Tooltip--end-bottom:dir(rtl),
@@ -748,12 +390,5 @@ governing permissions and limitations under the License.
 :host([dir='rtl'][open]) .spectrum-Tooltip--end-bottom,
 :host([dir='rtl'][open]) .spectrum-Tooltip--end-top,
 :host([dir='rtl'][open]) .spectrum-Tooltip--end {
-    transform: translateX(
-        calc(
-            var(
-                    --mod-tooltip-animation-distance,
-                    var(--spectrum-tooltip-animation-distance)
-                ) * -1
-        )
-    );
+    transform: translateX(calc(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)) * -1));
 }

--- a/packages/tray/src/spectrum-tray.css
+++ b/packages/tray/src/spectrum-tray.css
@@ -15,114 +15,35 @@ governing permissions and limitations under the License.
     --mod-modal-max-width: 100%;
     inline-size: 100%;
     max-inline-size: 100%;
-    max-block-size: calc(
-        100vh -
-            var(
-                --mod-tray-spacing-edge-to-tray-safe-zone,
-                var(--spectrum-tray-spacing-edge-to-tray-safe-zone)
-            )
-    );
+    max-block-size: calc(100vh - var(--mod-tray-spacing-edge-to-tray-safe-zone, var(--spectrum-tray-spacing-edge-to-tray-safe-zone)));
     box-sizing: border-box;
     border-radius: 0;
-    border-radius: var(--mod-tray-corner-radius-portrait, 0)
-        var(--mod-tray-corner-radius-portrait, 0) 0 0;
+    border-radius: var(--mod-tray-corner-radius-portrait, 0) var(--mod-tray-corner-radius-portrait, 0) 0 0;
     transition:
-        opacity
-            var(
-                --mod-tray-exit-animation-duration,
-                var(--spectrum-tray-exit-animation-duration)
-            )
-            cubic-bezier(0.5, 0, 1, 1)
-            var(
-                --mod-tray-exit-animation-delay,
-                var(--spectrum-tray-exit-animation-delay)
-            ),
-        visibility
-            var(
-                --mod-tray-exit-animation-duration,
-                var(--spectrum-tray-exit-animation-duration)
-            )
-            linear
-            calc(
-                var(
-                        --mod-tray-exit-animation-delay,
-                        var(--spectrum-tray-exit-animation-delay)
-                    ) +
-                    var(
-                        --mod-tray-exit-animation-duration,
-                        var(--spectrum-tray-exit-animation-duration)
-                    )
-            ),
-        transform
-            var(
-                --mod-tray-exit-animation-duration,
-                var(--spectrum-tray-exit-animation-duration)
-            )
-            cubic-bezier(0.5, 0, 1, 1)
-            var(
-                --mod-tray-exit-animation-delay,
-                var(--spectrum-tray-exit-animation-delay)
-            );
-    background-color: var(
-        --highcontrast-tray-background-color,
-        var(--mod-tray-background-color, var(--spectrum-tray-background-color))
-    );
+        opacity var(--mod-tray-exit-animation-duration, var(--spectrum-tray-exit-animation-duration)) cubic-bezier(0.5, 0, 1, 1) var(--mod-tray-exit-animation-delay, var(--spectrum-tray-exit-animation-delay)),
+        visibility var(--mod-tray-exit-animation-duration, var(--spectrum-tray-exit-animation-duration)) linear calc(var(--mod-tray-exit-animation-delay, var(--spectrum-tray-exit-animation-delay)) + var(--mod-tray-exit-animation-duration, var(--spectrum-tray-exit-animation-duration))),
+        transform var(--mod-tray-exit-animation-duration, var(--spectrum-tray-exit-animation-duration)) cubic-bezier(0.5, 0, 1, 1) var(--mod-tray-exit-animation-delay, var(--spectrum-tray-exit-animation-delay));
+    background-color: var(--highcontrast-tray-background-color, var(--mod-tray-background-color, var(--spectrum-tray-background-color)));
     outline: none;
-    margin-block-start: var(
-        --mod-tray-spacing-edge-to-tray-safe-zone,
-        var(--spectrum-tray-spacing-edge-to-tray-safe-zone)
-    );
-    padding-block-start: var(
-        --mod-tray-top-to-content-area,
-        var(--spectrum-tray-top-to-content-area)
-    );
-    padding-block-end: var(
-        --mod-tray-bottom-to-content-area,
-        var(--spectrum-tray-top-to-content-area)
-    );
+    margin-block-start: var(--mod-tray-spacing-edge-to-tray-safe-zone, var(--spectrum-tray-spacing-edge-to-tray-safe-zone));
+    padding-block-start: var(--mod-tray-top-to-content-area, var(--spectrum-tray-top-to-content-area));
+    padding-block-end: var(--mod-tray-bottom-to-content-area, var(--spectrum-tray-top-to-content-area));
     overflow: auto;
     transform: translateY(100%);
 }
 
 :host([open]) .tray {
     transition:
-        transform
-            var(
-                --mod-tray-entry-animation-duration,
-                var(--spectrum-tray-entry-animation-duration)
-            )
-            cubic-bezier(0, 0, 0.4, 1)
-            var(
-                --mod-tray-entry-animation-delay,
-                var(--spectrum-tray-entry-animation-delay)
-            ),
-        opacity
-            var(
-                --spectrum-tray-entry-animation-duration,
-                var(--mod-tray-entry-animation-duration)
-            )
-            cubic-bezier(0, 0, 0.4, 1)
-            var(
-                --mod-tray-entry-animation-delay,
-                var(--spectrum-tray-entry-animation-delay)
-            );
+        transform var(--mod-tray-entry-animation-duration, var(--spectrum-tray-entry-animation-duration)) cubic-bezier(0, 0, 0.4, 1) var(--mod-tray-entry-animation-delay, var(--spectrum-tray-entry-animation-delay)),
+        opacity var(--spectrum-tray-entry-animation-duration, var(--mod-tray-entry-animation-duration)) cubic-bezier(0, 0, 0.4, 1) var(--mod-tray-entry-animation-delay, var(--spectrum-tray-entry-animation-delay));
     transform: translateY(0);
 }
 
 @media screen and (orientation: landscape) {
     .tray {
-        max-inline-size: var(
-            --mod-tray-max-inline-size,
-            var(--spectrum-tray-max-inline-size)
-        );
-        border-start-start-radius: var(
-            --mod-tray-corner-radius,
-            var(--spectrum-tray-corner-radius)
-        );
-        border-start-end-radius: var(
-            --mod-tray-corner-radius,
-            var(--spectrum-tray-corner-radius)
-        );
+        max-inline-size: var(--mod-tray-max-inline-size, var(--spectrum-tray-max-inline-size));
+        border-start-start-radius: var(--mod-tray-corner-radius, var(--spectrum-tray-corner-radius));
+        border-start-end-radius: var(--mod-tray-corner-radius, var(--spectrum-tray-corner-radius));
     }
 }
 

--- a/packages/underlay/src/spectrum-underlay.css
+++ b/packages/underlay/src/spectrum-underlay.css
@@ -20,23 +20,9 @@ governing permissions and limitations under the License.
         opacity 0.13s ease-in-out,
         visibility 0s linear 0.13s;
     transition:
-        transform
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        opacity
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            )
-            ease-in-out,
-        visibility 0s linear
-            var(
-                --mod-overlay-animation-duration,
-                var(--spectrum-animation-duration-100, 0.13s)
-            );
+        transform var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        opacity var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s)) ease-in-out,
+        visibility 0s linear var(--mod-overlay-animation-duration, var(--spectrum-animation-duration-100, 0.13s));
 }
 
 :host([open]) {
@@ -44,45 +30,15 @@ governing permissions and limitations under the License.
     visibility: visible;
     opacity: 1;
     transition-delay: 0s;
-    transition-delay: var(
-        --mod-overlay-animation-duration-opened,
-        var(--spectrum-animation-duration-0, 0s)
-    );
+    transition-delay: var(--mod-overlay-animation-duration-opened, var(--spectrum-animation-duration-0, 0s));
 }
 
 :host {
-    background-color: var(
-        --mod-underlay-background-color,
-        var(--spectrum-underlay-background-color)
-    );
+    background-color: var(--mod-underlay-background-color, var(--spectrum-underlay-background-color));
     z-index: 1;
     transition:
-        opacity
-            var(
-                --mod-underlay-background-exit-animation-duration,
-                var(--spectrum-underlay-background-exit-animation-duration)
-            )
-            var(
-                --mod-underlay-background-exit-animation-ease,
-                var(--spectrum-underlay-background-exit-animation-ease)
-            )
-            var(
-                --mod-underlay-background-exit-animation-delay,
-                var(--spectrum-underlay-background-exit-animation-delay)
-            ),
-        visibility 0s linear
-            calc(
-                var(
-                        --mod-underlay-background-exit-animation-delay,
-                        var(--spectrum-underlay-background-exit-animation-delay)
-                    ) +
-                    var(
-                        --mod-underlay-background-exit-animation-duration,
-                        var(
-                            --spectrum-underlay-background-exit-animation-duration
-                        )
-                    )
-            );
+        opacity var(--mod-underlay-background-exit-animation-duration, var(--spectrum-underlay-background-exit-animation-duration)) var(--mod-underlay-background-exit-animation-ease, var(--spectrum-underlay-background-exit-animation-ease)) var(--mod-underlay-background-exit-animation-delay, var(--spectrum-underlay-background-exit-animation-delay)),
+        visibility 0s linear calc(var(--mod-underlay-background-exit-animation-delay, var(--spectrum-underlay-background-exit-animation-delay)) + var(--mod-underlay-background-exit-animation-duration, var(--spectrum-underlay-background-exit-animation-duration)));
     position: fixed;
     inset-block: 0;
     inset-inline: 0;
@@ -90,17 +46,5 @@ governing permissions and limitations under the License.
 }
 
 :host([open]) {
-    transition: opacity
-        var(
-            --mod-underlay-background-entry-animation-duration,
-            var(--spectrum-underlay-background-entry-animation-duration)
-        )
-        var(
-            --mod-underlay-background-entry-animation-ease,
-            var(--spectrum-underlay-background-entry-animation-ease)
-        )
-        var(
-            --mod-underlay-background-entry-animation-delay,
-            var(--spectrum-underlay-background-entry-animation-delay)
-        );
+    transition: opacity var(--mod-underlay-background-entry-animation-duration, var(--spectrum-underlay-background-entry-animation-duration)) var(--mod-underlay-background-entry-animation-ease, var(--spectrum-underlay-background-entry-animation-ease)) var(--mod-underlay-background-entry-animation-delay, var(--spectrum-underlay-background-entry-animation-delay));
 }

--- a/tools/opacity-checkerboard/src/spectrum-is-opacity-checkerboard.css
+++ b/tools/opacity-checkerboard/src/spectrum-is-opacity-checkerboard.css
@@ -12,63 +12,12 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    background: repeating-conic-gradient(
-            var(
-                    --mod-opacity-checkerboard-light,
-                    var(--spectrum-opacity-checkerboard-square-light)
-                )
-                0 25%,
-            var(
-                    --mod-opacity-checkerboard-dark,
-                    var(--spectrum-opacity-checkerboard-square-dark)
-                )
-                0 50%
-        )
-        0 0 /
-        calc(
-            var(
-                    --mod-opacity-checkerboard-size,
-                    var(--spectrum-opacity-checkerboard-square-size)
-                ) * 2
-        )
-        calc(
-            var(
-                    --mod-opacity-checkerboard-size,
-                    var(--spectrum-opacity-checkerboard-square-size)
-                ) * 2
-        );
+    background: repeating-conic-gradient(var(--mod-opacity-checkerboard-light, var(--spectrum-opacity-checkerboard-square-light)) 0 25%, var(--mod-opacity-checkerboard-dark, var(--spectrum-opacity-checkerboard-square-dark)) 0 50%) 0 0 / calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-square-size)) * 2) calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-square-size)) * 2);
 }
 
-@supports (
-    background:
-        repeating-conic-gradient(from 0deg, red 0deg, red 0deg 1deg, red 2deg)
-) {
+@supports (background: repeating-conic-gradient(from 0deg, red 0deg, red 0deg 1deg, red 2deg)) {
     :host {
-        background: repeating-conic-gradient(
-                var(
-                        --mod-opacity-checkerboard-light,
-                        var(--spectrum-opacity-checkerboard-square-light)
-                    )
-                    0 25%,
-                var(
-                        --mod-opacity-checkerboard-dark,
-                        var(--spectrum-opacity-checkerboard-square-dark)
-                    )
-                    0 50%
-            )
-            var(--mod-opacity-checkerboard-position, left top) /
-            calc(
-                var(
-                        --mod-opacity-checkerboard-size,
-                        var(--spectrum-opacity-checkerboard-square-size)
-                    ) * 2
-            )
-            calc(
-                var(
-                        --mod-opacity-checkerboard-size,
-                        var(--spectrum-opacity-checkerboard-square-size)
-                    ) * 2
-            );
+        background: repeating-conic-gradient(var(--mod-opacity-checkerboard-light, var(--spectrum-opacity-checkerboard-square-light)) 0 25%, var(--mod-opacity-checkerboard-dark, var(--spectrum-opacity-checkerboard-square-dark)) 0 50%) var(--mod-opacity-checkerboard-position, left top) / calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-square-size)) * 2) calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-square-size)) * 2);
     }
 }
 

--- a/tools/opacity-checkerboard/src/spectrum-opacity-checkerboard.css
+++ b/tools/opacity-checkerboard/src/spectrum-opacity-checkerboard.css
@@ -12,63 +12,12 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .opacity-checkerboard {
-    background: repeating-conic-gradient(
-            var(
-                    --mod-opacity-checkerboard-light,
-                    var(--spectrum-opacity-checkerboard-square-light)
-                )
-                0 25%,
-            var(
-                    --mod-opacity-checkerboard-dark,
-                    var(--spectrum-opacity-checkerboard-square-dark)
-                )
-                0 50%
-        )
-        0 0 /
-        calc(
-            var(
-                    --mod-opacity-checkerboard-size,
-                    var(--spectrum-opacity-checkerboard-square-size)
-                ) * 2
-        )
-        calc(
-            var(
-                    --mod-opacity-checkerboard-size,
-                    var(--spectrum-opacity-checkerboard-square-size)
-                ) * 2
-        );
+    background: repeating-conic-gradient(var(--mod-opacity-checkerboard-light, var(--spectrum-opacity-checkerboard-square-light)) 0 25%, var(--mod-opacity-checkerboard-dark, var(--spectrum-opacity-checkerboard-square-dark)) 0 50%) 0 0 / calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-square-size)) * 2) calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-square-size)) * 2);
 }
 
-@supports (
-    background:
-        repeating-conic-gradient(from 0deg, red 0deg, red 0deg 1deg, red 2deg)
-) {
+@supports (background: repeating-conic-gradient(from 0deg, red 0deg, red 0deg 1deg, red 2deg)) {
     .opacity-checkerboard {
-        background: repeating-conic-gradient(
-                var(
-                        --mod-opacity-checkerboard-light,
-                        var(--spectrum-opacity-checkerboard-square-light)
-                    )
-                    0 25%,
-                var(
-                        --mod-opacity-checkerboard-dark,
-                        var(--spectrum-opacity-checkerboard-square-dark)
-                    )
-                    0 50%
-            )
-            var(--mod-opacity-checkerboard-position, left top) /
-            calc(
-                var(
-                        --mod-opacity-checkerboard-size,
-                        var(--spectrum-opacity-checkerboard-square-size)
-                    ) * 2
-            )
-            calc(
-                var(
-                        --mod-opacity-checkerboard-size,
-                        var(--spectrum-opacity-checkerboard-square-size)
-                    ) * 2
-            );
+        background: repeating-conic-gradient(var(--mod-opacity-checkerboard-light, var(--spectrum-opacity-checkerboard-square-light)) 0 25%, var(--mod-opacity-checkerboard-dark, var(--spectrum-opacity-checkerboard-square-dark)) 0 50%) var(--mod-opacity-checkerboard-position, left top) / calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-square-size)) * 2) calc(var(--mod-opacity-checkerboard-size, var(--spectrum-opacity-checkerboard-square-size)) * 2);
     }
 }
 

--- a/tools/styles/src/spectrum-body.css
+++ b/tools/styles/src/spectrum-body.css
@@ -12,10 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Typography .spectrum-Body {
-    --spectrum-body-margin-end: calc(
-        var(--mod-body-font-size, var(--spectrum-body-font-size)) *
-            var(--spectrum-body-margin-multiplier)
-    );
+    --spectrum-body-margin-end: calc(var(--mod-body-font-size, var(--spectrum-body-font-size)) * var(--spectrum-body-margin-multiplier));
 }
 
 @media (forced-colors: active) {
@@ -25,94 +22,43 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Body {
-    font-family: var(
-        --mod-body-sans-serif-font-family,
-        var(--spectrum-body-sans-serif-font-family)
-    );
-    font-style: var(
-        --mod-body-sans-serif-font-style,
-        var(--spectrum-body-sans-serif-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-font-weight,
-        var(--spectrum-body-sans-serif-font-weight)
-    );
+    font-family: var(--mod-body-sans-serif-font-family, var(--spectrum-body-sans-serif-font-family));
+    font-style: var(--mod-body-sans-serif-font-style, var(--spectrum-body-sans-serif-font-style));
+    font-weight: var(--mod-body-sans-serif-font-weight, var(--spectrum-body-sans-serif-font-weight));
     font-size: var(--mod-body-font-size, var(--spectrum-body-font-size));
-    color: var(
-        --highcontrast-body-font-color,
-        var(--mod-body-font-color, var(--spectrum-body-font-color))
-    );
+    color: var(--highcontrast-body-font-color, var(--mod-body-font-color, var(--spectrum-body-font-color)));
     line-height: var(--mod-body-line-height, var(--spectrum-body-line-height));
-    margin-block-start: var(
-        --mod-body-margin-start,
-        var(--mod-body-margin, var(--spectrum-body-margin-start, 0))
-    );
-    margin-block-end: var(
-        --mod-body-margin-end,
-        var(--mod-body-margin, var(--spectrum-body-margin-end, 0))
-    );
+    margin-block-start: var(--mod-body-margin-start, var(--mod-body-margin, var(--spectrum-body-margin-start, 0)));
+    margin-block-end: var(--mod-body-margin-end, var(--mod-body-margin, var(--spectrum-body-margin-end, 0)));
 }
 
 .spectrum-Body .spectrum-Body-strong,
 .spectrum-Body strong {
-    font-style: var(
-        --mod-body-sans-serif-strong-font-style,
-        var(--spectrum-body-sans-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-strong-font-weight,
-        var(--spectrum-body-sans-serif-strong-font-weight)
-    );
+    font-style: var(--mod-body-sans-serif-strong-font-style, var(--spectrum-body-sans-serif-strong-font-style));
+    font-weight: var(--mod-body-sans-serif-strong-font-weight, var(--spectrum-body-sans-serif-strong-font-weight));
 }
 
 .spectrum-Body .spectrum-Body-emphasized,
 .spectrum-Body em {
-    font-style: var(
-        --mod-body-sans-serif-emphasized-font-style,
-        var(--spectrum-body-sans-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-emphasized-font-weight,
-        var(--spectrum-body-sans-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-sans-serif-emphasized-font-style, var(--spectrum-body-sans-serif-emphasized-font-style));
+    font-weight: var(--mod-body-sans-serif-emphasized-font-weight, var(--spectrum-body-sans-serif-emphasized-font-weight));
 }
 
 .spectrum-Body .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body em strong,
 .spectrum-Body strong em {
-    font-style: var(
-        --mod-body-sans-serif-strong-emphasized-font-style,
-        var(--spectrum-body-sans-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-strong-emphasized-font-weight,
-        var(--spectrum-body-sans-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-sans-serif-strong-emphasized-font-style, var(--spectrum-body-sans-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-body-sans-serif-strong-emphasized-font-weight, var(--spectrum-body-sans-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Body:lang(ja),
 .spectrum-Body:lang(ko),
 .spectrum-Body:lang(zh) {
-    font-family: var(
-        --mod-body-cjk-font-family,
-        var(--spectrum-body-cjk-font-family)
-    );
-    font-style: var(
-        --mod-body-cjk-font-style,
-        var(--spectrum-body-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-font-weight,
-        var(--spectrum-body-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-body-cjk-line-height,
-        var(--spectrum-body-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-body-cjk-letter-spacing,
-        var(--spectrum-body-cjk-letter-spacing)
-    );
+    font-family: var(--mod-body-cjk-font-family, var(--spectrum-body-cjk-font-family));
+    font-style: var(--mod-body-cjk-font-style, var(--spectrum-body-cjk-font-style));
+    font-weight: var(--mod-body-cjk-font-weight, var(--spectrum-body-cjk-font-weight));
+    line-height: var(--mod-body-cjk-line-height, var(--spectrum-body-cjk-line-height));
+    letter-spacing: var(--mod-body-cjk-letter-spacing, var(--spectrum-body-cjk-letter-spacing));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-strong,
@@ -121,14 +67,8 @@ governing permissions and limitations under the License.
 .spectrum-Body:lang(ko) strong,
 .spectrum-Body:lang(zh) .spectrum-Body-strong,
 .spectrum-Body:lang(zh) strong {
-    font-style: var(
-        --mod-body-cjk-strong-font-style,
-        var(--spectrum-body-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-strong-font-weight,
-        var(--spectrum-body-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-body-cjk-strong-font-style, var(--spectrum-body-cjk-strong-font-style));
+    font-weight: var(--mod-body-cjk-strong-font-weight, var(--spectrum-body-cjk-strong-font-weight));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-emphasized,
@@ -137,14 +77,8 @@ governing permissions and limitations under the License.
 .spectrum-Body:lang(ko) em,
 .spectrum-Body:lang(zh) .spectrum-Body-emphasized,
 .spectrum-Body:lang(zh) em {
-    font-style: var(
-        --mod-body-cjk-emphasized-font-style,
-        var(--spectrum-body-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-emphasized-font-weight,
-        var(--spectrum-body-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-cjk-emphasized-font-style, var(--spectrum-body-cjk-emphasized-font-style));
+    font-weight: var(--mod-body-cjk-emphasized-font-weight, var(--spectrum-body-cjk-emphasized-font-weight));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-strong.spectrum-Body-emphasized,
@@ -156,87 +90,41 @@ governing permissions and limitations under the License.
 .spectrum-Body:lang(zh) .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body:lang(zh) em strong,
 .spectrum-Body:lang(zh) strong em {
-    font-style: var(
-        --mod-body-cjk-strong-emphasized-font-style,
-        var(--spectrum-body-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-strong-emphasized-font-weight,
-        var(--spectrum-body-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-cjk-strong-emphasized-font-style, var(--spectrum-body-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-body-cjk-strong-emphasized-font-weight, var(--spectrum-body-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Body--serif {
-    font-family: var(
-        --mod-body-serif-font-family,
-        var(--spectrum-body-serif-font-family)
-    );
-    font-weight: var(
-        --mod-body-serif-font-weight,
-        var(--spectrum-body-serif-font-weight)
-    );
-    font-style: var(
-        --mod-body-serif-font-style,
-        var(--spectrum-body-serif-font-style)
-    );
+    font-family: var(--mod-body-serif-font-family, var(--spectrum-body-serif-font-family));
+    font-weight: var(--mod-body-serif-font-weight, var(--spectrum-body-serif-font-weight));
+    font-style: var(--mod-body-serif-font-style, var(--spectrum-body-serif-font-style));
 }
 
 .spectrum-Body--serif .spectrum-Body-strong,
 .spectrum-Body--serif strong {
-    font-style: var(
-        --mod-body-serif-strong-font-style,
-        var(--spectrum-body-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-serif-strong-font-weight,
-        var(--spectrum-body-serif-strong-font-weight)
-    );
+    font-style: var(--mod-body-serif-strong-font-style, var(--spectrum-body-serif-strong-font-style));
+    font-weight: var(--mod-body-serif-strong-font-weight, var(--spectrum-body-serif-strong-font-weight));
 }
 
 .spectrum-Body--serif .spectrum-Body-emphasized,
 .spectrum-Body--serif em {
-    font-style: var(
-        --mod-body-serif-emphasized-font-style,
-        var(--spectrum-body-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-serif-emphasized-font-weight,
-        var(--spectrum-body-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-serif-emphasized-font-style, var(--spectrum-body-serif-emphasized-font-style));
+    font-weight: var(--mod-body-serif-emphasized-font-weight, var(--spectrum-body-serif-emphasized-font-weight));
 }
 
 .spectrum-Body--serif .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body--serif em strong,
 .spectrum-Body--serif strong em {
-    font-style: var(
-        --mod-body-serif-strong-emphasized-font-style,
-        var(--spectrum-body-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-serif-strong-emphasized-font-weight,
-        var(--spectrum-body-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-serif-strong-emphasized-font-style, var(--spectrum-body-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-body-serif-strong-emphasized-font-weight, var(--spectrum-body-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-strong.spectrum-Body-emphasized {
-    font-style: var(
-        --mod-detail-sans-serif-light-strong-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-strong-emphasized-font-style, var(--spectrum-detail-sans-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-strong-emphasized-font-weight, var(--spectrum-detail-sans-serif-light-strong-emphasized-font-weight));
 }
 
-.spectrum-Detail--serif.spectrum-Detail--light
-    .spectrum-Detail-strong.spectrum-Body-emphasized {
-    font-style: var(
-        --mod-detail-serif-light-strong-emphasized-font-style,
-        var(--spectrum-detail-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-serif-light-strong-emphasized-font-weight)
-    );
+.spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-strong.spectrum-Body-emphasized {
+    font-style: var(--mod-detail-serif-light-strong-emphasized-font-style, var(--spectrum-detail-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-light-strong-emphasized-font-weight, var(--spectrum-detail-serif-light-strong-emphasized-font-weight));
 }

--- a/tools/styles/src/spectrum-code.css
+++ b/tools/styles/src/spectrum-code.css
@@ -23,80 +23,38 @@ governing permissions and limitations under the License.
     font-weight: var(--mod-code-font-weight, var(--spectrum-code-font-weight));
     font-size: var(--mod-code-font-size, var(--spectrum-code-font-size));
     line-height: var(--mod-code-line-height, var(--spectrum-code-line-height));
-    color: var(
-        --highcontrast-code-font-color,
-        var(--mod-code-font-color, var(--spectrum-code-font-color))
-    );
-    margin-block-start: var(
-        --mod-code-margin-start,
-        var(--spectrum-code-margin-end, 0)
-    );
-    margin-block-end: var(
-        --mod-code-margin-end,
-        var(--spectrum-code-margin-end, 0)
-    );
+    color: var(--highcontrast-code-font-color, var(--mod-code-font-color, var(--spectrum-code-font-color)));
+    margin-block-start: var(--mod-code-margin-start, var(--spectrum-code-margin-end, 0));
+    margin-block-end: var(--mod-code-margin-end, var(--spectrum-code-margin-end, 0));
 }
 
 .spectrum-Code .spectrum-Code-strong,
 .spectrum-Code strong {
-    font-style: var(
-        --mod-code-strong-font-style,
-        var(--spectrum-code-strong-font-style)
-    );
-    font-weight: var(
-        --mod-code-strong-font-weight,
-        var(--spectrum-code-strong-font-weight)
-    );
+    font-style: var(--mod-code-strong-font-style, var(--spectrum-code-strong-font-style));
+    font-weight: var(--mod-code-strong-font-weight, var(--spectrum-code-strong-font-weight));
 }
 
 .spectrum-Code .spectrum-Code-emphasized,
 .spectrum-Code em {
-    font-style: var(
-        --mod-code-emphasized-font-style,
-        var(--spectrum-code-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-emphasized-font-weight,
-        var(--spectrum-code-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-emphasized-font-style, var(--spectrum-code-emphasized-font-style));
+    font-weight: var(--mod-code-emphasized-font-weight, var(--spectrum-code-emphasized-font-weight));
 }
 
 .spectrum-Code .spectrum-Code-strong.spectrum-Code-emphasized,
 .spectrum-Code em strong,
 .spectrum-Code strong em {
-    font-style: var(
-        --mod-code-strong-emphasized-font-style,
-        var(--spectrum-code-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-strong-emphasized-font-weight,
-        var(--spectrum-code-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-strong-emphasized-font-style, var(--spectrum-code-strong-emphasized-font-style));
+    font-weight: var(--mod-code-strong-emphasized-font-weight, var(--spectrum-code-strong-emphasized-font-weight));
 }
 
 .spectrum-Code:lang(ja),
 .spectrum-Code:lang(ko),
 .spectrum-Code:lang(zh) {
-    font-family: var(
-        --mod-code-cjk-font-family,
-        var(--spectrum-code-cjk-font-family)
-    );
-    font-style: var(
-        --mod-code-cjk-font-style,
-        var(--spectrum-code-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-font-weight,
-        var(--spectrum-code-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-code-cjk-line-height,
-        var(--spectrum-code-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-code-cjk-letter-spacing,
-        var(--spectrum-code-cjk-letter-spacing)
-    );
+    font-family: var(--mod-code-cjk-font-family, var(--spectrum-code-cjk-font-family));
+    font-style: var(--mod-code-cjk-font-style, var(--spectrum-code-cjk-font-style));
+    font-weight: var(--mod-code-cjk-font-weight, var(--spectrum-code-cjk-font-weight));
+    line-height: var(--mod-code-cjk-line-height, var(--spectrum-code-cjk-line-height));
+    letter-spacing: var(--mod-code-cjk-letter-spacing, var(--spectrum-code-cjk-letter-spacing));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-strong,
@@ -105,14 +63,8 @@ governing permissions and limitations under the License.
 .spectrum-Code:lang(ko) strong,
 .spectrum-Code:lang(zh) .spectrum-Code-strong,
 .spectrum-Code:lang(zh) strong {
-    font-style: var(
-        --mod-code-cjk-strong-font-style,
-        var(--spectrum-code-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-strong-font-weight,
-        var(--spectrum-code-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-code-cjk-strong-font-style, var(--spectrum-code-cjk-strong-font-style));
+    font-weight: var(--mod-code-cjk-strong-font-weight, var(--spectrum-code-cjk-strong-font-weight));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-emphasized,
@@ -121,14 +73,8 @@ governing permissions and limitations under the License.
 .spectrum-Code:lang(ko) em,
 .spectrum-Code:lang(zh) .spectrum-Code-emphasized,
 .spectrum-Code:lang(zh) em {
-    font-style: var(
-        --mod-code-cjk-emphasized-font-style,
-        var(--spectrum-code-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-emphasized-font-weight,
-        var(--spectrum-code-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-cjk-emphasized-font-style, var(--spectrum-code-cjk-emphasized-font-style));
+    font-weight: var(--mod-code-cjk-emphasized-font-weight, var(--spectrum-code-cjk-emphasized-font-weight));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-strong.spectrum-Code-emphasized,
@@ -140,12 +86,6 @@ governing permissions and limitations under the License.
 .spectrum-Code:lang(zh) .spectrum-Code-strong.spectrum-Code-emphasized,
 .spectrum-Code:lang(zh) em strong,
 .spectrum-Code:lang(zh) strong em {
-    font-style: var(
-        --mod-code-cjk-strong-emphasized-font-style,
-        var(--spectrum-code-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-strong-emphasized-font-weight,
-        var(--spectrum-code-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-cjk-strong-emphasized-font-style, var(--spectrum-code-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-code-cjk-strong-emphasized-font-weight, var(--spectrum-code-cjk-strong-emphasized-font-weight));
 }

--- a/tools/styles/src/spectrum-detail.css
+++ b/tools/styles/src/spectrum-detail.css
@@ -12,14 +12,8 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Typography .spectrum-Detail {
-    --spectrum-detail-margin-start: calc(
-        var(--mod-detail-font-size, var(--spectrum-detail-font-size)) *
-            var(--spectrum-detail-margin-top-multiplier)
-    );
-    --spectrum-detail-margin-end: calc(
-        var(--mod-detail-font-size, var(--spectrum-detail-font-size)) *
-            var(--spectrum-detail-margin-bottom-multiplier)
-    );
+    --spectrum-detail-margin-start: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-top-multiplier));
+    --spectrum-detail-margin-end: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-bottom-multiplier));
 }
 
 @media (forced-colors: active) {
@@ -29,98 +23,44 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Detail {
-    font-family: var(
-        --mod-detail-sans-serif-font-family,
-        var(--spectrum-detail-sans-serif-font-family)
-    );
-    font-style: var(
-        --mod-detail-sans-serif-font-style,
-        var(--spectrum-detail-sans-serif-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-font-weight,
-        var(--spectrum-detail-sans-serif-font-weight)
-    );
+    font-family: var(--mod-detail-sans-serif-font-family, var(--spectrum-detail-sans-serif-font-family));
+    font-style: var(--mod-detail-sans-serif-font-style, var(--spectrum-detail-sans-serif-font-style));
+    font-weight: var(--mod-detail-sans-serif-font-weight, var(--spectrum-detail-sans-serif-font-weight));
     font-size: var(--mod-detail-font-size, var(--spectrum-detail-font-size));
-    color: var(
-        --highcontrast-detail-font-color,
-        var(--mod-detail-font-color, var(--spectrum-detail-font-color))
-    );
-    line-height: var(
-        --mod-detail-line-height,
-        var(--spectrum-detail-line-height)
-    );
-    letter-spacing: var(
-        --mod-detail-letter-spacing,
-        var(--spectrum-detail-letter-spacing)
-    );
+    color: var(--highcontrast-detail-font-color, var(--mod-detail-font-color, var(--spectrum-detail-font-color)));
+    line-height: var(--mod-detail-line-height, var(--spectrum-detail-line-height));
+    letter-spacing: var(--mod-detail-letter-spacing, var(--spectrum-detail-letter-spacing));
     text-transform: uppercase;
-    margin-block-start: var(
-        --mod-detail-margin-start,
-        var(--spectrum-detail-margin-start, 0)
-    );
-    margin-block-end: var(
-        --mod-detail-margin-end,
-        var(--spectrum-detail-margin-end, 0)
-    );
+    margin-block-start: var(--mod-detail-margin-start, var(--spectrum-detail-margin-start, 0));
+    margin-block-end: var(--mod-detail-margin-end, var(--spectrum-detail-margin-end, 0));
 }
 
 .spectrum-Detail .spectrum-Detail-strong,
 .spectrum-Detail strong {
-    font-style: var(
-        --mod-detail-sans-serif-strong-font-style,
-        var(--spectrum-detail-sans-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-strong-font-weight,
-        var(--spectrum-detail-sans-serif-strong-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-strong-font-style, var(--spectrum-detail-sans-serif-strong-font-style));
+    font-weight: var(--mod-detail-sans-serif-strong-font-weight, var(--spectrum-detail-sans-serif-strong-font-weight));
 }
 
 .spectrum-Detail .spectrum-Detail-emphasized,
 .spectrum-Detail em {
-    font-style: var(
-        --mod-detail-sans-serif-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-emphasized-font-style, var(--spectrum-detail-sans-serif-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-emphasized-font-weight, var(--spectrum-detail-sans-serif-emphasized-font-weight));
 }
 
 .spectrum-Detail .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail em strong,
 .spectrum-Detail strong em {
-    font-style: var(
-        --mod-detail-sans-serif-strong-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-strong-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-strong-emphasized-font-style, var(--spectrum-detail-sans-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-strong-emphasized-font-weight, var(--spectrum-detail-sans-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail:lang(ja),
 .spectrum-Detail:lang(ko),
 .spectrum-Detail:lang(zh) {
-    font-family: var(
-        --mod-detail-cjk-font-family,
-        var(--spectrum-detail-cjk-font-family)
-    );
-    font-style: var(
-        --mod-detail-cjk-font-style,
-        var(--spectrum-detail-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-font-weight,
-        var(--spectrum-detail-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-detail-cjk-line-height,
-        var(--spectrum-detail-cjk-line-height)
-    );
+    font-family: var(--mod-detail-cjk-font-family, var(--spectrum-detail-cjk-font-family));
+    font-style: var(--mod-detail-cjk-font-style, var(--spectrum-detail-cjk-font-style));
+    font-weight: var(--mod-detail-cjk-font-weight, var(--spectrum-detail-cjk-font-weight));
+    line-height: var(--mod-detail-cjk-line-height, var(--spectrum-detail-cjk-line-height));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-strong,
@@ -129,14 +69,8 @@ governing permissions and limitations under the License.
 .spectrum-Detail:lang(ko) strong,
 .spectrum-Detail:lang(zh) .spectrum-Detail-strong,
 .spectrum-Detail:lang(zh) strong {
-    font-style: var(
-        --mod-detail-cjk-strong-font-style,
-        var(--spectrum-detail-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-strong-font-weight,
-        var(--spectrum-detail-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-strong-font-style, var(--spectrum-detail-cjk-strong-font-style));
+    font-weight: var(--mod-detail-cjk-strong-font-weight, var(--spectrum-detail-cjk-strong-font-weight));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-emphasized,
@@ -145,14 +79,8 @@ governing permissions and limitations under the License.
 .spectrum-Detail:lang(ko) em,
 .spectrum-Detail:lang(zh) .spectrum-Detail-emphasized,
 .spectrum-Detail:lang(zh) em {
-    font-style: var(
-        --mod-detail-cjk-emphasized-font-style,
-        var(--spectrum-detail-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-emphasized-font-weight,
-        var(--spectrum-detail-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-emphasized-font-style, var(--spectrum-detail-cjk-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-emphasized-font-weight, var(--spectrum-detail-cjk-emphasized-font-weight));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-strong.spectrum-Detail-emphasized,
@@ -164,127 +92,64 @@ governing permissions and limitations under the License.
 .spectrum-Detail:lang(zh) .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail:lang(zh) em strong,
 .spectrum-Detail:lang(zh) strong em {
-    font-style: var(
-        --mod-detail-cjk-strong-emphasized-font-style,
-        var(--spectrum-detail-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-strong-emphasized-font-weight,
-        var(--spectrum-detail-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-strong-emphasized-font-style, var(--spectrum-detail-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-strong-emphasized-font-weight, var(--spectrum-detail-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--serif {
-    font-family: var(
-        --mod-detail-serif-font-family,
-        var(--spectrum-detail-serif-font-family)
-    );
-    font-style: var(
-        --mod-detail-serif-font-style,
-        var(--spectrum-detail-serif-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-font-weight,
-        var(--spectrum-detail-serif-font-weight)
-    );
+    font-family: var(--mod-detail-serif-font-family, var(--spectrum-detail-serif-font-family));
+    font-style: var(--mod-detail-serif-font-style, var(--spectrum-detail-serif-font-style));
+    font-weight: var(--mod-detail-serif-font-weight, var(--spectrum-detail-serif-font-weight));
 }
 
 .spectrum-Detail--serif .spectrum-Detail-strong,
 .spectrum-Detail--serif strong {
-    font-style: var(
-        --mod-detail-serif-strong-font-style,
-        var(--spectrum-detail-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-strong-font-weight,
-        var(--spectrum-detail-serif-strong-font-weight)
-    );
+    font-style: var(--mod-detail-serif-strong-font-style, var(--spectrum-detail-serif-strong-font-style));
+    font-weight: var(--mod-detail-serif-strong-font-weight, var(--spectrum-detail-serif-strong-font-weight));
 }
 
 .spectrum-Detail--serif .spectrum-Detail-emphasized,
 .spectrum-Detail--serif em {
-    font-style: var(
-        --mod-detail-serif-emphasized-font-style,
-        var(--spectrum-detail-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-emphasized-font-weight,
-        var(--spectrum-detail-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-emphasized-font-style, var(--spectrum-detail-serif-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-emphasized-font-weight, var(--spectrum-detail-serif-emphasized-font-weight));
 }
 
 .spectrum-Detail--serif .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail--serif em strong,
 .spectrum-Detail--serif strong em {
-    font-style: var(
-        --mod-detail-serif-strong-emphasized-font-style,
-        var(--spectrum-detail-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-strong-emphasized-font-weight,
-        var(--spectrum-detail-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-strong-emphasized-font-style, var(--spectrum-detail-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-strong-emphasized-font-weight, var(--spectrum-detail-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--light {
-    font-style: var(
-        --mod-detail-sans-serif-light-font-style,
-        var(--spectrum-detail-sans-serif-light-font-style)
-    );
-    font-weight: var(
-        --spectrum-detail-sans-serif-light-font-weight,
-        var(--spectrum-detail-sans-serif-light-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-font-style, var(--spectrum-detail-sans-serif-light-font-style));
+    font-weight: var(--spectrum-detail-sans-serif-light-font-weight, var(--spectrum-detail-sans-serif-light-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-strong,
 .spectrum-Detail--light strong {
-    font-style: var(
-        --mod-detail-sans-serif-light-strong-font-style,
-        var(--spectrum-detail-sans-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-strong-font-weight,
-        var(--spectrum-detail-sans-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-strong-font-style, var(--spectrum-detail-sans-serif-light-strong-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-strong-font-weight, var(--spectrum-detail-sans-serif-light-strong-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-emphasized,
 .spectrum-Detail--light em {
-    font-style: var(
-        --mod-detail-sans-serif-light-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-emphasized-font-style, var(--spectrum-detail-sans-serif-light-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-emphasized-font-weight, var(--spectrum-detail-sans-serif-light-emphasized-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-strong.spectrum-Body-emphasized,
 .spectrum-Detail--light em strong,
 .spectrum-Detail--light strong em {
-    font-style: var(
-        --mod-detail-sans-serif-light-strong-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-strong-emphasized-font-style, var(--spectrum-detail-sans-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-strong-emphasized-font-weight, var(--spectrum-detail-sans-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja),
 .spectrum-Detail--light:lang(ko),
 .spectrum-Detail--light:lang(zh) {
-    font-style: var(
-        --mod-detail-cjk-light-font-style,
-        var(--spectrum-detail-cjk-light-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-font-weight,
-        var(--spectrum-detail-cjk-light-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-font-style, var(--spectrum-detail-cjk-light-font-style));
+    font-weight: var(--mod-detail-cjk-light-font-weight, var(--spectrum-detail-cjk-light-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja) .spectrum-Detail-strong,
@@ -293,14 +158,8 @@ governing permissions and limitations under the License.
 .spectrum-Detail--light:lang(ko) strong,
 .spectrum-Detail--light:lang(zh) .spectrum-Detail-strong,
 .spectrum-Detail--light:lang(zh) strong {
-    font-style: var(
-        --mod-detail-cjk-light-strong-font-style,
-        var(--spectrum-detail-cjk-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-strong-font-weight,
-        var(--spectrum-detail-cjk-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-strong-font-style, var(--spectrum-detail-cjk-light-strong-font-style));
+    font-weight: var(--mod-detail-cjk-light-strong-font-weight, var(--spectrum-detail-cjk-light-strong-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja) .spectrum-Detail-emphasized,
@@ -309,77 +168,37 @@ governing permissions and limitations under the License.
 .spectrum-Detail--light:lang(ko) em,
 .spectrum-Detail--light:lang(zh) .spectrum-Detail-emphasized,
 .spectrum-Detail--light:lang(zh) em {
-    font-style: var(
-        --mod-detail-cjk-light-emphasized-font-style,
-        var(--spectrum-detail-cjk-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-emphasized-font-weight,
-        var(--spectrum-detail-cjk-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-emphasized-font-style, var(--spectrum-detail-cjk-light-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-light-emphasized-font-weight, var(--spectrum-detail-cjk-light-emphasized-font-weight));
 }
 
-.spectrum-Detail--light:lang(ja)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized,
-.spectrum-Detail--light:lang(ko)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized,
-.spectrum-Detail--light:lang(zh)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized {
-    font-style: var(
-        --mod-detail-cjk-light-strong-emphasized-font-style,
-        var(--spectrum-detail-cjk-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-cjk-light-strong-emphasized-font-weight)
-    );
+.spectrum-Detail--light:lang(ja) .spectrum-Detail-strong.spectrum-Detail-emphasized,
+.spectrum-Detail--light:lang(ko) .spectrum-Detail-strong.spectrum-Detail-emphasized,
+.spectrum-Detail--light:lang(zh) .spectrum-Detail-strong.spectrum-Detail-emphasized {
+    font-style: var(--mod-detail-cjk-light-strong-emphasized-font-style, var(--spectrum-detail-cjk-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-light-strong-emphasized-font-weight, var(--spectrum-detail-cjk-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--serif.spectrum-Detail--light {
-    font-style: var(
-        --mod-detail-serif-light-font-style,
-        var(--spectrum-detail-serif-light-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-font-weight,
-        var(--spectrum-detail-serif-light-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-font-style, var(--spectrum-detail-serif-light-font-style));
+    font-weight: var(--mod-detail-serif-light-font-weight, var(--spectrum-detail-serif-light-font-weight));
 }
 
 .spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-strong,
 .spectrum-Detail--serif.spectrum-Detail--light strong {
-    font-style: var(
-        --mod-detail-serif-light-strong-font-style,
-        var(--spectrum-detail-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-strong-font-weight,
-        var(--spectrum-detail-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-strong-font-style, var(--spectrum-detail-serif-light-strong-font-style));
+    font-weight: var(--mod-detail-serif-light-strong-font-weight, var(--spectrum-detail-serif-light-strong-font-weight));
 }
 
 .spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-emphasized,
 .spectrum-Detail--serif.spectrum-Detail--light em {
-    font-style: var(
-        --mod-detail-serif-light-emphasized-font-style,
-        var(--spectrum-detail-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-emphasized-font-weight,
-        var(--spectrum-detail-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-emphasized-font-style, var(--spectrum-detail-serif-light-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-light-emphasized-font-weight, var(--spectrum-detail-serif-light-emphasized-font-weight));
 }
 
-.spectrum-Detail--serif.spectrum-Detail--light
-    .spectrum-Detail-strong.spectrum-Body-emphasized,
+.spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-strong.spectrum-Body-emphasized,
 .spectrum-Detail--serif.spectrum-Detail--light em strong,
 .spectrum-Detail--serif.spectrum-Detail--light strong em {
-    font-style: var(
-        --mod-detail-serif-light-strong-emphasized-font-style,
-        var(--spectrum-detail-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-strong-emphasized-font-style, var(--spectrum-detail-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-light-strong-emphasized-font-weight, var(--spectrum-detail-serif-light-strong-emphasized-font-weight));
 }

--- a/tools/styles/src/spectrum-heading.css
+++ b/tools/styles/src/spectrum-heading.css
@@ -12,14 +12,8 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Typography .spectrum-Heading {
-    --spectrum-heading-margin-start: calc(
-        var(--mod-heading-font-size, var(--spectrum-heading-font-size)) *
-            var(--spectrum-heading-margin-top-multiplier)
-    );
-    --spectrum-heading-margin-end: calc(
-        var(--mod-heading-font-size, var(--spectrum-heading-font-size)) *
-            var(--spectrum-heading-margin-bottom-multiplier)
-    );
+    --spectrum-heading-margin-start: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-top-multiplier));
+    --spectrum-heading-margin-end: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-bottom-multiplier));
 }
 
 @media (forced-colors: active) {
@@ -29,101 +23,44 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Heading {
-    font-family: var(
-        --mod-heading-sans-serif-font-family,
-        var(--spectrum-heading-sans-serif-font-family)
-    );
-    font-style: var(
-        --mod-heading-sans-serif-font-style,
-        var(--spectrum-heading-sans-serif-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-font-weight,
-        var(--spectrum-heading-sans-serif-font-weight)
-    );
+    font-family: var(--mod-heading-sans-serif-font-family, var(--spectrum-heading-sans-serif-font-family));
+    font-style: var(--mod-heading-sans-serif-font-style, var(--spectrum-heading-sans-serif-font-style));
+    font-weight: var(--mod-heading-sans-serif-font-weight, var(--spectrum-heading-sans-serif-font-weight));
     font-size: var(--mod-heading-font-size, var(--spectrum-heading-font-size));
-    color: var(
-        --highcontrast-heading-font-color,
-        var(--mod-heading-font-color, var(--spectrum-heading-font-color))
-    );
-    line-height: var(
-        --mod-heading-line-height,
-        var(--spectrum-heading-line-height)
-    );
-    margin-block-start: var(
-        --mod-heading-margin-start,
-        var(--spectrum-heading-margin-start, 0)
-    );
-    margin-block-end: var(
-        --mod-heading-margin-end,
-        var(--spectrum-heading-margin-end, 0)
-    );
+    color: var(--highcontrast-heading-font-color, var(--mod-heading-font-color, var(--spectrum-heading-font-color)));
+    line-height: var(--mod-heading-line-height, var(--spectrum-heading-line-height));
+    margin-block-start: var(--mod-heading-margin-start, var(--spectrum-heading-margin-start, 0));
+    margin-block-end: var(--mod-heading-margin-end, var(--spectrum-heading-margin-end, 0));
 }
 
 .spectrum-Heading .spectrum-Heading-strong,
 .spectrum-Heading strong {
-    font-style: var(
-        --mod-heading-sans-serif-strong-font-style,
-        var(--spectrum-heading-sans-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-strong-font-weight,
-        var(--spectrum-heading-sans-serif-strong-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-strong-font-style, var(--spectrum-heading-sans-serif-strong-font-style));
+    font-weight: var(--mod-heading-sans-serif-strong-font-weight, var(--spectrum-heading-sans-serif-strong-font-weight));
 }
 
 .spectrum-Heading .spectrum-Heading-emphasized,
 .spectrum-Heading em {
-    font-style: var(
-        --mod-heading-sans-serif-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-emphasized-font-style, var(--spectrum-heading-sans-serif-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-emphasized-font-weight, var(--spectrum-heading-sans-serif-emphasized-font-weight));
 }
 
 .spectrum-Heading .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading em strong,
 .spectrum-Heading strong em {
-    font-style: var(
-        --mod-heading-sans-serif-strong-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-strong-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-strong-emphasized-font-style, var(--spectrum-heading-sans-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-strong-emphasized-font-weight, var(--spectrum-heading-sans-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading:lang(ja),
 .spectrum-Heading:lang(ko),
 .spectrum-Heading:lang(zh) {
-    font-family: var(
-        --mod-heading-cjk-font-family,
-        var(--spectrum-heading-cjk-font-family)
-    );
-    font-style: var(
-        --mod-heading-cjk-font-style,
-        var(--spectrum-heading-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-font-weight,
-        var(--spectrum-heading-cjk-font-weight)
-    );
-    font-size: var(
-        --mod-heading-cjk-font-size,
-        var(--spectrum-heading-cjk-font-size)
-    );
-    line-height: var(
-        --mod-heading-cjk-line-height,
-        var(--spectrum-heading-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-heading-cjk-letter-spacing,
-        var(--spectrum-heading-cjk-letter-spacing)
-    );
+    font-family: var(--mod-heading-cjk-font-family, var(--spectrum-heading-cjk-font-family));
+    font-style: var(--mod-heading-cjk-font-style, var(--spectrum-heading-cjk-font-style));
+    font-weight: var(--mod-heading-cjk-font-weight, var(--spectrum-heading-cjk-font-weight));
+    font-size: var(--mod-heading-cjk-font-size, var(--spectrum-heading-cjk-font-size));
+    line-height: var(--mod-heading-cjk-line-height, var(--spectrum-heading-cjk-line-height));
+    letter-spacing: var(--mod-heading-cjk-letter-spacing, var(--spectrum-heading-cjk-letter-spacing));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-emphasized,
@@ -132,14 +69,8 @@ governing permissions and limitations under the License.
 .spectrum-Heading:lang(ko) em,
 .spectrum-Heading:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-emphasized-font-style,
-        var(--spectrum-heading-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-emphasized-font-weight,
-        var(--spectrum-heading-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-emphasized-font-style, var(--spectrum-heading-cjk-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-emphasized-font-weight, var(--spectrum-heading-cjk-emphasized-font-weight));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-strong,
@@ -148,14 +79,8 @@ governing permissions and limitations under the License.
 .spectrum-Heading:lang(ko) strong,
 .spectrum-Heading:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-strong-font-style,
-        var(--spectrum-heading-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-strong-font-weight,
-        var(--spectrum-heading-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-strong-font-style, var(--spectrum-heading-cjk-strong-font-style));
+    font-weight: var(--mod-heading-cjk-strong-font-weight, var(--spectrum-heading-cjk-strong-font-weight));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
@@ -167,75 +92,39 @@ governing permissions and limitations under the License.
 .spectrum-Heading:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading:lang(zh) em strong,
 .spectrum-Heading:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-strong-emphasized-font-style, var(--spectrum-heading-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-strong-emphasized-font-weight, var(--spectrum-heading-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-font-style,
-        var(--spectrum-heading-sans-serif-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-font-style, var(--spectrum-heading-sans-serif-heavy-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-font-weight, var(--spectrum-heading-sans-serif-heavy-font-weight));
 }
 
 .spectrum-Heading--heavy .spectrum-Heading-strong,
 .spectrum-Heading--heavy strong {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-strong-font-style,
-        var(--spectrum-heading-sans-serif-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-strong-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-strong-font-style, var(--spectrum-heading-sans-serif-heavy-strong-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-strong-font-weight, var(--spectrum-heading-sans-serif-heavy-strong-font-weight));
 }
 
 .spectrum-Heading--heavy .spectrum-Heading-emphasized,
 .spectrum-Heading--heavy em {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-emphasized-font-style, var(--spectrum-heading-sans-serif-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-emphasized-font-weight, var(--spectrum-heading-sans-serif-heavy-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy em strong,
 .spectrum-Heading--heavy strong em {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-strong-emphasized-font-style, var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-strong-emphasized-font-weight, var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja),
 .spectrum-Heading--heavy:lang(ko),
 .spectrum-Heading--heavy:lang(zh) {
-    font-style: var(
-        --mod-heading-cjk-heavy-font-style,
-        var(--spectrum-heading-cjk-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-font-weight,
-        var(--spectrum-heading-cjk-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-font-style, var(--spectrum-heading-cjk-heavy-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-font-weight, var(--spectrum-heading-cjk-heavy-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja) .spectrum-Heading-emphasized,
@@ -244,14 +133,8 @@ governing permissions and limitations under the License.
 .spectrum-Heading--heavy:lang(ko) em,
 .spectrum-Heading--heavy:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-heavy-emphasized-font-style,
-        var(--spectrum-heading-cjk-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-emphasized-font-weight,
-        var(--spectrum-heading-cjk-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-emphasized-font-style, var(--spectrum-heading-cjk-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-emphasized-font-weight, var(--spectrum-heading-cjk-heavy-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja) .spectrum-Heading-strong,
@@ -260,97 +143,52 @@ governing permissions and limitations under the License.
 .spectrum-Heading--heavy:lang(ko) strong,
 .spectrum-Heading--heavy:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading--heavy:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-heavy-strong-font-style,
-        var(--spectrum-heading-cjk-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-strong-font-weight,
-        var(--spectrum-heading-cjk-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-strong-font-style, var(--spectrum-heading-cjk-heavy-strong-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-strong-font-weight, var(--spectrum-heading-cjk-heavy-strong-font-weight));
 }
 
-.spectrum-Heading--heavy:lang(ja)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(ja) em strong,
 .spectrum-Heading--heavy:lang(ja) strong em,
-.spectrum-Heading--heavy:lang(ko)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(ko) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(ko) em strong,
 .spectrum-Heading--heavy:lang(ko) strong em,
-.spectrum-Heading--heavy:lang(zh)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(zh) em strong,
 .spectrum-Heading--heavy:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-strong-emphasized-font-style, var(--spectrum-heading-cjk-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-strong-emphasized-font-weight, var(--spectrum-heading-cjk-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--light {
-    font-style: var(
-        --mod-heading-sans-serif-light-font-style,
-        var(--spectrum-heading-sans-serif-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-font-weight,
-        var(--spectrum-heading-sans-serif-light-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-font-style, var(--spectrum-heading-sans-serif-light-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-font-weight, var(--spectrum-heading-sans-serif-light-font-weight));
 }
 
 .spectrum-Heading--light .spectrum-Heading-emphasized,
 .spectrum-Heading--light em {
-    font-style: var(
-        --mod-heading-sans-serif-light-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-emphasized-font-style, var(--spectrum-heading-sans-serif-light-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-emphasized-font-weight, var(--spectrum-heading-sans-serif-light-emphasized-font-weight));
 }
 
 .spectrum-Heading--light .spectrum-Heading-strong,
 .spectrum-Heading--light strong {
-    font-style: var(
-        --mod-heading-sans-serif-light-strong-font-style,
-        var(--spectrum-heading-sans-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-strong-font-weight,
-        var(--spectrum-heading-sans-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-strong-font-style, var(--spectrum-heading-sans-serif-light-strong-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-strong-font-weight, var(--spectrum-heading-sans-serif-light-strong-font-weight));
 }
 
 .spectrum-Heading--light .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light em strong,
 .spectrum-Heading--light strong em {
-    font-style: var(
-        --mod-heading-sans-serif-light-strong-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-strong-emphasized-font-style, var(--spectrum-heading-sans-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-strong-emphasized-font-weight, var(--spectrum-heading-sans-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja),
 .spectrum-Heading--light:lang(ko),
 .spectrum-Heading--light:lang(zh) {
-    font-style: var(
-        --mod-heading-cjk-light-font-style,
-        var(--spectrum-heading-cjk-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-font-weight,
-        var(--spectrum-heading-cjk-light-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-font-style, var(--spectrum-heading-cjk-light-font-style));
+    font-weight: var(--mod-heading-cjk-light-font-weight, var(--spectrum-heading-cjk-light-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja) .spectrum-Heading-strong,
@@ -359,14 +197,8 @@ governing permissions and limitations under the License.
 .spectrum-Heading--light:lang(ko) strong,
 .spectrum-Heading--light:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading--light:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-light-strong-font-style,
-        var(--spectrum-heading-cjk-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-strong-font-weight,
-        var(--spectrum-heading-cjk-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-strong-font-style, var(--spectrum-heading-cjk-light-strong-font-style));
+    font-weight: var(--mod-heading-cjk-light-strong-font-weight, var(--spectrum-heading-cjk-light-strong-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja) .spectrum-Heading-emphasized,
@@ -375,184 +207,92 @@ governing permissions and limitations under the License.
 .spectrum-Heading--light:lang(ko) em,
 .spectrum-Heading--light:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-light-emphasized-font-style,
-        var(--spectrum-heading-cjk-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-emphasized-font-weight,
-        var(--spectrum-heading-cjk-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-emphasized-font-style, var(--spectrum-heading-cjk-light-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-light-emphasized-font-weight, var(--spectrum-heading-cjk-light-emphasized-font-weight));
 }
 
-.spectrum-Heading--light:lang(ja)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(ja) em strong,
 .spectrum-Heading--light:lang(ja) strong em,
-.spectrum-Heading--light:lang(ko)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(ko) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(ko) em strong,
 .spectrum-Heading--light:lang(ko) strong em,
-.spectrum-Heading--light:lang(zh)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(zh) em strong,
 .spectrum-Heading--light:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-light-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-strong-emphasized-font-style, var(--spectrum-heading-cjk-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-light-strong-emphasized-font-weight, var(--spectrum-heading-cjk-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif {
-    font-family: var(
-        --mod-heading-serif-font-family,
-        var(--spectrum-heading-serif-font-family)
-    );
-    font-style: var(
-        --mod-heading-serif-font-style,
-        var(--spectrum-heading-serif-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-font-weight,
-        var(--spectrum-heading-serif-font-weight)
-    );
+    font-family: var(--mod-heading-serif-font-family, var(--spectrum-heading-serif-font-family));
+    font-style: var(--mod-heading-serif-font-style, var(--spectrum-heading-serif-font-style));
+    font-weight: var(--mod-heading-serif-font-weight, var(--spectrum-heading-serif-font-weight));
 }
 
 .spectrum-Heading--serif .spectrum-Heading-emphasized,
 .spectrum-Heading--serif em {
-    font-style: var(
-        --mod-heading-serif-emphasized-font-style,
-        var(--spectrum-heading-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-emphasized-font-weight,
-        var(--spectrum-heading-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-emphasized-font-style, var(--spectrum-heading-serif-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-emphasized-font-weight, var(--spectrum-heading-serif-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif .spectrum-Heading-strong,
 .spectrum-Heading--serif strong {
-    font-style: var(
-        --mod-heading-serif-strong-font-style,
-        var(--spectrum-heading-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-strong-font-weight,
-        var(--spectrum-heading-serif-strong-font-weight)
-    );
+    font-style: var(--mod-heading-serif-strong-font-style, var(--spectrum-heading-serif-strong-font-style));
+    font-weight: var(--mod-heading-serif-strong-font-weight, var(--spectrum-heading-serif-strong-font-weight));
 }
 
 .spectrum-Heading--serif .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--serif em strong,
 .spectrum-Heading--serif strong em {
-    font-style: var(
-        --mod-heading-serif-strong-emphasized-font-style,
-        var(--spectrum-heading-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-strong-emphasized-font-weight,
-        var(--spectrum-heading-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-strong-emphasized-font-style, var(--spectrum-heading-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-strong-emphasized-font-weight, var(--spectrum-heading-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--heavy {
-    font-style: var(
-        --mod-heading-serif-heavy-font-style,
-        var(--spectrum-heading-serif-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-font-weight,
-        var(--spectrum-heading-serif-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-font-style, var(--spectrum-heading-serif-heavy-font-style));
+    font-weight: var(--mod-heading-serif-heavy-font-weight, var(--spectrum-heading-serif-heavy-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--heavy .spectrum-Heading-strong,
 .spectrum-Heading--serif.spectrum-Heading--heavy strong {
-    font-style: var(
-        --mod-heading-serif-heavy-strong-font-style,
-        var(--spectrum-heading-serif-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-strong-font-weight,
-        var(--spectrum-heading-serif-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-strong-font-style, var(--spectrum-heading-serif-heavy-strong-font-style));
+    font-weight: var(--mod-heading-serif-heavy-strong-font-weight, var(--spectrum-heading-serif-heavy-strong-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--heavy .spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--heavy em {
-    font-style: var(
-        --mod-heading-serif-heavy-emphasized-font-style,
-        var(--spectrum-heading-serif-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-emphasized-font-weight,
-        var(--spectrum-heading-serif-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-emphasized-font-style, var(--spectrum-heading-serif-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-heavy-emphasized-font-weight, var(--spectrum-heading-serif-heavy-emphasized-font-weight));
 }
 
-.spectrum-Heading--serif.spectrum-Heading--heavy
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--serif.spectrum-Heading--heavy .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--heavy em strong,
 .spectrum-Heading--serif.spectrum-Heading--heavy strong em {
-    font-style: var(
-        --mod-heading-serif-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-serif-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-serif-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-strong-emphasized-font-style, var(--spectrum-heading-serif-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-heavy-strong-emphasized-font-weight, var(--spectrum-heading-serif-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--light {
-    font-style: var(
-        --mod-heading-serif-light-font-style,
-        var(--spectrum-heading-serif-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-font-weight,
-        var(--spectrum-heading-serif-light-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-font-style, var(--spectrum-heading-serif-light-font-style));
+    font-weight: var(--mod-heading-serif-light-font-weight, var(--spectrum-heading-serif-light-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--light .spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--light em {
-    font-style: var(
-        --mod-heading-serif-light-emphasized-font-style,
-        var(--spectrum-heading-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-emphasized-font-weight,
-        var(--spectrum-heading-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-emphasized-font-style, var(--spectrum-heading-serif-light-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-light-emphasized-font-weight, var(--spectrum-heading-serif-light-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--light .spectrum-Heading-strong,
 .spectrum-Heading--serif.spectrum-Heading--light strong {
-    font-style: var(
-        --mod-heading-serif-light-strong-font-style,
-        var(--spectrum-heading-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-strong-font-weight,
-        var(--spectrum-heading-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-strong-font-style, var(--spectrum-heading-serif-light-strong-font-style));
+    font-weight: var(--mod-heading-serif-light-strong-font-weight, var(--spectrum-heading-serif-light-strong-font-weight));
 }
 
-.spectrum-Heading--serif.spectrum-Heading--light
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--serif.spectrum-Heading--light .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--light em strong,
 .spectrum-Heading--serif.spectrum-Heading--light strong em {
-    font-style: var(
-        --mod-heading-serif-light-strong-emphasized-font-style,
-        var(--spectrum-heading-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-strong-emphasized-font-style, var(--spectrum-heading-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-light-strong-emphasized-font-weight, var(--spectrum-heading-serif-light-strong-emphasized-font-weight));
 }

--- a/tools/styles/src/spectrum-lang.css
+++ b/tools/styles/src/spectrum-lang.css
@@ -22,30 +22,12 @@ governing permissions and limitations under the License.
 .spectrum-Heading:lang(ja),
 .spectrum-Heading:lang(ko),
 .spectrum-Heading:lang(zh) {
-    font-family: var(
-        --mod-heading-cjk-font-family,
-        var(--spectrum-heading-cjk-font-family)
-    );
-    font-style: var(
-        --mod-heading-cjk-font-style,
-        var(--spectrum-heading-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-font-weight,
-        var(--spectrum-heading-cjk-font-weight)
-    );
-    font-size: var(
-        --mod-heading-cjk-font-size,
-        var(--spectrum-heading-cjk-font-size)
-    );
-    line-height: var(
-        --mod-heading-cjk-line-height,
-        var(--spectrum-heading-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-heading-cjk-letter-spacing,
-        var(--spectrum-heading-cjk-letter-spacing)
-    );
+    font-family: var(--mod-heading-cjk-font-family, var(--spectrum-heading-cjk-font-family));
+    font-style: var(--mod-heading-cjk-font-style, var(--spectrum-heading-cjk-font-style));
+    font-weight: var(--mod-heading-cjk-font-weight, var(--spectrum-heading-cjk-font-weight));
+    font-size: var(--mod-heading-cjk-font-size, var(--spectrum-heading-cjk-font-size));
+    line-height: var(--mod-heading-cjk-line-height, var(--spectrum-heading-cjk-line-height));
+    letter-spacing: var(--mod-heading-cjk-letter-spacing, var(--spectrum-heading-cjk-letter-spacing));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-emphasized,
@@ -54,14 +36,8 @@ governing permissions and limitations under the License.
 .spectrum-Heading:lang(ko) em,
 .spectrum-Heading:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-emphasized-font-style,
-        var(--spectrum-heading-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-emphasized-font-weight,
-        var(--spectrum-heading-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-emphasized-font-style, var(--spectrum-heading-cjk-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-emphasized-font-weight, var(--spectrum-heading-cjk-emphasized-font-weight));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-strong,
@@ -70,14 +46,8 @@ governing permissions and limitations under the License.
 .spectrum-Heading:lang(ko) strong,
 .spectrum-Heading:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-strong-font-style,
-        var(--spectrum-heading-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-strong-font-weight,
-        var(--spectrum-heading-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-strong-font-style, var(--spectrum-heading-cjk-strong-font-style));
+    font-weight: var(--mod-heading-cjk-strong-font-weight, var(--spectrum-heading-cjk-strong-font-weight));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
@@ -89,27 +59,15 @@ governing permissions and limitations under the License.
 .spectrum-Heading:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading:lang(zh) em strong,
 .spectrum-Heading:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-strong-emphasized-font-style, var(--spectrum-heading-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-strong-emphasized-font-weight, var(--spectrum-heading-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja),
 .spectrum-Heading--heavy:lang(ko),
 .spectrum-Heading--heavy:lang(zh) {
-    font-style: var(
-        --mod-heading-cjk-heavy-font-style,
-        var(--spectrum-heading-cjk-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-font-weight,
-        var(--spectrum-heading-cjk-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-font-style, var(--spectrum-heading-cjk-heavy-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-font-weight, var(--spectrum-heading-cjk-heavy-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja) .spectrum-Heading-emphasized,
@@ -118,14 +76,8 @@ governing permissions and limitations under the License.
 .spectrum-Heading--heavy:lang(ko) em,
 .spectrum-Heading--heavy:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-heavy-emphasized-font-style,
-        var(--spectrum-heading-cjk-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-emphasized-font-weight,
-        var(--spectrum-heading-cjk-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-emphasized-font-style, var(--spectrum-heading-cjk-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-emphasized-font-weight, var(--spectrum-heading-cjk-heavy-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja) .spectrum-Heading-strong,
@@ -134,49 +86,28 @@ governing permissions and limitations under the License.
 .spectrum-Heading--heavy:lang(ko) strong,
 .spectrum-Heading--heavy:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading--heavy:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-heavy-strong-font-style,
-        var(--spectrum-heading-cjk-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-strong-font-weight,
-        var(--spectrum-heading-cjk-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-strong-font-style, var(--spectrum-heading-cjk-heavy-strong-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-strong-font-weight, var(--spectrum-heading-cjk-heavy-strong-font-weight));
 }
 
-.spectrum-Heading--heavy:lang(ja)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(ja) em strong,
 .spectrum-Heading--heavy:lang(ja) strong em,
-.spectrum-Heading--heavy:lang(ko)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(ko) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(ko) em strong,
 .spectrum-Heading--heavy:lang(ko) strong em,
-.spectrum-Heading--heavy:lang(zh)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(zh) em strong,
 .spectrum-Heading--heavy:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-strong-emphasized-font-style, var(--spectrum-heading-cjk-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-strong-emphasized-font-weight, var(--spectrum-heading-cjk-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja),
 .spectrum-Heading--light:lang(ko),
 .spectrum-Heading--light:lang(zh) {
-    font-style: var(
-        --mod-heading-cjk-light-font-style,
-        var(--spectrum-heading-cjk-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-font-weight,
-        var(--spectrum-heading-cjk-light-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-font-style, var(--spectrum-heading-cjk-light-font-style));
+    font-weight: var(--mod-heading-cjk-light-font-weight, var(--spectrum-heading-cjk-light-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja) .spectrum-Heading-strong,
@@ -185,14 +116,8 @@ governing permissions and limitations under the License.
 .spectrum-Heading--light:lang(ko) strong,
 .spectrum-Heading--light:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading--light:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-light-strong-font-style,
-        var(--spectrum-heading-cjk-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-strong-font-weight,
-        var(--spectrum-heading-cjk-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-strong-font-style, var(--spectrum-heading-cjk-light-strong-font-style));
+    font-weight: var(--mod-heading-cjk-light-strong-font-weight, var(--spectrum-heading-cjk-light-strong-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja) .spectrum-Heading-emphasized,
@@ -201,61 +126,31 @@ governing permissions and limitations under the License.
 .spectrum-Heading--light:lang(ko) em,
 .spectrum-Heading--light:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-light-emphasized-font-style,
-        var(--spectrum-heading-cjk-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-emphasized-font-weight,
-        var(--spectrum-heading-cjk-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-emphasized-font-style, var(--spectrum-heading-cjk-light-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-light-emphasized-font-weight, var(--spectrum-heading-cjk-light-emphasized-font-weight));
 }
 
-.spectrum-Heading--light:lang(ja)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(ja) em strong,
 .spectrum-Heading--light:lang(ja) strong em,
-.spectrum-Heading--light:lang(ko)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(ko) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(ko) em strong,
 .spectrum-Heading--light:lang(ko) strong em,
-.spectrum-Heading--light:lang(zh)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(zh) em strong,
 .spectrum-Heading--light:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-light-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-strong-emphasized-font-style, var(--spectrum-heading-cjk-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-light-strong-emphasized-font-weight, var(--spectrum-heading-cjk-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Body:lang(ja),
 .spectrum-Body:lang(ko),
 .spectrum-Body:lang(zh) {
-    font-family: var(
-        --mod-body-cjk-font-family,
-        var(--spectrum-body-cjk-font-family)
-    );
-    font-style: var(
-        --mod-body-cjk-font-style,
-        var(--spectrum-body-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-font-weight,
-        var(--spectrum-body-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-body-cjk-line-height,
-        var(--spectrum-body-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-body-cjk-letter-spacing,
-        var(--spectrum-body-cjk-letter-spacing)
-    );
+    font-family: var(--mod-body-cjk-font-family, var(--spectrum-body-cjk-font-family));
+    font-style: var(--mod-body-cjk-font-style, var(--spectrum-body-cjk-font-style));
+    font-weight: var(--mod-body-cjk-font-weight, var(--spectrum-body-cjk-font-weight));
+    line-height: var(--mod-body-cjk-line-height, var(--spectrum-body-cjk-line-height));
+    letter-spacing: var(--mod-body-cjk-letter-spacing, var(--spectrum-body-cjk-letter-spacing));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-strong,
@@ -264,14 +159,8 @@ governing permissions and limitations under the License.
 .spectrum-Body:lang(ko) strong,
 .spectrum-Body:lang(zh) .spectrum-Body-strong,
 .spectrum-Body:lang(zh) strong {
-    font-style: var(
-        --mod-body-cjk-strong-font-style,
-        var(--spectrum-body-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-strong-font-weight,
-        var(--spectrum-body-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-body-cjk-strong-font-style, var(--spectrum-body-cjk-strong-font-style));
+    font-weight: var(--mod-body-cjk-strong-font-weight, var(--spectrum-body-cjk-strong-font-weight));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-emphasized,
@@ -280,14 +169,8 @@ governing permissions and limitations under the License.
 .spectrum-Body:lang(ko) em,
 .spectrum-Body:lang(zh) .spectrum-Body-emphasized,
 .spectrum-Body:lang(zh) em {
-    font-style: var(
-        --mod-body-cjk-emphasized-font-style,
-        var(--spectrum-body-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-emphasized-font-weight,
-        var(--spectrum-body-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-cjk-emphasized-font-style, var(--spectrum-body-cjk-emphasized-font-style));
+    font-weight: var(--mod-body-cjk-emphasized-font-weight, var(--spectrum-body-cjk-emphasized-font-weight));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-strong.spectrum-Body-emphasized,
@@ -299,35 +182,17 @@ governing permissions and limitations under the License.
 .spectrum-Body:lang(zh) .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body:lang(zh) em strong,
 .spectrum-Body:lang(zh) strong em {
-    font-style: var(
-        --mod-body-cjk-strong-emphasized-font-style,
-        var(--spectrum-body-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-strong-emphasized-font-weight,
-        var(--spectrum-body-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-cjk-strong-emphasized-font-style, var(--spectrum-body-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-body-cjk-strong-emphasized-font-weight, var(--spectrum-body-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail:lang(ja),
 .spectrum-Detail:lang(ko),
 .spectrum-Detail:lang(zh) {
-    font-family: var(
-        --mod-detail-cjk-font-family,
-        var(--spectrum-detail-cjk-font-family)
-    );
-    font-style: var(
-        --mod-detail-cjk-font-style,
-        var(--spectrum-detail-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-font-weight,
-        var(--spectrum-detail-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-detail-cjk-line-height,
-        var(--spectrum-detail-cjk-line-height)
-    );
+    font-family: var(--mod-detail-cjk-font-family, var(--spectrum-detail-cjk-font-family));
+    font-style: var(--mod-detail-cjk-font-style, var(--spectrum-detail-cjk-font-style));
+    font-weight: var(--mod-detail-cjk-font-weight, var(--spectrum-detail-cjk-font-weight));
+    line-height: var(--mod-detail-cjk-line-height, var(--spectrum-detail-cjk-line-height));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-strong,
@@ -336,14 +201,8 @@ governing permissions and limitations under the License.
 .spectrum-Detail:lang(ko) strong,
 .spectrum-Detail:lang(zh) .spectrum-Detail-strong,
 .spectrum-Detail:lang(zh) strong {
-    font-style: var(
-        --mod-detail-cjk-strong-font-style,
-        var(--spectrum-detail-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-strong-font-weight,
-        var(--spectrum-detail-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-strong-font-style, var(--spectrum-detail-cjk-strong-font-style));
+    font-weight: var(--mod-detail-cjk-strong-font-weight, var(--spectrum-detail-cjk-strong-font-weight));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-emphasized,
@@ -352,14 +211,8 @@ governing permissions and limitations under the License.
 .spectrum-Detail:lang(ko) em,
 .spectrum-Detail:lang(zh) .spectrum-Detail-emphasized,
 .spectrum-Detail:lang(zh) em {
-    font-style: var(
-        --mod-detail-cjk-emphasized-font-style,
-        var(--spectrum-detail-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-emphasized-font-weight,
-        var(--spectrum-detail-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-emphasized-font-style, var(--spectrum-detail-cjk-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-emphasized-font-weight, var(--spectrum-detail-cjk-emphasized-font-weight));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-strong.spectrum-Detail-emphasized,
@@ -371,27 +224,15 @@ governing permissions and limitations under the License.
 .spectrum-Detail:lang(zh) .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail:lang(zh) em strong,
 .spectrum-Detail:lang(zh) strong em {
-    font-style: var(
-        --mod-detail-cjk-strong-emphasized-font-style,
-        var(--spectrum-detail-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-strong-emphasized-font-weight,
-        var(--spectrum-detail-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-strong-emphasized-font-style, var(--spectrum-detail-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-strong-emphasized-font-weight, var(--spectrum-detail-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja),
 .spectrum-Detail--light:lang(ko),
 .spectrum-Detail--light:lang(zh) {
-    font-style: var(
-        --mod-detail-cjk-light-font-style,
-        var(--spectrum-detail-cjk-light-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-font-weight,
-        var(--spectrum-detail-cjk-light-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-font-style, var(--spectrum-detail-cjk-light-font-style));
+    font-weight: var(--mod-detail-cjk-light-font-weight, var(--spectrum-detail-cjk-light-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja) .spectrum-Detail-strong,
@@ -400,14 +241,8 @@ governing permissions and limitations under the License.
 .spectrum-Detail--light:lang(ko) strong,
 .spectrum-Detail--light:lang(zh) .spectrum-Detail-strong,
 .spectrum-Detail--light:lang(zh) strong {
-    font-style: var(
-        --mod-detail-cjk-light-strong-font-style,
-        var(--spectrum-detail-cjk-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-strong-font-weight,
-        var(--spectrum-detail-cjk-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-strong-font-style, var(--spectrum-detail-cjk-light-strong-font-style));
+    font-weight: var(--mod-detail-cjk-light-strong-font-weight, var(--spectrum-detail-cjk-light-strong-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja) .spectrum-Detail-emphasized,
@@ -416,55 +251,25 @@ governing permissions and limitations under the License.
 .spectrum-Detail--light:lang(ko) em,
 .spectrum-Detail--light:lang(zh) .spectrum-Detail-emphasized,
 .spectrum-Detail--light:lang(zh) em {
-    font-style: var(
-        --mod-detail-cjk-light-emphasized-font-style,
-        var(--spectrum-detail-cjk-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-emphasized-font-weight,
-        var(--spectrum-detail-cjk-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-emphasized-font-style, var(--spectrum-detail-cjk-light-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-light-emphasized-font-weight, var(--spectrum-detail-cjk-light-emphasized-font-weight));
 }
 
-.spectrum-Detail--light:lang(ja)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized,
-.spectrum-Detail--light:lang(ko)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized,
-.spectrum-Detail--light:lang(zh)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized {
-    font-style: var(
-        --mod-detail-cjk-light-strong-emphasized-font-style,
-        var(--spectrum-detail-cjk-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-cjk-light-strong-emphasized-font-weight)
-    );
+.spectrum-Detail--light:lang(ja) .spectrum-Detail-strong.spectrum-Detail-emphasized,
+.spectrum-Detail--light:lang(ko) .spectrum-Detail-strong.spectrum-Detail-emphasized,
+.spectrum-Detail--light:lang(zh) .spectrum-Detail-strong.spectrum-Detail-emphasized {
+    font-style: var(--mod-detail-cjk-light-strong-emphasized-font-style, var(--spectrum-detail-cjk-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-light-strong-emphasized-font-weight, var(--spectrum-detail-cjk-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Code:lang(ja),
 .spectrum-Code:lang(ko),
 .spectrum-Code:lang(zh) {
-    font-family: var(
-        --mod-code-cjk-font-family,
-        var(--spectrum-code-cjk-font-family)
-    );
-    font-style: var(
-        --mod-code-cjk-font-style,
-        var(--spectrum-code-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-font-weight,
-        var(--spectrum-code-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-code-cjk-line-height,
-        var(--spectrum-code-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-code-cjk-letter-spacing,
-        var(--spectrum-code-cjk-letter-spacing)
-    );
+    font-family: var(--mod-code-cjk-font-family, var(--spectrum-code-cjk-font-family));
+    font-style: var(--mod-code-cjk-font-style, var(--spectrum-code-cjk-font-style));
+    font-weight: var(--mod-code-cjk-font-weight, var(--spectrum-code-cjk-font-weight));
+    line-height: var(--mod-code-cjk-line-height, var(--spectrum-code-cjk-line-height));
+    letter-spacing: var(--mod-code-cjk-letter-spacing, var(--spectrum-code-cjk-letter-spacing));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-strong,
@@ -473,14 +278,8 @@ governing permissions and limitations under the License.
 .spectrum-Code:lang(ko) strong,
 .spectrum-Code:lang(zh) .spectrum-Code-strong,
 .spectrum-Code:lang(zh) strong {
-    font-style: var(
-        --mod-code-cjk-strong-font-style,
-        var(--spectrum-code-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-strong-font-weight,
-        var(--spectrum-code-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-code-cjk-strong-font-style, var(--spectrum-code-cjk-strong-font-style));
+    font-weight: var(--mod-code-cjk-strong-font-weight, var(--spectrum-code-cjk-strong-font-weight));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-emphasized,
@@ -489,14 +288,8 @@ governing permissions and limitations under the License.
 .spectrum-Code:lang(ko) em,
 .spectrum-Code:lang(zh) .spectrum-Code-emphasized,
 .spectrum-Code:lang(zh) em {
-    font-style: var(
-        --mod-code-cjk-emphasized-font-style,
-        var(--spectrum-code-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-emphasized-font-weight,
-        var(--spectrum-code-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-cjk-emphasized-font-style, var(--spectrum-code-cjk-emphasized-font-style));
+    font-weight: var(--mod-code-cjk-emphasized-font-weight, var(--spectrum-code-cjk-emphasized-font-weight));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-strong.spectrum-Code-emphasized,
@@ -508,12 +301,6 @@ governing permissions and limitations under the License.
 .spectrum-Code:lang(zh) .spectrum-Code-strong.spectrum-Code-emphasized,
 .spectrum-Code:lang(zh) em strong,
 .spectrum-Code:lang(zh) strong em {
-    font-style: var(
-        --mod-code-cjk-strong-emphasized-font-style,
-        var(--spectrum-code-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-strong-emphasized-font-weight,
-        var(--spectrum-code-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-cjk-strong-emphasized-font-style, var(--spectrum-code-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-code-cjk-strong-emphasized-font-weight, var(--spectrum-code-cjk-strong-emphasized-font-weight));
 }

--- a/tools/styles/src/spectrum-typography.css
+++ b/tools/styles/src/spectrum-typography.css
@@ -26,30 +26,15 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Typography .spectrum-Heading {
-    --spectrum-heading-margin-start: calc(
-        var(--mod-heading-font-size, var(--spectrum-heading-font-size)) *
-            var(--spectrum-heading-margin-top-multiplier)
-    );
-    --spectrum-heading-margin-end: calc(
-        var(--mod-heading-font-size, var(--spectrum-heading-font-size)) *
-            var(--spectrum-heading-margin-bottom-multiplier)
-    );
+    --spectrum-heading-margin-start: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-top-multiplier));
+    --spectrum-heading-margin-end: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-bottom-multiplier));
 }
 
 .spectrum-Typography .spectrum-Body {
-    --spectrum-body-margin-end: calc(
-        var(--mod-body-font-size, var(--spectrum-body-font-size)) *
-            var(--spectrum-body-margin-multiplier)
-    );
+    --spectrum-body-margin-end: calc(var(--mod-body-font-size, var(--spectrum-body-font-size)) * var(--spectrum-body-margin-multiplier));
 }
 
 .spectrum-Typography .spectrum-Detail {
-    --spectrum-detail-margin-start: calc(
-        var(--mod-detail-font-size, var(--spectrum-detail-font-size)) *
-            var(--spectrum-detail-margin-top-multiplier)
-    );
-    --spectrum-detail-margin-end: calc(
-        var(--mod-detail-font-size, var(--spectrum-detail-font-size)) *
-            var(--spectrum-detail-margin-bottom-multiplier)
-    );
+    --spectrum-detail-margin-start: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-top-multiplier));
+    --spectrum-detail-margin-end: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-bottom-multiplier));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,8 +303,6 @@ __metadata:
     typescript: "npm:^5.3.3"
     wireit: "npm:^0.14.3"
     yargs: "npm:^17.2.1"
-  peerDependencies:
-    common-tags: ^1.8.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

### Pre-commit improvements

Previous the husky pre-commit task was running analysis and linting on files whether they were present in the commit or not. This update adds a specificity to the pre-commit tool by ensuring commands are run _only_ on those files being modified by that commit.

Most relevantly, `yarn analyze` was running the lit-analyzer on 5,840 files every single commit even if no changes were made to lit-based assets.

### CSS import improvements

Prettier's line wrapping for CSS does not have exceptions for var functions; adding whitespace or newlines to var functions cannot be minified safely downstream (and many minifiers won't) because whitespace is valid in a CSS var function. By increasing the line-length for CSS, we prevent invalid newlines being adding into var functions.

This PR adds a spectrum-*.css exception to prettier to allow for up-to-500 characters per line to prevent aggressive line wrapping that will break that downstream minification.

It also swaps stylelint configurations to only lean on the header plugin by default and adds the stylelint-config settings for files _not_ being imported from Spectrum CSS. Spectrum CSS already processes the assets according to rigorous Stylelint configurations and these were stripping important vendor prefixes from the results.

## How has this been tested?

**Setup**: Before testing the husky pre-commit hooks, add `exit 1` to the bottom of the pre-commit script. [Docs](https://typicode.github.io/husky/how-to.html#testing-hooks-without-committing). Remove this once testing is complete and do not commit that change.

- [ ] To validate the update to line 6 of .husky/pre-commit (eslint), update any `*.ts` file in the project, `git add . && git commit -m "chore: testing pre-commit hook`. Expect it to run eslint against that file (but no others).
- [ ] To validate the update to line 7 of .husky/pre-commit (lit-analyzer), update any `packages/*/src/**/*.ts` file in the project, `git add . && git commit -m "chore: testing pre-commit hook`. Expect it to run lit-analyzer against that file (but no others).
- [ ] To validate the update to line 8 of .husky/pre-commit (linting css), update any `packages/**/*.css` file in the project, `git add . && git commit -m "chore: testing pre-commit hook`. Expect it to run stylelint against that file (but no others).
- [x] We can already validate the prettier and stylelint updates by reviewing the committed `packages/*/src/spectrum-*.css` files which now have significantly fewer line breaks inside of var functions.
- [ ] To validate no regressions in how stylelint formats non-imported CSS assets, make a change to `packages/accordion/src/accordion.css` to remove the copyright and add `-webkit-animation: alternate;` to the `:host` selector. Run `yarn lint:css` and expect to see:

```sh
packages/accordion/src/accordion.css
  1:1  ✖  Header not found                              header/header
  6:5  ✖  Expected empty line before declaration        declaration-empty-line-before
  6:5  ✖  Unexpected vendor-prefix "-webkit-animation"  property-no-vendor-prefix
```

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   **N/A**  I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
