### PR TITLE
test(picker): force menu-item selected

### DIFF
--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -395,7 +395,7 @@ export const iconsNone = (args: StoryArgs): TemplateResult => {
             value="1"
             icons="none"
         >
-            <sp-menu-item value="1" active>
+            <sp-menu-item value="1" selected active focused>
                 <sp-icon-edit slot="icon"></sp-icon-edit>
                 Edit
             </sp-menu-item>


### PR DESCRIPTION
## Description

There's a flaky test in picker where the first menu item should be selected but sometimes the `value="1"` from picker hasn't updated the nested `menu-item` before a snapshot is taken. To address this and reduce flakiness, this update adds the selected state to the first item to prevent this instability.

## How has this been tested?

-   [ ] _Picker iconsNone_: Expect this test case to pass consistently

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
