### PR TITLE
fix(picker): added helptext component under same shadow root for screen reader

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -61,6 +61,7 @@ import type { FieldLabel } from '@spectrum-web-components/field-label';
 import { DesktopController } from './DesktopController.js';
 import { MobileController } from './MobileController.js';
 import { strategies } from './strategies.js';
+import { ManageHelpText } from '@spectrum-web-components/help-text/src/manage-help-text.js';
 
 const chevronClass = {
     s: 'spectrum-UIIcon-ChevronDown75',
@@ -80,9 +81,11 @@ export const DESCRIPTION_ID = 'option-picker';
  * @fires change - Announces that the `value` of the element has changed
  * @fires sp-opened - Announces that the overlay has been opened
  */
-export class PickerBase extends SizedMixin(SpectrumElement, {
-    noDefaultSize: true,
-}) {
+export class PickerBase extends ManageHelpText(
+    SizedMixin(SpectrumElement, {
+        noDefaultSize: true,
+    })
+) {
     static override shadowRootOptions = {
         ...SpectrumElement.shadowRootOptions,
         delegatesFocus: true,
@@ -594,6 +597,7 @@ export class PickerBase extends SizedMixin(SpectrumElement, {
             >
                 ${this.buttonContent}
             </button>
+            ${this.renderHelpText(this.invalid)}
             <slot
                 aria-hidden="true"
                 name="tooltip"
@@ -720,6 +724,7 @@ export class PickerBase extends SizedMixin(SpectrumElement, {
             >
                 ${accessibleMenu}
             </sp-popover>
+            ${this.renderHelpText(this.invalid)}
         `;
     }
 

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -29,6 +29,7 @@ import { areIconsPresent, isOverlayOpen } from '../../overlay/stories/index.js';
 import { argTypes } from './args.js';
 import { states } from './states.js';
 import { handleChange, StoryArgs, Template } from './template.js';
+import '@spectrum-web-components/help-text/sp-help-text.js';
 
 export default {
     title: 'Picker',
@@ -790,3 +791,14 @@ export const BackgroundClickTest = (): TemplateResult => {
 BackgroundClickTest.swc_vrt = {
     skip: true,
 };
+export const withHelpText = (): TemplateResult => html`
+    <sp-field-label for="picker-help-text">Choose an option</sp-field-label>
+    <sp-picker id="picker-help-text">
+        <sp-menu-item value="option-1">Option 1</sp-menu-item>
+        <sp-menu-item value="option-2">Option 2</sp-menu-item>
+        <sp-menu-item value="option-3">Option 3</sp-menu-item>
+        <sp-help-text slot="help-text">
+            Select an option from the dropdown menu.
+        </sp-help-text>
+    </sp-picker>
+`;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR addresses an accessibility issue where help text associated with sp-picker is not properly announced by screen readers. The problem occurs because help text elements (`sp-help-text`) outside the shadow DOM aren't correctly associated with the picker in the accessibility tree.
The changes add proper ARIA relationships and support for slotting help text directly into the picker component.
Changes
Added a dedicated `help-text` slot to `sp-picker`





<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/5361

## Motivation and context
### Before
Previously, help text needed to be explicitly referenced by ID and wasn't being properly announced by screen readers:
```html
<sp-picker id="text" label="Select contact method" aria-describedby="help-text">
    <sp-menu-item>Phone</sp-menu-item>
    <sp-menu-item>Text</sp-menu-item>
    <sp-menu-item>Email</sp-menu-item>
</sp-picker>
<sp-help-text id="help-text">
    Choose the best way to contact you in case there's an issue with your account.
</sp-help-text>
```

### After
Now developers can slot help text directly into the picker, and it will be properly announced by screen readers:
```html
<sp-picker label="Select contact method">
    <sp-menu-item>Phone</sp-menu-item>
    <sp-menu-item>Text</sp-menu-item>
    <sp-menu-item>Email</sp-menu-item>
    <sp-help-text slot="help-text">
        Choose the best way to contact you in case there's an issue with your account.
    </sp-help-text>
</sp-picker>
```
<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_

    1. Go here
    2. Do this

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
