### PR TITLE
chore(tabs): update access modifiers, changedProperties type

### DIFF
--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -15,7 +15,6 @@ import {
     CSSResult,
     CSSResultArray,
     html,
-    PropertyValueMap,
     PropertyValues,
     SizedMixin,
     TemplateResult,
@@ -161,7 +160,7 @@ export class Tabs extends SizedMixin(Focusable, { noDefaultSize: true }) {
     private slotEl!: HTMLSlotElement;
 
     @query('#list')
-    private tabList!: HTMLDivElement;
+    protected tabList!: HTMLDivElement;
 
     @property({ reflect: true })
     selected = '';
@@ -178,7 +177,7 @@ export class Tabs extends SizedMixin(Focusable, { noDefaultSize: true }) {
         this.rovingTabindexController.clearElementCache();
     }
 
-    private get tabs(): Tab[] {
+    protected get tabs(): Tab[] {
         return this._tabs;
     }
 
@@ -300,7 +299,7 @@ export class Tabs extends SizedMixin(Focusable, { noDefaultSize: true }) {
         return complete;
     }
 
-    private getNecessaryAutoScroll(index: number): number {
+    protected getNecessaryAutoScroll(index: number): number {
         const selectedTab = this.tabs[index];
         const selectionEnd = selectedTab.offsetLeft + selectedTab.offsetWidth;
         const viewportEnd = this.tabList.scrollLeft + this.tabList.offsetWidth;
@@ -350,9 +349,7 @@ export class Tabs extends SizedMixin(Focusable, { noDefaultSize: true }) {
         }
     }
 
-    protected override updated(
-        changedProperties: PropertyValueMap<this>
-    ): void {
+    protected override updated(changedProperties: PropertyValues<this>): void {
         super.updated(changedProperties);
 
         if (changedProperties.has('selected')) {

--- a/packages/tabs/src/TabsOverflow.ts
+++ b/packages/tabs/src/TabsOverflow.ts
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
-    PropertyValueMap,
     PropertyValues,
     SizedMixin,
     SpectrumElement,
@@ -101,7 +100,7 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
         this._updateScrollState();
     }
 
-    private _updateScrollState(): void {
+    protected _updateScrollState(): void {
         const { scrollContent, overflowState } = this;
 
         if (scrollContent) {
@@ -132,9 +131,7 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
         tabsElement.scrollTabs(left, 'smooth');
     }
 
-    protected override updated(
-        changedProperties: PropertyValueMap<this>
-    ): void {
+    protected override updated(changedProperties: PropertyValues<this>): void {
         super.updated(changedProperties);
         if (changedProperties.has('dir')) {
             this._updateScrollState();


### PR DESCRIPTION
## Description

Changes the access modifiers for some properties of Tabs and TabsOverflow. Also updates the deprecated type of `changedProperties` to `PropertyValues`.

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/5368
- https://github.com/adobe/spectrum-web-components/issues/5369

## Motivation and context

Child classes extending from Tabs and TabsOverflow can access previously guarded properties of the parent class.
`PropertyValueMap` is deprecated by Lit, and `PropertyValues` is preferred ([Lit docs](https://lit.dev/docs/components/lifecycle/#typescript-types-for-changedproperties)).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_

    1. Go here
    2. Do this

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
