### PR TITLE
chore: update tachometer reporting to stabilize ci [SWC-767] 

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
         types: [opened, synchronize, reopened]
 
+permissions:
+    contents: read
+    pull-requests: write
+
 jobs:
     test-changed-packages:
         strategy:
@@ -13,7 +17,7 @@ jobs:
 
         # The job will only run if the pull request is from the same repository.
         # Benchmarks can't run on PRs from forked repos due to comment posting restrictions without a GitHub token.
-        if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         runs-on: ubuntu-22.04
         steps:
             - name: Checkout main
@@ -50,6 +54,7 @@ jobs:
               run: touch tachometer.${{ matrix.browser }}-ran.txt
 
             - name: Archive ${{ matrix.browser }} tachometer results
+              id: upload-artifact
               uses: actions/upload-artifact@v4
               with:
                   name: tachometer-results-${{ matrix.browser }}
@@ -73,11 +78,16 @@ jobs:
 
             - name: Checkout PR branch
               uses: actions/checkout@v4
+              with:
+                  fetch-depth: 2
 
             - name: Setup Job and Install Dependencies
               uses: ./.github/actions/setup-job
 
             - uses: actions/download-artifact@v4
+              with:
+                  pattern: tachometer-results-*
+                  merge-multiple: true
 
             - name: Post Tachometer Performance Comment
               uses: actions/github-script@v7


### PR DESCRIPTION
## Description

When pull requests are opened by tools or utilities, [example](https://github.com/adobe/spectrum-web-components/actions/runs/13961757174), pull request comments cannot be written.

## How has this been tested?

The best way to validate this fix is to merge this update into main and then see if the comment step of the tachometer passes when dependabot opens another pull request.

- [x] Expect to see no regressions to tachometer comments on non-tooling pull requests. Validate that on this pull request [here](https://github.com/adobe/spectrum-web-components/actions/runs/13975871850/job/39129503463?pr=5224). [@castastrophe]

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
