### PR TITLE
fix(button): hoisted modifier access 

### DIFF
--- a/.changeset/curvy-boxes-poke.md
+++ b/.changeset/curvy-boxes-poke.md
@@ -1,0 +1,21 @@
+---
+'@spectrum-web-components/button': patch
+'@spectrum-web-components/styles': patch
+---
+
+This update aims to simplify `--mod-*` access by ensuring local variants and states aren't hooking into those custom properties for overrides. This updates all local variants and states to override the `--spectrum-button-*` properties instead and adjusts the specificity to ensure no regressions in rendered results.
+
+From [@spectrum-css/button v14.1.3](https://www.npmjs.com/package/@spectrum-css/button/v/14.1.3): [#3613](https://github.com/adobe/spectrum-css/pull/3613) Thanks [@​rise-erpelding](https://github.com/rise-erpelding)!
+
+Adjusts static color buttons to more closely resemble the S2 specifications. There are no expected changes to non-static button variants in S2, and no expected changes to other themes.
+
+This PR includes changes to:
+
+-   Static white primary button (outline variant), static white secondary button (fill variant), static black primary button (outline variant), static black secondary button (fill variant)
+-   Static white secondary button (outline variant) and static black secondary button (outline variant) border and background colors
+-   Static color buttons' content color
+-   Static white primary button (fill variant) and static black primary button (fill variant) background colors
+
+From [@spectrum-css/button v14.1.2](https://www.npmjs.com/package/@spectrum-css/button/v/14.1.2): [#​3600](https://github.com/adobe/spectrum-css/pull/3600) Thanks [@​rise-erpelding](https://github.com/rise-erpelding)!
+
+Adjust border colors for static black and static white outline buttons, primary variant to match S2 specifications.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
     # 3. Commit this change to the PR branch where the changes exist.
     current_golden_images_hash:
         type: string
-        default: f0b3f3b4daf8fe12a6f13ff2e3b84dab31c76091
+        default: 8f3ecb2c63d401eeb80e88e9f1eefa38f271734c
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -99,7 +99,7 @@
         "@spectrum-web-components/shared": "1.4.0"
     },
     "devDependencies": {
-        "@spectrum-css/button": "14.1.1"
+        "@spectrum-css/button": "14.1.6"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button/src/button-overrides.css
+++ b/packages/button/src/button-overrides.css
@@ -40,340 +40,319 @@ governing permissions and limitations under the License.
     --spectrum-button-border-color-disabled: var(
         --system-button-border-color-disabled
     );
-    --mod-button-background-color-default: var(
-        --system-button-background-color-default
-    );
-    --mod-button-background-color-hover: var(
-        --system-button-background-color-hover
-    );
-    --mod-button-background-color-down: var(
-        --system-button-background-color-down
-    );
-    --mod-button-background-color-focus: var(
-        --system-button-background-color-focus
-    );
-    --mod-button-border-color-default: var(
-        --system-button-border-color-default
-    );
-    --mod-button-border-color-hover: var(--system-button-border-color-hover);
-    --mod-button-border-color-down: var(--system-button-border-color-down);
-    --mod-button-border-color-focus: var(--system-button-border-color-focus);
 }
 
 :host([selected]) {
-    --mod-button-background-color-default: var(
+    --spectrum-button-background-color-default: var(
         --system-button-selected-background-color-default
     );
-    --mod-button-background-color-hover: var(
+    --spectrum-button-background-color-hover: var(
         --system-button-selected-background-color-hover
     );
-    --mod-button-background-color-down: var(
+    --spectrum-button-background-color-down: var(
         --system-button-selected-background-color-down
     );
-    --mod-button-background-color-focus: var(
+    --spectrum-button-background-color-focus: var(
         --system-button-selected-background-color-focus
     );
 }
 
 :host([variant='primary']) {
-    --mod-button-content-color-default: var(
+    --spectrum-button-content-color-default: var(
         --system-button-primary-content-color-default
     );
-    --mod-button-content-color-hover: var(
+    --spectrum-button-content-color-hover: var(
         --system-button-primary-content-color-hover
     );
-    --mod-button-content-color-down: var(
+    --spectrum-button-content-color-down: var(
         --system-button-primary-content-color-down
     );
-    --mod-button-content-color-focus: var(
+    --spectrum-button-content-color-focus: var(
         --system-button-primary-content-color-focus
     );
 }
 
 :host([variant='primary'][treatment='outline']) {
-    --mod-button-background-color-hover: var(
+    --spectrum-button-background-color-hover: var(
         --system-button-primary-outline-background-color-hover
     );
-    --mod-button-background-color-down: var(
+    --spectrum-button-background-color-down: var(
         --system-button-primary-outline-background-color-down
     );
-    --mod-button-background-color-focus: var(
+    --spectrum-button-background-color-focus: var(
         --system-button-primary-outline-background-color-focus
     );
 }
 
 :host([variant='secondary']) {
-    --mod-button-background-color-default: var(
+    --spectrum-button-background-color-default: var(
         --system-button-secondary-background-color-default
     );
-}
-
-:host([variant='secondary']:not([treatment='outline'])) {
-    --mod-button-background-color-hover: var(
-        --system-button-secondary-not-outline-background-color-hover
+    --spectrum-button-background-color-hover: var(
+        --system-button-secondary-background-color-hover
     );
-    --mod-button-background-color-down: var(
-        --system-button-secondary-not-outline-background-color-down
+    --spectrum-button-background-color-down: var(
+        --system-button-secondary-background-color-down
     );
-    --mod-button-background-color-focus: var(
-        --system-button-secondary-not-outline-background-color-focus
+    --spectrum-button-background-color-focus: var(
+        --system-button-secondary-background-color-focus
     );
 }
 
 :host([variant='secondary'][treatment='outline']) {
-    --mod-button-background-color-hover: var(
+    --spectrum-button-background-color-hover: var(
         --system-button-secondary-outline-background-color-hover
     );
-    --mod-button-background-color-down: var(
+    --spectrum-button-background-color-down: var(
         --system-button-secondary-outline-background-color-down
     );
-    --mod-button-background-color-focus: var(
+    --spectrum-button-background-color-focus: var(
         --system-button-secondary-outline-background-color-focus
     );
-    --mod-button-border-color-default: var(
+    --spectrum-button-border-color-default: var(
         --system-button-secondary-outline-border-color-default
+    );
+    --spectrum-button-border-color-down: var(
+        --system-button-secondary-outline-border-color-down
     );
 }
 
 :host([static-color='white']) {
-    --mod-button-background-color-default: var(
+    --spectrum-button-background-color-default: var(
         --system-button-static-white-background-color-default
     );
-    --mod-button-background-color-hover: var(
+    --spectrum-button-background-color-hover: var(
         --system-button-static-white-background-color-hover
     );
-    --mod-button-background-color-down: var(
+    --spectrum-button-background-color-down: var(
         --system-button-static-white-background-color-down
     );
-    --mod-button-background-color-focus: var(
+    --spectrum-button-background-color-focus: var(
         --system-button-static-white-background-color-focus
     );
-    --mod-button-content-color-default: var(
+    --spectrum-button-content-color-default: var(
         --system-button-static-white-content-color-default
     );
-    --mod-button-content-color-hover: var(
+    --spectrum-button-content-color-hover: var(
         --system-button-static-white-content-color-hover
     );
-    --mod-button-content-color-down: var(
+    --spectrum-button-content-color-down: var(
         --system-button-static-white-content-color-down
     );
-    --mod-button-content-color-focus: var(
+    --spectrum-button-content-color-focus: var(
         --system-button-static-white-content-color-focus
     );
 }
 
+:host([static-color='white'][treatment='outline']) {
+    --spectrum-button-background-color-default: var(
+        --system-button-static-white-outline-background-color-default
+    );
+    --spectrum-button-background-color-hover: var(
+        --system-button-static-white-outline-background-color-hover
+    );
+    --spectrum-button-background-color-down: var(
+        --system-button-static-white-outline-background-color-down
+    );
+    --spectrum-button-background-color-focus: var(
+        --system-button-static-white-outline-background-color-focus
+    );
+    --spectrum-button-content-color-default: var(
+        --system-button-static-white-outline-content-color-default
+    );
+    --spectrum-button-content-color-hover: var(
+        --system-button-static-white-outline-content-color-hover
+    );
+    --spectrum-button-content-color-down: var(
+        --system-button-static-white-outline-content-color-down
+    );
+    --spectrum-button-content-color-focus: var(
+        --system-button-static-white-outline-content-color-focus
+    );
+    --spectrum-button-border-color-default: var(
+        --system-button-static-white-outline-border-color-default
+    );
+    --spectrum-button-border-color-hover: var(
+        --system-button-static-white-outline-border-color-hover
+    );
+    --spectrum-button-border-color-down: var(
+        --system-button-static-white-outline-border-color-down
+    );
+    --spectrum-button-border-color-focus: var(
+        --system-button-static-white-outline-border-color-focus
+    );
+}
+
 :host([static-color='white'][variant='secondary']) {
-    --mod-button-background-color-default: var(
+    --spectrum-button-background-color-default: var(
         --system-button-static-white-secondary-background-color-default
     );
-    --mod-button-background-color-hover: var(
+    --spectrum-button-background-color-hover: var(
         --system-button-static-white-secondary-background-color-hover
     );
-    --mod-button-background-color-down: var(
+    --spectrum-button-background-color-down: var(
         --system-button-static-white-secondary-background-color-down
     );
-    --mod-button-background-color-focus: var(
+    --spectrum-button-background-color-focus: var(
         --system-button-static-white-secondary-background-color-focus
     );
-    --mod-button-content-color-default: var(
+    --spectrum-button-content-color-default: var(
         --system-button-static-white-secondary-content-color-default
     );
-    --mod-button-content-color-hover: var(
+    --spectrum-button-content-color-hover: var(
         --system-button-static-white-secondary-content-color-hover
     );
-    --mod-button-content-color-down: var(
+    --spectrum-button-content-color-down: var(
         --system-button-static-white-secondary-content-color-down
     );
-    --mod-button-content-color-focus: var(
+    --spectrum-button-content-color-focus: var(
         --system-button-static-white-secondary-content-color-focus
     );
 }
 
 :host([static-color='white'][variant='secondary'][treatment='outline']) {
-    --mod-button-border-color-default: var(
+    --spectrum-button-border-color-default: var(
         --system-button-static-white-secondary-outline-border-color-default
     );
-    --mod-button-border-color-hover: var(
+    --spectrum-button-border-color-hover: var(
         --system-button-static-white-secondary-outline-border-color-hover
     );
-    --mod-button-border-color-down: var(
+    --spectrum-button-border-color-down: var(
         --system-button-static-white-secondary-outline-border-color-down
     );
-    --mod-button-border-color-focus: var(
+    --spectrum-button-border-color-focus: var(
         --system-button-static-white-secondary-outline-border-color-focus
     );
-}
-
-:host([static-color='white'][treatment='outline']:not([variant='secondary'])) {
-    --mod-button-background-color-hover: var(
-        --system-button-static-white-outline-not-secondary-background-color-hover
+    --spectrum-button-background-color-default: var(
+        --system-button-static-white-secondary-outline-background-color-default
     );
-    --mod-button-background-color-down: var(
-        --system-button-static-white-outline-not-secondary-background-color-down
+    --spectrum-button-background-color-hover: var(
+        --system-button-static-white-secondary-outline-background-color-hover
     );
-    --mod-button-background-color-focus: var(
-        --system-button-static-white-outline-not-secondary-background-color-focus
+    --spectrum-button-background-color-down: var(
+        --system-button-static-white-secondary-outline-background-color-down
     );
-    --mod-button-content-color-default: var(
-        --system-button-static-white-outline-not-secondary-content-color-default
-    );
-    --mod-button-content-color-hover: var(
-        --system-button-static-white-outline-not-secondary-content-color-hover
-    );
-    --mod-button-content-color-down: var(
-        --system-button-static-white-outline-not-secondary-content-color-down
-    );
-    --mod-button-content-color-focus: var(
-        --system-button-static-white-outline-not-secondary-content-color-focus
-    );
-    --mod-button-border-color-default: var(
-        --system-button-static-white-outline-not-secondary-border-color-default
-    );
-    --mod-button-border-color-hover: var(
-        --system-button-static-white-outline-not-secondary-border-color-hover
-    );
-    --mod-button-border-color-down: var(
-        --system-button-static-white-outline-not-secondary-border-color-down
-    );
-    --mod-button-border-color-focus: var(
-        --system-button-static-white-outline-not-secondary-border-color-focus
-    );
-}
-
-:host([static-color='white'][treatment='outline'][variant='secondary']) {
-    --mod-button-background-color-hover: var(
-        --system-button-static-white-outline-secondary-background-color-hover
-    );
-    --mod-button-background-color-down: var(
-        --system-button-static-white-outline-secondary-background-color-down
-    );
-    --mod-button-background-color-focus: var(
-        --system-button-static-white-outline-secondary-background-color-focus
+    --spectrum-button-background-color-focus: var(
+        --system-button-static-white-secondary-outline-background-color-focus
     );
 }
 
 :host([static-color='black']) {
-    --mod-button-background-color-default: var(
+    --spectrum-button-background-color-default: var(
         --system-button-static-black-background-color-default
     );
-    --mod-button-background-color-hover: var(
+    --spectrum-button-background-color-hover: var(
         --system-button-static-black-background-color-hover
     );
-    --mod-button-background-color-down: var(
+    --spectrum-button-background-color-down: var(
         --system-button-static-black-background-color-down
     );
-    --mod-button-background-color-focus: var(
+    --spectrum-button-background-color-focus: var(
         --system-button-static-black-background-color-focus
     );
-    --mod-button-content-color-default: var(
+    --spectrum-button-content-color-default: var(
         --system-button-static-black-content-color-default
     );
-    --mod-button-content-color-hover: var(
+    --spectrum-button-content-color-hover: var(
         --system-button-static-black-content-color-hover
     );
-    --mod-button-content-color-down: var(
+    --spectrum-button-content-color-down: var(
         --system-button-static-black-content-color-down
     );
-    --mod-button-content-color-focus: var(
+    --spectrum-button-content-color-focus: var(
         --system-button-static-black-content-color-focus
     );
 }
 
+:host([static-color='black'][treatment='outline']) {
+    --spectrum-button-background-color-default: var(
+        --system-button-static-black-outline-background-color-default
+    );
+    --spectrum-button-background-color-hover: var(
+        --system-button-static-black-outline-background-color-hover
+    );
+    --spectrum-button-background-color-down: var(
+        --system-button-static-black-outline-background-color-down
+    );
+    --spectrum-button-background-color-focus: var(
+        --system-button-static-black-outline-background-color-focus
+    );
+    --spectrum-button-content-color-default: var(
+        --system-button-static-black-outline-content-color-default
+    );
+    --spectrum-button-content-color-hover: var(
+        --system-button-static-black-outline-content-color-hover
+    );
+    --spectrum-button-content-color-down: var(
+        --system-button-static-black-outline-content-color-down
+    );
+    --spectrum-button-content-color-focus: var(
+        --system-button-static-black-outline-content-color-focus
+    );
+    --spectrum-button-border-color-default: var(
+        --system-button-static-black-outline-border-color-default
+    );
+    --spectrum-button-border-color-hover: var(
+        --system-button-static-black-outline-border-color-hover
+    );
+    --spectrum-button-border-color-down: var(
+        --system-button-static-black-outline-border-color-down
+    );
+    --spectrum-button-border-color-focus: var(
+        --system-button-static-black-outline-border-color-focus
+    );
+}
+
 :host([static-color='black'][variant='secondary']) {
-    --mod-button-background-color-default: var(
+    --spectrum-button-background-color-default: var(
         --system-button-static-black-secondary-background-color-default
     );
-    --mod-button-background-color-hover: var(
+    --spectrum-button-background-color-hover: var(
         --system-button-static-black-secondary-background-color-hover
     );
-    --mod-button-background-color-down: var(
+    --spectrum-button-background-color-down: var(
         --system-button-static-black-secondary-background-color-down
     );
-    --mod-button-background-color-focus: var(
+    --spectrum-button-background-color-focus: var(
         --system-button-static-black-secondary-background-color-focus
     );
-    --mod-button-content-color-default: var(
+    --spectrum-button-content-color-default: var(
         --system-button-static-black-secondary-content-color-default
     );
-    --mod-button-content-color-hover: var(
+    --spectrum-button-content-color-hover: var(
         --system-button-static-black-secondary-content-color-hover
     );
-    --mod-button-content-color-down: var(
+    --spectrum-button-content-color-down: var(
         --system-button-static-black-secondary-content-color-down
     );
-    --mod-button-content-color-focus: var(
+    --spectrum-button-content-color-focus: var(
         --system-button-static-black-secondary-content-color-focus
     );
 }
 
 :host([static-color='black'][variant='secondary'][treatment='outline']) {
-    --mod-button-background-color-hover: var(
-        --system-button-static-black-secondary-outline-background-color-hover
-    );
-    --mod-button-background-color-down: var(
-        --system-button-static-black-secondary-outline-background-color-down
-    );
-    --mod-button-background-color-focus: var(
-        --system-button-static-black-secondary-outline-background-color-focus
-    );
-    --mod-button-border-color-default: var(
+    --spectrum-button-border-color-default: var(
         --system-button-static-black-secondary-outline-border-color-default
     );
-    --mod-button-border-color-hover: var(
+    --spectrum-button-border-color-hover: var(
         --system-button-static-black-secondary-outline-border-color-hover
     );
-    --mod-button-border-color-down: var(
+    --spectrum-button-border-color-down: var(
         --system-button-static-black-secondary-outline-border-color-down
     );
-    --mod-button-border-color-focus: var(
+    --spectrum-button-border-color-focus: var(
         --system-button-static-black-secondary-outline-border-color-focus
     );
-}
-
-:host([static-color='black'][treatment='outline']:not([variant='secondary'])) {
-    --mod-button-background-color-hover: var(
-        --system-button-static-black-outline-not-secondary-background-color-hover
+    --spectrum-button-background-color-default: var(
+        --system-button-static-black-secondary-outline-background-color-default
     );
-    --mod-button-background-color-down: var(
-        --system-button-static-black-outline-not-secondary-background-color-down
+    --spectrum-button-background-color-hover: var(
+        --system-button-static-black-secondary-outline-background-color-hover
     );
-    --mod-button-background-color-focus: var(
-        --system-button-static-black-outline-not-secondary-background-color-focus
+    --spectrum-button-background-color-down: var(
+        --system-button-static-black-secondary-outline-background-color-down
     );
-    --mod-button-content-color-default: var(
-        --system-button-static-black-outline-not-secondary-content-color-default
-    );
-    --mod-button-content-color-hover: var(
-        --system-button-static-black-outline-not-secondary-content-color-hover
-    );
-    --mod-button-content-color-down: var(
-        --system-button-static-black-outline-not-secondary-content-color-down
-    );
-    --mod-button-content-color-focus: var(
-        --system-button-static-black-outline-not-secondary-content-color-focus
-    );
-    --mod-button-border-color-default: var(
-        --system-button-static-black-outline-not-secondary-border-color-default
-    );
-    --mod-button-border-color-hover: var(
-        --system-button-static-black-outline-not-secondary-border-color-hover
-    );
-    --mod-button-border-color-down: var(
-        --system-button-static-black-outline-not-secondary-border-color-down
-    );
-    --mod-button-border-color-focus: var(
-        --system-button-static-black-outline-not-secondary-border-color-focus
-    );
-}
-
-:host([static-color='black'][treatment='outline'][variant='secondary']) {
-    --mod-button-background-color-hover: var(
-        --system-button-static-black-outline-secondary-background-color-hover
-    );
-    --mod-button-background-color-down: var(
-        --system-button-static-black-outline-secondary-background-color-down
-    );
-    --mod-button-background-color-focus: var(
-        --system-button-static-black-outline-secondary-background-color-focus
+    --spectrum-button-background-color-focus: var(
+        --system-button-static-black-secondary-outline-background-color-focus
     );
 }

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -61,6 +61,7 @@ governing permissions and limitations under the License.
 }
 
 #label {
+    text-align: center;
     place-self: center;
 }
 
@@ -68,7 +69,6 @@ governing permissions and limitations under the License.
     display: none;
 }
 
-:host,
 :host {
     --spectrum-button-sized-height: var(--spectrum-component-height-100);
     --spectrum-button-sized-font-size: var(--spectrum-font-size-100);
@@ -121,158 +121,165 @@ governing permissions and limitations under the License.
     --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-300);
 }
 
+:host {
+    --spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
+    --spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
+}
+
 :host([selected]) {
-    --mod-button-border-color-default: transparent;
-    --mod-button-border-color-hover: transparent;
-    --mod-button-border-color-down: transparent;
-    --mod-button-border-color-focus: transparent;
-    --mod-button-content-color-default: var(--spectrum-white);
-    --mod-button-content-color-hover: var(--spectrum-white);
-    --mod-button-content-color-down: var(--spectrum-white);
-    --mod-button-content-color-focus: var(--spectrum-white);
-    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
-    --mod-button-border-color-disabled: transparent;
+    --spectrum-button-border-color-default: transparent;
+    --spectrum-button-border-color-hover: transparent;
+    --spectrum-button-border-color-down: transparent;
+    --spectrum-button-border-color-focus: transparent;
+    --spectrum-button-content-color-default: var(--spectrum-white);
+    --spectrum-button-content-color-hover: var(--spectrum-white);
+    --spectrum-button-content-color-down: var(--spectrum-white);
+    --spectrum-button-content-color-focus: var(--spectrum-white);
+    --spectrum-button-background-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-button-border-color-disabled: transparent;
 }
 
 :host([selected][emphasized]),
 :host([variant='accent']) {
-    --mod-button-background-color-default: var(--spectrum-accent-background-color-default);
-    --mod-button-background-color-hover: var(--spectrum-accent-background-color-hover);
-    --mod-button-background-color-down: var(--spectrum-accent-background-color-down);
-    --mod-button-background-color-focus: var(--spectrum-accent-background-color-key-focus);
+    --spectrum-button-background-color-default: var(--spectrum-accent-background-color-default);
+    --spectrum-button-background-color-hover: var(--spectrum-accent-background-color-hover);
+    --spectrum-button-background-color-down: var(--spectrum-accent-background-color-down);
+    --spectrum-button-background-color-focus: var(--spectrum-accent-background-color-key-focus);
 }
 
 :host([variant='accent']) {
-    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
-    --mod-button-border-color-default: transparent;
-    --mod-button-border-color-hover: transparent;
-    --mod-button-border-color-down: transparent;
-    --mod-button-border-color-focus: transparent;
-    --mod-button-border-color-disabled: transparent;
-    --mod-button-content-color-default: var(--spectrum-white);
-    --mod-button-content-color-hover: var(--spectrum-white);
-    --mod-button-content-color-down: var(--spectrum-white);
-    --mod-button-content-color-focus: var(--spectrum-white);
+    --spectrum-button-background-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-button-border-color-default: transparent;
+    --spectrum-button-border-color-hover: transparent;
+    --spectrum-button-border-color-down: transparent;
+    --spectrum-button-border-color-focus: transparent;
+    --spectrum-button-border-color-disabled: transparent;
+    --spectrum-button-content-color-default: var(--spectrum-white);
+    --spectrum-button-content-color-hover: var(--spectrum-white);
+    --spectrum-button-content-color-down: var(--spectrum-white);
+    --spectrum-button-content-color-focus: var(--spectrum-white);
 }
 
 :host([variant='accent'][treatment='outline']) {
-    --mod-button-background-color-hover: var(--spectrum-accent-color-200);
-    --mod-button-background-color-down: var(--spectrum-accent-color-300);
-    --mod-button-background-color-focus: var(--spectrum-accent-color-200);
-    --mod-button-border-color-default: var(--spectrum-accent-color-900);
-    --mod-button-border-color-hover: var(--spectrum-accent-color-1000);
-    --mod-button-border-color-down: var(--spectrum-accent-color-1100);
-    --mod-button-border-color-focus: var(--spectrum-accent-color-1000);
-    --mod-button-border-color-disabled: var(--spectrum-disabled-border-color);
-    --mod-button-content-color-default: var(--spectrum-accent-content-color-default);
-    --mod-button-content-color-hover: var(--spectrum-accent-content-color-hover);
-    --mod-button-content-color-down: var(--spectrum-accent-content-color-down);
-    --mod-button-content-color-focus: var(--spectrum-accent-content-color-key-focus);
-    --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-button-background-color-hover: var(--spectrum-accent-color-200);
+    --spectrum-button-background-color-down: var(--spectrum-accent-color-300);
+    --spectrum-button-background-color-focus: var(--spectrum-accent-color-200);
+    --spectrum-button-border-color-default: var(--spectrum-accent-color-900);
+    --spectrum-button-border-color-hover: var(--spectrum-accent-color-1000);
+    --spectrum-button-border-color-down: var(--spectrum-accent-color-1100);
+    --spectrum-button-border-color-focus: var(--spectrum-accent-color-1000);
+    --spectrum-button-border-color-disabled: var(--spectrum-disabled-border-color);
+    --spectrum-button-content-color-default: var(--spectrum-accent-content-color-default);
+    --spectrum-button-content-color-hover: var(--spectrum-accent-content-color-hover);
+    --spectrum-button-content-color-down: var(--spectrum-accent-content-color-down);
+    --spectrum-button-content-color-focus: var(--spectrum-accent-content-color-key-focus);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 :host([variant='negative']) {
-    --mod-button-background-color-default: var(--spectrum-negative-background-color-default);
-    --mod-button-background-color-hover: var(--spectrum-negative-background-color-hover);
-    --mod-button-background-color-down: var(--spectrum-negative-background-color-down);
-    --mod-button-background-color-focus: var(--spectrum-negative-background-color-key-focus);
-    --mod-button-border-color-default: transparent;
-    --mod-button-border-color-hover: transparent;
-    --mod-button-border-color-down: transparent;
-    --mod-button-border-color-focus: transparent;
-    --mod-button-content-color-default: var(--spectrum-white);
-    --mod-button-content-color-hover: var(--spectrum-white);
-    --mod-button-content-color-down: var(--spectrum-white);
-    --mod-button-content-color-focus: var(--spectrum-white);
-    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
-    --mod-button-border-color-disabled: transparent;
-    --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-button-background-color-default: var(--spectrum-negative-background-color-default);
+    --spectrum-button-background-color-hover: var(--spectrum-negative-background-color-hover);
+    --spectrum-button-background-color-down: var(--spectrum-negative-background-color-down);
+    --spectrum-button-background-color-focus: var(--spectrum-negative-background-color-key-focus);
+    --spectrum-button-border-color-default: transparent;
+    --spectrum-button-border-color-hover: transparent;
+    --spectrum-button-border-color-down: transparent;
+    --spectrum-button-border-color-focus: transparent;
+    --spectrum-button-content-color-default: var(--spectrum-white);
+    --spectrum-button-content-color-hover: var(--spectrum-white);
+    --spectrum-button-content-color-down: var(--spectrum-white);
+    --spectrum-button-content-color-focus: var(--spectrum-white);
+    --spectrum-button-background-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-button-border-color-disabled: transparent;
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 :host([variant='negative'][treatment='outline']) {
-    --mod-button-background-color-hover: var(--spectrum-negative-color-200);
-    --mod-button-background-color-down: var(--spectrum-negative-color-300);
-    --mod-button-background-color-focus: var(--spectrum-negative-color-200);
-    --mod-button-border-color-default: var(--spectrum-negative-color-900);
-    --mod-button-border-color-hover: var(--spectrum-negative-color-1000);
-    --mod-button-border-color-down: var(--spectrum-negative-color-1100);
-    --mod-button-border-color-focus: var(--spectrum-negative-color-1000);
-    --mod-button-border-color-disabled: var(--spectrum-disabled-border-color);
-    --mod-button-content-color-default: var(--spectrum-negative-content-color-default);
-    --mod-button-content-color-hover: var(--spectrum-negative-content-color-hover);
-    --mod-button-content-color-down: var(--spectrum-negative-content-color-down);
-    --mod-button-content-color-focus: var(--spectrum-negative-content-color-key-focus);
-    --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-button-background-color-hover: var(--spectrum-negative-color-200);
+    --spectrum-button-background-color-down: var(--spectrum-negative-color-300);
+    --spectrum-button-background-color-focus: var(--spectrum-negative-color-200);
+    --spectrum-button-border-color-default: var(--spectrum-negative-color-900);
+    --spectrum-button-border-color-hover: var(--spectrum-negative-color-1000);
+    --spectrum-button-border-color-down: var(--spectrum-negative-color-1100);
+    --spectrum-button-border-color-focus: var(--spectrum-negative-color-1000);
+    --spectrum-button-border-color-disabled: var(--spectrum-disabled-border-color);
+    --spectrum-button-content-color-default: var(--spectrum-negative-content-color-default);
+    --spectrum-button-content-color-hover: var(--spectrum-negative-content-color-hover);
+    --spectrum-button-content-color-down: var(--spectrum-negative-content-color-down);
+    --spectrum-button-content-color-focus: var(--spectrum-negative-content-color-key-focus);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 :host([variant='primary']) {
-    --mod-button-background-color-default: var(--spectrum-neutral-background-color-default);
-    --mod-button-background-color-hover: var(--spectrum-neutral-background-color-hover);
-    --mod-button-background-color-down: var(--spectrum-neutral-background-color-down);
-    --mod-button-background-color-focus: var(--spectrum-neutral-background-color-key-focus);
-    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
-    --mod-button-border-color-default: transparent;
-    --mod-button-border-color-hover: transparent;
-    --mod-button-border-color-down: transparent;
-    --mod-button-border-color-focus: transparent;
-    --mod-button-border-color-disabled: transparent;
+    --spectrum-button-background-color-default: var(--spectrum-neutral-background-color-default);
+    --spectrum-button-background-color-hover: var(--spectrum-neutral-background-color-hover);
+    --spectrum-button-background-color-down: var(--spectrum-neutral-background-color-down);
+    --spectrum-button-background-color-focus: var(--spectrum-neutral-background-color-key-focus);
+    --spectrum-button-background-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-button-border-color-default: transparent;
+    --spectrum-button-border-color-hover: transparent;
+    --spectrum-button-border-color-down: transparent;
+    --spectrum-button-border-color-focus: transparent;
+    --spectrum-button-border-color-disabled: transparent;
 }
 
 :host([variant='primary'][treatment='outline']) {
-    --mod-button-border-color-default: var(--spectrum-gray-800);
-    --mod-button-border-color-hover: var(--spectrum-gray-900);
-    --mod-button-border-color-down: var(--spectrum-gray-900);
-    --mod-button-border-color-focus: var(--spectrum-gray-900);
-    --mod-button-content-color-default: var(--spectrum-neutral-content-color-default);
-    --mod-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
-    --mod-button-content-color-down: var(--spectrum-neutral-content-color-down);
-    --mod-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
-    --mod-button-border-color-disabled: var(--spectrum-disabled-border-color);
-    --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-button-border-color-default: var(--spectrum-gray-800);
+    --spectrum-button-border-color-hover: var(--spectrum-gray-900);
+    --spectrum-button-border-color-down: var(--spectrum-gray-900);
+    --spectrum-button-border-color-focus: var(--spectrum-gray-900);
+    --spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
+    --spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-button-border-color-disabled: var(--spectrum-disabled-border-color);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 :host([variant='secondary']) {
-    --mod-button-background-color-disabled: var(--spectrum-disabled-background-color);
-    --mod-button-border-color-default: transparent;
-    --mod-button-border-color-hover: transparent;
-    --mod-button-border-color-down: transparent;
-    --mod-button-border-color-focus: transparent;
-    --mod-button-border-color-disabled: transparent;
-    --mod-button-content-color-default: var(--spectrum-neutral-content-color-default);
-    --mod-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
-    --mod-button-content-color-down: var(--spectrum-neutral-content-color-down);
-    --mod-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
-    --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-button-background-color-disabled: var(--spectrum-disabled-background-color);
+    --spectrum-button-border-color-default: transparent;
+    --spectrum-button-border-color-hover: transparent;
+    --spectrum-button-border-color-down: transparent;
+    --spectrum-button-border-color-focus: transparent;
+    --spectrum-button-border-color-disabled: transparent;
+    --spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
+    --spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 :host([variant='secondary'][treatment='outline']) {
-    --mod-button-background-color-down: var(--spectrum-gray-400);
-    --mod-button-border-color-default: var(--spectrum-gray-300);
-    --mod-button-border-color-hover: var(--spectrum-gray-400);
-    --mod-button-border-color-down: var(--spectrum-gray-500);
-    --mod-button-border-color-focus: var(--spectrum-gray-400);
-    --mod-button-border-color-disabled: var(--spectrum-disabled-border-color);
-    --mod-button-content-color-default: var(--spectrum-neutral-content-color-default);
-    --mod-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
-    --mod-button-content-color-down: var(--spectrum-neutral-content-color-down);
-    --mod-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
-    --mod-button-content-color-disabled: var(--spectrum-disabled-content-color);
+    --spectrum-button-background-color-down: var(--spectrum-gray-400);
+    --spectrum-button-border-color-default: var(--spectrum-gray-300);
+    --spectrum-button-border-color-hover: var(--spectrum-gray-400);
+    --spectrum-button-border-color-focus: var(--spectrum-gray-400);
+    --spectrum-button-border-color-disabled: var(--spectrum-disabled-border-color);
+    --spectrum-button-content-color-default: var(--spectrum-neutral-content-color-default);
+    --spectrum-button-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --spectrum-button-content-color-down: var(--spectrum-neutral-content-color-down);
+    --spectrum-button-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
 :host([quiet]) {
-    --mod-button-background-color-hover: var(--spectrum-gray-200);
-    --mod-button-background-color-down: var(--spectrum-gray-300);
-    --mod-button-background-color-focus: var(--spectrum-gray-200);
+    --spectrum-button-background-color-hover: var(--spectrum-gray-200);
+    --spectrum-button-background-color-down: var(--spectrum-gray-300);
+    --spectrum-button-background-color-focus: var(--spectrum-gray-200);
 }
 
 :host([quiet]),
 :host([static-color='black']),
 :host([static-color='white']) {
-    --mod-button-border-color-default: transparent;
-    --mod-button-border-color-hover: transparent;
-    --mod-button-border-color-down: transparent;
-    --mod-button-border-color-focus: transparent;
-    --mod-button-border-color-disabled: transparent;
+    --spectrum-button-border-color-default: transparent;
+    --spectrum-button-border-color-hover: transparent;
+    --spectrum-button-border-color-down: transparent;
+    --spectrum-button-border-color-focus: transparent;
+    --spectrum-button-border-color-disabled: transparent;
 }
 
 :host([static-color='black'][selected]),
@@ -281,54 +288,66 @@ governing permissions and limitations under the License.
     --mod-button-content-color-hover: var(--mod-button-static-content-color);
     --mod-button-content-color-down: var(--mod-button-static-content-color);
     --mod-button-content-color-focus: var(--mod-button-static-content-color);
-    --mod-button-border-color-disabled: transparent;
+    --spectrum-button-border-color-disabled: transparent;
+}
+
+:host([static-color='black'][variant='secondary']),
+:host([static-color='white'][variant='secondary']) {
+    --spectrum-button-border-color-default: transparent;
+    --spectrum-button-border-color-hover: transparent;
+    --spectrum-button-border-color-down: transparent;
+    --spectrum-button-border-color-focus: transparent;
+    --spectrum-button-border-color-disabled: transparent;
+}
+
+:host([static-color='black'][variant='secondary'][treatment='outline']),
+:host([static-color='white'][variant='secondary'][treatment='outline']) {
+    --spectrum-button-background-color-disabled: transparent;
 }
 
 :host([static-color='black'][quiet]),
-:host([static-color='black'][variant='secondary']),
-:host([static-color='white'][quiet]),
-:host([static-color='white'][variant='secondary']) {
-    --mod-button-border-color-default: transparent;
-    --mod-button-border-color-hover: transparent;
-    --mod-button-border-color-down: transparent;
-    --mod-button-border-color-focus: transparent;
-    --mod-button-border-color-disabled: transparent;
+:host([static-color='white'][quiet]) {
+    --spectrum-button-border-color-default: transparent;
+    --spectrum-button-border-color-hover: transparent;
+    --spectrum-button-border-color-down: transparent;
+    --spectrum-button-border-color-focus: transparent;
+    --spectrum-button-border-color-disabled: transparent;
 }
 
 :host([static-color='white']) {
-    --mod-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
-    --mod-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
-    --mod-button-focus-ring-color: var(--spectrum-static-white-focus-indicator-color);
-}
-
-:host([static-color='white'][variant='secondary']:not([treatment='outline'])) {
-    --mod-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
+    --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
+    --spectrum-button-focus-indicator-color: var(--spectrum-static-white-focus-indicator-color);
 }
 
 :host([static-color='white'][treatment='outline']) {
-    --mod-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
-    --mod-button-border-color-disabled: var(--spectrum-disabled-static-white-border-color);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
+    --spectrum-button-border-color-disabled: var(--spectrum-disabled-static-white-border-color);
+}
+
+:host([static-color='white'][variant='secondary']) {
+    --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
 }
 
 :host([static-color='black']) {
-    --mod-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
-    --mod-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
-    --mod-button-focus-ring-color: var(--mod-static-black-focus-indicator-color, var(--spectrum-static-black-focus-indicator-color));
-}
-
-:host([static-color='black'][variant='secondary']:not([treatment='outline'])) {
-    --mod-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
+    --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
+    --spectrum-button-focus-indicator-color: var(--mod-static-black-focus-indicator-color, var(--spectrum-static-black-focus-indicator-color));
 }
 
 :host([static-color='black'][treatment='outline']) {
-    --mod-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
-    --mod-button-border-color-disabled: var(--spectrum-disabled-static-black-border-color);
+    --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
+    --spectrum-button-border-color-disabled: var(--spectrum-disabled-static-black-border-color);
+}
+
+:host([static-color='black'][variant='secondary']) {
+    --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
 }
 
 :host([treatment='outline']),
 :host([quiet]) {
-    --mod-button-background-color-default: transparent;
-    --mod-button-background-color-disabled: transparent;
+    --spectrum-button-background-color-default: transparent;
+    --spectrum-button-background-color-disabled: transparent;
 }
 
 :host {
@@ -349,18 +368,12 @@ governing permissions and limitations under the License.
     --spectrum-button-border-width: var(--mod-button-border-width, var(--spectrum-border-width-200));
     --spectrum-button-focus-ring-gap: var(--mod-focus-indicator-gap, var(--mod-button-focus-ring-gap, var(--spectrum-focus-indicator-gap)));
     --spectrum-button-border-radius: var(--mod-button-border-radius, calc(var(--spectrum-button-height) / 2));
-    --spectrum-button-content-color-default: var(--highcontrast-button-content-color-default, var(--mod-button-content-color-default, var(--spectrum-neutral-content-color-default)));
-    --spectrum-button-content-color-hover: var(--highcontrast-button-content-color-hover, var(--mod-button-content-color-hover, var(--spectrum-neutral-content-color-hover)));
-    --spectrum-button-content-color-down: var(--highcontrast-button-content-color-down, var(--mod-button-content-color-down, var(--spectrum-neutral-content-color-down)));
-    --spectrum-button-content-color-focus: var(--highcontrast-button-content-color-focus, var(--mod-button-content-color-focus, var(--spectrum-neutral-content-color-key-focus)));
-    --spectrum-button-content-color-disabled: var(--highcontrast-button-content-color-disabled, var(--mod-button-content-color-disabled, var(--spectrum-disabled-content-color)));
     --mod-progress-circle-position: absolute;
     border-radius: var(--spectrum-button-border-radius);
     border-width: var(--spectrum-button-border-width);
     font-size: var(--spectrum-button-font-size);
     font-weight: var(--mod-bold-font-weight, var(--spectrum-bold-font-weight));
     gap: var(--spectrum-button-padding-label-to-icon);
-    max-inline-size: none;
     max-inline-size: var(--mod-button-max-inline-size, none);
     min-inline-size: var(--spectrum-button-min-width);
     min-block-size: var(--spectrum-button-height);
@@ -370,12 +383,7 @@ governing permissions and limitations under the License.
     background-color: var(--highcontrast-button-background-color-default, var(--mod-button-background-color-default, var(--spectrum-button-background-color-default)));
     border-style: solid;
     border-color: var(--highcontrast-button-border-color-default, var(--mod-button-border-color-default, var(--spectrum-button-border-color-default)));
-    color: inherit;
-    color: var(--spectrum-button-content-color-default, inherit);
-    transition:
-        border 0.13s linear,
-        color 0.13s linear,
-        background-color 0.13s linear;
+    color: var(--highcontrast-button-content-color-default, var(--mod-button-content-color-default, var(--spectrum-button-content-color-default, inherit)));
     transition:
         border var(--spectrum-button-animation-duration, 0.13s) linear,
         color var(--spectrum-button-animation-duration, 0.13s) linear,
@@ -402,7 +410,7 @@ governing permissions and limitations under the License.
 :host(:focus-visible) {
     background-color: var(--highcontrast-button-background-color-focus, var(--mod-button-background-color-focus, var(--spectrum-button-background-color-focus)));
     border-color: var(--highcontrast-button-border-color-focus, var(--mod-button-border-color-focus, var(--spectrum-button-border-color-focus)));
-    color: var(--spectrum-button-content-color-focus);
+    color: var(--highcontrast-button-content-color-focus, var(--mod-button-content-color-focus, var(--spectrum-button-content-color-focus)));
     box-shadow: none;
     outline: none;
 }
@@ -415,7 +423,7 @@ governing permissions and limitations under the License.
 :host(:is(:active, [active])) {
     background-color: var(--highcontrast-button-background-color-down, var(--mod-button-background-color-down, var(--spectrum-button-background-color-down)));
     border-color: var(--highcontrast-button-border-color-down, var(--mod-button-border-color-down, var(--spectrum-button-border-color-down)));
-    color: var(--spectrum-button-content-color-down);
+    color: var(--highcontrast-button-content-color-down, var(--mod-button-content-color-down, var(--spectrum-button-content-color-down)));
     box-shadow: none;
 }
 
@@ -423,7 +431,7 @@ governing permissions and limitations under the License.
     :host(:hover) {
         background-color: var(--highcontrast-button-background-color-hover, var(--mod-button-background-color-hover, var(--spectrum-button-background-color-hover)));
         border-color: var(--highcontrast-button-border-color-hover, var(--mod-button-border-color-hover, var(--spectrum-button-border-color-hover)));
-        color: var(--spectrum-button-content-color-hover);
+        color: var(--highcontrast-button-content-color-hover, var(--mod-button-content-color-hover, var(--spectrum-button-content-color-hover)));
         box-shadow: none;
     }
 }
@@ -434,7 +442,7 @@ governing permissions and limitations under the License.
 :host([pending]) {
     background-color: var(--highcontrast-button-background-color-disabled, var(--mod-button-background-color-disabled, var(--spectrum-button-background-color-disabled)));
     border-color: var(--highcontrast-button-border-color-disabled, var(--mod-button-border-color-disabled, var(--spectrum-button-border-color-disabled)));
-    color: var(--spectrum-button-content-color-disabled);
+    color: var(--highcontrast-button-content-color-disabled, var(--mod-button-content-color-disabled, var(--spectrum-button-content-color-disabled)));
 }
 
 ::slotted([slot='icon']) {
@@ -451,16 +459,12 @@ governing permissions and limitations under the License.
 ::slotted([slot='icon']) {
     visibility: visible;
     opacity: 1;
-    transition: opacity 0.13s ease-in-out;
     transition: opacity var(--spectrum-button-animation-duration, 0.13s) ease-in-out;
 }
 
 .spectrum-ProgressCircle {
     visibility: hidden;
     opacity: 0;
-    transition:
-        opacity 0.13s ease-in-out,
-        visibility 0s linear 0.13s;
     transition:
         opacity var(--spectrum-button-animation-duration, 0.13s) ease-in-out,
         visibility 0s linear var(--spectrum-button-animation-duration, 0.13s);
@@ -475,7 +479,6 @@ governing permissions and limitations under the License.
 :host([pending]) .spectrum-ProgressCircle {
     visibility: visible;
     opacity: 1;
-    transition: opacity 0.13s ease-in-out;
     transition: opacity var(--spectrum-button-animation-duration, 0.13s) ease-in-out;
 }
 
@@ -505,13 +508,11 @@ governing permissions and limitations under the License.
 }
 
 [name='icon'] + #label {
-    text-align: start;
     text-align: var(--mod-button-text-align-with-icon, start);
 }
 
 #label {
     line-height: var(--spectrum-button-line-height);
-    text-align: center;
     text-align: var(--mod-button-text-align, center);
     align-self: start;
     padding-block-start: calc(var(--spectrum-button-top-to-text) - var(--spectrum-button-border-width));
@@ -544,7 +545,7 @@ governing permissions and limitations under the License.
         --mod-progress-circle-track-border-color: ButtonText;
         --mod-progress-circle-track-border-color-over-background: ButtonText;
         --mod-progress-circle-thickness: var(--spectrum-progress-circle-thickness-medium);
-        --mod-button-animation-duration: 0s;
+        --spectrum-button-animation-duration: 0s;
     }
 
     #label {
@@ -554,10 +555,6 @@ governing permissions and limitations under the License.
     :host(:focus-visible):after {
         forced-color-adjust: none;
         box-shadow: 0 0 0 var(--spectrum-button-focus-ring-thickness) ButtonText;
-    }
-
-    :host([static-color='white'][variant='accent']) {
-        --highcontrast-button-content-color-disabled: GrayText;
     }
 
     :host([variant='accent'][treatment='fill']) {
@@ -574,5 +571,9 @@ governing permissions and limitations under the License.
         --highcontrast-button-border-color-hover: Highlight;
         --highcontrast-button-border-color-focus: Highlight;
         --highcontrast-button-border-color-down: Highlight;
+    }
+
+    :host([static-color='white'][variant='accent']) {
+        --highcontrast-button-content-color-disabled: GrayText;
     }
 }

--- a/tools/styles/tokens-v2/system-theme-bridge.css
+++ b/tools/styles/tokens-v2/system-theme-bridge.css
@@ -167,225 +167,234 @@
     --system-button-primary-content-color-down: var(--spectrum-gray-25);
     --system-button-primary-content-color-focus: var(--spectrum-gray-25);
     --system-button-primary-outline-background-color-hover: var(
-        --spectrum-gray-200
+        --spectrum-gray-100
     );
     --system-button-primary-outline-background-color-down: var(
-        --spectrum-gray-400
+        --spectrum-gray-100
     );
     --system-button-primary-outline-background-color-focus: var(
-        --spectrum-gray-200
+        --spectrum-gray-100
     );
     --system-button-secondary-background-color-default: var(
         --spectrum-gray-100
     );
-    --system-button-secondary-not-outline-background-color-hover: var(
-        --spectrum-gray-200
-    );
-    --system-button-secondary-not-outline-background-color-down: var(
-        --spectrum-gray-400
-    );
-    --system-button-secondary-not-outline-background-color-focus: var(
-        --spectrum-gray-200
-    );
+    --system-button-secondary-background-color-hover: var(--spectrum-gray-200);
+    --system-button-secondary-background-color-down: var(--spectrum-gray-200);
+    --system-button-secondary-background-color-focus: var(--spectrum-gray-200);
     --system-button-secondary-outline-background-color-hover: var(
-        --spectrum-gray-200
+        --spectrum-gray-100
     );
     --system-button-secondary-outline-background-color-down: var(
-        --spectrum-gray-400
+        --spectrum-gray-100
     );
     --system-button-secondary-outline-background-color-focus: var(
-        --spectrum-gray-200
+        --spectrum-gray-100
     );
     --system-button-secondary-outline-border-color-default: var(
-        --spectrum-gray-200
+        --spectrum-gray-300
+    );
+    --system-button-secondary-outline-border-color-down: var(
+        --spectrum-gray-400
     );
     --system-button-static-white-background-color-default: var(
-        --spectrum-transparent-white-900
+        --spectrum-transparent-white-800
     );
     --system-button-static-white-background-color-hover: var(
-        --spectrum-transparent-white-1000
+        --spectrum-transparent-white-900
     );
     --system-button-static-white-background-color-down: var(
-        --spectrum-transparent-white-1000
+        --spectrum-transparent-white-900
     );
     --system-button-static-white-background-color-focus: var(
-        --spectrum-transparent-white-1000
+        --spectrum-transparent-white-900
     );
     --system-button-static-white-content-color-default: var(--spectrum-black);
     --system-button-static-white-content-color-hover: var(--spectrum-black);
     --system-button-static-white-content-color-down: var(--spectrum-black);
     --system-button-static-white-content-color-focus: var(--spectrum-black);
-    --system-button-static-white-secondary-background-color-default: var(
-        --spectrum-transparent-white-300
+    --system-button-static-white-outline-background-color-default: var(
+        --spectrum-transparent-white-25
     );
-    --system-button-static-white-secondary-background-color-hover: var(
-        --spectrum-transparent-white-400
+    --system-button-static-white-outline-background-color-hover: var(
+        --spectrum-transparent-white-100
     );
-    --system-button-static-white-secondary-background-color-down: var(
-        --spectrum-transparent-white-500
+    --system-button-static-white-outline-background-color-down: var(
+        --spectrum-transparent-white-100
     );
-    --system-button-static-white-secondary-background-color-focus: var(
-        --spectrum-transparent-white-400
+    --system-button-static-white-outline-background-color-focus: var(
+        --spectrum-transparent-white-100
     );
-    --system-button-static-white-secondary-content-color-default: var(
-        --spectrum-white
+    --system-button-static-white-outline-content-color-default: var(
+        --spectrum-transparent-white-800
     );
-    --system-button-static-white-secondary-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-content-color-down: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-content-color-focus: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-outline-border-color-default: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-border-color-hover: var(
-        --spectrum-transparent-white-500
-    );
-    --system-button-static-white-secondary-outline-border-color-down: var(
-        --spectrum-transparent-white-600
-    );
-    --system-button-static-white-secondary-outline-border-color-focus: var(
-        --spectrum-transparent-white-500
-    );
-    --system-button-static-white-outline-not-secondary-background-color-hover: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-outline-not-secondary-background-color-down: var(
-        --spectrum-transparent-white-500
-    );
-    --system-button-static-white-outline-not-secondary-background-color-focus: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-outline-not-secondary-content-color-default: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-content-color-down: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-content-color-focus: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-border-color-default: var(
+    --system-button-static-white-outline-content-color-hover: var(
         --spectrum-transparent-white-900
     );
-    --system-button-static-white-outline-not-secondary-border-color-hover: var(
-        --spectrum-transparent-white-1000
+    --system-button-static-white-outline-content-color-down: var(
+        --spectrum-transparent-white-900
     );
-    --system-button-static-white-outline-not-secondary-border-color-down: var(
-        --spectrum-transparent-white-1000
+    --system-button-static-white-outline-content-color-focus: var(
+        --spectrum-transparent-white-900
     );
-    --system-button-static-white-outline-not-secondary-border-color-focus: var(
-        --spectrum-transparent-white-1000
+    --system-button-static-white-outline-border-color-default: var(
+        --spectrum-transparent-white-800
     );
-    --system-button-static-white-outline-secondary-background-color-hover: var(
+    --system-button-static-white-outline-border-color-hover: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-outline-border-color-down: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-outline-border-color-focus: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-secondary-background-color-default: var(
+        --spectrum-transparent-white-100
+    );
+    --system-button-static-white-secondary-background-color-hover: var(
+        --spectrum-transparent-white-200
+    );
+    --system-button-static-white-secondary-background-color-down: var(
+        --spectrum-transparent-white-200
+    );
+    --system-button-static-white-secondary-background-color-focus: var(
+        --spectrum-transparent-white-200
+    );
+    --system-button-static-white-secondary-content-color-default: var(
+        --spectrum-transparent-white-800
+    );
+    --system-button-static-white-secondary-content-color-hover: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-secondary-content-color-down: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-secondary-content-color-focus: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-secondary-outline-border-color-default: var(
+        --spectrum-transparent-white-300
+    );
+    --system-button-static-white-secondary-outline-border-color-hover: var(
         --spectrum-transparent-white-400
     );
-    --system-button-static-white-outline-secondary-background-color-down: var(
-        --spectrum-transparent-white-500
-    );
-    --system-button-static-white-outline-secondary-background-color-focus: var(
+    --system-button-static-white-secondary-outline-border-color-down: var(
         --spectrum-transparent-white-400
+    );
+    --system-button-static-white-secondary-outline-border-color-focus: var(
+        --spectrum-transparent-white-400
+    );
+    --system-button-static-white-secondary-outline-background-color-default: var(
+        --spectrum-transparent-white-25
+    );
+    --system-button-static-white-secondary-outline-background-color-hover: var(
+        --spectrum-transparent-white-100
+    );
+    --system-button-static-white-secondary-outline-background-color-down: var(
+        --spectrum-transparent-white-100
+    );
+    --system-button-static-white-secondary-outline-background-color-focus: var(
+        --spectrum-transparent-white-100
     );
     --system-button-static-black-background-color-default: var(
-        --spectrum-transparent-black-900
+        --spectrum-transparent-black-800
     );
     --system-button-static-black-background-color-hover: var(
-        --spectrum-transparent-black-1000
+        --spectrum-transparent-black-900
     );
     --system-button-static-black-background-color-down: var(
-        --spectrum-transparent-black-1000
+        --spectrum-transparent-black-900
     );
     --system-button-static-black-background-color-focus: var(
-        --spectrum-transparent-black-1000
+        --spectrum-transparent-black-900
     );
     --system-button-static-black-content-color-default: var(--spectrum-white);
     --system-button-static-black-content-color-hover: var(--spectrum-white);
     --system-button-static-black-content-color-down: var(--spectrum-white);
     --system-button-static-black-content-color-focus: var(--spectrum-white);
+    --system-button-static-black-outline-background-color-default: var(
+        --spectrum-transparent-black-25
+    );
+    --system-button-static-black-outline-background-color-hover: var(
+        --spectrum-transparent-black-100
+    );
+    --system-button-static-black-outline-background-color-down: var(
+        --spectrum-transparent-black-100
+    );
+    --system-button-static-black-outline-background-color-focus: var(
+        --spectrum-transparent-black-100
+    );
+    --system-button-static-black-outline-content-color-default: var(
+        --spectrum-transparent-black-800
+    );
+    --system-button-static-black-outline-content-color-hover: var(
+        --spectrum-transparent-black-900
+    );
+    --system-button-static-black-outline-content-color-down: var(
+        --spectrum-transparent-black-900
+    );
+    --system-button-static-black-outline-content-color-focus: var(
+        --spectrum-transparent-black-900
+    );
+    --system-button-static-black-outline-border-color-default: var(
+        --spectrum-transparent-black-800
+    );
+    --system-button-static-black-outline-border-color-hover: var(
+        --spectrum-transparent-black-900
+    );
+    --system-button-static-black-outline-border-color-down: var(
+        --spectrum-transparent-black-900
+    );
+    --system-button-static-black-outline-border-color-focus: var(
+        --spectrum-transparent-black-900
+    );
     --system-button-static-black-secondary-background-color-default: var(
-        --spectrum-transparent-black-300
+        --spectrum-transparent-black-100
     );
     --system-button-static-black-secondary-background-color-hover: var(
-        --spectrum-transparent-black-400
+        --spectrum-transparent-black-200
     );
     --system-button-static-black-secondary-background-color-down: var(
-        --spectrum-transparent-black-500
+        --spectrum-transparent-black-200
     );
     --system-button-static-black-secondary-background-color-focus: var(
-        --spectrum-transparent-black-400
+        --spectrum-transparent-black-200
     );
     --system-button-static-black-secondary-content-color-default: var(
-        --spectrum-black
+        --spectrum-transparent-black-800
     );
     --system-button-static-black-secondary-content-color-hover: var(
-        --spectrum-black
+        --spectrum-transparent-black-900
     );
     --system-button-static-black-secondary-content-color-down: var(
-        --spectrum-black
+        --spectrum-transparent-black-900
     );
     --system-button-static-black-secondary-content-color-focus: var(
-        --spectrum-black
-    );
-    --system-button-static-black-secondary-outline-background-color-hover: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-background-color-down: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-secondary-outline-background-color-focus: var(
-        --spectrum-transparent-black-400
+        --spectrum-transparent-black-900
     );
     --system-button-static-black-secondary-outline-border-color-default: var(
-        --spectrum-transparent-black-400
+        --spectrum-transparent-black-300
     );
     --system-button-static-black-secondary-outline-border-color-hover: var(
-        --spectrum-transparent-black-500
+        --spectrum-transparent-black-400
     );
     --system-button-static-black-secondary-outline-border-color-down: var(
-        --spectrum-transparent-black-600
+        --spectrum-transparent-black-400
     );
     --system-button-static-black-secondary-outline-border-color-focus: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-outline-not-secondary-background-color-hover: var(
         --spectrum-transparent-black-400
     );
-    --system-button-static-black-outline-not-secondary-background-color-down: var(
-        --spectrum-transparent-black-500
+    --system-button-static-black-secondary-outline-background-color-default: var(
+        --spectrum-transparent-black-25
     );
-    --system-button-static-black-outline-not-secondary-background-color-focus: var(
-        --spectrum-transparent-black-400
+    --system-button-static-black-secondary-outline-background-color-hover: var(
+        --spectrum-transparent-black-100
     );
-    --system-button-static-black-outline-not-secondary-content-color-default: var(
-        --spectrum-black
+    --system-button-static-black-secondary-outline-background-color-down: var(
+        --spectrum-transparent-black-100
     );
-    --system-button-static-black-outline-not-secondary-content-color-hover: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-content-color-down: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-content-color-focus: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-border-color-default: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-outline-not-secondary-border-color-hover: var(
-        --spectrum-transparent-black-600
-    );
-    --system-button-static-black-outline-not-secondary-border-color-down: var(
-        --spectrum-transparent-black-700
-    );
-    --system-button-static-black-outline-not-secondary-border-color-focus: var(
-        --spectrum-transparent-black-600
+    --system-button-static-black-secondary-outline-background-color-focus: var(
+        --spectrum-transparent-black-100
     );
     --system-checkbox-control-color-default: var(
         --spectrum-neutral-content-color-default

--- a/tools/styles/tokens/express/system-theme-bridge.css
+++ b/tools/styles/tokens/express/system-theme-bridge.css
@@ -185,15 +185,9 @@
     --system-button-secondary-background-color-default: var(
         --spectrum-gray-200
     );
-    --system-button-secondary-not-outline-background-color-hover: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-not-outline-background-color-down: var(
-        --spectrum-gray-400
-    );
-    --system-button-secondary-not-outline-background-color-focus: var(
-        --spectrum-gray-300
-    );
+    --system-button-secondary-background-color-hover: var(--spectrum-gray-300);
+    --system-button-secondary-background-color-down: var(--spectrum-gray-400);
+    --system-button-secondary-background-color-focus: var(--spectrum-gray-300);
     --system-button-secondary-outline-background-color-hover: var(
         --spectrum-gray-300
     );
@@ -205,6 +199,9 @@
     );
     --system-button-secondary-outline-border-color-default: var(
         --spectrum-gray-300
+    );
+    --system-button-secondary-outline-border-color-down: var(
+        --spectrum-gray-500
     );
     --system-button-static-white-background-color-default: var(
         --spectrum-transparent-white-800
@@ -222,6 +219,42 @@
     --system-button-static-white-content-color-hover: var(--spectrum-black);
     --system-button-static-white-content-color-down: var(--spectrum-black);
     --system-button-static-white-content-color-focus: var(--spectrum-black);
+    --system-button-static-white-outline-background-color-default: var(
+        --spectrum-transparent-white-25
+    );
+    --system-button-static-white-outline-background-color-hover: var(
+        --spectrum-transparent-white-300
+    );
+    --system-button-static-white-outline-background-color-down: var(
+        --spectrum-transparent-white-400
+    );
+    --system-button-static-white-outline-background-color-focus: var(
+        --spectrum-transparent-white-300
+    );
+    --system-button-static-white-outline-content-color-default: var(
+        --spectrum-white
+    );
+    --system-button-static-white-outline-content-color-hover: var(
+        --spectrum-white
+    );
+    --system-button-static-white-outline-content-color-down: var(
+        --spectrum-white
+    );
+    --system-button-static-white-outline-content-color-focus: var(
+        --spectrum-white
+    );
+    --system-button-static-white-outline-border-color-default: var(
+        --spectrum-transparent-white-800
+    );
+    --system-button-static-white-outline-border-color-hover: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-outline-border-color-down: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-outline-border-color-focus: var(
+        --spectrum-transparent-white-900
+    );
     --system-button-static-white-secondary-background-color-default: var(
         --spectrum-transparent-white-200
     );
@@ -258,46 +291,16 @@
     --system-button-static-white-secondary-outline-border-color-focus: var(
         --spectrum-transparent-white-400
     );
-    --system-button-static-white-outline-not-secondary-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-outline-not-secondary-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-outline-not-secondary-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-outline-not-secondary-content-color-default: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-content-color-down: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-content-color-focus: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-border-color-default: var(
+    --system-button-static-white-secondary-outline-background-color-default: var(
         --spectrum-transparent-white-800
     );
-    --system-button-static-white-outline-not-secondary-border-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-not-secondary-border-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-not-secondary-border-color-focus: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-secondary-background-color-hover: var(
+    --system-button-static-white-secondary-outline-background-color-hover: var(
         --spectrum-transparent-white-300
     );
-    --system-button-static-white-outline-secondary-background-color-down: var(
+    --system-button-static-white-secondary-outline-background-color-down: var(
         --spectrum-transparent-white-400
     );
-    --system-button-static-white-outline-secondary-background-color-focus: var(
+    --system-button-static-white-secondary-outline-background-color-focus: var(
         --spectrum-transparent-white-300
     );
     --system-button-static-black-background-color-default: var(
@@ -316,6 +319,42 @@
     --system-button-static-black-content-color-hover: var(--spectrum-white);
     --system-button-static-black-content-color-down: var(--spectrum-white);
     --system-button-static-black-content-color-focus: var(--spectrum-white);
+    --system-button-static-black-outline-background-color-default: var(
+        --spectrum-transparent-black-25
+    );
+    --system-button-static-black-outline-background-color-hover: var(
+        --spectrum-transparent-black-300
+    );
+    --system-button-static-black-outline-background-color-down: var(
+        --spectrum-transparent-black-400
+    );
+    --system-button-static-black-outline-background-color-focus: var(
+        --spectrum-transparent-black-300
+    );
+    --system-button-static-black-outline-content-color-default: var(
+        --spectrum-black
+    );
+    --system-button-static-black-outline-content-color-hover: var(
+        --spectrum-black
+    );
+    --system-button-static-black-outline-content-color-down: var(
+        --spectrum-black
+    );
+    --system-button-static-black-outline-content-color-focus: var(
+        --spectrum-black
+    );
+    --system-button-static-black-outline-border-color-default: var(
+        --spectrum-transparent-black-400
+    );
+    --system-button-static-black-outline-border-color-hover: var(
+        --spectrum-transparent-black-500
+    );
+    --system-button-static-black-outline-border-color-down: var(
+        --spectrum-transparent-black-600
+    );
+    --system-button-static-black-outline-border-color-focus: var(
+        --spectrum-transparent-black-500
+    );
     --system-button-static-black-secondary-background-color-default: var(
         --spectrum-transparent-black-200
     );
@@ -340,15 +379,6 @@
     --system-button-static-black-secondary-content-color-focus: var(
         --spectrum-black
     );
-    --system-button-static-black-secondary-outline-background-color-hover: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-background-color-down: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-secondary-outline-background-color-focus: var(
-        --spectrum-transparent-black-400
-    );
     --system-button-static-black-secondary-outline-border-color-default: var(
         --spectrum-transparent-black-300
     );
@@ -361,46 +391,16 @@
     --system-button-static-black-secondary-outline-border-color-focus: var(
         --spectrum-transparent-black-400
     );
-    --system-button-static-black-outline-not-secondary-background-color-hover: var(
+    --system-button-static-black-secondary-outline-background-color-default: var(
+        --spectrum-transparent-black-800
+    );
+    --system-button-static-black-secondary-outline-background-color-hover: var(
         --spectrum-transparent-black-300
     );
-    --system-button-static-black-outline-not-secondary-background-color-down: var(
+    --system-button-static-black-secondary-outline-background-color-down: var(
         --spectrum-transparent-black-400
     );
-    --system-button-static-black-outline-not-secondary-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-outline-not-secondary-content-color-default: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-content-color-hover: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-content-color-down: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-content-color-focus: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-border-color-default: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-outline-not-secondary-border-color-hover: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-outline-not-secondary-border-color-down: var(
-        --spectrum-transparent-black-600
-    );
-    --system-button-static-black-outline-not-secondary-border-color-focus: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-outline-secondary-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-outline-secondary-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-outline-secondary-background-color-focus: var(
+    --system-button-static-black-secondary-outline-background-color-focus: var(
         --spectrum-transparent-black-300
     );
     --system-checkbox-control-color-default: var(--spectrum-gray-800);

--- a/tools/styles/tokens/spectrum/system-theme-bridge.css
+++ b/tools/styles/tokens/spectrum/system-theme-bridge.css
@@ -191,15 +191,9 @@
     --system-button-secondary-background-color-default: var(
         --spectrum-gray-200
     );
-    --system-button-secondary-not-outline-background-color-hover: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-not-outline-background-color-down: var(
-        --spectrum-gray-400
-    );
-    --system-button-secondary-not-outline-background-color-focus: var(
-        --spectrum-gray-300
-    );
+    --system-button-secondary-background-color-hover: var(--spectrum-gray-300);
+    --system-button-secondary-background-color-down: var(--spectrum-gray-400);
+    --system-button-secondary-background-color-focus: var(--spectrum-gray-300);
     --system-button-secondary-outline-background-color-hover: var(
         --spectrum-gray-300
     );
@@ -211,6 +205,9 @@
     );
     --system-button-secondary-outline-border-color-default: var(
         --spectrum-gray-300
+    );
+    --system-button-secondary-outline-border-color-down: var(
+        --spectrum-gray-500
     );
     --system-button-static-white-background-color-default: var(
         --spectrum-transparent-white-800
@@ -228,6 +225,42 @@
     --system-button-static-white-content-color-hover: var(--spectrum-black);
     --system-button-static-white-content-color-down: var(--spectrum-black);
     --system-button-static-white-content-color-focus: var(--spectrum-black);
+    --system-button-static-white-outline-background-color-default: var(
+        --spectrum-transparent-white-25
+    );
+    --system-button-static-white-outline-background-color-hover: var(
+        --spectrum-transparent-white-300
+    );
+    --system-button-static-white-outline-background-color-down: var(
+        --spectrum-transparent-white-400
+    );
+    --system-button-static-white-outline-background-color-focus: var(
+        --spectrum-transparent-white-300
+    );
+    --system-button-static-white-outline-content-color-default: var(
+        --spectrum-white
+    );
+    --system-button-static-white-outline-content-color-hover: var(
+        --spectrum-white
+    );
+    --system-button-static-white-outline-content-color-down: var(
+        --spectrum-white
+    );
+    --system-button-static-white-outline-content-color-focus: var(
+        --spectrum-white
+    );
+    --system-button-static-white-outline-border-color-default: var(
+        --spectrum-transparent-white-800
+    );
+    --system-button-static-white-outline-border-color-hover: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-outline-border-color-down: var(
+        --spectrum-transparent-white-900
+    );
+    --system-button-static-white-outline-border-color-focus: var(
+        --spectrum-transparent-white-900
+    );
     --system-button-static-white-secondary-background-color-default: var(
         --spectrum-transparent-white-200
     );
@@ -264,46 +297,16 @@
     --system-button-static-white-secondary-outline-border-color-focus: var(
         --spectrum-transparent-white-400
     );
-    --system-button-static-white-outline-not-secondary-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-outline-not-secondary-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-outline-not-secondary-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-outline-not-secondary-content-color-default: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-content-color-down: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-content-color-focus: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-not-secondary-border-color-default: var(
+    --system-button-static-white-secondary-outline-background-color-default: var(
         --spectrum-transparent-white-800
     );
-    --system-button-static-white-outline-not-secondary-border-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-not-secondary-border-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-not-secondary-border-color-focus: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-secondary-background-color-hover: var(
+    --system-button-static-white-secondary-outline-background-color-hover: var(
         --spectrum-transparent-white-300
     );
-    --system-button-static-white-outline-secondary-background-color-down: var(
+    --system-button-static-white-secondary-outline-background-color-down: var(
         --spectrum-transparent-white-400
     );
-    --system-button-static-white-outline-secondary-background-color-focus: var(
+    --system-button-static-white-secondary-outline-background-color-focus: var(
         --spectrum-transparent-white-300
     );
     --system-button-static-black-background-color-default: var(
@@ -322,6 +325,42 @@
     --system-button-static-black-content-color-hover: var(--spectrum-white);
     --system-button-static-black-content-color-down: var(--spectrum-white);
     --system-button-static-black-content-color-focus: var(--spectrum-white);
+    --system-button-static-black-outline-background-color-default: var(
+        --spectrum-transparent-black-25
+    );
+    --system-button-static-black-outline-background-color-hover: var(
+        --spectrum-transparent-black-300
+    );
+    --system-button-static-black-outline-background-color-down: var(
+        --spectrum-transparent-black-400
+    );
+    --system-button-static-black-outline-background-color-focus: var(
+        --spectrum-transparent-black-300
+    );
+    --system-button-static-black-outline-content-color-default: var(
+        --spectrum-black
+    );
+    --system-button-static-black-outline-content-color-hover: var(
+        --spectrum-black
+    );
+    --system-button-static-black-outline-content-color-down: var(
+        --spectrum-black
+    );
+    --system-button-static-black-outline-content-color-focus: var(
+        --spectrum-black
+    );
+    --system-button-static-black-outline-border-color-default: var(
+        --spectrum-transparent-black-400
+    );
+    --system-button-static-black-outline-border-color-hover: var(
+        --spectrum-transparent-black-500
+    );
+    --system-button-static-black-outline-border-color-down: var(
+        --spectrum-transparent-black-600
+    );
+    --system-button-static-black-outline-border-color-focus: var(
+        --spectrum-transparent-black-500
+    );
     --system-button-static-black-secondary-background-color-default: var(
         --spectrum-transparent-black-200
     );
@@ -346,15 +385,6 @@
     --system-button-static-black-secondary-content-color-focus: var(
         --spectrum-black
     );
-    --system-button-static-black-secondary-outline-background-color-hover: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-background-color-down: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-secondary-outline-background-color-focus: var(
-        --spectrum-transparent-black-400
-    );
     --system-button-static-black-secondary-outline-border-color-default: var(
         --spectrum-transparent-black-300
     );
@@ -367,46 +397,16 @@
     --system-button-static-black-secondary-outline-border-color-focus: var(
         --spectrum-transparent-black-400
     );
-    --system-button-static-black-outline-not-secondary-background-color-hover: var(
+    --system-button-static-black-secondary-outline-background-color-default: var(
+        --spectrum-transparent-black-800
+    );
+    --system-button-static-black-secondary-outline-background-color-hover: var(
         --spectrum-transparent-black-300
     );
-    --system-button-static-black-outline-not-secondary-background-color-down: var(
+    --system-button-static-black-secondary-outline-background-color-down: var(
         --spectrum-transparent-black-400
     );
-    --system-button-static-black-outline-not-secondary-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-outline-not-secondary-content-color-default: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-content-color-hover: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-content-color-down: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-content-color-focus: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-not-secondary-border-color-default: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-outline-not-secondary-border-color-hover: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-outline-not-secondary-border-color-down: var(
-        --spectrum-transparent-black-600
-    );
-    --system-button-static-black-outline-not-secondary-border-color-focus: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-outline-secondary-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-outline-secondary-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-outline-secondary-background-color-focus: var(
+    --system-button-static-black-secondary-outline-background-color-focus: var(
         --spectrum-transparent-black-300
     );
     --system-checkbox-control-color-default: var(--spectrum-gray-600);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6976,9 +6976,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@spectrum-css/button@npm:14.1.1":
-  version: 14.1.1
-  resolution: "@spectrum-css/button@npm:14.1.1"
+"@spectrum-css/button@npm:14.1.6":
+  version: 14.1.6
+  resolution: "@spectrum-css/button@npm:14.1.6"
   peerDependencies:
     "@spectrum-css/icon": ">=9.0.0 <10.0.0"
     "@spectrum-css/progresscircle": ">=5.0.0 <6.0.0"
@@ -6990,7 +6990,7 @@ __metadata:
       optional: true
     "@spectrum-css/tokens":
       optional: true
-  checksum: 10c0/b05affa64a8188e43e929180205315576ab9704647308c2313fbaad6480d50edf34e7f0ce9ac4066a4772c2e6df09896246186360ad5ce0facb0e4221936d9d3
+  checksum: 10c0/f30cf3f4f0f40ba998d5c659b4602f5755a21b2b273003734cfa814851753722518301681f814d7d436cd4176e44be7af055fad45ef866d144acad32a829adb2
   languageName: node
   linkType: hard
 
@@ -8093,7 +8093,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@spectrum-web-components/button@workspace:packages/button"
   dependencies:
-    "@spectrum-css/button": "npm:14.1.1"
+    "@spectrum-css/button": "npm:14.1.6"
     "@spectrum-web-components/base": "npm:1.4.0"
     "@spectrum-web-components/clear-button": "npm:1.4.0"
     "@spectrum-web-components/close-button": "npm:1.4.0"


### PR DESCRIPTION
## Description

This update aims to simplify `--mod-*` access by ensuring local variants and states aren't hooking into those custom properties for overrides. This updates all local variants and states to override the `--spectrum-button-*` properties instead and adjusts the specificity to ensure no regressions in rendered results.

This also involves pulling in the fixes from the previous 2 releases as well:

From [@spectrum-css/button v14.1.3](https://www.npmjs.com/package/@spectrum-css/button/v/14.1.3): [#3613](https://github.com/adobe/spectrum-css/pull/3613)

Adjusts static color buttons to more closely resemble the S2 specifications. There are no expected changes to non-static button variants in S2, and no expected changes to other themes.

This PR includes changes to:

-   Static white primary button (outline variant), static white secondary button (fill variant), static black primary button (outline variant), static black secondary button (fill variant)
-   Static white secondary button (outline variant) and static black secondary button (outline variant) border and background colors
-   Static color buttons' content color
-   Static white primary button (fill variant) and static black primary button (fill variant) background colors

From [@spectrum-css/button v14.1.2](https://www.npmjs.com/package/@spectrum-css/button/v/14.1.2): [#​3600](https://github.com/adobe/spectrum-css/pull/3600)

Adjust border colors for static black and static white outline buttons, primary variant to match S2 specifications.

## Screenshots

This overlay test case actually failed in a previous update but was committed as a baseline and now it's passing again! It verifies that the --mod passthroughs on button are working:

<img width="708" alt="Screenshot 2025-04-10 at 3 22 37 PM" src="https://github.com/user-attachments/assets/0e9541ca-ac9c-4c63-93e1-badce14714f4" />

## How has this been tested?

-   [x] Expect the background color of all buttons in the group to update to hotpink.
    1. Go to the [button group](https://fix-button-upgrade-latest-css--spectrum-wc.netlify.app/storybook/?path=/story/button-group--buttons)
    2. At the sp-theme element, add the following CSS to the inspector: `--mod-button-background-color-default: hotpink;`

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [n/a] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
