### PR TITLE
chore: correct package name in changeset

### DIFF
--- a/.changeset/stale-candies-camp.md
+++ b/.changeset/stale-candies-camp.md
@@ -1,6 +1,6 @@
 ---
 '@spectrum-web-components/close-button': patch
-'@spectrum-web-components/drop-zone': patch
+'@spectrum-web-components/dropzone': patch
 '@spectrum-web-components/illustrated-message': patch
 '@spectrum-web-components/menu': patch
 '@spectrum-web-components/status-light': patch


### PR DESCRIPTION
## Description

Package name was mistyped in the changes: https://github.com/adobe/spectrum-web-components/actions/runs/14597650232/job/40947560598

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
