### PR TITLE
test(action-group): fix flaky test

### DIFF
--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -54,6 +54,7 @@ import { sendMouse } from '../../../test/plugins/browser.js';
 import { HasActionMenuAsChild } from '../stories/action-group.stories.js';
 import '../stories/action-group.stories.js';
 import sinon from 'sinon';
+import { isWebKit } from '@spectrum-web-components/shared';
 
 class QuietActionGroup extends LitElement {
     protected override render(): TemplateResult {
@@ -355,8 +356,13 @@ describe('ActionGroup', () => {
         expect(actionMenu).to.equal(document.activeElement);
         const closed = oneEvent(el.children[3] as ActionMenu, 'sp-closed');
 
-        // use keyboard to navigate to the second menu item and select it
-        await sendKeys({ press: 'ArrowDown' });
+        if (isWebKit()) {
+            // focus on the first menu item as not all items are keyboard focusable in Safari bu default
+            actionMenu.optionsMenu.focus();
+        } else {
+            // use keyboard to navigate to the second menu item and select it
+            await sendKeys({ press: 'ArrowDown' });
+        }
         expect(actionMenu.children[0]).to.equal(document.activeElement);
         await sendKeys({ press: 'Enter' });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Actual behavior
`action-group with action-menu manages tabIndex correctly while using mouse` times out on Webkit because [not all elements are keyboard focusable on Webkit by default](https://www.scottohara.me/blog/2014/10/03/link-tabbing-firefox-osx.html).

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- 5396

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] From terminal
    1. `yarn test:focus action-group`
    2. Notice the test passes.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
