### PR TITLE
style(tabs): added sp-tabs-overflow mod tokens

### DIFF
--- a/.changeset/rotten-seals-sniff.md
+++ b/.changeset/rotten-seals-sniff.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/tabs': patch
+---
+
+feat(tabs): add customization tokens for overflow button positioning and shadow

--- a/packages/tabs/src/tabs-overflow.css
+++ b/packages/tabs/src/tabs-overflow.css
@@ -14,11 +14,13 @@ governing permissions and limitations under the License.
     inset: 0;
     width: 100%;
 
-    --sp-tabs-overflow-next-button-right: calc(
-        -1 * var(--spectrum-component-edge-to-text-100)
+    --sp-tabs-overflow-next-button-right: var(
+        --mod-sp-tabs-overflow-next-button-right,
+        calc(-1 * var(--spectrum-component-edge-to-text-100))
     );
-    --sp-tabs-overflow-previous-button-left: calc(
-        -1 * var(--spectrum-component-edge-to-text-100)
+    --sp-tabs-overflow-previous-button-left: var(
+        --mod-sp-tabs-overflow-previous-button-left,
+        calc(-1 * var(--spectrum-component-edge-to-text-100))
     );
     --sp-tabs-overflow-button-height: calc(
         var(--spectrum-tab-item-height-medium) -
@@ -26,7 +28,10 @@ governing permissions and limitations under the License.
     );
     --sp-tabs-overflow-button-size: var(--spectrum-tab-item-height-medium);
     --sp-tabs-overflow-icon-color: var(--spectrum-gray-800);
-    --sp-tabs-overflow-shadow-color: var(--spectrum-gray-100);
+    --sp-tabs-overflow-shadow-color: var(
+        --mod-sp-tabs-overflow-shadow-color,
+        var(--spectrum-gray-100)
+    );
     --sp-tabs-overflow-shadow-width: 50px;
     --mod-actionbutton-icon-size: var(--spectrum-workflow-icon-size-100);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds some --mod tokens to the sp-tabs-overflow component's styles to allow further customization.

Added --mod tokens to allow customization of:
- Tabs Overflow next button position (`--mod-sp-tabs-overflow-next-button-right`)
- Tabs Overflow previous button position (`--mod-sp-tabs-overflow-previous-button-left`)
- Tabs Overflow shadow color (`--mod-sp-tabs-overflow-shadow-color`)

## Related issue(s)

- N/A

## Motivation and context

With the current styling, this can have an undesired look when the sp-tabs-overflow element does not ocupy the whole width of the parent. 
<img width="356" alt="Screenshot 2025-04-22 at 10 04 35" src="https://github.com/user-attachments/assets/97aed236-3870-4f3b-9825-acbe1398cb94" />

The change will allow for looks similar to this one (see that the gradient fades into the background)
![Screenshot 2025-04-22 at 10 05 39](https://github.com/user-attachments/assets/ba1760a2-6185-48ea-a9c2-97ff7a0be56d)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
