### PR TITLE
chore: align and update changesets

### DIFF
--- a/.changeset/brave-crews-win.md
+++ b/.changeset/brave-crews-win.md
@@ -1,11 +1,21 @@
 ---
 '@spectrum-web-components/accordion': patch
 '@spectrum-web-components/action-bar': patch
+'@spectrum-web-components/alert-dialog': patch
+'@spectrum-web-components/asset': patch
+'@spectrum-web-components/avatar': patch
+'@spectrum-web-components/badge': patch
 '@spectrum-web-components/button-group': patch
 '@spectrum-web-components/card': patch
 '@spectrum-web-components/color-area': patch
+'@spectrum-web-components/color-handle': patch
 '@spectrum-web-components/color-loupe': patch
 '@spectrum-web-components/divider': patch
+'@spectrum-web-components/field-label': patch
+'@spectrum-web-components/help-text': patch
+'@spectrum-web-components/illustrated-message': patch
+'@spectrum-web-components/link': patch
+'@spectrum-web-components/modal': patch
 '@spectrum-web-components/styles': patch
 '@spectrum-web-components/tray': patch
 '@spectrum-web-components/underlay': patch

--- a/.changeset/cool-emus-appear.md
+++ b/.changeset/cool-emus-appear.md
@@ -1,6 +1,0 @@
----
-'@spectrum-web-components/modal': patch
-'@spectrum-web-components/styles': patch
----
-
-Remove unnecessary system theme references to reduce complexity for components that don't need the additional mapping layer.

--- a/.changeset/cute-peas-chew.md
+++ b/.changeset/cute-peas-chew.md
@@ -1,6 +1,0 @@
----
-'@spectrum-web-components/badge': patch
-'@spectrum-web-components/styles': patch
----
-
-Remove unnecessary system theme references to reduce complexity for components that don't need the additional mapping layer.

--- a/.changeset/good-lizards-brake.md
+++ b/.changeset/good-lizards-brake.md
@@ -1,6 +1,0 @@
----
-'@spectrum-web-components/field-label': patch
-'@spectrum-web-components/styles': patch
----
-
-Remove unnecessary system theme references to reduce complexity for components that don't need the additional mapping layer.

--- a/.changeset/itchy-dots-draw.md
+++ b/.changeset/itchy-dots-draw.md
@@ -1,6 +1,0 @@
----
-'@spectrum-web-components/help-text': patch
-'@spectrum-web-components/styles': patch
----
-
-Remove unnecessary system theme references to reduce complexity for components that don't need the additional mapping layer.

--- a/.changeset/lazy-rivers-camp.md
+++ b/.changeset/lazy-rivers-camp.md
@@ -1,6 +1,0 @@
----
-'@spectrum-web-components/avatar': patch
-'@spectrum-web-components/styles': patch
----
-
-Remove unnecessary system theme references to reduce complexity for components that don't need the additional mapping layer.

--- a/.changeset/public-steaks-juggle.md
+++ b/.changeset/public-steaks-juggle.md
@@ -1,6 +1,0 @@
----
-'@spectrum-web-components/alert-dialog': patch
-'@spectrum-web-components/styles': patch
----
-
-Remove unnecessary system theme references to reduce complexity for components that don't need the additional mapping layer.

--- a/.changeset/sharp-dodos-start.md
+++ b/.changeset/sharp-dodos-start.md
@@ -1,6 +1,0 @@
----
-'@spectrum-web-components/illustrated-message': patch
-'@spectrum-web-components/styles': patch
----
-
-Remove unnecessary system theme references to reduce complexity for components that don't need the additional mapping layer.

--- a/.changeset/tidy-oranges-agree.md
+++ b/.changeset/tidy-oranges-agree.md
@@ -1,6 +1,0 @@
----
-'@spectrum-web-components/asset': patch
-'@spectrum-web-components/styles': patch
----
-
-Remove unnecessary system theme references to reduce complexity for components that don't need the additional mapping layer.

--- a/.changeset/warm-ducks-dig.md
+++ b/.changeset/warm-ducks-dig.md
@@ -1,6 +1,0 @@
----
-'@spectrum-web-components/link': patch
-'@spectrum-web-components/styles': patch
----
-
-Remove unnecessary system theme references to reduce complexity for components that don't need the additional mapping layer.


### PR DESCRIPTION
## Description

Update changesets to collate duplicate messages into 1 changeset. Also adds the missing color-handle update.

- Expect to see 1 changeset and the deletion of all other changesets with the same messaging.

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [n/a] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [n/a] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
