### PR TITLE
ci: stop dependabot PRs for cutoff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# Temporarily disable dependabot PRs
 version: 2
 updates:
     - package-ecosystem: 'npm'
@@ -7,7 +8,8 @@ updates:
           day: 'tuesday'
           time: '12:00'
           timezone: 'America/Los_Angeles'
-      open-pull-requests-limit: 5
+      # Set open-pull-requests-limit to 0 to disable PRs
+      open-pull-requests-limit: 0
       reviewers:
           - 'adobe/swc-maintainers'
       groups:
@@ -38,3 +40,5 @@ updates:
       directory: '/'
       schedule:
           interval: 'monthly'
+      # Set open-pull-requests-limit to 0 to disable PRs
+      open-pull-requests-limit: 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates .github/dependabot.yml to set open-pull-requests-limit: 0, effectively preventing Dependabot from opening new version bump PRs while keeping security updates active.


<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- Reduce noise from unnecessary dependency update PRs.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Stop automatic version bump PRs while still allowing security alerts.


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] Verified that security updates remain active.
-   [ ] Confirmed that no existing PRs are affected by this change.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
