### PR TITLE
fix(tabs): added missing direct dependency of action-button in TabsOverflow component

### DIFF
--- a/.changeset/tricky-fans-drive.md
+++ b/.changeset/tricky-fans-drive.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/tabs': patch
+---
+
+Added @spectrum-web-components/action-button dependency in Tabs since it uses in the direction button as its direct dependency

--- a/.changeset/tricky-fans-drive.md
+++ b/.changeset/tricky-fans-drive.md
@@ -2,4 +2,4 @@
 '@spectrum-web-components/tabs': patch
 ---
 
-Added @spectrum-web-components/action-button dependency in Tabs since it uses in the direction button as its direct dependency
+Added `@spectrum-web-components/action-button` as a dependency for Tabs as its used in the direction button.

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -94,6 +94,7 @@
     ],
     "dependencies": {
         "@lit-labs/observers": "^2.0.2",
+        "@spectrum-web-components/action-button": "1.6.0",
         "@spectrum-web-components/base": "1.6.0",
         "@spectrum-web-components/icon": "1.6.0",
         "@spectrum-web-components/icons-ui": "1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8381,6 +8381,7 @@ __metadata:
   dependencies:
     "@lit-labs/observers": "npm:^2.0.2"
     "@spectrum-css/tabs": "npm:6.1.1"
+    "@spectrum-web-components/action-button": "npm:1.6.0"
     "@spectrum-web-components/base": "npm:1.6.0"
     "@spectrum-web-components/icon": "npm:1.6.0"
     "@spectrum-web-components/icons-ui": "npm:1.6.0"


### PR DESCRIPTION
# Description

This PR adds the `@spectrum-web-components/action-button` dependency to the `sp-tabs` component to maintain consistency with other components in the library. TabsOverflow uses `sp-action-button` as its direct dependency.

## Related issue(s)

- N/A

## Motivation and context

The TabsOverflow component was missing the `@spectrum-web-components/action-button` dependency that other components utilize, which could lead to inconsistencies when implementing shared features. Adding this dependency ensures that the TabsOverflow component follows the same patterns as the rest of the library and can leverage common functionality.

## How has this been tested?

- [x] Verified sp-tabs functionality still works while importing it in a kitchen sink
- [x] Verified no side effects from adding shared dependency

- [x] Did it pass in Desktop?
- [x] Did it pass in Mobile?
- [x] Did it pass in iPad?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
