### PR TITLE
docs(dialog): updated dialog docs for accessbility

### DIFF
--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -1,4 +1,4 @@
-## Description
+## Overview
 
 `sp-dialog` displays important information that users need to acknowledge. They appear over the interface and block further interactions. When used directly the `sp-dialog` element surfaces a `slot` based API for deep customization of the content to be included in the overlay.
 
@@ -8,23 +8,50 @@
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/dialog?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/dialog)
 [![Try it on webcomponents.dev](https://img.shields.io/badge/Try%20it%20on-webcomponents.dev-green?style=for-the-badge)](https://webcomponents.dev/edit/collection/fO75441E1Q5ZlI0e9pgq/RSDikStPmUPSioVpCsYb/src/index.ts)
 
-```
+```bash
 yarn add @spectrum-web-components/dialog
 ```
 
 Import the side effectful registration of `<sp-dialog>` via:
 
-```
+```ts
 import '@spectrum-web-components/dialog/sp-dialog.js';
 ```
 
 When looking to leverage the `Dialog` base class as a type and/or for extension purposes, do so via:
 
-```
+```ts
 import { Dialog } from '@spectrum-web-components/dialog';
 ```
 
-## Sizes
+### Anatomy
+
+The dialog consists of several key parts:
+
+-   A heading (via `slot="heading"`)
+-   Content (via default slot)
+-   Optional hero content (via `slot="hero"`)
+-   Optional buttons (via `slot="button"`)
+-   Optional footer content (via `slot="footer"`)
+-   Optional dismiss button (via `dismissable` attribute)
+
+```html
+<sp-dialog size="s">
+    <div
+        slot="hero"
+        style="background-image: url(https://picsum.photos/1400/260)"
+    ></div>
+    <h2 slot="heading">Disclaimer</h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua.
+    <div slot="footer">Footer information</div>
+    <sp-button slot="button">Button</sp-button>
+</sp-dialog>
+```
+
+### Options
+
+#### Sizes
 
 <sp-tabs selected="m" auto label="Size Attribute Options">
 <sp-tab value="s">Small</sp-tab>
@@ -89,16 +116,14 @@ import { Dialog } from '@spectrum-web-components/dialog';
 </sp-tab-panel>
 </sp-tabs>
 
-## Variants
-
-### Dismissable
+#### Dismissable
 
 When supplied with the `dissmissable` attribute an `<sp-dialog>` element will surface a "close" button afordance that will dispatch a DOM event with the name of `close` when pressed.
 
 Note: the `dissmissable` attribute will not be followed when `mode="fullscreen"` or `mode="fullscreenTakeover"` are applies in accordance with the Spectrum specification.
 
 ```html
-<sp-dialog size="m" dismissable>
+<sp-dialog dismissable>
     <h2 slot="heading">Disclaimer</h2>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
@@ -113,10 +138,10 @@ Note: the `dissmissable` attribute will not be followed when `mode="fullscreen"`
 </sp-dialog>
 ```
 
-### No Divider
+#### No Divider
 
 ```html
-<sp-dialog size="m" dismissable no-divider>
+<sp-dialog dismissable no-divider>
     <h2 slot="heading">Disclaimer</h2>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
@@ -131,24 +156,67 @@ Note: the `dissmissable` attribute will not be followed when `mode="fullscreen"`
 </sp-dialog>
 ```
 
-### Hero
+### Behaviors
+
+Use the dialog with an overlay to create a dialog that appears over the current page. The dialog manages several behaviors:
+
+1. Animation of the dialog content when opening/closing
+2. Focus management when the dialog opens
+3. Event handling for closing the dialog
 
 ```html
-<sp-dialog size="medium" dismissable no-divider>
-    <div
-        slot="hero"
-        style="background-image: url(https://picsum.photos/1400/260)"
-    ></div>
-    <h2 slot="heading">Disclaimer</h2>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
-    augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam
-    in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra
-    nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo
-    duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus
-    nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem
-    ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu
-    mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper
-    dignissim cras lobortis.
-</sp-dialog>
+<sp-button id="trigger">Overlay Trigger</sp-button>
+<sp-overlay trigger="trigger@click" placement="bottom">
+    <sp-popover>
+        <sp-dialog>
+            <h2 slot="heading">Overlay 1</h2>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
+            augue mauris augue neque gravida. Libero volutpat sed ornare arcu.
+        </sp-dialog>
+    </sp-popover>
+</sp-overlay>
+<overlay-trigger placement="top" type="replace">
+    <sp-button slot="trigger">Overlay Trigger 2</sp-button>
+    <sp-popover slot="click-content" open>
+        <sp-dialog size="s">
+            <h2 slot="heading">Overlay 2</h2>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
+            augue mauris augue neque gravida. Libero volutpat sed ornare arcu.
+            <sp-button
+                slot="button"
+                onclick="javascript: this.dispatchEvent(new Event('close', {bubbles: true, composed: true}));"
+            >
+                I understand
+            </sp-button>
+        </sp-dialog>
+    </sp-popover>
+</overlay-trigger>
 ```
+
+#### Receives focus
+
+The `receives-focus` attribute can be used to control whether the dialog should receive focus when it is opened. Leverage the `type="modal"` and `receives-focus="auto"` settings in the Overlay API to ensure that focus is thrown into the dialog content when opened and that the tab order will be trapped within it while open.
+
+```html
+<sp-button id="focus">Overlay Trigger</sp-button>
+<sp-overlay trigger="focus@click" type="modal" receives-focus="auto">
+    <sp-dialog>
+        <h2 slot="heading">Dialog Heading</h2>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
+        augue neque gravida. Libero volutpat sed ornare arcu.
+    </sp-dialog>
+</sp-overlay>
+```
+
+### Accessibility
+
+The dialog component ensures proper focus management by:
+
+-   Moving focus into the dialog when opened
+-   Trapping tab order within the dialog while open
+-   Returning focus to the trigger element when closed
+
+For more information on accessibility features, see the [Dialog Base](./dialog-base) component.

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -202,12 +202,14 @@ The `receives-focus` attribute can be used to control whether the dialog should 
 ```html
 <sp-button id="focus">Overlay Trigger</sp-button>
 <sp-overlay trigger="focus@click" type="modal" receives-focus="auto">
-    <sp-dialog>
-        <h2 slot="heading">Dialog Heading</h2>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
-        augue neque gravida. Libero volutpat sed ornare arcu.
-    </sp-dialog>
+    <sp-popover>
+        <sp-dialog>
+            <h2 slot="heading">Dialog Heading</h2>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
+            augue neque gravida. Libero volutpat sed ornare arcu.
+        </sp-dialog>
+    </sp-popover>
 </sp-overlay>
 ```
 

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -201,6 +201,14 @@ Use the dialog with an overlay to create a dialog that appears over the current 
 
 The `receives-focus` attribute can be used to control whether the dialog should receive focus when it is opened. Leverage the `type="modal"` and `receives-focus="auto"` settings in the Overlay API to ensure that focus is thrown into the dialog content when opened and that the tab order will be trapped within it while open.
 
+The `receives-focus` attribute on `overlay-trigger` has three possible values:
+
+-   `auto` (default): Focus will automatically move to the first focusable element in the dialog
+-   `true`: Forces focus to move to the overlay content
+-   `false`: Prevents focus from moving to the overlay
+
+For accessible dialogs, always use `receives-focus="auto"` or `receives-focus="true"` to ensure keyboard users can interact with the dialog content.
+
 ```html
 <sp-button id="focus">Overlay Trigger</sp-button>
 <sp-overlay trigger="focus@click" type="modal" receives-focus="auto">
@@ -217,10 +225,6 @@ The `receives-focus` attribute can be used to control whether the dialog should 
 
 ### Accessibility
 
-The dialog component ensures proper focus management by:
+#### Include a heading
 
--   Moving focus into the dialog when opened
--   Trapping tab order within the dialog while open
--   Returning focus to the trigger element when closed
-
-For more information on accessibility features, see the [Dialog Base](./dialog-base) component.
+The `heading` slot is of the `sp-dialog` dialog element is used to label the dialog content for screen readers.

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -2,6 +2,8 @@
 
 `sp-dialog` displays important information that users need to acknowledge. They appear over the interface and block further interactions. When used directly the `sp-dialog` element surfaces a `slot` based API for deep customization of the content to be included in the overlay.
 
+Note: the `sp-dialog` element is a component that is used to create a dialog layout. For modal and popover behavior, it should be used within a component that manages the overlay state.
+
 ### Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/dialog?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/dialog)
@@ -205,9 +207,9 @@ The `receives-focus` attribute can be used to control whether the dialog should 
     <sp-popover>
         <sp-dialog>
             <h2 slot="heading">Dialog Heading</h2>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-            tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
-            augue neque gravida. Libero volutpat sed ornare arcu.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
+            augue mauris augue neque gravida. Libero volutpat sed ornare arcu.
         </sp-dialog>
     </sp-popover>
 </sp-overlay>

--- a/packages/dialog/dialog-base.md
+++ b/packages/dialog/dialog-base.md
@@ -1,6 +1,20 @@
 ## Overview
 
-`sp-dialog-base` accepts slotted dialog content (often an `<sp-dialog>`) and presents that content in a container that is animated into place when toggling the `open` attribute. In concert with the [Overlay API](../overlay) or [Overlay Trigger](../overlay-trigger), the provided dialog content will be displayed over the rest of the page.
+`DialogBase` is a foundational class that handles the core functionality of displaying and managing dialog content in an overlay. This base class provides the foundation for more specific dialog implementations like [`sp-dialog`](./dialog) and [`sp-dialog-wrapper`](./dialog-wrapper), handling the core functionality while allowing those implementations to focus on their specific features.
+
+Use `sp-dialog-wrapper`, or `DialogBase` when:
+
+-   You need to present important information that requires user acknowledgment
+-   You're building a modal interface that blocks interaction with the page
+-   You need a structured container with features like backdrop/underlay
+-   Your content is complex and requires formal layout with headings, content sections, and actions
+
+Use [`sp-popover`](./popover) when:
+
+-   You need a lightweight, contextual container that's positioned relative to a trigger element
+-   You want to display simple content like menus, tooltips, or additional options
+-   You're building a non-modal interface where users can still interact with the page
+-   You need an element with an arrow/tip pointing to the trigger
 
 ### Usage
 
@@ -24,181 +38,33 @@ When looking to leverage the `DialogBase` base class as a type and/or for extens
 import { DialogBase } from '@spectrum-web-components/dialog';
 ```
 
-### Anatomy
+Extend the dialog base to create a new component that uses the same base functionality but with additional features. See [`DialogWrapper.ts`](https://github.com/adobe/spectrum-web-components/blob/main/packages/dialog/src/DialogWrapper.ts) for an example component that extends the dialog base.
 
-The dialog base consists of a single default slot that expects an [`sp-dialog` element](./dialog) to be provided. The dialog base manages the presentation and animation of this content.
+```ts
+export class MyCustomDialog extends DialogBase {
+    public static override get styles(): CSSResultArray {
+        return [...super.styles];
+    }
 
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-base slot="click-content">
-        <sp-dialog>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-            <p>
-                The click events for the "OK" button are bound to the story not
-                to the components in specific.
-            </p>
-            <sp-button
-                variant="secondary"
-                treatment="fill"
-                slot="button"
-                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
-            >
-                Ok
-            </sp-button>
-            <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
-        </sp-dialog>
-    </sp-dialog-base>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
+    protected override renderDialog(): TemplateResult {
+        ...
+    }
+}
 ```
 
 ### Options
-
-#### Sizes
-
-The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, `l`.
-
-<sp-tabs selected="m" auto label="Size attribute options">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab-panel value="s">
-
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content" size="s">
-        <sp-dialog size="s" dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
-    </sp-dialog-base>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
-</sp-tab-panel>
-<sp-tab value="m">Medium</sp-tab>
-<sp-tab-panel value="m">
-
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content" size="m">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
-    </sp-dialog-base>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
-</sp-tab-panel>
-<sp-tab value="l">Large</sp-tab>
-<sp-tab-panel value="l">
-
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content" size="l">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
-    </sp-dialog-base>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
-</sp-tab-panel>
-</sp-tabs>
 
 #### Underlay
 
 The `underlay` attribute can be used to add an underlay element between the page content and the dialog.
 
-```html
-</style>
-<overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content">
-        <sp-dialog>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-            <p>
-                The click events for the "OK" button are bound to the story not
-                to the components in specific.
-            </p>
-            <sp-button
-                variant="secondary"
-                treatment="fill"
-                slot="button"
-                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
-            >
-                Ok
-            </sp-button>
-            <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
-        </sp-dialog>
-    </sp-dialog-base>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
 #### Dismissable
 
 The `dismissable` attribute can be used to add an underlay element between the page content and the dialog.
 
-```html
-</style>
-<overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
-    </sp-dialog-base>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
 #### Mode
 
-The dialog base supports different display modes:
-
-<sp-tabs selected="fullscreen" auto label="Mode attribute options">
-    <sp-tab value="fullscreen">Fullscreen Mode</sp-tab>
-    <sp-tab-panel value="fullscreen">
-
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-base underlay mode="fullscreen" slot="click-content">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
-    </sp-dialog-base>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
-</sp-tab-panel>
-<sp-tab value="fullscreenTakeover">Fullscreen Takeover Mode</sp-tab>
-<sp-tab-panel value="fullscreenTakeover">
-
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-base underlay mode="fullscreenTakeover" slot="click-content">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-            <p>
-                The click events for the "OK" button are bound to the story not
-                to the components in specific.
-            </p>
-        </sp-dialog>
-    </sp-dialog-base>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
-</sp-tab-panel>
-</sp-tabs>
+The dialog base supports different display modes: `fullscreen` and `fullscreenTakeover`.
 
 ### Behaviors
 
@@ -207,26 +73,6 @@ The dialog base manages several behaviors:
 1. Animation of the dialog content when opening/closing
 2. Focus management when the dialog opens
 3. Event handling for closing the dialog
-
-#### Receives focus
-
-The `receives-focus` attribute can be used to control whether the dialog should receive focus when it is opened. Leverage the `type="modal"` and `receives-focus="auto"` settings in the Overlay API to ensure that focus is thrown into the dialog content when opened and that the tab order will be trapped within it while open.
-
-```html
-<overlay-trigger type="modal" receives-focus="auto">
-    <sp-dialog-base underlay mode="fullscreenTakeover" slot="click-content">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-            <p>
-                The click events for the "OK" button are bound to the story not
-                to the components in specific.
-            </p>
-        </sp-dialog>
-    </sp-dialog-base>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
 
 ### Accessibility
 

--- a/packages/dialog/dialog-base.md
+++ b/packages/dialog/dialog-base.md
@@ -2,14 +2,14 @@
 
 `DialogBase` is a foundational class that handles the core functionality of displaying and managing dialog content in an overlay. This base class provides the foundation for more specific dialog implementations like [`sp-dialog`](./dialog) and [`sp-dialog-wrapper`](./dialog-wrapper), handling the core functionality while allowing those implementations to focus on their specific features.
 
-Use `sp-dialog-wrapper`, or `DialogBase` when:
+Use `DialogBase` when:
 
 -   You need to present important information that requires user acknowledgment
 -   You're building a modal interface that blocks interaction with the page
 -   You need a structured container with features like backdrop/underlay
 -   Your content is complex and requires formal layout with headings, content sections, and actions
 
-Use [`sp-popover`](./popover) when:
+Use an [`sp-popover`](./popover) when:
 
 -   You need a lightweight, contextual container that's positioned relative to a trigger element
 -   You want to display simple content like menus, tooltips, or additional options
@@ -38,18 +38,33 @@ When looking to leverage the `DialogBase` base class as a type and/or for extens
 import { DialogBase } from '@spectrum-web-components/dialog';
 ```
 
-Extend the dialog base to create a new component that uses the same base functionality but with additional features. See [`DialogWrapper.ts`](https://github.com/adobe/spectrum-web-components/blob/main/packages/dialog/src/DialogWrapper.ts) for an example component that extends the dialog base.
+### Anatomy
 
-```ts
-export class MyCustomDialog extends DialogBase {
-    public static override get styles(): CSSResultArray {
-        return [...super.styles];
-    }
+The `sp-dialog-base` element is a wrapper that provides animation and positioning for the dialog content.
 
-    protected override renderDialog(): TemplateResult {
-        ...
-    }
-}
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content">
+        <sp-dialog size="s">
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <p>
+                The click events for the "OK" button are bound to the story not
+                to the components in specific.
+            </p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+            <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
 ```
 
 ### Options
@@ -73,6 +88,35 @@ The dialog base manages several behaviors:
 1. Animation of the dialog content when opening/closing
 2. Focus management when the dialog opens
 3. Event handling for closing the dialog
+
+### Extending `DialogBase`
+
+Extend the dialog base to create a new component that uses the same base functionality but with additional features.
+
+`sp-dialog-base` expects a single slotted child element to play the role of the dialog that it will deliver within your application. When leveraging it as a base class be sure to customize the `dialog` getter to ensure that it acquires the appropriate element for your use case in order to correctly pass focus into your content when the dialog is opened.
+
+See [`DialogWrapper.ts`](https://github.com/adobe/spectrum-web-components/blob/main/packages/dialog/src/DialogWrapper.ts) for an example component that extends the dialog base.
+
+```ts
+import { DialogBase } from '@spectrum-web-components/dialog';
+
+export class MyCustomDialogWrapper extends DialogBase {
+    public static override get styles(): CSSResultArray {
+        return [...super.styles];
+
+    protected override renderDialog(): TemplateResult {
+        return html`
+            <my-custom-dialog>
+                <slot></slot>
+            </my-custom-dialog>
+        `;
+    }
+
+    protected override get dialog(): Dialog {
+        return this.shadowRoot.querySelector('my-custom-dialog') as Dialog;
+    }
+}
+```
 
 ### Accessibility
 

--- a/packages/dialog/dialog-base.md
+++ b/packages/dialog/dialog-base.md
@@ -1,6 +1,6 @@
-## Description
+## Overview
 
-`sp-dialog-base` accepts slotted dialog content (often an `<sp-dialog>`) and presents that content in a container that is animated into place when toggling the `open` attribute. In concert with the [Overlay API](../overlay) or [Overlay Trigger](../overlay-trigger), the provided dialog content will be displayed over the rest of the page. Leverage the `interaction = modal` and `receivesFocus = 'auto'` settings in the Overlay API to ensure that focus is thrown into the dialog content when opened and that the tab order will be trapped within it while open.
+`sp-dialog-base` accepts slotted dialog content (often an `<sp-dialog>`) and presents that content in a container that is animated into place when toggling the `open` attribute. In concert with the [Overlay API](../overlay) or [Overlay Trigger](../overlay-trigger), the provided dialog content will be displayed over the rest of the page.
 
 ### Usage
 
@@ -8,28 +8,30 @@
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/dialog?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/dialog)
 [![Try it on webcomponents.dev](https://img.shields.io/badge/Try%20it%20on-webcomponents.dev-green?style=for-the-badge)](https://webcomponents.dev/edit/collection/fO75441E1Q5ZlI0e9pgq/MLYDVWpWhNxJZDW3Ywqq/src/index.ts)
 
-```
+```bash
 yarn add @spectrum-web-components/dialog
 ```
 
 Import the side effectful registration of `<sp-dialog-base>` via:
 
-```
+```ts
 import '@spectrum-web-components/dialog/sp-dialog-base.js';
 ```
 
 When looking to leverage the `DialogBase` base class as a type and/or for extension purposes, do so via:
 
-```
+```ts
 import { DialogBase } from '@spectrum-web-components/dialog';
 ```
 
-## Example
+### Anatomy
+
+The dialog base consists of a single default slot that expects an [`sp-dialog` element](./dialog) to be provided. The dialog base manages the presentation and animation of this content.
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content">
-        <sp-dialog size="s">
+    <sp-dialog-base slot="click-content">
+        <sp-dialog>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
             <p>
@@ -51,6 +53,180 @@ import { DialogBase } from '@spectrum-web-components/dialog';
 </overlay-trigger>
 ```
 
-## Dialog
+### Options
 
-`sp-dialog-base` expects a single slotted child element to play the role of the dialog that it will deliver within your application. When leveraging it as a base class be sure to customize the `dialog` getter to ensure that it acquires the appropriate element for your use case in order to correctly pass focus into your content when the dialog is opened.
+#### Sizes
+
+The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, `l`.
+
+<sp-tabs selected="m" auto label="Size attribute options">
+    <sp-tab value="s">Small</sp-tab>
+    <sp-tab-panel value="s">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content" size="s">
+        <sp-dialog size="s" dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content" size="m">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content" size="l">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
+#### Underlay
+
+The `underlay` attribute can be used to add an underlay element between the page content and the dialog.
+
+```html
+</style>
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <p>
+                The click events for the "OK" button are bound to the story not
+                to the components in specific.
+            </p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+            <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+#### Dismissable
+
+The `dismissable` attribute can be used to add an underlay element between the page content and the dialog.
+
+```html
+</style>
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+#### Mode
+
+The dialog base supports different display modes:
+
+##### Fullscreen Mode
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay mode="fullscreen" slot="click-content">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+##### Fullscreen Takeover Mode
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay mode="fullscreenTakeover" slot="click-content">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <p>
+                The click events for the "OK" button are bound to the story not
+                to the components in specific.
+            </p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+### Behaviors
+
+The dialog base manages several behaviors:
+
+1. Animation of the dialog content when opening/closing
+2. Focus management when the dialog opens
+3. Event handling for closing the dialog
+
+#### Receives focus
+
+The `receives-focus` attribute can be used to control whether the dialog should receive focus when it is opened. Leverage the `type="modal"` and `receives-focus="auto"` settings in the Overlay API to ensure that focus is thrown into the dialog content when opened and that the tab order will be trapped within it while open.
+
+```html
+<overlay-trigger type="modal" receives-focus="auto">
+    <sp-dialog-base underlay mode="fullscreenTakeover" slot="click-content">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <p>
+                The click events for the "OK" button are bound to the story not
+                to the components in specific.
+            </p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+### Accessibility
+
+The dialog base component ensures proper focus management by:
+
+-   Moving focus into the dialog when opened
+-   Trapping tab order within the dialog while open
+-   Returning focus to the trigger element when closed
+
+See the [Dialog](./dialog) component for more information on the accessibility features of the dialog content.

--- a/packages/dialog/dialog-base.md
+++ b/packages/dialog/dialog-base.md
@@ -181,7 +181,7 @@ The `dismissable` attribute can be used to add an underlay element between the p
 
 The dialog base supports different display modes: `fullscreen` and `fullscreenTakeover`.
 
-<sp-tabs selected="fullscreen" auto label="Modes">
+<sp-tabs selected="fullscreen" auto label="Mode attribute options">
     <sp-tab value="fullscreen">Fullscreen</sp-tab>
     <sp-tab-panel value="fullscreen">
 

--- a/packages/dialog/dialog-base.md
+++ b/packages/dialog/dialog-base.md
@@ -161,7 +161,9 @@ The `dismissable` attribute can be used to add an underlay element between the p
 
 The dialog base supports different display modes:
 
-##### Fullscreen Mode
+<sp-tabs selected="fullscreen" auto label="Mode attribute options">
+    <sp-tab value="fullscreen">Fullscreen Mode</sp-tab>
+    <sp-tab-panel value="fullscreen">
 
 ```html
 <overlay-trigger type="modal">
@@ -175,7 +177,9 @@ The dialog base supports different display modes:
 </overlay-trigger>
 ```
 
-##### Fullscreen Takeover Mode
+</sp-tab-panel>
+<sp-tab value="fullscreenTakeover">Fullscreen Takeover Mode</sp-tab>
+<sp-tab-panel value="fullscreenTakeover">
 
 ```html
 <overlay-trigger type="modal">
@@ -192,6 +196,9 @@ The dialog base supports different display modes:
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
+
+</sp-tab-panel>
+</sp-tabs>
 
 ### Behaviors
 

--- a/packages/dialog/dialog-base.md
+++ b/packages/dialog/dialog-base.md
@@ -45,7 +45,7 @@ The `sp-dialog-base` element is a wrapper that provides animation and positionin
 ```html
 <overlay-trigger type="modal">
     <sp-dialog-base underlay slot="click-content">
-        <sp-dialog size="s">
+        <sp-dialog>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
             <p>
@@ -73,13 +73,158 @@ The `sp-dialog-base` element is a wrapper that provides animation and positionin
 
 The `underlay` attribute can be used to add an underlay element between the page content and the dialog.
 
+<sp-tabs selected="underlay" auto label="Underlay options">
+    <sp-tab value="underlay">With underlay</sp-tab>
+    <sp-tab-panel value="underlay">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+<sp-tab value="no-underlay">Without underlay</sp-tab>
+<sp-tab-panel value="no-underlay">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
 #### Dismissable
 
 The `dismissable` attribute can be used to add an underlay element between the page content and the dialog.
 
+<sp-tabs selected="dismissable" auto label="Dismissable options">
+    <sp-tab value="dismissable">Dismissable</sp-tab>
+    <sp-tab-panel value="dismissable">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base dismissable slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+<sp-tab value="not-dismissable">Not dismissable</sp-tab>
+<sp-tab-panel value="not-dismissable">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
 #### Mode
 
 The dialog base supports different display modes: `fullscreen` and `fullscreenTakeover`.
+
+<sp-tabs selected="fullscreen" auto label="Modes">
+    <sp-tab value="fullscreen">Fullscreen</sp-tab>
+    <sp-tab-panel value="fullscreen">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base mode="fullscreen" slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+<sp-tab value="fullscreen-takeover">Fullscreen Takeover</sp-tab>
+<sp-tab-panel value="fullscreen-takeover">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base mode="fullscreenTakeover" slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+</sp-tabs>
 
 ### Behaviors
 

--- a/packages/dialog/dialog-base.md
+++ b/packages/dialog/dialog-base.md
@@ -2,20 +2,6 @@
 
 `DialogBase` is a foundational class that handles the core functionality of displaying and managing dialog content in an overlay. This base class provides the foundation for more specific dialog implementations like [`sp-dialog`](./dialog) and [`sp-dialog-wrapper`](./dialog-wrapper), handling the core functionality while allowing those implementations to focus on their specific features.
 
-Use `DialogBase` when:
-
--   You need to present important information that requires user acknowledgment
--   You're building a modal interface that blocks interaction with the page
--   You need a structured container with features like backdrop/underlay
--   Your content is complex and requires formal layout with headings, content sections, and actions
-
-Use an [`sp-popover`](./popover) when:
-
--   You need a lightweight, contextual container that's positioned relative to a trigger element
--   You want to display simple content like menus, tooltips, or additional options
--   You're building a non-modal interface where users can still interact with the page
--   You need an element with an arrow/tip pointing to the trigger
-
 ### Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/dialog?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/dialog)
@@ -41,6 +27,26 @@ import { DialogBase } from '@spectrum-web-components/dialog';
 ### Anatomy
 
 The `sp-dialog-base` element is a wrapper that provides animation and positioning for the dialog content.
+
+The dialog base manages several behaviors:
+
+1. Animation of the dialog content when opening/closing
+2. Focus management when the dialog opens
+3. Event handling for closing the dialog
+
+Use `DialogBase` when:
+
+-   You need to present important information that requires user acknowledgment
+-   You're building a modal interface that blocks interaction with the page
+-   You need a structured container with features like backdrop/underlay
+-   Your content is complex and requires formal layout with headings, content sections, and actions
+
+Use an [`sp-popover`](./popover) when:
+
+-   You need a lightweight, contextual container that's positioned relative to a trigger element
+-   You want to display simple content like menus, tooltips, or additional options
+-   You're building a non-modal interface where users can still interact with the page
+-   You need an element with an arrow/tip pointing to the trigger
 
 ```html
 <overlay-trigger type="modal">
@@ -226,14 +232,6 @@ The dialog base supports different display modes: `fullscreen` and `fullscreenTa
 </sp-tab-panel>
 </sp-tabs>
 
-### Behaviors
-
-The dialog base manages several behaviors:
-
-1. Animation of the dialog content when opening/closing
-2. Focus management when the dialog opens
-3. Event handling for closing the dialog
-
 ### Extending `DialogBase`
 
 Extend the dialog base to create a new component that uses the same base functionality but with additional features.
@@ -265,10 +263,42 @@ export class MyCustomDialogWrapper extends DialogBase {
 
 ### Accessibility
 
+#### Include a heading
+
+The `heading` slot is of the `sp-dialog` dialog element is used to label the dialog content for screen readers.
+
+#### Manage focus
+
 The dialog base component ensures proper focus management by:
 
 -   Moving focus into the dialog when opened
 -   Trapping tab order within the dialog while open
 -   Returning focus to the trigger element when closed
 
-See the [Dialog](./dialog) component for more information on the accessibility features of the dialog content.
+The `receives-focus` attribute can be used to control whether the dialog should receive focus when it is opened. Leverage the `type="modal"` and `receives-focus="auto"` settings in the Overlay API to ensure that focus is thrown into the dialog content when opened and that the tab order will be trapped within it while open.
+
+The `receives-focus` attribute on `overlay-trigger` has three possible values:
+
+-   `auto` (default): Focus will automatically move to the first focusable element in the dialog
+-   `true`: Forces focus to move to the overlay content
+-   `false`: Prevents focus from moving to the overlay
+
+```html
+<overlay-trigger type="modal" receives-focus="true">
+    <sp-dialog-base mode="fullscreenTakeover" slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```

--- a/packages/dialog/dialog-wrapper.md
+++ b/packages/dialog/dialog-wrapper.md
@@ -1,13 +1,13 @@
 ## Overview
 
-`sp-dialog-wrapper` accepts slotted dialog content (often an `<sp-dialog>`) and presents that content in a container that is animated into place when toggling the `open` attribute. In concert with the [Overlay API](../overlay) or [Overlay Trigger](../overlay-trigger), the provided dialog content will be displayed over the rest of the page.
+`sp-dialog-wrapper` supplies an attribute-based interface for the managed customization of an sp-dialog element and the light DOM supplied to it. This is paired it with an `underlay` attribute that opts-in to the use of an [`sp-underlay`](./underlay) element between your page content and the [`sp-dialog`](./dialog) that opens over it.
 
 Use `sp-dialog-wrapper` when:
 
 -   You need to present important information that requires user acknowledgment
 -   You're building a modal interface that blocks interaction with the page
 -   You need a structured container with features like backdrop/underlay
--   Your content is complex and requires formal layout with headings, content sections, and actions
+-   Your content is requires formal layout with headings, content sections, and actions
 
 Use [`sp-popover`](./popover) when:
 
@@ -32,36 +32,100 @@ Import the side effectful registration of `<sp-dialog-wrapper>` via:
 import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
 ```
 
-When looking to leverage the `DialogBase` base class as a type and/or for extension purposes, do so via:
-
-```ts
-import { DialogBase } from '@spectrum-web-components/dialog';
-```
-
 ### Anatomy
 
-The dialog base consists of a single default slot that expects an [`sp-dialog` element](./dialog) to be provided. The dialog base manages the presentation and animation of this content.
+The dialog wrapper is a high-level component that combines the [`sp-dialog-base`](./dialog-base) functionality and the [`sp-dialog`](./dialog) layout and stylingwith an attribute-based API.
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper slot="click-content">
-        <sp-dialog>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-            <p>
-                The click events for the "OK" button are bound to the story not
-                to the components in specific.
-            </p>
-            <sp-button
-                variant="secondary"
-                treatment="fill"
-                slot="button"
-                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
-            >
-                Ok
-            </sp-button>
-            <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
-        </sp-dialog>
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+        footer="Content for footer"
+    >
+        Content of the dialog
+    </sp-dialog-wrapper>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+#### Hero
+
+The hero content is displayed above the dialog content. Use the `hero` attribute to provide the hero content.
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-wrapper
+        slot="click-content"
+        hero="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+    >
+        Content of the dialog
+    </sp-dialog-wrapper>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+#### Headline
+
+The headline content is displayed as the dialog title. Use the `headline` attribute to provide the headline content.
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+    >
+        Content of the dialog
+    </sp-dialog-wrapper>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+#### Footer
+
+The footer content is displayed as below the dialog content. Use the `footer` attribute to provide the footer content.
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+        footer="Content for footer"
+    >
+        Content of the dialog
+    </sp-dialog-wrapper>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+#### Buttons
+
+The dialog wrapper supports different buttons via the `confirm-label`, `cancel-label`, `secondary-label`, `dismiss-label` attributes.
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        confirm-label="Confirm"
+        cancel-label="Cancel"
+        secondary-label="Secondary"
+        underlay
+    >
+        Content of the dialog
     </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
@@ -79,11 +143,16 @@ The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, 
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper underlay slot="click-content" size="s">
-        <sp-dialog size="s" dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
+    <sp-dialog-wrapper
+        size="s"
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+        footer="Content for footer"
+    >
+        Content of the dialog
     </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
@@ -95,11 +164,16 @@ The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, 
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper underlay slot="click-content" size="m">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
+    <sp-dialog-wrapper
+        size="m"
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+        footer="Content for footer"
+    >
+        Content of the dialog
     </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
@@ -111,11 +185,16 @@ The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, 
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper underlay slot="click-content" size="l">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
+    <sp-dialog-wrapper
+        size="l"
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+        footer="Content for footer"
+    >
+        Content of the dialog
     </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
@@ -128,62 +207,110 @@ The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, 
 
 The `underlay` attribute can be used to add an underlay element between the page content and the dialog.
 
+<sp-tabs selected="underlay" auto label="Underlay options">
+    <sp-tab value="underlay">With underlay</sp-tab>
+    <sp-tab-panel value="underlay">
+
 ```html
-</style>
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper underlay slot="click-content">
-        <sp-dialog>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-            <p>
-                The click events for the "OK" button are bound to the story not
-                to the components in specific.
-            </p>
-            <sp-button
-                variant="secondary"
-                treatment="fill"
-                slot="button"
-                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
-            >
-                Ok
-            </sp-button>
-            <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
-        </sp-dialog>
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+        footer="Content for footer"
+    >
+        Content of the dialog
     </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
+
+</sp-tab-panel>
+<sp-tab value="no-underlay">Without underlay</sp-tab>
+<sp-tab-panel value="no-underlay">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        footer="Content for footer"
+    >
+        Content of the dialog
+    </sp-dialog-wrapper>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+</sp-tabs>
 
 #### Dismissable
 
 The `dismissable` attribute can be used to add an underlay element between the page content and the dialog.
 
+<sp-tabs selected="dismissable" auto label="Dismissable options">
+    <sp-tab value="dismissable">Dismissable</sp-tab>
+    <sp-tab-panel value="dismissable">
+
 ```html
-</style>
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper underlay slot="click-content">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+        footer="Content for footer"
+    >
+        Content of the dialog
     </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
 
+</sp-tab-panel>
+<sp-tab value="not-dismissable">Not dismissable</sp-tab>
+<sp-tab-panel value="not-dismissable">
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        underlay
+        footer="Content for footer"
+    >
+        Content of the dialog
+    </sp-dialog-wrapper>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
 #### Mode
 
-The dialog base supports different display modes:
+The dialog wrapper supports different display modes:
 
 ##### Fullscreen Mode
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper underlay mode="fullscreen" slot="click-content">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-        </sp-dialog>
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        cancel-label="Cancel"
+        underlay
+        footer="Content for footer"
+        mode="fullscreen"
+    >
+        Content of the dialog
     </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
@@ -193,15 +320,15 @@ The dialog base supports different display modes:
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper underlay mode="fullscreenTakeover" slot="click-content">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-            <p>
-                The click events for the "OK" button are bound to the story not
-                to the components in specific.
-            </p>
-        </sp-dialog>
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        cancel-label="Cancel"
+        underlay
+        footer="Content for footer"
+        mode="fullscreenTakeover"
+    >
+        Content of the dialog
     </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
@@ -209,7 +336,7 @@ The dialog base supports different display modes:
 
 ### Behaviors
 
-The dialog base manages several behaviors:
+The dialog wrapper manages several behaviors:
 
 1. Animation of the dialog content when opening/closing
 2. Focus management when the dialog opens
@@ -221,15 +348,16 @@ The `receives-focus` attribute can be used to control whether the dialog should 
 
 ```html
 <overlay-trigger type="modal" receives-focus="auto">
-    <sp-dialog-wrapper underlay mode="fullscreenTakeover" slot="click-content">
-        <sp-dialog dismissable>
-            <h2 slot="heading">A thing is about to happen</h2>
-            <p>Something that might happen a lot is about to happen.</p>
-            <p>
-                The click events for the "OK" button are bound to the story not
-                to the components in specific.
-            </p>
-        </sp-dialog>
+    <sp-dialog-wrapper
+        slot="click-content"
+        headline="Dialog title"
+        dismissable
+        dismiss-label="Close"
+        underlay
+        footer="Content for footer"
+        mode="fullscreenTakeover"
+    >
+        Content of the dialog
     </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
@@ -237,7 +365,13 @@ The `receives-focus` attribute can be used to control whether the dialog should 
 
 ### Accessibility
 
-The dialog base component ensures proper focus management by:
+#### Include a headline
+
+An sp-dialog-wrapper element leverages the headline attribute/property to label the dialog content for screen readers. The headline-visibility attribute will accept a value of "none" to suppress the headline visually.
+
+#### Focus management
+
+The dialog wrapper component ensures proper focus management by:
 
 -   Moving focus into the dialog when opened
 -   Trapping tab order within the dialog while open

--- a/packages/dialog/dialog-wrapper.md
+++ b/packages/dialog/dialog-wrapper.md
@@ -2,20 +2,6 @@
 
 `sp-dialog-wrapper` supplies an attribute-based interface for the managed customization of an sp-dialog element and the light DOM supplied to it. This is paired it with an `underlay` attribute that opts-in to the use of an [`sp-underlay`](./underlay) element between your page content and the [`sp-dialog`](./dialog) that opens over it.
 
-Use `sp-dialog-wrapper` when:
-
--   You need to present important information that requires user acknowledgment
--   You're building a modal interface that blocks interaction with the page
--   You need a structured container with features like backdrop/underlay
--   Your content is requires formal layout with headings, content sections, and actions
-
-Use [`sp-popover`](./popover) when:
-
--   You need a lightweight, contextual container that's positioned relative to a trigger element
--   You want to display simple content like menus, tooltips, or additional options
--   You're building a non-modal interface where users can still interact with the page
--   You need an element with an arrow/tip pointing to the trigger
-
 ### Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/dialog?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/dialog)
@@ -36,94 +22,27 @@ import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
 
 The dialog wrapper is a high-level component that combines the [`sp-dialog-base`](./dialog-base) functionality and the [`sp-dialog`](./dialog) layout and stylingwith an attribute-based API.
 
+The dialog wrapper consists of several key parts:
+
+-   A headline used as the dialog title (via the `headline` attribute)
+-   Content (via default slot)
+-   Optional hero content (via the `hero` attribute)
+-   Optional footer content (via the `footer` attribute)
+-   Optional underlay (via the `underlay` attribute)
+-   Optional buttons (via the `confirm-label`, `cancel-label`, and `secondary-label` attributes)
+-   Optional dismiss button (via the `dismissable` attribute and the `dismiss-label` attribute)
+
 ```html
 <overlay-trigger type="modal">
     <sp-dialog-wrapper
         slot="click-content"
         headline="Dialog title"
-        dismissable
-        dismiss-label="Close"
-        underlay
-        footer="Content for footer"
-    >
-        Content of the dialog
-    </sp-dialog-wrapper>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
-#### Hero
-
-The hero content is displayed above the dialog content. Use the `hero` attribute to provide the hero content.
-
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-wrapper
-        slot="click-content"
         hero="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
-        headline="Dialog title"
-        dismissable
-        dismiss-label="Close"
-        underlay
-    >
-        Content of the dialog
-    </sp-dialog-wrapper>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
-#### Headline
-
-The headline content is displayed as the dialog title. Use the `headline` attribute to provide the headline content.
-
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-wrapper
-        slot="click-content"
-        headline="Dialog title"
-        dismissable
-        dismiss-label="Close"
-        underlay
-    >
-        Content of the dialog
-    </sp-dialog-wrapper>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
-#### Footer
-
-The footer content is displayed as below the dialog content. Use the `footer` attribute to provide the footer content.
-
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-wrapper
-        slot="click-content"
-        headline="Dialog title"
-        dismissable
-        dismiss-label="Close"
-        underlay
-        footer="Content for footer"
-    >
-        Content of the dialog
-    </sp-dialog-wrapper>
-    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
-</overlay-trigger>
-```
-
-#### Buttons
-
-The dialog wrapper supports different buttons via the `confirm-label`, `cancel-label`, `secondary-label`, `dismiss-label` attributes.
-
-```html
-<overlay-trigger type="modal">
-    <sp-dialog-wrapper
-        slot="click-content"
-        headline="Dialog title"
         confirm-label="Confirm"
         cancel-label="Cancel"
         secondary-label="Secondary"
         underlay
+        footer="Content for footer"
     >
         Content of the dialog
     </sp-dialog-wrapper>

--- a/packages/dialog/dialog-wrapper.md
+++ b/packages/dialog/dialog-wrapper.md
@@ -217,7 +217,9 @@ The `dismissable` attribute can be used to add an underlay element between the p
 
 The dialog wrapper supports different display modes:
 
-##### Fullscreen Mode
+<sp-tabs selected="fullscreen" auto label="Mode attribute options">
+    <sp-tab value="fullscreen">Fullscreen</sp-tab>
+    <sp-tab-panel value="fullscreen">
 
 ```html
 <overlay-trigger type="modal">
@@ -235,7 +237,9 @@ The dialog wrapper supports different display modes:
 </overlay-trigger>
 ```
 
-##### Fullscreen Takeover Mode
+</sp-tab-panel>
+<sp-tab value="fullscreen-takeover">Fullscreen Takeover</sp-tab>
+<sp-tab-panel value="fullscreen-takeover">
 
 ```html
 <overlay-trigger type="modal">
@@ -252,6 +256,9 @@ The dialog wrapper supports different display modes:
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
+
+</sp-tab-panel>
+</sp-tabs>
 
 ### Accessibility
 

--- a/packages/dialog/dialog-wrapper.md
+++ b/packages/dialog/dialog-wrapper.md
@@ -253,20 +253,32 @@ The dialog wrapper supports different display modes:
 </overlay-trigger>
 ```
 
-### Behaviors
+### Accessibility
 
-The dialog wrapper manages several behaviors:
+#### Include a headline
 
-1. Animation of the dialog content when opening/closing
-2. Focus management when the dialog opens
-3. Event handling for closing the dialog
+An sp-dialog-wrapper element leverages the headline attribute/property to label the dialog content for screen readers. The headline-visibility attribute will accept a value of "none" to suppress the headline visually.
 
-#### Receives focus
+#### Manage focus
+
+The dialog wrapper component ensures proper focus management by:
+
+-   Moving focus into the dialog when opened
+-   Trapping tab order within the dialog while open
+-   Returning focus to the trigger element when closed
 
 The `receives-focus` attribute can be used to control whether the dialog should receive focus when it is opened. Leverage the `type="modal"` and `receives-focus="auto"` settings in the Overlay API to ensure that focus is thrown into the dialog content when opened and that the tab order will be trapped within it while open.
 
+The `receives-focus` attribute on `overlay-trigger` has three possible values:
+
+-   `auto` (default): Focus will automatically move to the first focusable element in the dialog
+-   `true`: Forces focus to move to the overlay content
+-   `false`: Prevents focus from moving to the overlay
+
+For accessible dialogs, always use `receives-focus="auto"` or `receives-focus="true"` to ensure keyboard users can interact with the dialog content.
+
 ```html
-<overlay-trigger type="modal" receives-focus="auto">
+<overlay-trigger type="modal" receives-focus="true">
     <sp-dialog-wrapper
         slot="click-content"
         headline="Dialog title"
@@ -281,19 +293,3 @@ The `receives-focus` attribute can be used to control whether the dialog should 
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
-
-### Accessibility
-
-#### Include a headline
-
-An sp-dialog-wrapper element leverages the headline attribute/property to label the dialog content for screen readers. The headline-visibility attribute will accept a value of "none" to suppress the headline visually.
-
-#### Focus management
-
-The dialog wrapper component ensures proper focus management by:
-
--   Moving focus into the dialog when opened
--   Trapping tab order within the dialog while open
--   Returning focus to the trigger element when closed
-
-See the [Dialog](./dialog) component for more information on the accessibility features of the dialog content.

--- a/packages/dialog/dialog-wrapper.md
+++ b/packages/dialog/dialog-wrapper.md
@@ -1,6 +1,20 @@
 ## Overview
 
-`sp-dialog-base` accepts slotted dialog content (often an `<sp-dialog>`) and presents that content in a container that is animated into place when toggling the `open` attribute. In concert with the [Overlay API](../overlay) or [Overlay Trigger](../overlay-trigger), the provided dialog content will be displayed over the rest of the page.
+`sp-dialog-wrapper` accepts slotted dialog content (often an `<sp-dialog>`) and presents that content in a container that is animated into place when toggling the `open` attribute. In concert with the [Overlay API](../overlay) or [Overlay Trigger](../overlay-trigger), the provided dialog content will be displayed over the rest of the page.
+
+Use `sp-dialog-wrapper` when:
+
+-   You need to present important information that requires user acknowledgment
+-   You're building a modal interface that blocks interaction with the page
+-   You need a structured container with features like backdrop/underlay
+-   Your content is complex and requires formal layout with headings, content sections, and actions
+
+Use [`sp-popover`](./popover) when:
+
+-   You need a lightweight, contextual container that's positioned relative to a trigger element
+-   You want to display simple content like menus, tooltips, or additional options
+-   You're building a non-modal interface where users can still interact with the page
+-   You need an element with an arrow/tip pointing to the trigger
 
 ### Usage
 
@@ -12,10 +26,10 @@
 yarn add @spectrum-web-components/dialog
 ```
 
-Import the side effectful registration of `<sp-dialog-base>` via:
+Import the side effectful registration of `<sp-dialog-wrapper>` via:
 
 ```ts
-import '@spectrum-web-components/dialog/sp-dialog-base.js';
+import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
 ```
 
 When looking to leverage the `DialogBase` base class as a type and/or for extension purposes, do so via:
@@ -30,7 +44,7 @@ The dialog base consists of a single default slot that expects an [`sp-dialog` e
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-base slot="click-content">
+    <sp-dialog-wrapper slot="click-content">
         <sp-dialog>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
@@ -48,7 +62,7 @@ The dialog base consists of a single default slot that expects an [`sp-dialog` e
             </sp-button>
             <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
         </sp-dialog>
-    </sp-dialog-base>
+    </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
@@ -65,12 +79,12 @@ The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, 
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content" size="s">
+    <sp-dialog-wrapper underlay slot="click-content" size="s">
         <sp-dialog size="s" dismissable>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
         </sp-dialog>
-    </sp-dialog-base>
+    </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
@@ -81,12 +95,12 @@ The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, 
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content" size="m">
+    <sp-dialog-wrapper underlay slot="click-content" size="m">
         <sp-dialog dismissable>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
         </sp-dialog>
-    </sp-dialog-base>
+    </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
@@ -97,12 +111,12 @@ The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, 
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content" size="l">
+    <sp-dialog-wrapper underlay slot="click-content" size="l">
         <sp-dialog dismissable>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
         </sp-dialog>
-    </sp-dialog-base>
+    </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
@@ -117,7 +131,7 @@ The `underlay` attribute can be used to add an underlay element between the page
 ```html
 </style>
 <overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content">
+    <sp-dialog-wrapper underlay slot="click-content">
         <sp-dialog>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
@@ -135,7 +149,7 @@ The `underlay` attribute can be used to add an underlay element between the page
             </sp-button>
             <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
         </sp-dialog>
-    </sp-dialog-base>
+    </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
@@ -147,12 +161,12 @@ The `dismissable` attribute can be used to add an underlay element between the p
 ```html
 </style>
 <overlay-trigger type="modal">
-    <sp-dialog-base underlay slot="click-content">
+    <sp-dialog-wrapper underlay slot="click-content">
         <sp-dialog dismissable>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
         </sp-dialog>
-    </sp-dialog-base>
+    </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
@@ -165,12 +179,12 @@ The dialog base supports different display modes:
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-base underlay mode="fullscreen" slot="click-content">
+    <sp-dialog-wrapper underlay mode="fullscreen" slot="click-content">
         <sp-dialog dismissable>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
         </sp-dialog>
-    </sp-dialog-base>
+    </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
@@ -179,7 +193,7 @@ The dialog base supports different display modes:
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-base underlay mode="fullscreenTakeover" slot="click-content">
+    <sp-dialog-wrapper underlay mode="fullscreenTakeover" slot="click-content">
         <sp-dialog dismissable>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
@@ -188,7 +202,7 @@ The dialog base supports different display modes:
                 to the components in specific.
             </p>
         </sp-dialog>
-    </sp-dialog-base>
+    </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
@@ -207,7 +221,7 @@ The `receives-focus` attribute can be used to control whether the dialog should 
 
 ```html
 <overlay-trigger type="modal" receives-focus="auto">
-    <sp-dialog-base underlay mode="fullscreenTakeover" slot="click-content">
+    <sp-dialog-wrapper underlay mode="fullscreenTakeover" slot="click-content">
         <sp-dialog dismissable>
             <h2 slot="heading">A thing is about to happen</h2>
             <p>Something that might happen a lot is about to happen.</p>
@@ -216,7 +230,7 @@ The `receives-focus` attribute can be used to control whether the dialog should 
                 to the components in specific.
             </p>
         </sp-dialog>
-    </sp-dialog-base>
+    </sp-dialog-wrapper>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```

--- a/packages/dialog/dialog-wrapper.md
+++ b/packages/dialog/dialog-wrapper.md
@@ -1,6 +1,6 @@
-## Description
+## Overview
 
-`sp-dialog-wrapper` supplies an attribute based interface for the managed customization of an `sp-dialog` element and the light DOM supplied to it. This is paired it with an `underlay` attribute that opts-in to the use of an `sp-underlay` element between your page content and the `sp-dialog` that opens over it.
+`sp-dialog-base` accepts slotted dialog content (often an `<sp-dialog>`) and presents that content in a container that is animated into place when toggling the `open` attribute. In concert with the [Overlay API](../overlay) or [Overlay Trigger](../overlay-trigger), the provided dialog content will be displayed over the rest of the page.
 
 ### Usage
 
@@ -8,118 +8,225 @@
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/dialog?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/dialog)
 [![Try it on webcomponents.dev](https://img.shields.io/badge/Try%20it%20on-webcomponents.dev-green?style=for-the-badge)](https://webcomponents.dev/edit/collection/fO75441E1Q5ZlI0e9pgq/MLYDVWpWhNxJZDW3Ywqq/src/index.ts)
 
-```
+```bash
 yarn add @spectrum-web-components/dialog
 ```
 
-Import the side effectful registration of `<sp-dialog-wrapper>` via:
+Import the side effectful registration of `<sp-dialog-base>` via:
 
-```
-import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
-```
-
-When looking to leverage the `DialogWrapper` base class as a type and/or for extension purposes, do so via:
-
-```
-import { DialogWrapper } from '@spectrum-web-components/dialog';
+```ts
+import '@spectrum-web-components/dialog/sp-dialog-base.js';
 ```
 
-## Example
+When looking to leverage the `DialogBase` base class as a type and/or for extension purposes, do so via:
 
-### Small
+```ts
+import { DialogBase } from '@spectrum-web-components/dialog';
+```
+
+### Anatomy
+
+The dialog base consists of a single default slot that expects an [`sp-dialog` element](./dialog) to be provided. The dialog base manages the presentation and animation of this content.
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper
-        slot="click-content"
-        headline="Dialog title"
-        dismissable
-        dismiss-label="Close"
-        underlay
-        footer="Content for footer"
-    >
-        Content of the dialog
-    </sp-dialog-wrapper>
+    <sp-dialog-base slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <p>
+                The click events for the "OK" button are bound to the story not
+                to the components in specific.
+            </p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+            <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
+        </sp-dialog>
+    </sp-dialog-base>
     <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
 
-### Fullscreen Mode
+### Options
+
+#### Sizes
+
+The dialog wrapper supports different sizes via the `size` attribute: `s`, `m`, `l`.
+
+<sp-tabs selected="m" auto label="Size attribute options">
+    <sp-tab value="s">Small</sp-tab>
+    <sp-tab-panel value="s">
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper
-        slot="click-content"
-        headline="Dialog title"
-        mode="fullscreen"
-        confirm-label="Keep Both"
-        secondary-label="Replace"
-        cancel-label="Cancel"
-        footer="Content for footer"
-    >
-        Content of the dialog
-    </sp-dialog-wrapper>
-    <sp-button
-        slot="trigger"
-        variant="primary"
-        onClick="
-            const overlayTrigger = this.parentElement;
-            const dialogWrapper = overlayTrigger.clickContent;
-            function handleEvent({type}) {
-                spAlert(this, `<sp-dialog-wrapper> '${type}' event handled.`);
-                dialogWrapper.open = false;
-                dialogWrapper.removeEventListener('confirm', handleEvent);
-                dialogWrapper.removeEventListener('secondary', handleEvent);
-                dialogWrapper.removeEventListener('cancel', handleEvent);
-            }
-            dialogWrapper.addEventListener('confirm', handleEvent);
-            dialogWrapper.addEventListener('secondary', handleEvent);
-            dialogWrapper.addEventListener('cancel', handleEvent);
-        "
-    >
-        Toggle Dialog
-    </sp-button>
+    <sp-dialog-base underlay slot="click-content" size="s">
+        <sp-dialog size="s" dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
 
-### Fullscreen Takeover Mode
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html
 <overlay-trigger type="modal">
-    <sp-dialog-wrapper
-        slot="click-content"
-        headline="Dialog title"
-        mode="fullscreenTakeover"
-        confirm-label="Keep Both"
-        secondary-label="Replace"
-        cancel-label="Cancel"
-        footer="Content for footer"
-    >
-        Content of the dialog
-    </sp-dialog-wrapper>
-    <sp-button
-        slot="trigger"
-        variant="primary"
-        onClick="
-            const overlayTrigger = this.parentElement;
-            const dialogWrapper = overlayTrigger.clickContent;
-            function handleEvent({type}) {
-                spAlert(this, `<sp-dialog-wrapper> '${type}' event handled.`);
-                dialogWrapper.open = false;
-                dialogWrapper.removeEventListener('confirm', handleEvent);
-                dialogWrapper.removeEventListener('secondary', handleEvent);
-                dialogWrapper.removeEventListener('cancel', handleEvent);
-            }
-            dialogWrapper.addEventListener('confirm', handleEvent);
-            dialogWrapper.addEventListener('secondary', handleEvent);
-            dialogWrapper.addEventListener('cancel', handleEvent);
-        "
-    >
-        Toggle Dialog
-    </sp-button>
+    <sp-dialog-base underlay slot="click-content" size="m">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
 </overlay-trigger>
 ```
 
-## Accessibility
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
-An `sp-dialog-wrapper` element leverages the `headline` attribute/property to label the dialog content for screen readers. The `headline-visibility` attribute will accept a value of `"none"` to suppress the headline visually.
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content" size="l">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
+#### Underlay
+
+The `underlay` attribute can be used to add an underlay element between the page content and the dialog.
+
+```html
+</style>
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content">
+        <sp-dialog>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <p>
+                The click events for the "OK" button are bound to the story not
+                to the components in specific.
+            </p>
+            <sp-button
+                variant="secondary"
+                treatment="fill"
+                slot="button"
+                onclick="this.dispatchEvent(new Event('close', { bubbles: true, composed: true }));"
+            >
+                Ok
+            </sp-button>
+            <sp-checkbox slot="footer">Don't show me this again</sp-checkbox>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+#### Dismissable
+
+The `dismissable` attribute can be used to add an underlay element between the page content and the dialog.
+
+```html
+</style>
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay slot="click-content">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+#### Mode
+
+The dialog base supports different display modes:
+
+##### Fullscreen Mode
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay mode="fullscreen" slot="click-content">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+##### Fullscreen Takeover Mode
+
+```html
+<overlay-trigger type="modal">
+    <sp-dialog-base underlay mode="fullscreenTakeover" slot="click-content">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <p>
+                The click events for the "OK" button are bound to the story not
+                to the components in specific.
+            </p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+### Behaviors
+
+The dialog base manages several behaviors:
+
+1. Animation of the dialog content when opening/closing
+2. Focus management when the dialog opens
+3. Event handling for closing the dialog
+
+#### Receives focus
+
+The `receives-focus` attribute can be used to control whether the dialog should receive focus when it is opened. Leverage the `type="modal"` and `receives-focus="auto"` settings in the Overlay API to ensure that focus is thrown into the dialog content when opened and that the tab order will be trapped within it while open.
+
+```html
+<overlay-trigger type="modal" receives-focus="auto">
+    <sp-dialog-base underlay mode="fullscreenTakeover" slot="click-content">
+        <sp-dialog dismissable>
+            <h2 slot="heading">A thing is about to happen</h2>
+            <p>Something that might happen a lot is about to happen.</p>
+            <p>
+                The click events for the "OK" button are bound to the story not
+                to the components in specific.
+            </p>
+        </sp-dialog>
+    </sp-dialog-base>
+    <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+</overlay-trigger>
+```
+
+### Accessibility
+
+The dialog base component ensures proper focus management by:
+
+-   Moving focus into the dialog when opened
+-   Trapping tab order within the dialog while open
+-   Returning focus to the trigger element when closed
+
+See the [Dialog](./dialog) component for more information on the accessibility features of the dialog content.

--- a/projects/documentation/content/guides/adding-component.md
+++ b/projects/documentation/content/guides/adding-component.md
@@ -388,11 +388,16 @@ for an example.
 Each component's `packages/_componentname_/README.md`. These files must meet our standards below:
 
 -   Heading structure must communicate the organization of the docs page. See W3C WAI's Tutorial on [Headings](https://www.w3.org/WAI/tutorials/page-structure/headings/).
--   Main headings (level 2 and 3) should be consistent from component to component. See W3C WAI's [Understanding SC 3.2: Predictable](https://www.w3.org/WAI/WCAG21/Understanding/predictable.html) and the [Documentation structure](#documentatio-structuren) section below.
+-   Main headings (level 2 and 3) should be consistent from component to component. See W3C WAI's [Understanding SC 3.2: Predictable](https://www.w3.org/WAI/WCAG21/Understanding/predictable.html) and the [Documentation structure](#documentation-structure) section below.
+-   Consider using `<sp-tabs>` for related sections/examples, such as tabs for each of the sizes, states, types, or variants.
+-   Consider using an `<sp-table>` to make content like keyboard actions easiert to read.
+-   Use the `<kbd>` tag to semantically indicate keyboard input and make keyboard actions easier to read.
+-   Use the plain language to make the docs easier to understand.
 -   All examples code must be accessible.
 -   The example code must show the component with enough context to demonstrate how to use it with other elements in an accessible way. See how the examples in [`packages/help-text/README.md`](https://github.com/adobe/spectrum-web-components/blob/main/packages/help-text/README.md) show the component used with field elements.
 -   The "Accessibility" section contains tips on how to use the component accessibly. See the Accessibility section of [`packages/picker/README.md`](https://github.com/adobe/spectrum-web-components/blob/main/packages/menu/README.md).
 -   The "Accessibility" section contains notes on any accessibility considerations that affect the component's development. See the notes on cross-root ARIA in Accessibility section of [`packages/help-text/README.md`](https://github.com/adobe/spectrum-web-components/blob/main/packages/help-text/README.md).
+-   Check out the [Spectrum Design System documentation](https://spectrum.adobe.com/) to ensure our documentation is uses consistent langauge and component recommendations.
 
 #### Documentation structure
 

--- a/projects/documentation/scripts/build-search-index.js
+++ b/projects/documentation/scripts/build-search-index.js
@@ -164,9 +164,9 @@ async function main() {
         // Configure the index fields
         this.ref('metadata');
         // Boost title field for higher relevance when matching titles
-        this.field('title', { boost: 100 });
+        this.field('title', { boost: 50 });
         this.field('body');
-        this.field('category');
+        this.field('category', { boost: 10 });
 
         // Add all documents to the index
         for (const document of documents) {

--- a/projects/documentation/scripts/build-search-index.js
+++ b/projects/documentation/scripts/build-search-index.js
@@ -164,7 +164,7 @@ async function main() {
         // Configure the index fields
         this.ref('metadata');
         // Boost title field for higher relevance when matching titles
-        this.field('title', { boost: 10 });
+        this.field('title', { boost: 100 });
         this.field('body');
         this.field('category');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Improving the accessibility documentation of dialog components.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- SWC-374
- SWC-375
- SWC-376

## Motivation and context

Documentation should provide more information and examples that demonstrate how to use the components accessibly. 

## How has this been tested?

Review [dialog docs](https://nikkimk-dialog-docs--spectrum-wc.netlify.app/components/dialog/)

-  [ ] Do the docs examples give enough context to test for accessibility?
-  [ ] Do the docs examples and text provide information on how to use the component accessibly?
-  [ ] If the component is to be used in the context of another component, do the examples include how that component is used accessibly in that context?
-  [ ] Are the docs headings logical and consistent across these components? You can use the [WAVE browser extension's](https://wave.webaim.org/extension/) **Structure** tab to review heading structure.

Review [dialog base docs](https://nikkimk-dialog-docs--spectrum-wc.netlify.app/components/dialog-base/)

-  [ ] Do the docs examples give enough context to test for accessibility?
-  [ ] Do the docs examples and text provide information on how to use the component accessibly?
-  [ ] If the component is to be used in the context of another component, do the examples include how that component is used accessibly in that context?
-  [ ] Are the docs headings logical and consistent across these components? 

Review [dialog wrapper docs](https://nikkimk-dialog-docs--spectrum-wc.netlify.app/components/dialog-wrapper/)

-  [ ] Do the docs examples give enough context to test for accessibility?
-  [ ] Do the docs examples and text provide information on how to use the component accessibly?
-  [ ] If the component is to be used in the context of another component, do the examples include how that component is used accessibly in that context?
-  [ ] Are the docs headings logical and consistent across these components? 


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
