### PR TITLE
fix(number-field): fix keyboard flickering when using increment/decrement buttons

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -720,8 +720,8 @@ export class NumberField extends TextfieldBase {
                           class="buttons"
                           @focusin=${this.handleFocusin}
                           @focusout=${this.handleFocusout}
-                          @mousedown=${(e: MouseEvent) => {
-                              e.preventDefault();
+                          @mousedown=${(event: MouseEvent) => {
+                              event.preventDefault();
                           }}
                           ${streamingListener({
                               start: ['pointerdown', this.handlePointerdown],

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -720,6 +720,9 @@ export class NumberField extends TextfieldBase {
                           class="buttons"
                           @focusin=${this.handleFocusin}
                           @focusout=${this.handleFocusout}
+                          @mousedown=${(e: MouseEvent) => {
+                              e.preventDefault();
+                          }}
                           ${streamingListener({
                               start: ['pointerdown', this.handlePointerdown],
                               streamInside: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The number-field relies on pointer events for its behaviour but the mousedown trigger caused an undesired focus cycle that resulted in a keyboard flicker. This PR aims to stop the unnecessary focus cycle by preventing the behaviour of mousedown events on the buttons container.

**New behaviour:**


https://github.com/user-attachments/assets/d86e3d2c-f9ff-494f-848a-f3495bbdd545


## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/4788

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Check out the [sp-number-field storybook](https://imizga-number-field-keyboard-mov--spectrum-w-c.netlify.app/storybook/?path=/story/number-field--default) on iPad/iPhone/Android
    2. Click on increment/decrement buttons
    3. Observe that the keyboard stays open

-   [ ] Did it pass in Desktop?
-   [x] Did it pass in Mobile?
-   [x] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
