### PR TITLE
fix: skip elements with focusable="false" attribute

### DIFF
--- a/tools/shared/src/focusable-selectors.ts
+++ b/tools/shared/src/focusable-selectors.ts
@@ -24,7 +24,7 @@ const focusables = [
     '[contenteditable]:not([contenteditable="false"]):not([inert])',
     'details>summary:first-of-type:not([inert])',
     'details:not([inert])',
-    '[focusable]', // custom dev use-case
+    '[focusable]:not([focusable="false"])', // custom dev use-case
 ];
 
 const userFocuable = ':not([tabindex="-1"])';


### PR DESCRIPTION
## Description
Extend the focusable selector to avoid retrieving elements with attribute `focusable="false"` , see: #5431 

## Related issue(s)
- fixes #5431

## Motivation and context

SVGs with `focusable="false"` should not be detected.

## How has this been tested?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
