### PR TITLE
chore: add build command to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,9 @@
     "extends": ["config:recommended"],
     "timezone": "America/Los_Angeles",
     "schedule": ["after 12pm on thursday"],
-    "semanticCommitScope": ""
+    "semanticCommitScope": "",
+    "postUpgradeTasks": {
+        "commands": ["yarn build"],
+        "executionMode": "branch"
+    }
 }


### PR DESCRIPTION
## Description

Adding a [postUpgradeTask](https://docs.renovatebot.com/configuration-options/#postupgradetasks) to the renovate workflow, we give it the opportunity to generate and commit the processed assets when the @spectrum-css packages are updated.

## Motivation and context

This update is a step toward having renovate automatically generate dependency updates for SWC without manual developer intervention or initiative.

## TODOs

Some enhancements we can explore in the future but don't block this current update.

- fileFilters: seems valuable to be more explicit here about what file updates are allowed
- Once constraints are added, we should probably run the `yarn constraints --fix` command here as well
- Can these commands be customized to only run for certain types of package updates?
- Option to add an npm script to create the changeset we want when a @spectrum-css file is updated that uses the changeset content from the Spectrum CSS release for content.

## How has this been tested?

**Validation would need to happen after merge.** When the next Renovate pull request for an @spectrum-css package is opened, we'd expect to see updated spectrum-*.css files.

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
