### PR TITLE
fix(overlay): remove pointer events from disabled overlay trigger

### DIFF
--- a/packages/overlay/src/overlay-trigger.css
+++ b/packages/overlay/src/overlay-trigger.css
@@ -10,10 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-:host([disabled]) ::slotted([slot='trigger']) {
-    pointer-events: none;
-}
-
 slot[name='longpress-describedby-descriptor'] {
     display: none;
 }

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -1611,3 +1611,106 @@ export const triggeredByOptimization = (): TemplateResult => {
         </div>
     `;
 };
+
+export const disabledOverlayTrigger = (): TemplateResult => {
+    return html`
+        ${storyStyles}
+        <h2>Disabled Overlay Trigger</h2>
+        <p>This demonstrates how disabled overlay-triggers should work:</p>
+        <ul>
+            <li>
+                The overlay (tooltip/popover) functionality should be disabled
+            </li>
+            <li>But the trigger content itself should remain interactive</li>
+        </ul>
+
+        <div style="display: flex; gap: 24px; margin: 24px 0;">
+            <!-- Disabled overlay-trigger with interactive content -->
+            <div>
+                <h3>Disabled overlay-trigger</h3>
+                <overlay-trigger triggered-by="click hover" disabled>
+                    <div
+                        slot="trigger"
+                        style="padding: 8px; border: 1px solid #ccc;"
+                    >
+                        <p>This container has a disabled overlay-trigger</p>
+                        <sp-button variant="primary" id="test-button-disabled">
+                            This button should still be clickable
+                        </sp-button>
+                    </div>
+                    <sp-tooltip slot="hover-content">
+                        This tooltip should not appear (disabled)
+                    </sp-tooltip>
+                    <sp-popover slot="click-content" placement="bottom" tip>
+                        <sp-dialog size="s" no-divider>
+                            This popover should not appear (disabled)
+                        </sp-dialog>
+                    </sp-popover>
+                </overlay-trigger>
+                <p id="disabled-click-indicator">Button not clicked yet</p>
+            </div>
+
+            <!-- Regular overlay-trigger for comparison -->
+            <div>
+                <h3>Regular overlay-trigger (for comparison)</h3>
+                <overlay-trigger triggered-by="click hover">
+                    <div
+                        slot="trigger"
+                        style="padding: 8px; border: 1px solid #ccc;"
+                    >
+                        <p>This container has a regular overlay-trigger</p>
+                        <sp-button variant="primary" id="test-button-enabled">
+                            This button should be clickable
+                        </sp-button>
+                    </div>
+                    <sp-tooltip slot="hover-content">
+                        This tooltip should appear on hover
+                    </sp-tooltip>
+                    <sp-popover slot="click-content" placement="bottom" tip>
+                        <sp-dialog size="s" no-divider>
+                            This popover should appear on click
+                        </sp-dialog>
+                    </sp-popover>
+                </overlay-trigger>
+                <p id="enabled-click-indicator">Button not clicked yet</p>
+            </div>
+        </div>
+
+        <script>
+            // Add click handlers to demonstrate button interactivity
+            setTimeout(() => {
+                const disabledButton = document.getElementById(
+                    'test-button-disabled'
+                );
+                const enabledButton = document.getElementById(
+                    'test-button-enabled'
+                );
+                const disabledIndicator = document.getElementById(
+                    'disabled-click-indicator'
+                );
+                const enabledIndicator = document.getElementById(
+                    'enabled-click-indicator'
+                );
+
+                if (disabledButton) {
+                    disabledButton.addEventListener('click', () => {
+                        disabledIndicator.textContent =
+                            'Button was clicked! ✅';
+                        disabledIndicator.style.color = 'green';
+                    });
+                }
+
+                if (enabledButton) {
+                    enabledButton.addEventListener('click', () => {
+                        enabledIndicator.textContent = 'Button was clicked! ✅';
+                        enabledIndicator.style.color = 'green';
+                    });
+                }
+            }, 100);
+        </script>
+    `;
+};
+
+disabledOverlayTrigger.swc_vrt = {
+    skip: true,
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed `pointer-events:none` from the `slot-trigger` under `overlay-trigger` to disable the overlay content and not the trigger element.
Needs discussion with design how we can align the user to think that they are clicking on a disabled overlay.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- Raised in channel

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_

    1. Go here
    2. Do this

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
