### PR TITLE
Nikkimk/number field docs

### DIFF
--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -1,4 +1,4 @@
-## Description
+## Overview
 
 `<sp-number-field>` elements are used for numeric inputs. Upon interaction via the <kbd>ArrowUp</kbd> or <kbd>ArrowDown</kbd> keys, the scroll wheel, or the stepper UI, when not hidden by the `hide-stepper` attribute, the input value incrementally increases or decreases by the value of the `step` attribute. The <kbd>shift</kbd> key can be used to apply steps at 10 time (or the value of the `step-modifier` attribute times) their normal rate.
 
@@ -24,7 +24,28 @@ When looking to leverage the `NumberField` base class as a type and/or for exten
 import { NumberField } from '@spectrum-web-components/number-field';
 ```
 
-## Sizes
+### Anatomy
+
+A number field consists of an input field for numeric values and optional stepper buttons for incrementing and decrementing the value. The stepper UI can be hidden using the `hide-stepper` attribute.
+
+```html
+<sp-field-label>
+    What is the air-speed velocity of an unladen swallow?
+</sp-field-label>
+<sp-number-field
+    id="anatomy"
+    style="width: 400px"
+    format-options='{
+        "style": "unit",
+        "unit": "MPH",
+        "unitDisplay": "long"
+    }'
+></sp-number-field>
+```
+
+### Options
+
+#### Sizes
 
 <sp-tabs selected="m" auto label="Size Attribute Options">
 <sp-tab value="s">Small</sp-tab>
@@ -35,7 +56,7 @@ import { NumberField } from '@spectrum-web-components/number-field';
     label="Size"
     value="1024"
     size="s"
-    style="--spectrum-stepper-width: 85px"
+    style="--spectrum-stepper-width: 170px"
 ></sp-number-field>
 ```
 
@@ -48,7 +69,7 @@ import { NumberField } from '@spectrum-web-components/number-field';
     label="Size"
     value="1024"
     size="m"
-    style="--spectrum-stepper-width: 110px"
+    style="--spectrum-stepper-width: 220px"
 ></sp-number-field>
 ```
 
@@ -61,7 +82,7 @@ import { NumberField } from '@spectrum-web-components/number-field';
     label="Size"
     value="1024"
     size="l"
-    style="--spectrum-stepper-width: 135px"
+    style="--spectrum-stepper-width: 270px"
 ></sp-number-field>
 ```
 
@@ -74,20 +95,22 @@ import { NumberField } from '@spectrum-web-components/number-field';
     label="Size"
     value="1024"
     size="xl"
-    style="--spectrum-stepper-width: 160px"
+    style="--spectrum-stepper-width: 320px"
 ></sp-number-field>
 ```
 
 </sp-tab-panel>
 </sp-tabs>
 
-## Number formatting
+#### Formatting
 
 An `<sp-number-field>` element will process its numeric value with `new Intl.NumberFormat(this.resolvedLanguage, this.formatOptions).format(this.value)` in order to prepare it for visual delivery in the input. In order to customize this processing supply your own `Intl.NumberFormatOptions` via the `formatOptions` property, or `format-options` attribute as seen below.
 
 `this.resolvedLanguage` represents the language in which the `<sp-number-field>` element is currently being delivered. By default, this value will represent the language established by the `lang` attribute on the root `<html>` element while falling back to `navigator.language` when that is not present. This value can be customized via a language context provided by a parent element that listens for the `sp-language-context` event and supplies update language settings to the `callback` function contained therein. Applications leveraging the [`<sp-theme>`](./components/theme) element to manage the visual delivery or text direction of their content will be also be provided a reactive context for supplying language information to its descendants.
 
-### Decimals
+<sp-tabs selected="decimals" auto label="Number Formatting">
+<sp-tab value="decimals">Decimals</sp-tab>
+<sp-tab-panel value="decimals">
 
 The following example uses the `signDisplay` option to include the plus sign for positive numbers, for example to display an offset from some value. In addition, it always displays a minimum of 1 digit after the decimal point, and allows up to 2 fraction digits. If the user enters more than 2 fraction digits, the result will be rounded.
 
@@ -96,7 +119,7 @@ The following example uses the `signDisplay` option to include the plus sign for
 <sp-number-field
     id="decimals"
     value="0"
-    style="width: 100px"
+    style="width: 200px"
     format-options='{
         "signDisplay": "exceptZero",
         "minimumFractionDigits": 1,
@@ -105,7 +128,9 @@ The following example uses the `signDisplay` option to include the plus sign for
 ></sp-number-field>
 ```
 
-### Percentages
+</sp-tab-panel>
+<sp-tab value="percentages">Percentages</sp-tab>
+<sp-tab-panel value="percentages">
 
 The `style: 'percent'` option can be passed to the `formatOptions` property to treat the value as a percentage. In this mode, the value is multiplied by 100 before it is displayed, i.e. `0.45` is displayed as "45%". The reverse is also true: when the user enters a value, the `change` event will be triggered with the entered value divided by 100. When the percent option is enabled, the default step automatically changes to 0.01 such that incrementing and decrementing occurs by 1%. This can be overridden with the step property.
 
@@ -113,7 +138,7 @@ The `style: 'percent'` option can be passed to the `formatOptions` property to t
 <sp-field-label for="percents">Sales tax</sp-field-label>
 <sp-number-field
     id="percents"
-    style="width: 200px"
+    style="width: 400px"
     value="0.05"
     format-options='{
         "style": "percent"
@@ -121,7 +146,9 @@ The `style: 'percent'` option can be passed to the `formatOptions` property to t
 ></sp-number-field>
 ```
 
-### Currency values
+</sp-tab-panel>
+<sp-tab value="currency">Currency values</sp-tab>
+<sp-tab-panel value="currency">
 
 The `style: 'currency'` option can be passed to the `formatOptions` property to treat the value as a currency value. The `currency` option must also be passed to set the currency code (e.g. `USD`) to use. In addition, the `currencyDisplay` option can be used to choose whether to display the currency `symbol`, currency `code`, or currency `name`. Finally, the `currencySign` option can be set to `accounting` to use accounting notation for negative numbers, which uses parentheses rather than a minus sign in some locales.
 
@@ -131,7 +158,7 @@ If you need to allow the user to change the currency, you should include a separ
 <sp-field-label for="currency">Transaction amount</sp-field-label>
 <sp-number-field
     id="currency"
-    style="width: 200px"
+    style="width: 400px"
     value="45"
     format-options='{
         "style": "currency",
@@ -142,7 +169,9 @@ If you need to allow the user to change the currency, you should include a separ
 ></sp-number-field>
 ```
 
-### Units
+</sp-tab-panel>
+<sp-tab value="units">Units</sp-tab>
+<sp-tab-panel value="units">
 
 The `style: 'unit'` option can be passed to the `formatOptions` property to format the value with a unit of measurement. The `unit` option must also be passed to set which unit to use (e.g. `inch`). In addition, the `unitDisplay` option can be used to choose whether to display the unit in `long`, `short`, or `narrow` format.
 
@@ -154,7 +183,7 @@ Note: The unit style is not currently supported in Safari. A [polyfill](https://
 <sp-field-label for="units">Package width</sp-field-label>
 <sp-number-field
     id="units"
-    style="width: 200px"
+    style="width: 400px"
     value="4"
     format-options='{
         "style": "unit",
@@ -164,7 +193,9 @@ Note: The unit style is not currently supported in Safari. A [polyfill](https://
 ></sp-number-field>
 ```
 
-### Units not included in `Intl.NumberFormatOptions`
+</sp-tab-panel>
+<sp-tab value="custom-units">Custom Units</sp-tab>
+<sp-tab-panel value="custom-units">
 
 While `Intl.NumberFormatOptions` does support a [wide range of units](https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier), it is possible to encounter units (e.g. the graphics units of `pixel`, `pixels`, `points`, etc.) that are not supported therein. When this occurs, an `<sp-number-field>` element will attempt to polyfill support for this unit. See the following example delivering `{ style: "unit", unit: "px" }` below:
 
@@ -172,7 +203,7 @@ While `Intl.NumberFormatOptions` does support a [wide range of units](https://tc
 <sp-field-label for="units">Document width in pixels</sp-field-label>
 <sp-number-field
     id="units"
-    style="width: 200px"
+    style="width: 400px"
     value="500"
     format-options='{
         "style": "unit",
@@ -183,7 +214,9 @@ While `Intl.NumberFormatOptions` does support a [wide range of units](https://tc
 
 Note: the polyfilling done here is very simplistic and is triggered by supplying options that would otherwise cause the `Intl.NumberFormat()` call to throw an error. Once the unsupporting unit of `px` causes the construction of the object to throw, a back up formatter/parser pair will be created without the supplied unit data. When the `style` is set to `unit`, the `unit` value of will be adopted as the _static_ unit display. This means that neither pluralization or translation will be handled within the `<sp-number-field>` element itself. If pluralization or translation is important to the delivered interface, please be sure to handle passing those strings into to element via the `formatOptions` property reactively to the value of the element or locale of that page in question.
 
-## Minimum and maximum values
+</sp-tab-panel>
+<sp-tab value="min-max">Minimum and maximum values</sp-tab>
+<sp-tab-panel value="min-max">
 
 The `max` and `max` properties can be used to limit the entered value to a specific range. The value will be clamped when the user commits the value to the `<sp-number-field>` element. In addition, the increment and decrement buttons will be disabled when the value is within one step value from the bounds. Ranges can be open ended by only providing a value for either `min` or `max` rather than both.
 
@@ -194,7 +227,9 @@ If a valid range is known ahead of time, it is a good idea to provide it to `<sp
 <sp-number-field id="red" value="4" min="0" max="255"></sp-number-field>
 ```
 
-## Step values
+</sp-tab-panel>
+<sp-tab value="step">Step values</sp-tab>
+<sp-tab-panel value="step">
 
 The step prop can be used to snap the value to certain increments. If there is a `min` defined, the steps are calculated starting from that minimum value. For example, if `min === 2`, and `step === 3`, the valid step values would be 2, 5, 8, 11, etc. If no `min` is defined, the steps are calculated starting from zero and extending in both directions. In other words, such that the values are evenly divisible by the step. A step can be any positive decimal. If no step is defined, any decimal value may be typed, but incrementing and decrementing snaps the value to an integer.
 
@@ -230,11 +265,99 @@ If the user types a value that is between two steps and blurs the input, the val
 ></sp-number-field>
 ```
 
-## Default value
+</sp-tab-panel>
+</sp-tabs>
+
+### States
+
+#### Invalid
+
+The `invalid` attribute indicates that the number field's value is invalid. When set, appropriate ARIA attributes will be automatically applied.
+
+```html
+<sp-field-label for="invalid">
+    It's one banana, Michael, how much could it cost?
+</sp-field-label>
+<sp-number-field
+    id="invalid"
+    invalid
+    style="width: 400px"
+    value="10"
+    min="0"
+    max="0.3"
+    step="0.01"
+    format-options='{
+        "style": "currency",
+        "currency": "USD",
+        "currencyDisplay": "code",
+        "currencySign": "accounting",
+        "minimumFractionDigits": 2,
+        "maximumFractionDigits": 2
+    }'
+></sp-number-field>
+```
+
+#### Valid
+
+The `valid` attribute indicates that the number field's value is valid.
+
+```html
+<sp-field-label for="valid">
+    It's one banana, Michael, how much could it cost?
+</sp-field-label>
+<sp-number-field
+    id="invalid"
+    valid
+    style="width: 400px"
+    value="0.23"
+    min="0"
+    max="0.3"
+    step="0.01"
+    format-options='{
+        "style": "currency",
+        "currency": "USD",
+        "currencyDisplay": "code",
+        "currencySign": "accounting",
+        "minimumFractionDigits": 2,
+        "maximumFractionDigits": 2
+    }'
+></sp-number-field>
+```
+
+#### Required
+
+The `required` attribute sets the number field to an indeterminate state, visually distinct from both checked and unchecked states.
+
+```html
+<sp-field-label for="required" required>Number of tickets</sp-field-label>
+<sp-number-field id="required" required></sp-number-field>
+```
+
+#### Disabled
+
+The `disabled` attribute prevents the number field from receiving focus or events. The number field will appear faded.
+
+```html
+<sp-field-label for="disabled">Number of tickets</sp-field-label>
+<sp-number-field id="disabled" disabled value="0"></sp-number-field>
+```
+
+#### Read-only
+
+number fieldes have a `readonly` attribute for when they’re in the disabled state but still need their labels to be shown. This allows for content to be copied, but not interacted with or changed.
+
+```html
+<sp-field-label for="readonly">Number of tickets</sp-field-label>
+<sp-number-field id="readonly" readonly value="0"></sp-number-field>
+```
+
+### Behaviors
+
+#### Default value
 
 The `<sp-number-field>` component doesn't manage a default value by itself. This means that consumers can set the value of the number-field as an empty string by clearing the input. If we want the number-field to reset to a `default-value` when the user clears the input, we can listen for the `change` event on the number-field component and set its value to the desired `default-value` if the input is empty.
 
-```html-live
+```html
 <sp-field-label for="default">
     Default value of this number field is 42
 </sp-field-label>
@@ -245,6 +368,7 @@ The `<sp-number-field>` component doesn't manage a default value by itself. This
         const numberField = document.querySelector('#default');
 
         numberField.addEventListener('change', (event) => {
+            alert('change');
             const target = event.target;
             if (isNaN(target.value)) {
                 target.value = '42';
@@ -252,14 +376,37 @@ The `<sp-number-field>` component doesn't manage a default value by itself. This
         });
     });
 </script>
-
 ```
+
+### Accessibility
+
+#### Labels
+
+Every number field must have a label that clearly describes its purpose. The label can be provided either via the `label` attribute or with an associated `<sp-field-label>` element.
+
+#### Keyboard Navigation
+
+Number fields support the following keyboard interactions:
+
+-   <kbd>ArrowUp</kbd> and <kbd>ArrowDown</kbd> keys increment and decrement the value
+-   <kbd>Shift</kbd> + <kbd>ArrowUp</kbd> or <kbd>ArrowDown</kbd> applies steps at 10 times (or the value of `step-modifier`) the normal rate
+-   The scroll wheel can be used to increment and decrement the value when focused
+
+#### Help Text
+
+Consider providing help text to explain:
+
+-   The expected format of the input
+-   Any minimum or maximum values
+-   The meaning of units or special formatting (e.g., currency, percentages)
+-   Step increments if they differ from the default
 
 <script type="module">
     customElements.whenDefined('sp-number-field').then(() => {
         const numberField = document.querySelector('#default');
 
         numberField.addEventListener('change', (event) => {
+            alert('change');
             const target = event.target;
             if (isNaN(target.value)) {
                 target.value = '42';

--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -338,7 +338,7 @@ The `required` attribute sets the number field to an indeterminate state, visual
 The `disabled` attribute prevents the number field from receiving focus or events. The number field will appear faded.
 
 ```html
-<sp-field-label for="disabled">Number of tickets</sp-field-label>
+<sp-field-label for="disabled" disabled>Number of tickets</sp-field-label>
 <sp-number-field id="disabled" disabled value="0"></sp-number-field>
 ```
 

--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -295,6 +295,9 @@ The `invalid` attribute indicates that the number field's value is invalid. When
         "maximumFractionDigits": 2
     }'
 ></sp-number-field>
+<sp-help-text variant="negative">
+    Value should be between $0 and $0.3.
+</sp-help-text>
 ```
 
 #### Valid
@@ -330,7 +333,8 @@ The `required` attribute sets the number field to an indeterminate state, visual
 
 ```html
 <sp-field-label for="required" required>Number of tickets</sp-field-label>
-<sp-number-field id="required" required></sp-number-field>
+<sp-number-field id="required" required default="0"></sp-number-field>
+<sp-help-text>Number of tickets is required.</sp-help-text>
 ```
 
 #### Disabled


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improving the accessibility documentation of components.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- SWC-390

## Motivation and context

Documentation should provide more information and examples that demonstrate how to use the components accessibly. 

## How has this been tested?

Review [number-field docs](https://nikkimk-number-field-docs--spectrum-wc.netlify.app/components/number-field/)

-  [x] Do the docs examples give enough context to test for accessibility?
-  [x] Do the docs examples and text provide information on how to use the component accessibly?
-  [x] If the component is to be used in the context of another component, do the examples include how that component is used accessibly in that context?
-  [x] Are the docs headings logical and consistent across these components? You can use the [WAVE browser extension's](https://wave.webaim.org/extension/) **Structure** tab to review heading structure.

-   [x] Did it pass in Desktop?
-   [x] Did it pass in Mobile?
-   [x] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
