### PR TITLE
chore: prettier settings for all CSS

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -7,6 +7,7 @@ bracketSpacing: true
 arrowParens: always
 htmlWhitespaceSensitivity: ignore
 overrides:
-    - files: '{tools,packages}/*/src/spectrum-*.css'
+    - files: '*.css'
       options:
           printWidth: 500
+          singleQuote: false

--- a/packages/accordion/src/accordion-overrides.css
+++ b/packages/accordion/src/accordion-overrides.css
@@ -13,10 +13,6 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     --spectrum-accordion-divider-color: var(--system-accordion-divider-color);
-    --spectrum-accordion-item-content-disabled-color: var(
-        --system-accordion-item-content-disabled-color
-    );
-    --spectrum-accordion-item-content-color: var(
-        --system-accordion-item-content-color
-    );
+    --spectrum-accordion-item-content-disabled-color: var(--system-accordion-item-content-disabled-color);
+    --spectrum-accordion-item-content-color: var(--system-accordion-item-content-color);
 }

--- a/packages/accordion/src/spectrum-accordion-item.css
+++ b/packages/accordion/src/spectrum-accordion-item.css
@@ -47,7 +47,7 @@ governing permissions and limitations under the License.
 }
 
 .iconContainer:dir(rtl),
-:host([dir='rtl']) .iconContainer {
+:host([dir="rtl"]) .iconContainer {
     transform: scaleX(-1);
 }
 
@@ -93,7 +93,7 @@ governing permissions and limitations under the License.
 }
 
 #header:focus:after {
-    content: '';
+    content: "";
     position: absolute;
     inset-inline-start: 0;
 }
@@ -148,7 +148,7 @@ governing permissions and limitations under the License.
 @media (forced-colors: active) {
     #header:after {
         forced-color-adjust: none;
-        content: '';
+        content: "";
         position: absolute;
         inset-inline-start: 0;
     }

--- a/packages/accordion/src/spectrum-accordion.css
+++ b/packages/accordion/src/spectrum-accordion.css
@@ -53,7 +53,7 @@ governing permissions and limitations under the License.
 }
 
 :host:dir(rtl),
-:host([dir='rtl']) {
+:host([dir="rtl"]) {
     --spectrum-logical-rotation: matrix(-1, 0, 0, 1, 0, 0);
 }
 
@@ -64,55 +64,55 @@ governing permissions and limitations under the License.
     --spectrum-accordion-item-content-line-height: var(--spectrum-cjk-line-height-100);
 }
 
-:host([density='compact']) {
+:host([density="compact"]) {
     --spectrum-accordion-item-height: var(--spectrum-component-height-100);
     --spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-compact-medium);
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-compact-medium);
 }
 
-:host([density='compact'][size='s']) {
+:host([density="compact"][size="s"]) {
     --spectrum-accordion-item-height: var(--spectrum-component-height-75);
     --spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-compact-small);
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-compact-small);
 }
 
-:host([density='compact'][size='l']) {
+:host([density="compact"][size="l"]) {
     --spectrum-accordion-item-height: var(--spectrum-component-height-200);
     --spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-compact-large);
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-compact-large);
 }
 
-:host([density='compact'][size='xl']) {
+:host([density="compact"][size="xl"]) {
     --spectrum-accordion-item-height: var(--spectrum-component-height-300);
     --spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-compact-extra-large);
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-compact-extra-large);
 }
 
-:host([density='spacious']) {
+:host([density="spacious"]) {
     --spectrum-accordion-item-header-line-height: 1.278;
     --spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-spacious-medium);
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-spacious-medium);
 }
 
-:host([density='spacious'][size='s']) {
+:host([density="spacious"][size="s"]) {
     --spectrum-accordion-item-header-line-height: 1.25;
     --spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-small-top-to-text-spacious);
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-spacious-small);
 }
 
-:host([density='spacious'][size='l']) {
+:host([density="spacious"][size="l"]) {
     --spectrum-accordion-item-header-line-height: 1.273;
     --spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-spacious-large);
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-spacious-large);
 }
 
-:host([density='spacious'][size='xl']) {
+:host([density="spacious"][size="xl"]) {
     --spectrum-accordion-item-header-line-height: 1.25;
     --spectrum-accordion-item-header-top-to-text-space: var(--spectrum-accordion-top-to-text-spacious-extra-large);
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-spacious-extra-large);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-accordion-item-height: var(--spectrum-component-height-100);
     --spectrum-accordion-disclosure-indicator-height: var(--spectrum-component-height-75);
     --spectrum-accordion-component-edge-to-text: var(--spectrum-component-edge-to-text-50);
@@ -122,7 +122,7 @@ governing permissions and limitations under the License.
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-regular-small);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-accordion-item-height: var(--spectrum-component-height-300);
     --spectrum-accordion-disclosure-indicator-height: var(--spectrum-component-height-200);
     --spectrum-accordion-component-edge-to-text: var(--spectrum-component-edge-to-text-100);
@@ -132,7 +132,7 @@ governing permissions and limitations under the License.
     --spectrum-accordion-item-header-bottom-to-text-space: var(--spectrum-accordion-bottom-to-text-regular-large);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-accordion-item-height: var(--spectrum-component-height-400);
     --spectrum-accordion-disclosure-indicator-height: var(--spectrum-component-height-300);
     --spectrum-accordion-component-edge-to-text: var(--spectrum-component-edge-to-text-200);

--- a/packages/action-bar/src/action-bar-overrides.css
+++ b/packages/action-bar/src/action-bar-overrides.css
@@ -12,10 +12,6 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-actionbar-popover-background-color: var(
-        --system-action-bar-popover-background-color
-    );
-    --spectrum-actionbar-popover-border-color: var(
-        --system-action-bar-popover-border-color
-    );
+    --spectrum-actionbar-popover-background-color: var(--system-action-bar-popover-background-color);
+    --spectrum-actionbar-popover-border-color: var(--system-action-bar-popover-border-color);
 }

--- a/packages/action-bar/src/spectrum-action-bar.css
+++ b/packages/action-bar/src/spectrum-action-bar.css
@@ -115,12 +115,12 @@ governing permissions and limitations under the License.
     color: var(--mod-actionbar-emphasized-item-counter-color, var(--spectrum-actionbar-emphasized-item-counter-color));
 }
 
-:host([variant='sticky']) {
+:host([variant="sticky"]) {
     position: sticky;
     inset-inline: 0;
 }
 
-:host([variant='fixed']) {
+:host([variant="fixed"]) {
     position: fixed;
 }
 

--- a/packages/action-button/src/action-button-overrides.css
+++ b/packages/action-button/src/action-button-overrides.css
@@ -12,211 +12,93 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-actionbutton-background-color-default: var(
-        --system-action-button-background-color-default
-    );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-action-button-background-color-hover
-    );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-action-button-background-color-down
-    );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-action-button-background-color-focus
-    );
-    --spectrum-actionbutton-background-color-disabled: var(
-        --system-action-button-background-color-disabled
-    );
-    --spectrum-actionbutton-background-color-selected: var(
-        --system-action-button-background-color-selected
-    );
-    --spectrum-actionbutton-background-color-selected-hover: var(
-        --system-action-button-background-color-selected-hover
-    );
-    --spectrum-actionbutton-background-color-selected-down: var(
-        --system-action-button-background-color-selected-down
-    );
-    --spectrum-actionbutton-background-color-selected-focus: var(
-        --system-action-button-background-color-selected-focus
-    );
-    --spectrum-actionbutton-border-color-default: var(
-        --system-action-button-border-color-default
-    );
-    --spectrum-actionbutton-border-color-hover: var(
-        --system-action-button-border-color-hover
-    );
-    --spectrum-actionbutton-border-color-down: var(
-        --system-action-button-border-color-down
-    );
-    --spectrum-actionbutton-border-color-focus: var(
-        --system-action-button-border-color-focus
-    );
-    --spectrum-actionbutton-border-color-disabled: var(
-        --system-action-button-border-color-disabled
-    );
-    --spectrum-actionbutton-content-color-selected: var(
-        --system-action-button-content-color-selected
-    );
-    --spectrum-actionbutton-background-color-selected-disabled: var(
-        --system-action-button-background-color-selected-disabled
-    );
+    --spectrum-actionbutton-background-color-default: var(--system-action-button-background-color-default);
+    --spectrum-actionbutton-background-color-hover: var(--system-action-button-background-color-hover);
+    --spectrum-actionbutton-background-color-down: var(--system-action-button-background-color-down);
+    --spectrum-actionbutton-background-color-focus: var(--system-action-button-background-color-focus);
+    --spectrum-actionbutton-background-color-disabled: var(--system-action-button-background-color-disabled);
+    --spectrum-actionbutton-background-color-selected: var(--system-action-button-background-color-selected);
+    --spectrum-actionbutton-background-color-selected-hover: var(--system-action-button-background-color-selected-hover);
+    --spectrum-actionbutton-background-color-selected-down: var(--system-action-button-background-color-selected-down);
+    --spectrum-actionbutton-background-color-selected-focus: var(--system-action-button-background-color-selected-focus);
+    --spectrum-actionbutton-border-color-default: var(--system-action-button-border-color-default);
+    --spectrum-actionbutton-border-color-hover: var(--system-action-button-border-color-hover);
+    --spectrum-actionbutton-border-color-down: var(--system-action-button-border-color-down);
+    --spectrum-actionbutton-border-color-focus: var(--system-action-button-border-color-focus);
+    --spectrum-actionbutton-border-color-disabled: var(--system-action-button-border-color-disabled);
+    --spectrum-actionbutton-content-color-selected: var(--system-action-button-content-color-selected);
+    --spectrum-actionbutton-background-color-selected-disabled: var(--system-action-button-background-color-selected-disabled);
 }
 
 :host {
-    --spectrum-actionbutton-border-radius-default: var(
-        --system-action-button-size-m-border-radius-default
-    );
+    --spectrum-actionbutton-border-radius-default: var(--system-action-button-size-m-border-radius-default);
 }
 
-:host([size='xs']) {
-    --spectrum-actionbutton-border-radius-default: var(
-        --system-action-button-size-xs-border-radius-default
-    );
+:host([size="xs"]) {
+    --spectrum-actionbutton-border-radius-default: var(--system-action-button-size-xs-border-radius-default);
 }
 
-:host([size='s']) {
-    --spectrum-actionbutton-border-radius-default: var(
-        --system-action-button-size-s-border-radius-default
-    );
+:host([size="s"]) {
+    --spectrum-actionbutton-border-radius-default: var(--system-action-button-size-s-border-radius-default);
 }
 
-:host([size='l']) {
-    --spectrum-actionbutton-border-radius-default: var(
-        --system-action-button-size-l-border-radius-default
-    );
+:host([size="l"]) {
+    --spectrum-actionbutton-border-radius-default: var(--system-action-button-size-l-border-radius-default);
 }
 
-:host([size='xl']) {
-    --spectrum-actionbutton-border-radius-default: var(
-        --system-action-button-size-xl-border-radius-default
-    );
+:host([size="xl"]) {
+    --spectrum-actionbutton-border-radius-default: var(--system-action-button-size-xl-border-radius-default);
 }
 
 :host([quiet]) {
-    --spectrum-actionbutton-background-color-default: var(
-        --system-action-button-quiet-background-color-default
-    );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-action-button-quiet-background-color-hover
-    );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-action-button-quiet-background-color-down
-    );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-action-button-quiet-background-color-focus
-    );
-    --spectrum-actionbutton-background-color-disabled: var(
-        --system-action-button-quiet-background-color-disabled
-    );
-    --spectrum-actionbutton-background-color-selected-disabled: var(
-        --system-action-button-quiet-background-color-selected-disabled
-    );
+    --spectrum-actionbutton-background-color-default: var(--system-action-button-quiet-background-color-default);
+    --spectrum-actionbutton-background-color-hover: var(--system-action-button-quiet-background-color-hover);
+    --spectrum-actionbutton-background-color-down: var(--system-action-button-quiet-background-color-down);
+    --spectrum-actionbutton-background-color-focus: var(--system-action-button-quiet-background-color-focus);
+    --spectrum-actionbutton-background-color-disabled: var(--system-action-button-quiet-background-color-disabled);
+    --spectrum-actionbutton-background-color-selected-disabled: var(--system-action-button-quiet-background-color-selected-disabled);
 }
 
-:host([static-color='black']) {
-    --spectrum-actionbutton-border-color-default: var(
-        --system-action-button-static-black-border-color-default
-    );
-    --spectrum-actionbutton-border-color-hover: var(
-        --system-action-button-static-black-border-color-hover
-    );
-    --spectrum-actionbutton-border-color-down: var(
-        --system-action-button-static-black-border-color-down
-    );
-    --spectrum-actionbutton-border-color-focus: var(
-        --system-action-button-static-black-border-color-focus
-    );
-    --spectrum-actionbutton-border-color-disabled: var(
-        --system-action-button-static-black-border-color-disabled
-    );
-    --spectrum-actionbutton-background-color-disabled: var(
-        --system-action-button-static-black-background-color-disabled
-    );
-    --spectrum-actionbutton-background-color-selected-disabled: var(
-        --system-action-button-static-black-background-color-selected-disabled
-    );
-    --spectrum-actionbutton-background-color-default: var(
-        --system-action-button-static-black-background-color-default
-    );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-action-button-static-black-background-color-hover
-    );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-action-button-static-black-background-color-down
-    );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-action-button-static-black-background-color-focus
-    );
+:host([static-color="black"]) {
+    --spectrum-actionbutton-border-color-default: var(--system-action-button-static-black-border-color-default);
+    --spectrum-actionbutton-border-color-hover: var(--system-action-button-static-black-border-color-hover);
+    --spectrum-actionbutton-border-color-down: var(--system-action-button-static-black-border-color-down);
+    --spectrum-actionbutton-border-color-focus: var(--system-action-button-static-black-border-color-focus);
+    --spectrum-actionbutton-border-color-disabled: var(--system-action-button-static-black-border-color-disabled);
+    --spectrum-actionbutton-background-color-disabled: var(--system-action-button-static-black-background-color-disabled);
+    --spectrum-actionbutton-background-color-selected-disabled: var(--system-action-button-static-black-background-color-selected-disabled);
+    --spectrum-actionbutton-background-color-default: var(--system-action-button-static-black-background-color-default);
+    --spectrum-actionbutton-background-color-hover: var(--system-action-button-static-black-background-color-hover);
+    --spectrum-actionbutton-background-color-down: var(--system-action-button-static-black-background-color-down);
+    --spectrum-actionbutton-background-color-focus: var(--system-action-button-static-black-background-color-focus);
 }
 
-:host([static-color='black'][quiet]) {
-    --spectrum-actionbutton-background-color-default: var(
-        --system-action-button-static-black-quiet-background-color-default
-    );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-action-button-static-black-quiet-background-color-hover
-    );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-action-button-static-black-quiet-background-color-down
-    );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-action-button-static-black-quiet-background-color-focus
-    );
-    --spectrum-actionbutton-background-color-disabled: var(
-        --system-action-button-static-black-quiet-background-color-disabled
-    );
+:host([static-color="black"][quiet]) {
+    --spectrum-actionbutton-background-color-default: var(--system-action-button-static-black-quiet-background-color-default);
+    --spectrum-actionbutton-background-color-hover: var(--system-action-button-static-black-quiet-background-color-hover);
+    --spectrum-actionbutton-background-color-down: var(--system-action-button-static-black-quiet-background-color-down);
+    --spectrum-actionbutton-background-color-focus: var(--system-action-button-static-black-quiet-background-color-focus);
+    --spectrum-actionbutton-background-color-disabled: var(--system-action-button-static-black-quiet-background-color-disabled);
 }
 
-:host([static-color='white']) {
-    --spectrum-actionbutton-border-color-default: var(
-        --system-action-button-static-white-border-color-default
-    );
-    --spectrum-actionbutton-border-color-hover: var(
-        --system-action-button-static-white-border-color-hover
-    );
-    --spectrum-actionbutton-border-color-down: var(
-        --system-action-button-static-white-border-color-down
-    );
-    --spectrum-actionbutton-border-color-focus: var(
-        --system-action-button-static-white-border-color-focus
-    );
-    --spectrum-actionbutton-border-color-disabled: var(
-        --system-action-button-static-white-border-color-disabled
-    );
-    --spectrum-actionbutton-background-color-disabled: var(
-        --system-action-button-static-white-background-color-disabled
-    );
-    --spectrum-actionbutton-background-color-selected-disabled: var(
-        --system-action-button-static-white-background-color-selected-disabled
-    );
-    --spectrum-actionbutton-background-color-default: var(
-        --system-action-button-static-white-background-color-default
-    );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-action-button-static-white-background-color-hover
-    );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-action-button-static-white-background-color-down
-    );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-action-button-static-white-background-color-focus
-    );
+:host([static-color="white"]) {
+    --spectrum-actionbutton-border-color-default: var(--system-action-button-static-white-border-color-default);
+    --spectrum-actionbutton-border-color-hover: var(--system-action-button-static-white-border-color-hover);
+    --spectrum-actionbutton-border-color-down: var(--system-action-button-static-white-border-color-down);
+    --spectrum-actionbutton-border-color-focus: var(--system-action-button-static-white-border-color-focus);
+    --spectrum-actionbutton-border-color-disabled: var(--system-action-button-static-white-border-color-disabled);
+    --spectrum-actionbutton-background-color-disabled: var(--system-action-button-static-white-background-color-disabled);
+    --spectrum-actionbutton-background-color-selected-disabled: var(--system-action-button-static-white-background-color-selected-disabled);
+    --spectrum-actionbutton-background-color-default: var(--system-action-button-static-white-background-color-default);
+    --spectrum-actionbutton-background-color-hover: var(--system-action-button-static-white-background-color-hover);
+    --spectrum-actionbutton-background-color-down: var(--system-action-button-static-white-background-color-down);
+    --spectrum-actionbutton-background-color-focus: var(--system-action-button-static-white-background-color-focus);
 }
 
-:host([static-color='white'][quiet]) {
-    --spectrum-actionbutton-background-color-default: var(
-        --system-action-button-static-white-quiet-background-color-default
-    );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-action-button-static-white-quiet-background-color-hover
-    );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-action-button-static-white-quiet-background-color-down
-    );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-action-button-static-white-quiet-background-color-focus
-    );
-    --spectrum-actionbutton-background-color-disabled: var(
-        --system-action-button-static-white-quiet-background-color-disabled
-    );
+:host([static-color="white"][quiet]) {
+    --spectrum-actionbutton-background-color-default: var(--system-action-button-static-white-quiet-background-color-default);
+    --spectrum-actionbutton-background-color-hover: var(--system-action-button-static-white-quiet-background-color-hover);
+    --spectrum-actionbutton-background-color-down: var(--system-action-button-static-white-quiet-background-color-down);
+    --spectrum-actionbutton-background-color-focus: var(--system-action-button-static-white-quiet-background-color-focus);
+    --spectrum-actionbutton-background-color-disabled: var(--system-action-button-static-white-quiet-background-color-disabled);
 }

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -47,7 +47,7 @@ governing permissions and limitations under the License.
     cursor: default;
 }
 
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     max-block-size: 100%;
     flex-shrink: 0;
 }
@@ -78,7 +78,7 @@ governing permissions and limitations under the License.
     }
 
     :host([selected]) .hold-affordance,
-    :host([selected]) ::slotted([slot='icon']),
+    :host([selected]) ::slotted([slot="icon"]),
     :host([selected]) #label {
         forced-color-adjust: none;
     }
@@ -103,7 +103,7 @@ governing permissions and limitations under the License.
 }
 
 :host:dir(rtl),
-:host([dir='rtl']) {
+:host([dir="rtl"]) {
     --spectrum-logical-rotation: matrix(-1, 0, 0, 1, 0, 0);
 }
 
@@ -111,7 +111,7 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-border-color: transparent;
 }
 
-:host([emphasized]:not([static-color='black'], [static-color='white'])) {
+:host([emphasized]:not([static-color="black"], [static-color="white"])) {
     --mod-actionbutton-background-color-default-selected: var(--mod-actionbutton-background-color-default-selected-emphasized, var(--spectrum-accent-background-color-default));
     --mod-actionbutton-background-color-hover-selected: var(--mod-actionbutton-background-color-hover-selected-emphasized, var(--spectrum-accent-background-color-hover));
     --mod-actionbutton-background-color-down-selected: var(--mod-actionbutton-background-color-down-selected-emphasized, var(--spectrum-accent-background-color-down));
@@ -122,7 +122,7 @@ governing permissions and limitations under the License.
     --mod-actionbutton-content-color-focus-selected: var(--mod-actionbutton-content-color-focus-selected-emphasized, var(--spectrum-white));
 }
 
-:host([static-color='black']) {
+:host([static-color="black"]) {
     --mod-actionbutton-background-color-default-selected: var(--spectrum-transparent-black-800);
     --mod-actionbutton-background-color-hover-selected: var(--spectrum-transparent-black-900);
     --mod-actionbutton-background-color-down-selected: var(--spectrum-transparent-black-900);
@@ -139,7 +139,7 @@ governing permissions and limitations under the License.
     --mod-actionbutton-focus-indicator-color: var(--spectrum-static-black-focus-indicator-color);
 }
 
-:host([static-color='white']) {
+:host([static-color="white"]) {
     --mod-actionbutton-background-color-default-selected: var(--spectrum-transparent-white-800);
     --mod-actionbutton-background-color-hover-selected: var(--spectrum-transparent-white-900);
     --mod-actionbutton-background-color-down-selected: var(--spectrum-transparent-white-900);
@@ -212,7 +212,7 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-sized-edge-to-visual-only: var(--spectrum-component-edge-to-visual-only-100);
 }
 
-:host([size='xs']) {
+:host([size="xs"]) {
     --spectrum-actionbutton-sized-height: var(--spectrum-component-height-50);
     --spectrum-actionbutton-sized-icon-size: var(--spectrum-workflow-icon-size-50);
     --spectrum-actionbutton-sized-font-size: var(--spectrum-font-size-50);
@@ -223,7 +223,7 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-sized-edge-to-visual-only: var(--spectrum-component-edge-to-visual-only-50);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-actionbutton-sized-height: var(--spectrum-component-height-75);
     --spectrum-actionbutton-sized-icon-size: var(--spectrum-workflow-icon-size-75);
     --spectrum-actionbutton-sized-font-size: var(--spectrum-font-size-75);
@@ -234,7 +234,7 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-sized-edge-to-visual-only: var(--spectrum-component-edge-to-visual-only-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-actionbutton-sized-height: var(--spectrum-component-height-200);
     --spectrum-actionbutton-sized-icon-size: var(--spectrum-workflow-icon-size-200);
     --spectrum-actionbutton-sized-font-size: var(--spectrum-font-size-200);
@@ -245,7 +245,7 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-sized-edge-to-visual-only: var(--spectrum-component-edge-to-visual-only-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-actionbutton-sized-height: var(--spectrum-component-height-300);
     --spectrum-actionbutton-sized-icon-size: var(--spectrum-workflow-icon-size-300);
     --spectrum-actionbutton-sized-font-size: var(--spectrum-font-size-300);
@@ -283,7 +283,7 @@ governing permissions and limitations under the License.
     border-radius: var(--mod-actionbutton-focus-indicator-border-radius, calc(var(--spectrum-actionbutton-border-radius) + var(--spectrum-actionbutton-focus-indicator-gap)));
     transition: box-shadow var(--mod-actionbutton-animation-duration, var(--spectrum-animation-duration-100)) ease-in-out;
     pointer-events: none;
-    content: '';
+    content: "";
     position: absolute;
     inset: 0;
 }
@@ -297,7 +297,7 @@ governing permissions and limitations under the License.
     box-shadow: 0 0 0 var(--spectrum-actionbutton-focus-indicator-thickness) var(--spectrum-actionbutton-focus-indicator-color);
 }
 
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     inline-size: var(--spectrum-actionbutton-icon-size);
     block-size: var(--spectrum-actionbutton-icon-size);
     color: inherit;
@@ -305,8 +305,8 @@ governing permissions and limitations under the License.
     margin-inline-end: calc(var(--spectrum-actionbutton-edge-to-visual-only) - var(--spectrum-actionbutton-edge-to-text));
 }
 
-.hold-affordance + ::slotted([slot='icon']),
-[icon-only]::slotted([slot='icon']) {
+.hold-affordance + ::slotted([slot="icon"]),
+[icon-only]::slotted([slot="icon"]) {
     margin-inline-start: calc(var(--spectrum-actionbutton-edge-to-visual-only) - var(--spectrum-actionbutton-edge-to-text));
 }
 

--- a/packages/action-group/src/action-group-overrides.css
+++ b/packages/action-group/src/action-group-overrides.css
@@ -12,13 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-actiongroup-gap-size-compact: var(
-        --system-action-group-gap-size-compact
-    );
-    --spectrum-actiongroup-horizontal-spacing-compact: var(
-        --system-action-group-horizontal-spacing-compact
-    );
-    --spectrum-actiongroup-vertical-spacing-compact: var(
-        --system-action-group-vertical-spacing-compact
-    );
+    --spectrum-actiongroup-gap-size-compact: var(--system-action-group-gap-size-compact);
+    --spectrum-actiongroup-horizontal-spacing-compact: var(--system-action-group-horizontal-spacing-compact);
+    --spectrum-actiongroup-vertical-spacing-compact: var(--system-action-group-vertical-spacing-compact);
 }

--- a/packages/action-group/src/spectrum-action-group.css
+++ b/packages/action-group/src/spectrum-action-group.css
@@ -17,15 +17,15 @@ governing permissions and limitations under the License.
     --spectrum-actiongroup-border-radius: var(--spectrum-corner-radius-100);
 }
 
-:host([size='s']),
-:host([size='xs']) {
+:host([size="s"]),
+:host([size="xs"]) {
     --spectrum-actiongroup-horizontal-spacing-regular: var(--spectrum-spacing-75);
     --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-75);
 }
 
-:host([size='l']),
+:host([size="l"]),
 :host,
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-actiongroup-horizontal-spacing-regular: var(--spectrum-spacing-100);
     --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-100);
 }
@@ -44,7 +44,7 @@ governing permissions and limitations under the License.
     z-index: 3;
 }
 
-:host(:not([vertical='true'][compact='true'])) ::slotted(*) {
+:host(:not([vertical="true"][compact="true"])) ::slotted(*) {
     flex-shrink: 0;
 }
 

--- a/packages/alert-banner/src/alert-banner-overrides.css
+++ b/packages/alert-banner/src/alert-banner-overrides.css
@@ -12,7 +12,5 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-alert-banner-neutral-background: var(
-        --system-alert-banner-neutral-background
-    );
+    --spectrum-alert-banner-neutral-background: var(--system-alert-banner-neutral-background);
 }

--- a/packages/alert-banner/src/spectrum-alert-banner.css
+++ b/packages/alert-banner/src/spectrum-alert-banner.css
@@ -53,11 +53,11 @@ governing permissions and limitations under the License.
     display: flex;
 }
 
-:host([variant='info']) {
+:host([variant="info"]) {
     background-color: var(--mod-alert-banner-informative-background, var(--spectrum-alert-banner-informative-background));
 }
 
-:host([variant='negative']) {
+:host([variant="negative"]) {
     background-color: var(--mod-alert-banner-negative-background, var(--spectrum-alert-banner-negative-background));
 }
 

--- a/packages/alert-dialog/src/spectrum-alert-dialog.css
+++ b/packages/alert-dialog/src/spectrum-alert-dialog.css
@@ -50,11 +50,11 @@ governing permissions and limitations under the License.
     margin-inline-start: var(--mod-alert-dialog-title-to-icon, var(--spectrum-alert-dialog-title-to-icon));
 }
 
-:host([variant='warning']) {
+:host([variant="warning"]) {
     --mod-icon-color: var(--mod-alert-dialog-warning-icon-color, var(--spectrum-alert-dialog-warning-icon-color));
 }
 
-:host([variant='error']) {
+:host([variant="error"]) {
     --mod-icon-color: var(--mod-alert-dialog-error-icon-color, var(--spectrum-alert-dialog-error-icon-color));
 }
 
@@ -68,7 +68,7 @@ governing permissions and limitations under the License.
     display: flex;
 }
 
-::slotted([slot='heading']) {
+::slotted([slot="heading"]) {
     font-family: var(--mod-alert-dialog-title-font-family, var(--spectrum-alert-dialog-title-font-family));
     font-weight: var(--mod-alert-dialog-title-font-weight, var(--spectrum-alert-dialog-title-font-weight));
     font-style: var(--mod-alert-dialog-title-font-style, var(--spectrum-alert-dialog-title-font-style));

--- a/packages/asset/src/asset-overrides.css
+++ b/packages/asset/src/asset-overrides.css
@@ -12,11 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-asset-folder-background-color: var(
-        --system-asset-folder-background-color
-    );
-    --spectrum-asset-file-background-color: var(
-        --system-asset-file-background-color
-    );
+    --spectrum-asset-folder-background-color: var(--system-asset-folder-background-color);
+    --spectrum-asset-file-background-color: var(--system-asset-file-background-color);
     --spectrum-asset-icon-outline-color: var(--system-asset-icon-outline-color);
 }

--- a/packages/avatar/src/spectrum-avatar.css
+++ b/packages/avatar/src/spectrum-avatar.css
@@ -22,47 +22,47 @@ governing permissions and limitations under the License.
     --spectrum-avatar-color-opacity-disabled: var(--spectrum-avatar-opacity-disabled);
 }
 
-:host([size='50']) {
+:host([size="50"]) {
     --spectrum-avatar-inline-size: var(--spectrum-avatar-size-50);
     --spectrum-avatar-block-size: var(--spectrum-avatar-size-50);
 }
 
-:host([size='75']) {
+:host([size="75"]) {
     --spectrum-avatar-inline-size: var(--spectrum-avatar-size-75);
     --spectrum-avatar-block-size: var(--spectrum-avatar-size-75);
 }
 
-:host([size='100']) {
+:host([size="100"]) {
     --spectrum-avatar-inline-size: var(--spectrum-avatar-size-100);
     --spectrum-avatar-block-size: var(--spectrum-avatar-size-100);
 }
 
-:host([size='200']) {
+:host([size="200"]) {
     --spectrum-avatar-inline-size: var(--spectrum-avatar-size-200);
     --spectrum-avatar-block-size: var(--spectrum-avatar-size-200);
 }
 
-:host([size='300']) {
+:host([size="300"]) {
     --spectrum-avatar-inline-size: var(--spectrum-avatar-size-300);
     --spectrum-avatar-block-size: var(--spectrum-avatar-size-300);
 }
 
-:host([size='400']) {
+:host([size="400"]) {
     --spectrum-avatar-inline-size: var(--spectrum-avatar-size-400);
     --spectrum-avatar-block-size: var(--spectrum-avatar-size-400);
 }
 
-:host([size='500']) {
+:host([size="500"]) {
     --spectrum-avatar-inline-size: var(--spectrum-avatar-size-500);
     --spectrum-avatar-block-size: var(--spectrum-avatar-size-500);
 }
 
-:host([size='600']) {
+:host([size="600"]) {
     --spectrum-avatar-inline-size: var(--spectrum-avatar-size-600);
     --spectrum-avatar-block-size: var(--spectrum-avatar-size-600);
 }
 
-:host([size='700']) {
+:host([size="700"]) {
     --spectrum-avatar-inline-size: var(--spectrum-avatar-size-700);
     --spectrum-avatar-block-size: var(--spectrum-avatar-size-700);
 }
@@ -95,7 +95,7 @@ governing permissions and limitations under the License.
 :host(:not([disabled])) .is-focused:after,
 :host(:not([disabled])) .link:focus-visible:after {
     pointer-events: none;
-    content: '';
+    content: "";
     inline-size: calc(var(--mod-avatar-inline-size, var(--spectrum-avatar-inline-size)) + var(--mod-avatar-focus-indicator-gap, var(--spectrum-avatar-focus-indicator-gap)) * 2);
     block-size: calc(var(--mod-avatar-inline-size, var(--spectrum-avatar-inline-size)) + var(--mod-avatar-focus-indicator-gap, var(--spectrum-avatar-focus-indicator-gap)) * 2);
     border-style: solid;

--- a/packages/badge/src/spectrum-badge.css
+++ b/packages/badge/src/spectrum-badge.css
@@ -49,27 +49,27 @@ governing permissions and limitations under the License.
     --highcontrast-badge-border-color: CanvasText;
 }
 
-:host([variant='celery']),
-:host([variant='chartreuse']),
-:host([variant='orange']),
-:host([variant='yellow']) {
+:host([variant="celery"]),
+:host([variant="chartreuse"]),
+:host([variant="orange"]),
+:host([variant="yellow"]) {
     --spectrum-badge-label-icon-color: var(--spectrum-black);
 }
 
-:host([variant='blue']),
-:host([variant='cyan']),
-:host([variant='fuchsia']),
-:host([variant='gray']),
-:host([variant='green']),
-:host([variant='indigo']),
-:host([variant='magenta']),
-:host([variant='purple']),
-:host([variant='red']),
-:host([variant='seafoam']) {
+:host([variant="blue"]),
+:host([variant="cyan"]),
+:host([variant="fuchsia"]),
+:host([variant="gray"]),
+:host([variant="green"]),
+:host([variant="indigo"]),
+:host([variant="magenta"]),
+:host([variant="purple"]),
+:host([variant="red"]),
+:host([variant="seafoam"]) {
     --spectrum-badge-label-icon-color: var(--spectrum-badge-label-icon-color-primary);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-badge-height: var(--spectrum-component-height-75);
     --spectrum-badge-font-size: var(--spectrum-font-size-75);
     --spectrum-badge-label-spacing-vertical-top: var(--spectrum-component-top-to-text-75);
@@ -82,7 +82,7 @@ governing permissions and limitations under the License.
     --spectrum-badge-icon-only-spacing-horizontal: var(--spectrum-component-edge-to-visual-only-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-badge-height: var(--spectrum-component-height-100);
     --spectrum-badge-font-size: var(--spectrum-font-size-200);
     --spectrum-badge-label-spacing-vertical-top: var(--spectrum-component-top-to-text-200);
@@ -95,7 +95,7 @@ governing permissions and limitations under the License.
     --spectrum-badge-icon-only-spacing-horizontal: var(--spectrum-component-edge-to-visual-only-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-badge-height: var(--spectrum-component-height-100);
     --spectrum-badge-font-size: var(--spectrum-font-size-300);
     --spectrum-badge-label-spacing-vertical-top: var(--spectrum-component-top-to-text-300);
@@ -129,102 +129,102 @@ governing permissions and limitations under the License.
 }
 
 :host,
-:host([variant='neutral']) {
+:host([variant="neutral"]) {
     background: var(--mod-badge-background-color-default, var(--spectrum-badge-background-color-default));
 }
 
-:host([variant='accent']) {
+:host([variant="accent"]) {
     background: var(--mod-badge-background-color-accent, var(--spectrum-badge-background-color-accent));
 }
 
-:host([variant='informative']) {
+:host([variant="informative"]) {
     background: var(--mod-badge-background-color-informative, var(--spectrum-badge-background-color-informative));
 }
 
-:host([variant='negative']) {
+:host([variant="negative"]) {
     background: var(--mod-badge-background-color-negative, var(--spectrum-badge-background-color-negative));
 }
 
-:host([variant='positive']) {
+:host([variant="positive"]) {
     background: var(--mod-badge-background-color-positive, var(--spectrum-badge-background-color-positive));
 }
 
-:host([variant='notice']) {
+:host([variant="notice"]) {
     background: var(--mod-badge-background-color-notice, var(--spectrum-badge-background-color-notice));
 }
 
-:host([variant='gray']) {
+:host([variant="gray"]) {
     background: var(--mod-badge-background-color-gray, var(--spectrum-badge-background-color-gray));
 }
 
-:host([variant='red']) {
+:host([variant="red"]) {
     background: var(--mod-badge-background-color-red, var(--spectrum-badge-background-color-red));
 }
 
-:host([variant='orange']) {
+:host([variant="orange"]) {
     background: var(--mod-badge-background-color-orange, var(--spectrum-badge-background-color-orange));
 }
 
-:host([variant='yellow']) {
+:host([variant="yellow"]) {
     background: var(--mod-badge-background-color-yellow, var(--spectrum-badge-background-color-yellow));
 }
 
-:host([variant='chartreuse']) {
+:host([variant="chartreuse"]) {
     background: var(--mod-badge-background-color-chartreuse, var(--spectrum-badge-background-color-chartreuse));
 }
 
-:host([variant='celery']) {
+:host([variant="celery"]) {
     background: var(--mod-badge-background-color-celery, var(--spectrum-badge-background-color-celery));
 }
 
-:host([variant='green']) {
+:host([variant="green"]) {
     background: var(--mod-badge-background-color-green, var(--spectrum-badge-background-color-green));
 }
 
-:host([variant='seafoam']) {
+:host([variant="seafoam"]) {
     background: var(--mod-badge-background-color-seafoam, var(--spectrum-badge-background-color-seafoam));
 }
 
-:host([variant='cyan']) {
+:host([variant="cyan"]) {
     background: var(--mod-badge-background-color-cyan, var(--spectrum-badge-background-color-cyan));
 }
 
-:host([variant='blue']) {
+:host([variant="blue"]) {
     background: var(--mod-badge-background-color-blue, var(--spectrum-badge-background-color-blue));
 }
 
-:host([variant='indigo']) {
+:host([variant="indigo"]) {
     background: var(--mod-badge-background-color-indigo, var(--spectrum-badge-background-color-indigo));
 }
 
-:host([variant='purple']) {
+:host([variant="purple"]) {
     background: var(--mod-badge-background-color-purple, var(--spectrum-badge-background-color-purple));
 }
 
-:host([variant='fuchsia']) {
+:host([variant="fuchsia"]) {
     background: var(--mod-badge-background-color-fuchsia, var(--spectrum-badge-background-color-fuchsia));
 }
 
-:host([variant='magenta']) {
+:host([variant="magenta"]) {
     background: var(--mod-badge-background-color-magenta, var(--spectrum-badge-background-color-magenta));
 }
 
-:host([fixed='inline-start']) {
+:host([fixed="inline-start"]) {
     border-start-start-radius: 0;
     border-end-start-radius: 0;
 }
 
-:host([fixed='inline-end']) {
+:host([fixed="inline-end"]) {
     border-start-end-radius: 0;
     border-end-end-radius: 0;
 }
 
-:host([fixed='block-start']) {
+:host([fixed="block-start"]) {
     border-start-start-radius: 0;
     border-start-end-radius: 0;
 }
 
-:host([fixed='block-end']) {
+:host([fixed="block-end"]) {
     border-end-end-radius: 0;
     border-end-start-radius: 0;
 }
@@ -245,11 +245,11 @@ governing permissions and limitations under the License.
     line-height: var(--mod-badge-line-height-cjk, var(--spectrum-badge-line-height-cjk));
 }
 
-[name='icon'] + .label {
+[name="icon"] + .label {
     padding-inline-start: 0;
 }
 
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     block-size: var(--mod-badge-workflow-icon-size, var(--spectrum-badge-workflow-icon-size));
     inline-size: var(--mod-badge-workflow-icon-size, var(--spectrum-badge-workflow-icon-size));
     flex: 0 0 var(--mod-badge-workflow-icon-size, var(--spectrum-badge-workflow-icon-size));

--- a/packages/breadcrumbs/src/spectrum-breadcrumbs-item.css
+++ b/packages/breadcrumbs/src/spectrum-breadcrumbs-item.css
@@ -20,7 +20,7 @@ governing permissions and limitations under the License.
 }
 
 #separator:dir(rtl),
-:host([dir='rtl']) #separator {
+:host([dir="rtl"]) #separator {
     transform: scaleX(-1);
 }
 
@@ -75,7 +75,7 @@ governing permissions and limitations under the License.
 }
 
 #item-link.is-disabled,
-:host([aria-disabled='true']) #item-link {
+:host([aria-disabled="true"]) #item-link {
     color: var(--highcontrast-breadcrumbs-text-color-disabled, var(--mod-breadcrumbs-text-color-disabled, var(--spectrum-breadcrumbs-text-color-disabled)));
 }
 
@@ -113,7 +113,7 @@ governing permissions and limitations under the License.
     block-size: calc(100% + var(--mod-breadcrumbs-focus-indicator-gap, var(--spectrum-breadcrumbs-focus-indicator-gap)) * 2 + var(--mod-breadcrumbs-focus-indicator-thickness, var(--spectrum-breadcrumbs-focus-indicator-thickness)) * 2);
     border-width: var(--mod-breadcrumbs-focus-indicator-thickness, var(--spectrum-breadcrumbs-focus-indicator-thickness));
     border-radius: var(--mod-breadcrumbs-item-link-border-radius, var(--spectrum-breadcrumbs-item-link-border-radius));
-    content: '';
+    content: "";
     pointer-events: none;
     border-style: solid;
     border-color: var(--highcontrast-breadcrumbs-focus-indicator-color, var(--mod-breadcrumbs-focus-indicator-color, var(--spectrum-breadcrumbs-focus-indicator-color)));

--- a/packages/button-group/src/spectrum-button-group.css
+++ b/packages/button-group/src/spectrum-button-group.css
@@ -18,7 +18,7 @@ governing permissions and limitations under the License.
     --spectrum-buttongroup-justify-content: var(--mod-buttongroup-justify-content, normal);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-buttongroup-spacing: var(--mod-buttongroup-spacing, var(--mod-buttongroup-spacing-horizontal, var(--spectrum-spacing-200)));
 }
 

--- a/packages/button/src/button-overrides.css
+++ b/packages/button/src/button-overrides.css
@@ -12,347 +12,145 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-button-background-color-default: var(
-        --system-button-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-background-color-focus
-    );
-    --spectrum-button-border-color-default: var(
-        --system-button-border-color-default
-    );
-    --spectrum-button-border-color-hover: var(
-        --system-button-border-color-hover
-    );
+    --spectrum-button-background-color-default: var(--system-button-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-background-color-focus);
+    --spectrum-button-border-color-default: var(--system-button-border-color-default);
+    --spectrum-button-border-color-hover: var(--system-button-border-color-hover);
     --spectrum-button-border-color-down: var(--system-button-border-color-down);
-    --spectrum-button-border-color-focus: var(
-        --system-button-border-color-focus
-    );
-    --spectrum-button-background-color-disabled: var(
-        --system-button-background-color-disabled
-    );
-    --spectrum-button-border-color-disabled: var(
-        --system-button-border-color-disabled
-    );
+    --spectrum-button-border-color-focus: var(--system-button-border-color-focus);
+    --spectrum-button-background-color-disabled: var(--system-button-background-color-disabled);
+    --spectrum-button-border-color-disabled: var(--system-button-border-color-disabled);
 }
 
 :host([selected]) {
-    --spectrum-button-background-color-default: var(
-        --system-button-selected-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-selected-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-selected-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-selected-background-color-focus
-    );
+    --spectrum-button-background-color-default: var(--system-button-selected-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-selected-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-selected-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-selected-background-color-focus);
 }
 
-:host([variant='primary']) {
-    --spectrum-button-content-color-default: var(
-        --system-button-primary-content-color-default
-    );
-    --spectrum-button-content-color-hover: var(
-        --system-button-primary-content-color-hover
-    );
-    --spectrum-button-content-color-down: var(
-        --system-button-primary-content-color-down
-    );
-    --spectrum-button-content-color-focus: var(
-        --system-button-primary-content-color-focus
-    );
+:host([variant="primary"]) {
+    --spectrum-button-content-color-default: var(--system-button-primary-content-color-default);
+    --spectrum-button-content-color-hover: var(--system-button-primary-content-color-hover);
+    --spectrum-button-content-color-down: var(--system-button-primary-content-color-down);
+    --spectrum-button-content-color-focus: var(--system-button-primary-content-color-focus);
 }
 
-:host([variant='primary'][treatment='outline']) {
-    --spectrum-button-background-color-hover: var(
-        --system-button-primary-outline-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-primary-outline-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-primary-outline-background-color-focus
-    );
+:host([variant="primary"][treatment="outline"]) {
+    --spectrum-button-background-color-hover: var(--system-button-primary-outline-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-primary-outline-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-primary-outline-background-color-focus);
 }
 
-:host([variant='secondary']) {
-    --spectrum-button-background-color-default: var(
-        --system-button-secondary-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-secondary-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-secondary-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-secondary-background-color-focus
-    );
+:host([variant="secondary"]) {
+    --spectrum-button-background-color-default: var(--system-button-secondary-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-secondary-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-secondary-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-secondary-background-color-focus);
 }
 
-:host([variant='secondary'][treatment='outline']) {
-    --spectrum-button-background-color-hover: var(
-        --system-button-secondary-outline-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-secondary-outline-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-secondary-outline-background-color-focus
-    );
-    --spectrum-button-border-color-default: var(
-        --system-button-secondary-outline-border-color-default
-    );
-    --spectrum-button-border-color-down: var(
-        --system-button-secondary-outline-border-color-down
-    );
+:host([variant="secondary"][treatment="outline"]) {
+    --spectrum-button-background-color-hover: var(--system-button-secondary-outline-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-secondary-outline-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-secondary-outline-background-color-focus);
+    --spectrum-button-border-color-default: var(--system-button-secondary-outline-border-color-default);
+    --spectrum-button-border-color-down: var(--system-button-secondary-outline-border-color-down);
 }
 
-:host([static-color='white']) {
-    --spectrum-button-background-color-default: var(
-        --system-button-static-white-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-static-white-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-static-white-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-static-white-background-color-focus
-    );
-    --spectrum-button-content-color-default: var(
-        --system-button-static-white-content-color-default
-    );
-    --spectrum-button-content-color-hover: var(
-        --system-button-static-white-content-color-hover
-    );
-    --spectrum-button-content-color-down: var(
-        --system-button-static-white-content-color-down
-    );
-    --spectrum-button-content-color-focus: var(
-        --system-button-static-white-content-color-focus
-    );
+:host([static-color="white"]) {
+    --spectrum-button-background-color-default: var(--system-button-static-white-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-static-white-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-static-white-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-static-white-background-color-focus);
+    --spectrum-button-content-color-default: var(--system-button-static-white-content-color-default);
+    --spectrum-button-content-color-hover: var(--system-button-static-white-content-color-hover);
+    --spectrum-button-content-color-down: var(--system-button-static-white-content-color-down);
+    --spectrum-button-content-color-focus: var(--system-button-static-white-content-color-focus);
 }
 
-:host([static-color='white'][treatment='outline']) {
-    --spectrum-button-background-color-default: var(
-        --system-button-static-white-outline-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-static-white-outline-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-static-white-outline-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-static-white-outline-background-color-focus
-    );
-    --spectrum-button-content-color-default: var(
-        --system-button-static-white-outline-content-color-default
-    );
-    --spectrum-button-content-color-hover: var(
-        --system-button-static-white-outline-content-color-hover
-    );
-    --spectrum-button-content-color-down: var(
-        --system-button-static-white-outline-content-color-down
-    );
-    --spectrum-button-content-color-focus: var(
-        --system-button-static-white-outline-content-color-focus
-    );
-    --spectrum-button-border-color-default: var(
-        --system-button-static-white-outline-border-color-default
-    );
-    --spectrum-button-border-color-hover: var(
-        --system-button-static-white-outline-border-color-hover
-    );
-    --spectrum-button-border-color-down: var(
-        --system-button-static-white-outline-border-color-down
-    );
-    --spectrum-button-border-color-focus: var(
-        --system-button-static-white-outline-border-color-focus
-    );
+:host([static-color="white"][treatment="outline"]) {
+    --spectrum-button-background-color-default: var(--system-button-static-white-outline-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-static-white-outline-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-static-white-outline-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-static-white-outline-background-color-focus);
+    --spectrum-button-content-color-default: var(--system-button-static-white-outline-content-color-default);
+    --spectrum-button-content-color-hover: var(--system-button-static-white-outline-content-color-hover);
+    --spectrum-button-content-color-down: var(--system-button-static-white-outline-content-color-down);
+    --spectrum-button-content-color-focus: var(--system-button-static-white-outline-content-color-focus);
+    --spectrum-button-border-color-default: var(--system-button-static-white-outline-border-color-default);
+    --spectrum-button-border-color-hover: var(--system-button-static-white-outline-border-color-hover);
+    --spectrum-button-border-color-down: var(--system-button-static-white-outline-border-color-down);
+    --spectrum-button-border-color-focus: var(--system-button-static-white-outline-border-color-focus);
 }
 
-:host([static-color='white'][variant='secondary']) {
-    --spectrum-button-background-color-default: var(
-        --system-button-static-white-secondary-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-static-white-secondary-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-static-white-secondary-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-static-white-secondary-background-color-focus
-    );
-    --spectrum-button-content-color-default: var(
-        --system-button-static-white-secondary-content-color-default
-    );
-    --spectrum-button-content-color-hover: var(
-        --system-button-static-white-secondary-content-color-hover
-    );
-    --spectrum-button-content-color-down: var(
-        --system-button-static-white-secondary-content-color-down
-    );
-    --spectrum-button-content-color-focus: var(
-        --system-button-static-white-secondary-content-color-focus
-    );
+:host([static-color="white"][variant="secondary"]) {
+    --spectrum-button-background-color-default: var(--system-button-static-white-secondary-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-static-white-secondary-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-static-white-secondary-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-static-white-secondary-background-color-focus);
+    --spectrum-button-content-color-default: var(--system-button-static-white-secondary-content-color-default);
+    --spectrum-button-content-color-hover: var(--system-button-static-white-secondary-content-color-hover);
+    --spectrum-button-content-color-down: var(--system-button-static-white-secondary-content-color-down);
+    --spectrum-button-content-color-focus: var(--system-button-static-white-secondary-content-color-focus);
 }
 
-:host([static-color='white'][variant='secondary'][treatment='outline']) {
-    --spectrum-button-border-color-default: var(
-        --system-button-static-white-secondary-outline-border-color-default
-    );
-    --spectrum-button-border-color-hover: var(
-        --system-button-static-white-secondary-outline-border-color-hover
-    );
-    --spectrum-button-border-color-down: var(
-        --system-button-static-white-secondary-outline-border-color-down
-    );
-    --spectrum-button-border-color-focus: var(
-        --system-button-static-white-secondary-outline-border-color-focus
-    );
-    --spectrum-button-background-color-default: var(
-        --system-button-static-white-secondary-outline-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-static-white-secondary-outline-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-static-white-secondary-outline-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-static-white-secondary-outline-background-color-focus
-    );
+:host([static-color="white"][variant="secondary"][treatment="outline"]) {
+    --spectrum-button-border-color-default: var(--system-button-static-white-secondary-outline-border-color-default);
+    --spectrum-button-border-color-hover: var(--system-button-static-white-secondary-outline-border-color-hover);
+    --spectrum-button-border-color-down: var(--system-button-static-white-secondary-outline-border-color-down);
+    --spectrum-button-border-color-focus: var(--system-button-static-white-secondary-outline-border-color-focus);
+    --spectrum-button-background-color-default: var(--system-button-static-white-secondary-outline-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-static-white-secondary-outline-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-static-white-secondary-outline-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-static-white-secondary-outline-background-color-focus);
 }
 
-:host([static-color='black']) {
-    --spectrum-button-background-color-default: var(
-        --system-button-static-black-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-static-black-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-static-black-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-static-black-background-color-focus
-    );
-    --spectrum-button-content-color-default: var(
-        --system-button-static-black-content-color-default
-    );
-    --spectrum-button-content-color-hover: var(
-        --system-button-static-black-content-color-hover
-    );
-    --spectrum-button-content-color-down: var(
-        --system-button-static-black-content-color-down
-    );
-    --spectrum-button-content-color-focus: var(
-        --system-button-static-black-content-color-focus
-    );
+:host([static-color="black"]) {
+    --spectrum-button-background-color-default: var(--system-button-static-black-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-static-black-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-static-black-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-static-black-background-color-focus);
+    --spectrum-button-content-color-default: var(--system-button-static-black-content-color-default);
+    --spectrum-button-content-color-hover: var(--system-button-static-black-content-color-hover);
+    --spectrum-button-content-color-down: var(--system-button-static-black-content-color-down);
+    --spectrum-button-content-color-focus: var(--system-button-static-black-content-color-focus);
 }
 
-:host([static-color='black'][treatment='outline']) {
-    --spectrum-button-background-color-default: var(
-        --system-button-static-black-outline-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-static-black-outline-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-static-black-outline-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-static-black-outline-background-color-focus
-    );
-    --spectrum-button-content-color-default: var(
-        --system-button-static-black-outline-content-color-default
-    );
-    --spectrum-button-content-color-hover: var(
-        --system-button-static-black-outline-content-color-hover
-    );
-    --spectrum-button-content-color-down: var(
-        --system-button-static-black-outline-content-color-down
-    );
-    --spectrum-button-content-color-focus: var(
-        --system-button-static-black-outline-content-color-focus
-    );
-    --spectrum-button-border-color-default: var(
-        --system-button-static-black-outline-border-color-default
-    );
-    --spectrum-button-border-color-hover: var(
-        --system-button-static-black-outline-border-color-hover
-    );
-    --spectrum-button-border-color-down: var(
-        --system-button-static-black-outline-border-color-down
-    );
-    --spectrum-button-border-color-focus: var(
-        --system-button-static-black-outline-border-color-focus
-    );
+:host([static-color="black"][treatment="outline"]) {
+    --spectrum-button-background-color-default: var(--system-button-static-black-outline-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-static-black-outline-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-static-black-outline-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-static-black-outline-background-color-focus);
+    --spectrum-button-content-color-default: var(--system-button-static-black-outline-content-color-default);
+    --spectrum-button-content-color-hover: var(--system-button-static-black-outline-content-color-hover);
+    --spectrum-button-content-color-down: var(--system-button-static-black-outline-content-color-down);
+    --spectrum-button-content-color-focus: var(--system-button-static-black-outline-content-color-focus);
+    --spectrum-button-border-color-default: var(--system-button-static-black-outline-border-color-default);
+    --spectrum-button-border-color-hover: var(--system-button-static-black-outline-border-color-hover);
+    --spectrum-button-border-color-down: var(--system-button-static-black-outline-border-color-down);
+    --spectrum-button-border-color-focus: var(--system-button-static-black-outline-border-color-focus);
 }
 
-:host([static-color='black'][variant='secondary']) {
-    --spectrum-button-background-color-default: var(
-        --system-button-static-black-secondary-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-static-black-secondary-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-static-black-secondary-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-static-black-secondary-background-color-focus
-    );
-    --spectrum-button-content-color-default: var(
-        --system-button-static-black-secondary-content-color-default
-    );
-    --spectrum-button-content-color-hover: var(
-        --system-button-static-black-secondary-content-color-hover
-    );
-    --spectrum-button-content-color-down: var(
-        --system-button-static-black-secondary-content-color-down
-    );
-    --spectrum-button-content-color-focus: var(
-        --system-button-static-black-secondary-content-color-focus
-    );
+:host([static-color="black"][variant="secondary"]) {
+    --spectrum-button-background-color-default: var(--system-button-static-black-secondary-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-static-black-secondary-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-static-black-secondary-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-static-black-secondary-background-color-focus);
+    --spectrum-button-content-color-default: var(--system-button-static-black-secondary-content-color-default);
+    --spectrum-button-content-color-hover: var(--system-button-static-black-secondary-content-color-hover);
+    --spectrum-button-content-color-down: var(--system-button-static-black-secondary-content-color-down);
+    --spectrum-button-content-color-focus: var(--system-button-static-black-secondary-content-color-focus);
 }
 
-:host([static-color='black'][variant='secondary'][treatment='outline']) {
-    --spectrum-button-border-color-default: var(
-        --system-button-static-black-secondary-outline-border-color-default
-    );
-    --spectrum-button-border-color-hover: var(
-        --system-button-static-black-secondary-outline-border-color-hover
-    );
-    --spectrum-button-border-color-down: var(
-        --system-button-static-black-secondary-outline-border-color-down
-    );
-    --spectrum-button-border-color-focus: var(
-        --system-button-static-black-secondary-outline-border-color-focus
-    );
-    --spectrum-button-background-color-default: var(
-        --system-button-static-black-secondary-outline-background-color-default
-    );
-    --spectrum-button-background-color-hover: var(
-        --system-button-static-black-secondary-outline-background-color-hover
-    );
-    --spectrum-button-background-color-down: var(
-        --system-button-static-black-secondary-outline-background-color-down
-    );
-    --spectrum-button-background-color-focus: var(
-        --system-button-static-black-secondary-outline-background-color-focus
-    );
+:host([static-color="black"][variant="secondary"][treatment="outline"]) {
+    --spectrum-button-border-color-default: var(--system-button-static-black-secondary-outline-border-color-default);
+    --spectrum-button-border-color-hover: var(--system-button-static-black-secondary-outline-border-color-hover);
+    --spectrum-button-border-color-down: var(--system-button-static-black-secondary-outline-border-color-down);
+    --spectrum-button-border-color-focus: var(--system-button-static-black-secondary-outline-border-color-focus);
+    --spectrum-button-background-color-default: var(--system-button-static-black-secondary-outline-background-color-default);
+    --spectrum-button-background-color-hover: var(--system-button-static-black-secondary-outline-background-color-hover);
+    --spectrum-button-background-color-down: var(--system-button-static-black-secondary-outline-background-color-down);
+    --spectrum-button-background-color-focus: var(--system-button-static-black-secondary-outline-background-color-focus);
 }

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -82,7 +82,7 @@ governing permissions and limitations under the License.
     --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-100);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-button-sized-height: var(--spectrum-component-height-75);
     --spectrum-button-sized-font-size: var(--spectrum-font-size-75);
     --spectrum-button-sized-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-75) - var(--spectrum-button-border-width));
@@ -95,7 +95,7 @@ governing permissions and limitations under the License.
     --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-button-sized-height: var(--spectrum-component-height-200);
     --spectrum-button-sized-font-size: var(--spectrum-font-size-200);
     --spectrum-button-sized-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-200) - var(--spectrum-button-border-width));
@@ -108,7 +108,7 @@ governing permissions and limitations under the License.
     --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-button-sized-height: var(--spectrum-component-height-300);
     --spectrum-button-sized-font-size: var(--spectrum-font-size-300);
     --spectrum-button-sized-edge-to-visual: calc(var(--spectrum-component-pill-edge-to-visual-300) - var(--spectrum-button-border-width));
@@ -143,14 +143,14 @@ governing permissions and limitations under the License.
 }
 
 :host([selected][emphasized]),
-:host([variant='accent']) {
+:host([variant="accent"]) {
     --spectrum-button-background-color-default: var(--spectrum-accent-background-color-default);
     --spectrum-button-background-color-hover: var(--spectrum-accent-background-color-hover);
     --spectrum-button-background-color-down: var(--spectrum-accent-background-color-down);
     --spectrum-button-background-color-focus: var(--spectrum-accent-background-color-key-focus);
 }
 
-:host([variant='accent']) {
+:host([variant="accent"]) {
     --spectrum-button-background-color-disabled: var(--spectrum-disabled-background-color);
     --spectrum-button-border-color-default: transparent;
     --spectrum-button-border-color-hover: transparent;
@@ -163,7 +163,7 @@ governing permissions and limitations under the License.
     --spectrum-button-content-color-focus: var(--spectrum-white);
 }
 
-:host([variant='accent'][treatment='outline']) {
+:host([variant="accent"][treatment="outline"]) {
     --spectrum-button-background-color-hover: var(--spectrum-accent-color-200);
     --spectrum-button-background-color-down: var(--spectrum-accent-color-300);
     --spectrum-button-background-color-focus: var(--spectrum-accent-color-200);
@@ -179,7 +179,7 @@ governing permissions and limitations under the License.
     --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
-:host([variant='negative']) {
+:host([variant="negative"]) {
     --spectrum-button-background-color-default: var(--spectrum-negative-background-color-default);
     --spectrum-button-background-color-hover: var(--spectrum-negative-background-color-hover);
     --spectrum-button-background-color-down: var(--spectrum-negative-background-color-down);
@@ -197,7 +197,7 @@ governing permissions and limitations under the License.
     --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
-:host([variant='negative'][treatment='outline']) {
+:host([variant="negative"][treatment="outline"]) {
     --spectrum-button-background-color-hover: var(--spectrum-negative-color-200);
     --spectrum-button-background-color-down: var(--spectrum-negative-color-300);
     --spectrum-button-background-color-focus: var(--spectrum-negative-color-200);
@@ -213,7 +213,7 @@ governing permissions and limitations under the License.
     --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
-:host([variant='primary']) {
+:host([variant="primary"]) {
     --spectrum-button-background-color-default: var(--spectrum-neutral-background-color-default);
     --spectrum-button-background-color-hover: var(--spectrum-neutral-background-color-hover);
     --spectrum-button-background-color-down: var(--spectrum-neutral-background-color-down);
@@ -226,7 +226,7 @@ governing permissions and limitations under the License.
     --spectrum-button-border-color-disabled: transparent;
 }
 
-:host([variant='primary'][treatment='outline']) {
+:host([variant="primary"][treatment="outline"]) {
     --spectrum-button-border-color-default: var(--spectrum-gray-800);
     --spectrum-button-border-color-hover: var(--spectrum-gray-900);
     --spectrum-button-border-color-down: var(--spectrum-gray-900);
@@ -239,7 +239,7 @@ governing permissions and limitations under the License.
     --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
-:host([variant='secondary']) {
+:host([variant="secondary"]) {
     --spectrum-button-background-color-disabled: var(--spectrum-disabled-background-color);
     --spectrum-button-border-color-default: transparent;
     --spectrum-button-border-color-hover: transparent;
@@ -253,7 +253,7 @@ governing permissions and limitations under the License.
     --spectrum-button-content-color-disabled: var(--spectrum-disabled-content-color);
 }
 
-:host([variant='secondary'][treatment='outline']) {
+:host([variant="secondary"][treatment="outline"]) {
     --spectrum-button-background-color-down: var(--spectrum-gray-400);
     --spectrum-button-border-color-default: var(--spectrum-gray-300);
     --spectrum-button-border-color-hover: var(--spectrum-gray-400);
@@ -273,8 +273,8 @@ governing permissions and limitations under the License.
 }
 
 :host([quiet]),
-:host([static-color='black']),
-:host([static-color='white']) {
+:host([static-color="black"]),
+:host([static-color="white"]) {
     --spectrum-button-border-color-default: transparent;
     --spectrum-button-border-color-hover: transparent;
     --spectrum-button-border-color-down: transparent;
@@ -282,8 +282,8 @@ governing permissions and limitations under the License.
     --spectrum-button-border-color-disabled: transparent;
 }
 
-:host([static-color='black'][selected]),
-:host([static-color='white'][selected]) {
+:host([static-color="black"][selected]),
+:host([static-color="white"][selected]) {
     --mod-button-content-color-default: var(--mod-button-static-content-color);
     --mod-button-content-color-hover: var(--mod-button-static-content-color);
     --mod-button-content-color-down: var(--mod-button-static-content-color);
@@ -291,8 +291,8 @@ governing permissions and limitations under the License.
     --spectrum-button-border-color-disabled: transparent;
 }
 
-:host([static-color='black'][variant='secondary']),
-:host([static-color='white'][variant='secondary']) {
+:host([static-color="black"][variant="secondary"]),
+:host([static-color="white"][variant="secondary"]) {
     --spectrum-button-border-color-default: transparent;
     --spectrum-button-border-color-hover: transparent;
     --spectrum-button-border-color-down: transparent;
@@ -300,13 +300,13 @@ governing permissions and limitations under the License.
     --spectrum-button-border-color-disabled: transparent;
 }
 
-:host([static-color='black'][variant='secondary'][treatment='outline']),
-:host([static-color='white'][variant='secondary'][treatment='outline']) {
+:host([static-color="black"][variant="secondary"][treatment="outline"]),
+:host([static-color="white"][variant="secondary"][treatment="outline"]) {
     --spectrum-button-background-color-disabled: transparent;
 }
 
-:host([static-color='black'][quiet]),
-:host([static-color='white'][quiet]) {
+:host([static-color="black"][quiet]),
+:host([static-color="white"][quiet]) {
     --spectrum-button-border-color-default: transparent;
     --spectrum-button-border-color-hover: transparent;
     --spectrum-button-border-color-down: transparent;
@@ -314,37 +314,37 @@ governing permissions and limitations under the License.
     --spectrum-button-border-color-disabled: transparent;
 }
 
-:host([static-color='white']) {
+:host([static-color="white"]) {
     --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
     --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
     --spectrum-button-focus-indicator-color: var(--spectrum-static-white-focus-indicator-color);
 }
 
-:host([static-color='white'][treatment='outline']) {
+:host([static-color="white"][treatment="outline"]) {
     --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-white-content-color);
     --spectrum-button-border-color-disabled: var(--spectrum-disabled-static-white-border-color);
 }
 
-:host([static-color='white'][variant='secondary']) {
+:host([static-color="white"][variant="secondary"]) {
     --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
 }
 
-:host([static-color='black']) {
+:host([static-color="black"]) {
     --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
     --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
     --spectrum-button-focus-indicator-color: var(--mod-static-black-focus-indicator-color, var(--spectrum-static-black-focus-indicator-color));
 }
 
-:host([static-color='black'][treatment='outline']) {
+:host([static-color="black"][treatment="outline"]) {
     --spectrum-button-content-color-disabled: var(--spectrum-disabled-static-black-content-color);
     --spectrum-button-border-color-disabled: var(--spectrum-disabled-static-black-border-color);
 }
 
-:host([static-color='black'][variant='secondary']) {
+:host([static-color="black"][variant="secondary"]) {
     --spectrum-button-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
 }
 
-:host([treatment='outline']),
+:host([treatment="outline"]),
 :host([quiet]) {
     --spectrum-button-background-color-default: transparent;
     --spectrum-button-background-color-disabled: transparent;
@@ -393,7 +393,7 @@ governing permissions and limitations under the License.
     position: relative;
 }
 
-:host([treatment='outline']) {
+:host([treatment="outline"]) {
     background-color: initial;
 }
 
@@ -401,7 +401,7 @@ governing permissions and limitations under the License.
     margin: var(--mod-button-focus-ring-border-radius, calc((var(--spectrum-button-focus-ring-gap) + var(--spectrum-button-border-width)) * -1));
     transition: box-shadow var(--spectrum-button-animation-duration) ease-in-out;
     pointer-events: none;
-    content: '';
+    content: "";
     border-radius: calc(var(--spectrum-button-border-radius) + var(--spectrum-focus-indicator-gap));
     position: absolute;
     inset: 0;
@@ -445,7 +445,7 @@ governing permissions and limitations under the License.
     color: var(--highcontrast-button-content-color-disabled, var(--mod-button-content-color-disabled, var(--spectrum-button-content-color-disabled)));
 }
 
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     --_icon-size-difference: max(0px, var(--spectrum-button-intended-icon-size) - var(--spectrum-icon-block-size, var(--spectrum-button-intended-icon-size)));
     margin-block-start: var(--mod-button-icon-margin-block-start, max(0px, var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) - var(--mod-button-border-width, var(--spectrum-button-border-width)) + (var(--_icon-size-difference, 0px) / 2)));
     margin-inline-start: calc(var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) - var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text)));
@@ -456,7 +456,7 @@ governing permissions and limitations under the License.
 }
 
 #label,
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     visibility: visible;
     opacity: 1;
     transition: opacity var(--spectrum-button-animation-duration, 0.13s) ease-in-out;
@@ -482,7 +482,7 @@ governing permissions and limitations under the License.
     transition: opacity var(--spectrum-button-animation-duration, 0.13s) ease-in-out;
 }
 
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     --_icon-size-difference: max(0px, calc(var(--spectrum-button-intended-icon-size) - var(--spectrum-icon-block-size, var(--spectrum-button-intended-icon-size))));
     color: inherit;
     flex-shrink: 0;
@@ -497,7 +497,7 @@ governing permissions and limitations under the License.
     border-radius: 50%;
 }
 
-:host([icon-only]) ::slotted([slot='icon']) {
+:host([icon-only]) ::slotted([slot="icon"]) {
     align-self: center;
     margin-block-start: 0;
     margin-inline-start: 0;
@@ -507,7 +507,7 @@ governing permissions and limitations under the License.
     border-radius: 50%;
 }
 
-[name='icon'] + #label {
+[name="icon"] + #label {
     text-align: var(--mod-button-text-align-with-icon, start);
 }
 
@@ -557,7 +557,7 @@ governing permissions and limitations under the License.
         box-shadow: 0 0 0 var(--spectrum-button-focus-ring-thickness) ButtonText;
     }
 
-    :host([variant='accent'][treatment='fill']) {
+    :host([variant="accent"][treatment="fill"]) {
         --highcontrast-button-background-color-default: ButtonText;
         --highcontrast-button-background-color-hover: Highlight;
         --highcontrast-button-background-color-down: Highlight;
@@ -573,7 +573,7 @@ governing permissions and limitations under the License.
         --highcontrast-button-border-color-down: Highlight;
     }
 
-    :host([static-color='white'][variant='accent']) {
+    :host([static-color="white"][variant="accent"]) {
         --highcontrast-button-content-color-disabled: GrayText;
     }
 }

--- a/packages/card/src/card-overrides.css
+++ b/packages/card/src/card-overrides.css
@@ -15,10 +15,6 @@ governing permissions and limitations under the License.
     --spectrum-card-border-color: var(--system-card-border-color);
     --spectrum-card-border-color-hover: var(--system-card-border-color-hover);
     --spectrum-card-divider-color: var(--system-card-divider-color);
-    --spectrum-card-preview-background-color: var(
-        --system-card-preview-background-color
-    );
-    --spectrum-card-preview-background-color-hover: var(
-        --system-card-preview-background-color-hover
-    );
+    --spectrum-card-preview-background-color: var(--system-card-preview-background-color);
+    --spectrum-card-preview-background-color-hover: var(--system-card-preview-background-color-hover);
 }

--- a/packages/card/src/spectrum-card.css
+++ b/packages/card/src/spectrum-card.css
@@ -51,12 +51,12 @@ governing permissions and limitations under the License.
     --spectrum-card-horizontal-preview-padding: var(--mod-card-horizontal-preview-padding, var(--spectrum-spacing-200));
 }
 
-:host([variant='quiet']) {
+:host([variant="quiet"]) {
     --mod-card-minimum-width: var(--mod-card-minimum-width-quiet);
     --mod-card-content-margin-top: var(--mod-card-content-margin-top-quiet, var(--spectrum-spacing-100));
 }
 
-:host([variant='gallery']) {
+:host([variant="gallery"]) {
     --spectrum-card-content-margin-top: var(--spectrum-spacing-100);
 }
 
@@ -82,7 +82,7 @@ governing permissions and limitations under the License.
 
 :host:after,
 :host:before {
-    content: '';
+    content: "";
     block-size: 100%;
     inline-size: 100%;
     position: absolute;
@@ -225,25 +225,25 @@ governing permissions and limitations under the License.
     padding-inline-end: var(--spectrum-card-subtitle-padding-right);
 }
 
-.subtitle + ::slotted([slot='description']):before {
-    content: '•';
+.subtitle + ::slotted([slot="description"]):before {
+    content: "•";
     padding-inline-end: var(--spectrum-card-subtitle-padding-right);
 }
 
-::slotted([slot='description']) {
+::slotted([slot="description"]) {
     font-family: var(--spectrum-card-body-font-family);
     font-size: var(--spectrum-card-body-font-size);
     font-weight: var(--spectrum-card-body-font-weight);
     font-style: var(--spectrum-card-body-font-style);
 }
 
-::slotted([slot='description']),
-::slotted([slot='footer']) {
+::slotted([slot="description"]),
+::slotted([slot="footer"]) {
     line-height: var(--spectrum-card-body-line-height);
     color: var(--spectrum-card-body-font-color);
 }
 
-::slotted([slot='footer']) {
+::slotted([slot="footer"]) {
     border-block-start: var(--spectrum-card-border-width) solid var(--mod-card-divider-color, var(--spectrum-card-divider-color));
     margin-block-start: var(--mod-card-footer-margin-block-start, calc((var(--spectrum-card-body-spacing) - var(--spectrum-card-content-margin-bottom)) * -1));
     margin-inline-start: var(--mod-card-footer-margin-inline-start, var(--spectrum-card-body-spacing));
@@ -262,27 +262,27 @@ governing permissions and limitations under the License.
     z-index: 1;
 }
 
-:host([variant='quiet']) #preview {
+:host([variant="quiet"]) #preview {
     border: var(--spectrum-card-focus-indicator-width) solid transparent;
 }
 
-:host([variant='quiet'][focused]):after,
-:host([variant='quiet']:focus):after {
+:host([variant="quiet"][focused]):after,
+:host([variant="quiet"]:focus):after {
     border-width: 0;
 }
 
-:host([variant='quiet'][focused]) #preview:after,
-:host([variant='quiet']:focus) #preview:after {
+:host([variant="quiet"][focused]) #preview:after,
+:host([variant="quiet"]:focus) #preview:after {
     border-color: var(--spectrum-card-focus-indicator-color);
 }
 
-:host([variant='quiet'][selected]) #preview {
+:host([variant="quiet"][selected]) #preview {
     border: var(--spectrum-card-preview-border-width-selected) solid;
     border-color: var(--spectrum-card-border-color);
 }
 
-:host([variant='gallery']),
-:host([variant='quiet']) {
+:host([variant="gallery"]),
+:host([variant="quiet"]) {
     --mod-card-border-color-hover: transparent;
     background-color: initial;
     border-width: 0;
@@ -291,13 +291,13 @@ governing permissions and limitations under the License.
     overflow: visible;
 }
 
-:host([variant='gallery']):before,
-:host([variant='quiet']):before {
+:host([variant="gallery"]):before,
+:host([variant="quiet"]):before {
     display: none;
 }
 
-:host([variant='gallery']) #preview,
-:host([variant='quiet']) #preview {
+:host([variant="gallery"]) #preview,
+:host([variant="quiet"]) #preview {
     border-radius: var(--spectrum-card-corner-radius);
     background-color: var(--mod-card-preview-background-color, var(--mod-card-background-color, var(--spectrum-card-preview-background-color)));
     min-block-size: var(--mod-card-preview-minimum-height, var(--spectrum-card-preview-minimum-height));
@@ -310,9 +310,9 @@ governing permissions and limitations under the License.
     overflow: visible;
 }
 
-:host([variant='gallery']) #preview:before,
-:host([variant='quiet']) #preview:before {
-    content: '';
+:host([variant="gallery"]) #preview:before,
+:host([variant="quiet"]) #preview:before {
+    content: "";
     block-size: 100%;
     inline-size: 100%;
     position: absolute;
@@ -320,9 +320,9 @@ governing permissions and limitations under the License.
     inset-inline-start: 0;
 }
 
-:host([variant='gallery']) #preview:after,
-:host([variant='quiet']) #preview:after {
-    content: '';
+:host([variant="gallery"]) #preview:after,
+:host([variant="quiet"]) #preview:after {
+    content: "";
     block-size: 100%;
     inline-size: 100%;
     border-radius: calc(var(--spectrum-card-corner-radius) + var(--spectrum-card-focus-indicator-width));
@@ -334,38 +334,38 @@ governing permissions and limitations under the License.
     inset-inline: 0;
 }
 
-:host([variant='gallery'][drop-target]),
-:host([variant='quiet'][drop-target]) {
+:host([variant="gallery"][drop-target]),
+:host([variant="quiet"][drop-target]) {
     background-color: initial;
     box-shadow: none;
     border-color: #0000;
 }
 
-:host([variant='gallery'][drop-target]) #preview,
-:host([variant='quiet'][drop-target]) #preview {
+:host([variant="gallery"][drop-target]) #preview,
+:host([variant="quiet"][drop-target]) #preview {
     background-color: var(--mod-card-preview-background-color, var(--mod-card-background-color, var(--spectrum-card-preview-background-color)));
     transition: none;
 }
 
-:host([variant='gallery'][drop-target]) #preview:before,
-:host([variant='quiet'][drop-target]) #preview:before {
+:host([variant="gallery"][drop-target]) #preview:before,
+:host([variant="quiet"][drop-target]) #preview:before {
     border-color: var(--spectrum-card-focus-indicator-color);
     box-shadow: 0 0 0 1px var(--spectrum-card-focus-indicator-color);
 }
 
-:host([variant='gallery'][selected]) #preview:before,
-:host([variant='quiet'][selected]) #preview:before {
+:host([variant="gallery"][selected]) #preview:before,
+:host([variant="quiet"][selected]) #preview:before {
     background-color: rgba(var(--mod-card-selected-background-color-rgb, var(--spectrum-card-selected-background-color-rgb)), var(--mod-card-selected-background-opacity, var(--spectrum-card-selected-background-opacity)));
 }
 
-:host([variant='gallery']) .body,
-:host([variant='quiet']) .body {
+:host([variant="gallery"]) .body,
+:host([variant="quiet"]) .body {
     margin-block-start: var(--spectrum-card-content-margin-top);
     padding: 0;
 }
 
-:host([variant='gallery']) ::slotted([slot='footer']),
-:host([variant='quiet']) ::slotted([slot='footer']) {
+:host([variant="gallery"]) ::slotted([slot="footer"]),
+:host([variant="quiet"]) ::slotted([slot="footer"]) {
     margin-inline: 0;
 }
 
@@ -385,8 +385,8 @@ governing permissions and limitations under the License.
         pointer-events: all;
     }
 
-    :host([variant='gallery']:hover) #preview,
-    :host([variant='quiet']:hover) #preview {
+    :host([variant="gallery"]:hover) #preview,
+    :host([variant="quiet"]:hover) #preview {
         background-color: var(--mod-card-preview-background-color-hover, var(--mod-card-background-color-hover, var(--spectrum-card-preview-background-color-hover)));
     }
 
@@ -433,11 +433,11 @@ governing permissions and limitations under the License.
     display: flex;
 }
 
-:host([variant='gallery']) {
+:host([variant="gallery"]) {
     min-inline-size: 0;
 }
 
-:host([variant='gallery']) #preview {
+:host([variant="gallery"]) #preview {
     border-radius: 0;
     padding: 0;
 }

--- a/packages/checkbox/src/checkbox-overrides.css
+++ b/packages/checkbox/src/checkbox-overrides.css
@@ -12,20 +12,10 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-checkbox-control-color-default: var(
-        --system-checkbox-control-color-default
-    );
-    --spectrum-checkbox-control-color-hover: var(
-        --system-checkbox-control-color-hover
-    );
-    --spectrum-checkbox-control-color-down: var(
-        --system-checkbox-control-color-down
-    );
-    --spectrum-checkbox-control-color-focus: var(
-        --system-checkbox-control-color-focus
-    );
+    --spectrum-checkbox-control-color-default: var(--system-checkbox-control-color-default);
+    --spectrum-checkbox-control-color-hover: var(--system-checkbox-control-color-hover);
+    --spectrum-checkbox-control-color-down: var(--system-checkbox-control-color-down);
+    --spectrum-checkbox-control-color-focus: var(--system-checkbox-control-color-focus);
     --spectrum-checkbox-checkmark-color: var(--system-checkbox-checkmark-color);
-    --spectrum-checkbox-control-corner-radius: var(
-        --system-checkbox-control-corner-radius
-    );
+    --spectrum-checkbox-control-corner-radius: var(--system-checkbox-control-corner-radius);
 }

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -49,7 +49,7 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-100);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-checkbox-font-size: var(--spectrum-font-size-75);
     --spectrum-checkbox-height: var(--spectrum-component-height-75);
     --spectrum-checkbox-control-size: var(--spectrum-checkbox-control-size-small);
@@ -57,7 +57,7 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-checkbox-font-size: var(--spectrum-font-size-200);
     --spectrum-checkbox-height: var(--spectrum-component-height-200);
     --spectrum-checkbox-control-size: var(--spectrum-checkbox-control-size-large);
@@ -65,7 +65,7 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-checkbox-font-size: var(--spectrum-font-size-300);
     --spectrum-checkbox-height: var(--spectrum-component-height-300);
     --spectrum-checkbox-control-size: var(--spectrum-checkbox-control-size-extra-large);
@@ -317,7 +317,7 @@ governing permissions and limitations under the License.
     forced-color-adjust: none;
     border-color: var(--highcontrast-checkbox-color-default, var(--mod-checkbox-control-color-default, var(--spectrum-checkbox-control-color-default)));
     z-index: 0;
-    content: '';
+    content: "";
     border-radius: var(--mod-checkbox-control-corner-radius, var(--spectrum-checkbox-control-corner-radius));
     border-width: var(--mod-checkbox-border-width, var(--spectrum-checkbox-border-width));
     transition:
@@ -330,7 +330,7 @@ governing permissions and limitations under the License.
 
 #box:after {
     border-radius: calc(var(--mod-checkbox-control-corner-radius, var(--spectrum-checkbox-control-corner-radius)) + var(--mod-checkbox-focus-indicator-gap, var(--spectrum-checkbox-focus-indicator-gap)));
-    content: '';
+    content: "";
     margin: var(--mod-checkbox-focus-indicator-gap, var(--spectrum-checkbox-focus-indicator-gap));
     transition:
         box-shadow var(--mod-checkbox-animation-duration, var(--spectrum-checkbox-animation-duration)) ease-out,

--- a/packages/clear-button/src/clear-button-overrides.css
+++ b/packages/clear-button/src/clear-button-overrides.css
@@ -12,102 +12,56 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-clear-button-background-color: var(
-        --system-clear-button-background-color
-    );
-    --spectrum-clear-button-background-color-hover: var(
-        --system-clear-button-background-color-hover
-    );
-    --spectrum-clear-button-background-color-down: var(
-        --system-clear-button-background-color-down
-    );
-    --spectrum-clear-button-background-color-key-focus: var(
-        --system-clear-button-background-color-key-focus
-    );
+    --spectrum-clear-button-background-color: var(--system-clear-button-background-color);
+    --spectrum-clear-button-background-color-hover: var(--system-clear-button-background-color-hover);
+    --spectrum-clear-button-background-color-down: var(--system-clear-button-background-color-down);
+    --spectrum-clear-button-background-color-key-focus: var(--system-clear-button-background-color-key-focus);
     --spectrum-clear-button-height: var(--system-clear-button-height);
     --spectrum-clear-button-width: var(--system-clear-button-width);
     --spectrum-clear-button-padding: var(--system-clear-button-padding);
     --spectrum-clear-button-icon-color: var(--system-clear-button-icon-color);
-    --spectrum-clear-button-icon-color-hover: var(
-        --system-clear-button-icon-color-hover
-    );
-    --spectrum-clear-button-icon-color-down: var(
-        --system-clear-button-icon-color-down
-    );
-    --spectrum-clear-button-icon-color-key-focus: var(
-        --system-clear-button-icon-color-key-focus
-    );
+    --spectrum-clear-button-icon-color-hover: var(--system-clear-button-icon-color-hover);
+    --spectrum-clear-button-icon-color-down: var(--system-clear-button-icon-color-down);
+    --spectrum-clear-button-icon-color-key-focus: var(--system-clear-button-icon-color-key-focus);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-clear-button-height: var(--system-clear-button-size-s-height);
     --spectrum-clear-button-width: var(--system-clear-button-size-s-width);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-clear-button-height: var(--system-clear-button-size-l-height);
     --spectrum-clear-button-width: var(--system-clear-button-size-l-width);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-clear-button-height: var(--system-clear-button-size-xl-height);
     --spectrum-clear-button-width: var(--system-clear-button-size-xl-width);
 }
 
 :host .spectrum-ClearButton--quiet {
-    --spectrum-clear-button-background-color: var(
-        --system-clear-button-quiet-background-color
-    );
-    --spectrum-clear-button-background-color-hover: var(
-        --system-clear-button-quiet-background-color-hover
-    );
-    --spectrum-clear-button-background-color-down: var(
-        --system-clear-button-quiet-background-color-down
-    );
-    --spectrum-clear-button-background-color-key-focus: var(
-        --system-clear-button-quiet-background-color-key-focus
-    );
+    --spectrum-clear-button-background-color: var(--system-clear-button-quiet-background-color);
+    --spectrum-clear-button-background-color-hover: var(--system-clear-button-quiet-background-color-hover);
+    --spectrum-clear-button-background-color-down: var(--system-clear-button-quiet-background-color-down);
+    --spectrum-clear-button-background-color-key-focus: var(--system-clear-button-quiet-background-color-key-focus);
 }
 
-:host([variant='overBackground']) {
-    --spectrum-clear-button-icon-color: var(
-        --system-clear-button-over-background-icon-color
-    );
-    --spectrum-clear-button-icon-color-hover: var(
-        --system-clear-button-over-background-icon-color-hover
-    );
-    --spectrum-clear-button-icon-color-down: var(
-        --system-clear-button-over-background-icon-color-down
-    );
-    --spectrum-clear-button-icon-color-key-focus: var(
-        --system-clear-button-over-background-icon-color-key-focus
-    );
-    --spectrum-clear-button-background-color: var(
-        --system-clear-button-over-background-background-color
-    );
-    --spectrum-clear-button-background-color-hover: var(
-        --system-clear-button-over-background-background-color-hover
-    );
-    --spectrum-clear-button-background-color-down: var(
-        --system-clear-button-over-background-background-color-down
-    );
-    --spectrum-clear-button-background-color-key-focus: var(
-        --system-clear-button-over-background-background-color-key-focus
-    );
+:host([variant="overBackground"]) {
+    --spectrum-clear-button-icon-color: var(--system-clear-button-over-background-icon-color);
+    --spectrum-clear-button-icon-color-hover: var(--system-clear-button-over-background-icon-color-hover);
+    --spectrum-clear-button-icon-color-down: var(--system-clear-button-over-background-icon-color-down);
+    --spectrum-clear-button-icon-color-key-focus: var(--system-clear-button-over-background-icon-color-key-focus);
+    --spectrum-clear-button-background-color: var(--system-clear-button-over-background-background-color);
+    --spectrum-clear-button-background-color-hover: var(--system-clear-button-over-background-background-color-hover);
+    --spectrum-clear-button-background-color-down: var(--system-clear-button-over-background-background-color-down);
+    --spectrum-clear-button-background-color-key-focus: var(--system-clear-button-over-background-background-color-key-focus);
 }
 
 :host([disabled]),
 :host([disabled]) {
-    --spectrum-clear-button-icon-color: var(
-        --system-clear-button-disabled-icon-color
-    );
-    --spectrum-clear-button-icon-color-hover: var(
-        --system-clear-button-disabled-icon-color-hover
-    );
-    --spectrum-clear-button-icon-color-down: var(
-        --system-clear-button-disabled-icon-color-down
-    );
-    --spectrum-clear-button-background-color: var(
-        --system-clear-button-disabled-background-color
-    );
+    --spectrum-clear-button-icon-color: var(--system-clear-button-disabled-icon-color);
+    --spectrum-clear-button-icon-color-hover: var(--system-clear-button-disabled-icon-color-hover);
+    --spectrum-clear-button-icon-color-down: var(--system-clear-button-disabled-icon-color-down);
+    --spectrum-clear-button-background-color: var(--system-clear-button-disabled-background-color);
 }

--- a/packages/clear-button/src/spectrum-clear-button.css
+++ b/packages/clear-button/src/spectrum-clear-button.css
@@ -77,7 +77,7 @@ governing permissions and limitations under the License.
     display: flex;
 }
 
-:host([variant='overBackground']:focus-visible) {
+:host([variant="overBackground"]:focus-visible) {
     outline: none;
 }
 

--- a/packages/close-button/src/close-button-overrides.css
+++ b/packages/close-button/src/close-button-overrides.css
@@ -12,40 +12,20 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-closebutton-background-color-default: var(
-        --system-close-button-background-color-default
-    );
-    --spectrum-closebutton-background-color-hover: var(
-        --system-close-button-background-color-hover
-    );
-    --spectrum-closebutton-background-color-down: var(
-        --system-close-button-background-color-down
-    );
-    --spectrum-closebutton-background-color-focus: var(
-        --system-close-button-background-color-focus
-    );
+    --spectrum-closebutton-background-color-default: var(--system-close-button-background-color-default);
+    --spectrum-closebutton-background-color-hover: var(--system-close-button-background-color-hover);
+    --spectrum-closebutton-background-color-down: var(--system-close-button-background-color-down);
+    --spectrum-closebutton-background-color-focus: var(--system-close-button-background-color-focus);
 }
 
-:host([static-color='white']) {
-    --spectrum-closebutton-static-background-color-hover: var(
-        --system-close-button-static-white-static-background-color-hover
-    );
-    --spectrum-closebutton-static-background-color-down: var(
-        --system-close-button-static-white-static-background-color-down
-    );
-    --spectrum-closebutton-static-background-color-focus: var(
-        --system-close-button-static-white-static-background-color-focus
-    );
+:host([static-color="white"]) {
+    --spectrum-closebutton-static-background-color-hover: var(--system-close-button-static-white-static-background-color-hover);
+    --spectrum-closebutton-static-background-color-down: var(--system-close-button-static-white-static-background-color-down);
+    --spectrum-closebutton-static-background-color-focus: var(--system-close-button-static-white-static-background-color-focus);
 }
 
-:host([static-color='black']) {
-    --spectrum-closebutton-static-background-color-hover: var(
-        --system-close-button-static-black-static-background-color-hover
-    );
-    --spectrum-closebutton-static-background-color-down: var(
-        --system-close-button-static-black-static-background-color-down
-    );
-    --spectrum-closebutton-static-background-color-focus: var(
-        --system-close-button-static-black-static-background-color-focus
-    );
+:host([static-color="black"]) {
+    --spectrum-closebutton-static-background-color-hover: var(--system-close-button-static-black-static-background-color-hover);
+    --spectrum-closebutton-static-background-color-down: var(--system-close-button-static-black-static-background-color-down);
+    --spectrum-closebutton-static-background-color-focus: var(--system-close-button-static-black-static-background-color-focus);
 }

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -68,13 +68,13 @@ governing permissions and limitations under the License.
             margin var(--mod-closebutton-animation-duraction, var(--spectrum-closebutton-animation-duration)) ease-out;
     }
 
-    :host([static-color='black']) {
+    :host([static-color="black"]) {
         --highcontrast-closebutton-static-background-color-default: ButtonFace;
         --highcontrast-closebutton-icon-color-default: Highlight;
         --highcontrast-closebutton-icon-color-disabled: GrayText;
     }
 
-    :host([static-color='white']) {
+    :host([static-color="white"]) {
         --highcontrast-closebutton-static-background-color-default: ButtonFace;
         --highcontrast-closebutton-icon-color-default: Highlight;
         --highcontrast-closebutton-icon-color-disabled: Highlight;
@@ -109,7 +109,7 @@ governing permissions and limitations under the License.
     position: relative;
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-closebutton-size: var(--spectrum-component-height-75);
     --spectrum-closebutton-border-radius: var(--spectrum-component-height-75);
 }
@@ -120,24 +120,24 @@ governing permissions and limitations under the License.
     --spectrum-closebutton-border-radius: var(--spectrum-component-height-100);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-closebutton-size: var(--spectrum-component-height-200);
     --spectrum-closebutton-border-radius: var(--spectrum-component-height-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-closebutton-size: var(--spectrum-component-height-300);
     --spectrum-closebutton-border-radius: var(--spectrum-component-height-300);
 }
 
-:host([static-color='white']) {
+:host([static-color="white"]) {
     --spectrum-closebutton-static-background-color-default: transparent;
     --spectrum-closebutton-icon-color-default: var(--spectrum-white);
     --spectrum-closebutton-icon-color-disabled: var(--spectrum-disabled-static-white-content-color);
     --spectrum-closebutton-focus-indicator-color: var(--spectrum-static-white-focus-indicator-color);
 }
 
-:host([static-color='black']) {
+:host([static-color="black"]) {
     --spectrum-closebutton-static-background-color-default: transparent;
     --spectrum-closebutton-icon-color-default: var(--spectrum-black);
     --spectrum-closebutton-icon-color-disabled: var(--spectrum-disabled-static-black-content-color);
@@ -146,7 +146,7 @@ governing permissions and limitations under the License.
 
 :host:after {
     pointer-events: none;
-    content: '';
+    content: "";
     margin: calc(var(--mod-closebutton-focus-indicator-gap, var(--spectrum-closebutton-focus-indicator-gap)) * -1);
     border-radius: calc(var(--mod-closebutton-size, var(--spectrum-closebutton-size)) + var(--mod-closebutton-focus-indicator-gap, var(--spectrum-closebutton-focus-indicator-gap)));
     transition: box-shadow var(--mod-closebutton-animation-duration, var(--spectrum-closebutton-animation-duration)) ease-in-out;
@@ -203,8 +203,8 @@ governing permissions and limitations under the License.
     color: var(--highcontrast-closebutton-icon-color-disabled, var(--mod-closebutton-icon-color-disabled, var(--spectrum-closebutton-icon-color-disabled)));
 }
 
-:host([static-color='black']:not([disabled])),
-:host([static-color='white']:not([disabled])) {
+:host([static-color="black"]:not([disabled])),
+:host([static-color="white"]:not([disabled])) {
     background-color: var(--highcontrast-closebutton-static-background-color-default, var(--mod-closebutton-static-background-color-default, var(--spectrum-closebutton-static-background-color-default)));
 }
 
@@ -217,52 +217,52 @@ governing permissions and limitations under the License.
         color: var(--highcontrast-closebutton-icon-color-hover, var(--mod-closebutton-icon-color-hover, var(--spectrum-closebutton-icon-color-hover)));
     }
 
-    :host([static-color='black']:not([disabled]):hover),
-    :host([static-color='white']:not([disabled]):hover) {
+    :host([static-color="black"]:not([disabled]):hover),
+    :host([static-color="white"]:not([disabled]):hover) {
         background-color: var(--mod-closebutton-static-background-color-hover, var(--spectrum-closebutton-static-background-color-hover));
     }
 
-    :host([static-color='black']:not([disabled]):hover) .icon,
-    :host([static-color='white']:not([disabled]):hover) .icon {
+    :host([static-color="black"]:not([disabled]):hover) .icon,
+    :host([static-color="white"]:not([disabled]):hover) .icon {
         color: var(--highcontrast-closebutton-icon-color-default, var(--mod-closebutton-icon-color-default, var(--spectrum-closebutton-icon-color-default)));
     }
 }
 
-:host([static-color='black']:not([disabled]):is(:active, [active])),
-:host([static-color='white']:not([disabled]):is(:active, [active])) {
+:host([static-color="black"]:not([disabled]):is(:active, [active])),
+:host([static-color="white"]:not([disabled]):is(:active, [active])) {
     background-color: var(--mod-closebutton-static-background-color-down, var(--spectrum-closebutton-static-background-color-down));
 }
 
-:host([static-color='black']:not([disabled]):is(:active, [active])) .icon,
-:host([static-color='white']:not([disabled]):is(:active, [active])) .icon {
+:host([static-color="black"]:not([disabled]):is(:active, [active])) .icon,
+:host([static-color="white"]:not([disabled]):is(:active, [active])) .icon {
     color: var(--highcontrast-closebutton-icon-color-default, var(--mod-closebutton-icon-color-default, var(--spectrum-closebutton-icon-color-default)));
 }
 
-:host([static-color='black'][focused]:not([disabled])),
-:host([static-color='black']:not([disabled]):focus-visible),
-:host([static-color='white'][focused]:not([disabled])),
-:host([static-color='white']:not([disabled]):focus-visible) {
+:host([static-color="black"][focused]:not([disabled])),
+:host([static-color="black"]:not([disabled]):focus-visible),
+:host([static-color="white"][focused]:not([disabled])),
+:host([static-color="white"]:not([disabled]):focus-visible) {
     background-color: var(--mod-closebutton-static-background-color-focus, var(--spectrum-closebutton-static-background-color-focus));
 }
 
-:host([static-color='black'][focused]:not([disabled])) .icon,
-:host([static-color='black'][focused]:not([disabled])) .icon,
-:host([static-color='black']:not([disabled]):focus) .icon,
-:host([static-color='black']:not([disabled]):focus-visible) .icon,
-:host([static-color='white'][focused]:not([disabled])) .icon,
-:host([static-color='white'][focused]:not([disabled])) .icon,
-:host([static-color='white']:not([disabled]):focus) .icon,
-:host([static-color='white']:not([disabled]):focus-visible) .icon {
+:host([static-color="black"][focused]:not([disabled])) .icon,
+:host([static-color="black"][focused]:not([disabled])) .icon,
+:host([static-color="black"]:not([disabled]):focus) .icon,
+:host([static-color="black"]:not([disabled]):focus-visible) .icon,
+:host([static-color="white"][focused]:not([disabled])) .icon,
+:host([static-color="white"][focused]:not([disabled])) .icon,
+:host([static-color="white"]:not([disabled]):focus) .icon,
+:host([static-color="white"]:not([disabled]):focus-visible) .icon {
     color: var(--highcontrast-closebutton-icon-color-default, var(--mod-closebutton-icon-color-default, var(--spectrum-closebutton-icon-color-default)));
 }
 
-:host([static-color='black']:not([disabled])) .icon,
-:host([static-color='white']:not([disabled])) .icon {
+:host([static-color="black"]:not([disabled])) .icon,
+:host([static-color="white"]:not([disabled])) .icon {
     color: var(--mod-closebutton-icon-color-default, var(--spectrum-closebutton-icon-color-default));
 }
 
-:host([static-color='black'][disabled]) .icon,
-:host([static-color='white'][disabled]) .icon {
+:host([static-color="black"][disabled]) .icon,
+:host([static-color="white"][disabled]) .icon {
     color: var(--mod-closebutton-icon-color-disabled, var(--spectrum-closebutton-icon-color-disabled));
 }
 

--- a/packages/coachmark/src/coach-indicator-overrides.css
+++ b/packages/coachmark/src/coach-indicator-overrides.css
@@ -12,84 +12,34 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-coach-indicator-ring-border-size: var(
-        --system-coach-indicator-ring-border-size
-    );
-    --spectrum-coach-indicator-min-inline-size: var(
-        --system-coach-indicator-min-inline-size
-    );
-    --spectrum-coach-indicator-min-block-size: var(
-        --system-coach-indicator-min-block-size
-    );
-    --spectrum-coach-indicator-inline-size: var(
-        --system-coach-indicator-inline-size
-    );
-    --spectrum-coach-indicator-block-size: var(
-        --system-coach-indicator-block-size
-    );
-    --spectrum-coach-indicator-ring-inline-size: var(
-        --system-coach-indicator-ring-inline-size
-    );
-    --spectrum-coach-indicator-ring-block-size: var(
-        --system-coach-indicator-ring-block-size
-    );
-    --spectrum-coach-indicator-ring-dark-color: var(
-        --system-coach-indicator-ring-dark-color
-    );
-    --spectrum-coach-indicator-ring-light-color: var(
-        --system-coach-indicator-ring-light-color
-    );
+    --spectrum-coach-indicator-ring-border-size: var(--system-coach-indicator-ring-border-size);
+    --spectrum-coach-indicator-min-inline-size: var(--system-coach-indicator-min-inline-size);
+    --spectrum-coach-indicator-min-block-size: var(--system-coach-indicator-min-block-size);
+    --spectrum-coach-indicator-inline-size: var(--system-coach-indicator-inline-size);
+    --spectrum-coach-indicator-block-size: var(--system-coach-indicator-block-size);
+    --spectrum-coach-indicator-ring-inline-size: var(--system-coach-indicator-ring-inline-size);
+    --spectrum-coach-indicator-ring-block-size: var(--system-coach-indicator-ring-block-size);
+    --spectrum-coach-indicator-ring-dark-color: var(--system-coach-indicator-ring-dark-color);
+    --spectrum-coach-indicator-ring-light-color: var(--system-coach-indicator-ring-light-color);
     --spectrum-coach-indicator-top: var(--system-coach-indicator-top);
     --spectrum-coach-indicator-left: var(--system-coach-indicator-left);
-    --spectrum-coach-animation-indicator-ring-duration: var(
-        --system-coach-indicator-coach-animation-indicator-ring-duration
-    );
-    --spectrum-coach-animation-indicator-ring-inner-delay-multiple: var(
-        --system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple
-    );
-    --spectrum-coach-animation-indicator-ring-center-delay-multiple: var(
-        --system-coach-indicator-coach-animation-indicator-ring-center-delay-multiple
-    );
-    --spectrum-coach-animation-indicator-ring-outer-delay-multiple: var(
-        --system-coach-indicator-coach-animation-indicator-ring-outer-delay-multiple
-    );
-    --spectrum-coach-indicator-quiet-animation-ring-inner-delay-multiple: var(
-        --system-coach-indicator-quiet-animation-ring-inner-delay-multiple
-    );
-    --spectrum-coach-indicator-animation-name: var(
-        --system-coach-indicator-animation-name
-    );
-    --spectrum-coach-indicator-inner-animation-delay-multiple: var(
-        --system-coach-indicator-inner-animation-delay-multiple
-    );
-    --spectrum-coach-indicator-animation-keyframe-0-scale: var(
-        --system-coach-indicator-animation-keyframe-0-scale
-    );
-    --spectrum-coach-indicator-animation-keyframe-0-opacity: var(
-        --system-coach-indicator-animation-keyframe-0-opacity
-    );
-    --spectrum-coach-indicator-animation-keyframe-50-scale: var(
-        --system-coach-indicator-animation-keyframe-50-scale
-    );
-    --spectrum-coach-indicator-animation-keyframe-50-opacity: var(
-        --system-coach-indicator-animation-keyframe-50-opacity
-    );
-    --spectrum-coach-indicator-animation-keyframe-100-scale: var(
-        --system-coach-indicator-animation-keyframe-100-scale
-    );
-    --spectrum-coach-indicator-animation-keyframe-100-opacity: var(
-        --system-coach-indicator-animation-keyframe-100-opacity
-    );
-    --spectrum-coach-indicator-quiet-animation-keyframe-0-scale: var(
-        --system-coach-indicator-quiet-animation-keyframe-0-scale
-    );
+    --spectrum-coach-animation-indicator-ring-duration: var(--system-coach-indicator-coach-animation-indicator-ring-duration);
+    --spectrum-coach-animation-indicator-ring-inner-delay-multiple: var(--system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple);
+    --spectrum-coach-animation-indicator-ring-center-delay-multiple: var(--system-coach-indicator-coach-animation-indicator-ring-center-delay-multiple);
+    --spectrum-coach-animation-indicator-ring-outer-delay-multiple: var(--system-coach-indicator-coach-animation-indicator-ring-outer-delay-multiple);
+    --spectrum-coach-indicator-quiet-animation-ring-inner-delay-multiple: var(--system-coach-indicator-quiet-animation-ring-inner-delay-multiple);
+    --spectrum-coach-indicator-animation-name: var(--system-coach-indicator-animation-name);
+    --spectrum-coach-indicator-inner-animation-delay-multiple: var(--system-coach-indicator-inner-animation-delay-multiple);
+    --spectrum-coach-indicator-animation-keyframe-0-scale: var(--system-coach-indicator-animation-keyframe-0-scale);
+    --spectrum-coach-indicator-animation-keyframe-0-opacity: var(--system-coach-indicator-animation-keyframe-0-opacity);
+    --spectrum-coach-indicator-animation-keyframe-50-scale: var(--system-coach-indicator-animation-keyframe-50-scale);
+    --spectrum-coach-indicator-animation-keyframe-50-opacity: var(--system-coach-indicator-animation-keyframe-50-opacity);
+    --spectrum-coach-indicator-animation-keyframe-100-scale: var(--system-coach-indicator-animation-keyframe-100-scale);
+    --spectrum-coach-indicator-animation-keyframe-100-opacity: var(--system-coach-indicator-animation-keyframe-100-opacity);
+    --spectrum-coach-indicator-quiet-animation-keyframe-0-scale: var(--system-coach-indicator-quiet-animation-keyframe-0-scale);
 }
 
 :host([quiet]) {
-    --spectrum-coach-indicator-quiet-ring-diameter-size: var(
-        --system-coach-indicator-quiet-quiet-ring-diameter-size
-    );
-    --spectrum-coach-indicator-animation-name: var(
-        --system-coach-indicator-quiet-animation-name
-    );
+    --spectrum-coach-indicator-quiet-ring-diameter-size: var(--system-coach-indicator-quiet-quiet-ring-diameter-size);
+    --spectrum-coach-indicator-animation-name: var(--system-coach-indicator-quiet-animation-name);
 }

--- a/packages/coachmark/src/coachmark-overrides.css
+++ b/packages/coachmark/src/coachmark-overrides.css
@@ -16,79 +16,31 @@ governing permissions and limitations under the License.
     --spectrum-coachmark-width: var(--system-coach-mark-width);
     --spectrum-coachmark-max-width: var(--system-coach-mark-max-width);
     --spectrum-coachmark-media-height: var(--system-coach-mark-media-height);
-    --spectrum-coachmark-media-min-height: var(
-        --system-coach-mark-media-min-height
-    );
+    --spectrum-coachmark-media-min-height: var(--system-coach-mark-media-min-height);
     --spectrum-coachmark-padding: var(--system-coach-mark-padding);
-    --spectrum-coachmark-heading-to-action-button: var(
-        --system-coach-mark-heading-to-action-button
-    );
-    --spectrum-coachmark-header-to-body: var(
-        --system-coach-mark-header-to-body
-    );
-    --spectrum-coachmark-body-to-footer: var(
-        --system-coach-mark-body-to-footer
-    );
+    --spectrum-coachmark-heading-to-action-button: var(--system-coach-mark-heading-to-action-button);
+    --spectrum-coachmark-header-to-body: var(--system-coach-mark-header-to-body);
+    --spectrum-coachmark-body-to-footer: var(--system-coach-mark-body-to-footer);
     --spectrum-coachmark-title-color: var(--system-coach-mark-title-color);
-    --spectrum-coachmark-title-font-family: var(
-        --system-coach-mark-title-font-family
-    );
-    --spectrum-coachmark-title-font-style: var(
-        --system-coach-mark-title-font-style
-    );
-    --spectrum-coachmark-title-text-font-weight: var(
-        --system-coach-mark-title-text-font-weight
-    );
-    --spectrum-coachmark-title-font-size: var(
-        --system-coach-mark-title-font-size
-    );
-    --spectrum-coachmark-title-text-line-height: var(
-        --system-coach-mark-title-text-line-height
-    );
-    --spectrum-coachmark-content-font-color: var(
-        --system-coach-mark-content-font-color
-    );
-    --spectrum-coachmark-content-font-weight: var(
-        --system-coach-mark-content-font-weight
-    );
-    --spectrum-coachmark-content-font-family: var(
-        --system-coach-mark-content-font-family
-    );
-    --spectrum-coachmark-content-font-style: var(
-        --system-coach-mark-content-font-style
-    );
-    --spectrum-coachmark-content-line-height: var(
-        --system-coach-mark-content-line-height
-    );
-    --spectrum-coachmark-content-font-size: var(
-        --system-coach-mark-content-font-size
-    );
+    --spectrum-coachmark-title-font-family: var(--system-coach-mark-title-font-family);
+    --spectrum-coachmark-title-font-style: var(--system-coach-mark-title-font-style);
+    --spectrum-coachmark-title-text-font-weight: var(--system-coach-mark-title-text-font-weight);
+    --spectrum-coachmark-title-font-size: var(--system-coach-mark-title-font-size);
+    --spectrum-coachmark-title-text-line-height: var(--system-coach-mark-title-text-line-height);
+    --spectrum-coachmark-content-font-color: var(--system-coach-mark-content-font-color);
+    --spectrum-coachmark-content-font-weight: var(--system-coach-mark-content-font-weight);
+    --spectrum-coachmark-content-font-family: var(--system-coach-mark-content-font-family);
+    --spectrum-coachmark-content-font-style: var(--system-coach-mark-content-font-style);
+    --spectrum-coachmark-content-line-height: var(--system-coach-mark-content-line-height);
+    --spectrum-coachmark-content-font-size: var(--system-coach-mark-content-font-size);
     --spectrum-coachmark-step-color: var(--system-coach-mark-step-color);
-    --spectrum-coachmark-step-font-weight: var(
-        --system-coach-mark-step-font-weight
-    );
-    --spectrum-coachmark-step-font-family: var(
-        --system-coach-mark-step-font-family
-    );
-    --spectrum-coachmark-step-font-style: var(
-        --system-coach-mark-step-font-style
-    );
-    --spectrum-coachmark-step-line-height: var(
-        --system-coach-mark-step-line-height
-    );
-    --spectrum-coachmark-step-font-size: var(
-        --system-coach-mark-step-font-size
-    );
-    --spectrum-coachmark-step-to-bottom: var(
-        --system-coach-mark-step-to-bottom
-    );
-    --spectrum-coachmark-popover-border-width: var(
-        --system-coach-mark-popover-border-width
-    );
-    --spectrum-coachmark-popover-corner-radius: var(
-        --system-coach-mark-popover-corner-radius
-    );
-    --spectrum-coachmark-buttongroup-spacing-horizontal: var(
-        --system-coach-mark-buttongroup-spacing-horizontal
-    );
+    --spectrum-coachmark-step-font-weight: var(--system-coach-mark-step-font-weight);
+    --spectrum-coachmark-step-font-family: var(--system-coach-mark-step-font-family);
+    --spectrum-coachmark-step-font-style: var(--system-coach-mark-step-font-style);
+    --spectrum-coachmark-step-line-height: var(--system-coach-mark-step-line-height);
+    --spectrum-coachmark-step-font-size: var(--system-coach-mark-step-font-size);
+    --spectrum-coachmark-step-to-bottom: var(--system-coach-mark-step-to-bottom);
+    --spectrum-coachmark-popover-border-width: var(--system-coach-mark-popover-border-width);
+    --spectrum-coachmark-popover-corner-radius: var(--system-coach-mark-popover-corner-radius);
+    --spectrum-coachmark-buttongroup-spacing-horizontal: var(--system-coach-mark-buttongroup-spacing-horizontal);
 }

--- a/packages/coachmark/src/spectrum-coach-indicator.css
+++ b/packages/coachmark/src/spectrum-coach-indicator.css
@@ -58,11 +58,11 @@ governing permissions and limitations under the License.
     animation-delay: calc(var(--mod-coach-animation-indicator-ring-duration, var(--spectrum-coach-animation-indicator-ring-duration)) * var(--mod-coach-animation-indicator-ring-outer-delay-multiple, var(--spectrum-coach-animation-indicator-ring-outer-delay-multiple)));
 }
 
-:host([static-color='white']) .ring {
+:host([static-color="white"]) .ring {
     border-color: var(--mod-coach-indicator-ring-light-color, var(--spectrum-coach-indicator-ring-light-color));
 }
 
-:host([static-color='black']) .ring {
+:host([static-color="black"]) .ring {
     border-color: var(--mod-coach-indicator-ring-dark-color, var(--spectrum-coach-indicator-ring-dark-color));
 }
 

--- a/packages/color-area/src/spectrum-color-area.css
+++ b/packages/color-area/src/spectrum-color-area.css
@@ -60,7 +60,7 @@ governing permissions and limitations under the License.
 }
 
 .handle:dir(rtl),
-:host([dir='rtl']) .handle {
+:host([dir="rtl"]) .handle {
     inset-inline-end: 0;
 }
 

--- a/packages/color-handle/src/spectrum-color-handle.css
+++ b/packages/color-handle/src/spectrum-color-handle.css
@@ -49,7 +49,7 @@ governing permissions and limitations under the License.
 }
 
 :host:after {
-    content: '';
+    content: "";
     inset-inline: calc(50% - var(--mod-colorhandle-hitarea-size, var(--spectrum-color-control-track-width)) / 2);
     inset-block: calc(50% - var(--mod-colorhandle-hitarea-size, var(--spectrum-color-control-track-width)) / 2);
     inline-size: var(--mod-colorhandle-hitarea-size, var(--spectrum-color-control-track-width));

--- a/packages/color-loupe/src/spectrum-color-loupe.css
+++ b/packages/color-loupe/src/spectrum-color-loupe.css
@@ -29,7 +29,7 @@ governing permissions and limitations under the License.
 }
 
 :host:dir(rtl),
-:host([dir='rtl']) {
+:host([dir="rtl"]) {
     inset-inline-end: calc(50% - var(--spectrum-color-loupe-width) / 2 - 1px);
 }
 

--- a/packages/color-slider/src/spectrum-color-slider.css
+++ b/packages/color-slider/src/spectrum-color-slider.css
@@ -68,7 +68,7 @@ governing permissions and limitations under the License.
 }
 
 .checkerboard:before {
-    content: '';
+    content: "";
     z-index: 1;
     box-shadow: inset 0 0 0 var(--mod-color-slider-border-width, var(--spectrum-color-slider-border-width)) var(--spectrum-color-slider-border-color-local);
     border-radius: var(--mod-color-slider-border-rounding, var(--spectrum-color-slider-border-rounding));
@@ -89,7 +89,7 @@ governing permissions and limitations under the License.
 }
 
 .gradient:dir(rtl),
-:host([dir='rtl']) .gradient {
+:host([dir="rtl"]) .gradient {
     transform: scaleX(-1);
 }
 

--- a/packages/combobox/src/combobox-overrides.css
+++ b/packages/combobox/src/combobox-overrides.css
@@ -12,28 +12,12 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-combobox-border-color-default: var(
-        --system-combobox-border-color-default
-    );
-    --spectrum-combobox-border-color-hover: var(
-        --system-combobox-border-color-hover
-    );
-    --spectrum-combobox-border-color-focus: var(
-        --system-combobox-border-color-focus
-    );
-    --spectrum-combobox-border-color-focus-hover: var(
-        --system-combobox-border-color-focus-hover
-    );
-    --spectrum-combobox-border-color-key-focus: var(
-        --system-combobox-border-color-key-focus
-    );
-    --spectrum-combobox-readonly-input-border-color: var(
-        --system-combobox-readonly-input-border-color
-    );
-    --spectrum-combobox-background-color-disabled: var(
-        --system-combobox-background-color-disabled
-    );
-    --spectrum-combobox-border-color-disabled: var(
-        --system-combobox-border-color-disabled
-    );
+    --spectrum-combobox-border-color-default: var(--system-combobox-border-color-default);
+    --spectrum-combobox-border-color-hover: var(--system-combobox-border-color-hover);
+    --spectrum-combobox-border-color-focus: var(--system-combobox-border-color-focus);
+    --spectrum-combobox-border-color-focus-hover: var(--system-combobox-border-color-focus-hover);
+    --spectrum-combobox-border-color-key-focus: var(--system-combobox-border-color-key-focus);
+    --spectrum-combobox-readonly-input-border-color: var(--system-combobox-readonly-input-border-color);
+    --spectrum-combobox-background-color-disabled: var(--system-combobox-background-color-disabled);
+    --spectrum-combobox-border-color-disabled: var(--system-combobox-border-color-disabled);
 }

--- a/packages/combobox/src/spectrum-combobox.css
+++ b/packages/combobox/src/spectrum-combobox.css
@@ -93,7 +93,7 @@ governing permissions and limitations under the License.
     --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-100);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-combobox-block-size: var(--spectrum-component-height-75);
     --spectrum-combobox-icon-size: var(--spectrum-workflow-icon-size-75);
     --spectrum-combobox-font-size: var(--spectrum-font-size-75);
@@ -107,7 +107,7 @@ governing permissions and limitations under the License.
     --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-combobox-block-size: var(--spectrum-component-height-200);
     --spectrum-combobox-icon-size: var(--spectrum-workflow-icon-size-200);
     --spectrum-combobox-font-size: var(--spectrum-font-size-200);
@@ -121,7 +121,7 @@ governing permissions and limitations under the License.
     --spectrum-combobox-spacing-inline-end-edge-to-text: var(--spectrum-component-edge-to-text-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-combobox-block-size: var(--spectrum-component-height-300);
     --spectrum-combobox-icon-size: var(--spectrum-workflow-icon-size-300);
     --spectrum-combobox-font-size: var(--spectrum-font-size-300);
@@ -146,7 +146,7 @@ governing permissions and limitations under the License.
     --mod-picker-button-border-color-quiet: transparent;
 }
 
-:host([quiet][size='s']) {
+:host([quiet][size="s"]) {
     --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-small);
 }
 
@@ -154,11 +154,11 @@ governing permissions and limitations under the License.
     --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-medium);
 }
 
-:host([quiet][size='l']) {
+:host([quiet][size="l"]) {
     --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-large);
 }
 
-:host([quiet][size='xl']) {
+:host([quiet][size="xl"]) {
     --spectrum-combobox-spacing-label-to-combobox: var(--spectrum-field-label-to-component-quiet-extra-large);
 }
 
@@ -222,7 +222,7 @@ governing permissions and limitations under the License.
 }
 
 .progress-circle:dir(rtl),
-:host([dir='rtl']) .progress-circle {
+:host([dir="rtl"]) .progress-circle {
     inset-inline-start: calc(var(--mod-combobox-spacing-inline-icon-to-button, var(--spectrum-combobox-spacing-inline-icon-to-button)) + var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)));
     inset-inline-end: inherit;
 }

--- a/packages/contextual-help/src/spectrum-contextual-help.css
+++ b/packages/contextual-help/src/spectrum-contextual-help.css
@@ -22,17 +22,17 @@ governing permissions and limitations under the License.
 }
 
 .popover .body,
-.popover ::slotted([slot='heading']) {
+.popover ::slotted([slot="heading"]) {
     margin: 0;
 }
 
-.popover ::slotted([slot='heading']) {
+.popover ::slotted([slot="heading"]) {
     font-size: var(--mod-spectrum-contextual-help-heading-size, var(--spectrum-contextual-help-title-size));
     color: var(--highcontrast-contextual-help-heading-color, var(--mod-contextual-help-heading-color, var(--spectrum-heading-color)));
     margin-block-end: var(--mod-spectrum-contextual-help-content-spacing, var(--spectrum-contextual-help-content-spacing));
 }
 
-::slotted([slot='link']) {
+::slotted([slot="link"]) {
     margin-block-start: var(--mod-spectrum-contextual-help-link-spacing, var(--spectrum-spacing-300));
 }
 

--- a/packages/dialog/src/dialog-overrides.css
+++ b/packages/dialog/src/dialog-overrides.css
@@ -12,60 +12,24 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-dialog-fullscreen-header-text-size: var(
-        --system-dialog-fullscreen-header-text-size
-    );
+    --spectrum-dialog-fullscreen-header-text-size: var(--system-dialog-fullscreen-header-text-size);
     --spectrum-dialog-min-inline-size: var(--system-dialog-min-inline-size);
-    --spectrum-dialog-confirm-small-width: var(
-        --system-dialog-confirm-small-width
-    );
-    --spectrum-dialog-confirm-medium-width: var(
-        --system-dialog-confirm-medium-width
-    );
-    --spectrum-dialog-confirm-large-width: var(
-        --system-dialog-confirm-large-width
-    );
-    --spectrum-dialog-confirm-divider-block-spacing-start: var(
-        --system-dialog-confirm-divider-block-spacing-start
-    );
-    --spectrum-dialog-confirm-divider-block-spacing-end: var(
-        --system-dialog-confirm-divider-block-spacing-end
-    );
-    --spectrum-dialog-confirm-description-text-color: var(
-        --system-dialog-confirm-description-text-color
-    );
-    --spectrum-dialog-confirm-title-text-color: var(
-        --system-dialog-confirm-title-text-color
-    );
-    --spectrum-dialog-confirm-description-text-line-height: var(
-        --system-dialog-confirm-description-text-line-height
-    );
-    --spectrum-dialog-confirm-title-text-line-height: var(
-        --system-dialog-confirm-title-text-line-height
-    );
-    --spectrum-dialog-heading-font-weight: var(
-        --system-dialog-heading-font-weight
-    );
-    --spectrum-dialog-confirm-description-padding: var(
-        --system-dialog-confirm-description-padding
-    );
-    --spectrum-dialog-confirm-description-margin: var(
-        --system-dialog-confirm-description-margin
-    );
-    --spectrum-dialog-confirm-footer-padding-top: var(
-        --system-dialog-confirm-footer-padding-top
-    );
+    --spectrum-dialog-confirm-small-width: var(--system-dialog-confirm-small-width);
+    --spectrum-dialog-confirm-medium-width: var(--system-dialog-confirm-medium-width);
+    --spectrum-dialog-confirm-large-width: var(--system-dialog-confirm-large-width);
+    --spectrum-dialog-confirm-divider-block-spacing-start: var(--system-dialog-confirm-divider-block-spacing-start);
+    --spectrum-dialog-confirm-divider-block-spacing-end: var(--system-dialog-confirm-divider-block-spacing-end);
+    --spectrum-dialog-confirm-description-text-color: var(--system-dialog-confirm-description-text-color);
+    --spectrum-dialog-confirm-title-text-color: var(--system-dialog-confirm-title-text-color);
+    --spectrum-dialog-confirm-description-text-line-height: var(--system-dialog-confirm-description-text-line-height);
+    --spectrum-dialog-confirm-title-text-line-height: var(--system-dialog-confirm-title-text-line-height);
+    --spectrum-dialog-heading-font-weight: var(--system-dialog-heading-font-weight);
+    --spectrum-dialog-confirm-description-padding: var(--system-dialog-confirm-description-padding);
+    --spectrum-dialog-confirm-description-margin: var(--system-dialog-confirm-description-margin);
+    --spectrum-dialog-confirm-footer-padding-top: var(--system-dialog-confirm-footer-padding-top);
     --spectrum-dialog-confirm-gap-size: var(--system-dialog-confirm-gap-size);
-    --spectrum-dialog-confirm-buttongroup-padding-top: var(
-        --system-dialog-confirm-buttongroup-padding-top
-    );
-    --spectrum-dialog-confirm-close-button-size: var(
-        --system-dialog-confirm-close-button-size
-    );
-    --spectrum-dialog-confirm-close-button-padding: var(
-        --system-dialog-confirm-close-button-padding
-    );
-    --spectrum-dialog-confirm-divider-height: var(
-        --system-dialog-confirm-divider-height
-    );
+    --spectrum-dialog-confirm-buttongroup-padding-top: var(--system-dialog-confirm-buttongroup-padding-top);
+    --spectrum-dialog-confirm-close-button-size: var(--system-dialog-confirm-close-button-size);
+    --spectrum-dialog-confirm-close-button-padding: var(--system-dialog-confirm-close-button-padding);
+    --spectrum-dialog-confirm-divider-height: var(--system-dialog-confirm-divider-height);
 }

--- a/packages/dialog/src/spectrum-dialog.css
+++ b/packages/dialog/src/spectrum-dialog.css
@@ -21,19 +21,19 @@ governing permissions and limitations under the License.
     display: flex;
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     inline-size: var(--mod-dialog-confirm-small-width, var(--spectrum-dialog-confirm-small-width));
 }
 
-:host([size='m']) {
+:host([size="m"]) {
     inline-size: var(--mod-dialog-confirm-medium-width, var(--spectrum-dialog-confirm-medium-width));
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     inline-size: var(--mod-dialog-confirm-large-width, var(--spectrum-dialog-confirm-large-width));
 }
 
-::slotted([slot='hero']) {
+::slotted([slot="hero"]) {
     block-size: var(--mod-dialog-confirm-hero-height, var(--spectrum-dialog-confirm-hero-height));
     background-position: 50%;
     background-size: cover;
@@ -46,19 +46,19 @@ governing permissions and limitations under the License.
 .grid {
     grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto 1fr auto minmax(0, auto) var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     grid-template-areas:
-        'hero hero hero hero hero hero'
-        '. . . . . .'
-        '. heading header header header .'
-        '. divider divider divider divider .'
-        '. content content content content .'
-        '. footer footer buttonGroup buttonGroup .'
-        '. . . . . .';
+        "hero hero hero hero hero hero"
+        ". . . . . ."
+        ". heading header header header ."
+        ". divider divider divider divider ."
+        ". content content content content ."
+        ". footer footer buttonGroup buttonGroup ."
+        ". . . . . .";
     grid-template-rows: auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto auto 1fr auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     inline-size: 100%;
     display: grid;
 }
 
-::slotted([slot='heading']) {
+::slotted([slot="heading"]) {
     font-size: var(--mod-dialog-confirm-title-text-size, var(--spectrum-dialog-confirm-title-text-size));
     font-weight: var(--mod-dialog-heading-font-weight, var(--spectrum-dialog-heading-font-weight));
     line-height: var(--mod-dialog-confirm-title-text-line-height, var(--spectrum-dialog-confirm-title-text-line-height));
@@ -69,7 +69,7 @@ governing permissions and limitations under the License.
     padding-inline-end: var(--mod-dialog-confirm-gap-size, var(--spectrum-dialog-confirm-gap-size));
 }
 
-.no-header::slotted([slot='heading']) {
+.no-header::slotted([slot="heading"]) {
     grid-area: heading-start / heading-start / header-end / header-end;
     padding-inline-end: 0;
 }
@@ -90,7 +90,7 @@ governing permissions and limitations under the License.
     margin-block-end: var(--mod-dialog-confirm-divider-block-spacing-start, var(--spectrum-dialog-confirm-divider-block-spacing-start));
 }
 
-:host([mode='fullscreen']) [name='heading'] + .divider {
+:host([mode="fullscreen"]) [name="heading"] + .divider {
     margin-block-end: calc(var(--mod-dialog-confirm-divider-block-spacing-start, var(--spectrum-dialog-confirm-divider-block-spacing-start)) - var(--mod-dialog-confirm-description-padding, var(--spectrum-dialog-confirm-description-padding)) * 2);
 }
 
@@ -98,7 +98,7 @@ governing permissions and limitations under the License.
     display: none;
 }
 
-:host([no-divider]) ::slotted([slot='heading']) {
+:host([no-divider]) ::slotted([slot="heading"]) {
     padding-block-end: calc(var(--mod-dialog-confirm-divider-block-spacing-end, var(--spectrum-dialog-confirm-divider-block-spacing-end)) + var(--mod-dialog-confirm-divider-block-spacing-start, var(--spectrum-dialog-confirm-divider-block-spacing-start)) + var(--mod-dialog-confirm-divider-height, var(--spectrum-dialog-confirm-divider-height)));
 }
 
@@ -144,13 +144,13 @@ governing permissions and limitations under the License.
 :host([dismissable]) .grid {
     grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto 1fr auto minmax(0, auto) minmax(0, var(--mod-dialog-confirm-close-button-size, var(--spectrum-dialog-confirm-close-button-size))) var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     grid-template-areas:
-        'hero hero hero hero hero hero hero'
-        '. . . . . closeButton closeButton'
-        '. heading header header typeIcon closeButton closeButton'
-        '. divider divider divider divider divider .'
-        '. content content content content content .'
-        '. footer footer buttonGroup buttonGroup buttonGroup .'
-        '. . . . . . .';
+        "hero hero hero hero hero hero hero"
+        ". . . . . closeButton closeButton"
+        ". heading header header typeIcon closeButton closeButton"
+        ". divider divider divider divider divider ."
+        ". content content content content content ."
+        ". footer footer buttonGroup buttonGroup buttonGroup ."
+        ". . . . . . .";
     grid-template-rows: auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto auto 1fr auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
 }
 
@@ -170,60 +170,60 @@ governing permissions and limitations under the License.
     margin-inline-end: var(--mod-dialog-confirm-close-button-padding, var(--spectrum-dialog-confirm-close-button-padding));
 }
 
-:host([mode='fullscreen']) {
+:host([mode="fullscreen"]) {
     inline-size: 100%;
     block-size: 100%;
 }
 
-:host([mode='fullscreenTakeover']) {
+:host([mode="fullscreenTakeover"]) {
     inline-size: 100%;
     block-size: 100%;
     border-radius: 0;
 }
 
-:host([mode='fullscreen']),
-:host([mode='fullscreenTakeover']) {
+:host([mode="fullscreen"]),
+:host([mode="fullscreenTakeover"]) {
     max-block-size: none;
     max-inline-size: none;
 }
 
-:host([mode='fullscreen']) .grid,
-:host([mode='fullscreenTakeover']) .grid {
+:host([mode="fullscreen"]) .grid,
+:host([mode="fullscreenTakeover"]) .grid {
     grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) 1fr auto auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     grid-template-rows: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto auto 1fr var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
     grid-template-areas:
-        '. . . . .'
-        '. heading header buttonGroup .'
-        '. divider divider divider .'
-        '. content content content .'
-        '. . . . .';
+        ". . . . ."
+        ". heading header buttonGroup ."
+        ". divider divider divider ."
+        ". content content content ."
+        ". . . . .";
     display: grid;
 }
 
-:host([mode='fullscreen']) ::slotted([slot='heading']),
-:host([mode='fullscreenTakeover']) ::slotted([slot='heading']) {
+:host([mode="fullscreen"]) ::slotted([slot="heading"]),
+:host([mode="fullscreenTakeover"]) ::slotted([slot="heading"]) {
     font-size: var(--mod-dialog-fullscreen-header-text-size, var(--spectrum-dialog-fullscreen-header-text-size));
 }
 
-:host([mode='fullscreen']) .content,
-:host([mode='fullscreenTakeover']) .content {
+:host([mode="fullscreen"]) .content,
+:host([mode="fullscreenTakeover"]) .content {
     max-block-size: none;
 }
 
-:host([mode='fullscreen']) .button-group,
-:host([mode='fullscreen']) .footer,
-:host([mode='fullscreenTakeover']) .button-group,
-:host([mode='fullscreenTakeover']) .footer {
+:host([mode="fullscreen"]) .button-group,
+:host([mode="fullscreen"]) .footer,
+:host([mode="fullscreenTakeover"]) .button-group,
+:host([mode="fullscreenTakeover"]) .footer {
     padding-block-start: 0;
 }
 
-:host([mode='fullscreen']) .footer,
-:host([mode='fullscreenTakeover']) .footer {
+:host([mode="fullscreen"]) .footer,
+:host([mode="fullscreenTakeover"]) .footer {
     display: none;
 }
 
-:host([mode='fullscreen']) .button-group,
-:host([mode='fullscreenTakeover']) .button-group {
+:host([mode="fullscreen"]) .button-group,
+:host([mode="fullscreenTakeover"]) .button-group {
     grid-area: buttonGroup;
     align-self: start;
 }
@@ -232,14 +232,14 @@ governing permissions and limitations under the License.
     .grid {
         grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto 1fr auto minmax(0, auto) var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
         grid-template-areas:
-            'hero hero hero hero hero hero'
-            '. . . . . .'
-            '. heading heading heading heading .'
-            '. header header header header .'
-            '. divider divider divider divider .'
-            '. content content content content .'
-            '. footer footer buttonGroup buttonGroup .'
-            '. . . . . .';
+            "hero hero hero hero hero hero"
+            ". . . . . ."
+            ". heading heading heading heading ."
+            ". header header header header ."
+            ". divider divider divider divider ."
+            ". content content content content ."
+            ". footer footer buttonGroup buttonGroup ."
+            ". . . . . .";
     }
 
     .grid,
@@ -250,42 +250,42 @@ governing permissions and limitations under the License.
     :host([dismissable]) .grid {
         grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto 1fr auto minmax(0, auto) minmax(0, var(--mod-dialog-confirm-close-button-size, var(--spectrum-dialog-confirm-close-button-size))) var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
         grid-template-areas:
-            'hero hero hero hero hero hero hero'
-            '. . . . . closeButton closeButton'
-            '. heading heading heading heading closeButton closeButton'
-            '. header header header header header .'
-            '. divider divider divider divider divider .'
-            '. content content content content content .'
-            '. footer footer buttonGroup buttonGroup buttonGroup .'
-            '. . . . . . .';
+            "hero hero hero hero hero hero hero"
+            ". . . . . closeButton closeButton"
+            ". heading heading heading heading closeButton closeButton"
+            ". header header header header header ."
+            ". divider divider divider divider divider ."
+            ". content content content content content ."
+            ". footer footer buttonGroup buttonGroup buttonGroup ."
+            ". . . . . . .";
     }
 
     .header {
         justify-content: flex-start;
     }
 
-    :host([mode='fullscreen']) .grid,
-    :host([mode='fullscreenTakeover']) .grid {
+    :host([mode="fullscreen"]) .grid,
+    :host([mode="fullscreenTakeover"]) .grid {
         grid-template-columns: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) 1fr var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
         grid-template-rows: var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid)) auto auto auto 1fr auto var(--mod-dialog-confirm-padding-grid, var(--spectrum-dialog-confirm-padding-grid));
         grid-template-areas:
-            '. . .'
-            '. heading .'
-            '. header .'
-            '. divider .'
-            '. content .'
-            '. buttonGroup .'
-            '. . .';
+            ". . ."
+            ". heading ."
+            ". header ."
+            ". divider ."
+            ". content ."
+            ". buttonGroup ."
+            ". . .";
         display: grid;
     }
 
-    :host([mode='fullscreen']) .button-group,
-    :host([mode='fullscreenTakeover']) .button-group {
+    :host([mode="fullscreen"]) .button-group,
+    :host([mode="fullscreenTakeover"]) .button-group {
         padding-block-start: var(--mod-dialog-confirm-buttongroup-padding-top, var(--spectrum-dialog-confirm-buttongroup-padding-top));
     }
 
-    :host([mode='fullscreen']) ::slotted([slot='heading']),
-    :host([mode='fullscreenTakeover']) ::slotted([slot='heading']) {
+    :host([mode="fullscreen"]) ::slotted([slot="heading"]),
+    :host([mode="fullscreenTakeover"]) ::slotted([slot="heading"]) {
         font-size: var(--mod-dialog-confirm-title-text-size, var(--spectrum-dialog-confirm-title-text-size));
     }
 }

--- a/packages/divider/src/divider-overrides.css
+++ b/packages/divider/src/divider-overrides.css
@@ -13,10 +13,6 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     --spectrum-divider-background-color: var(--system-divider-background-color);
-    --spectrum-divider-background-color-static-white: var(
-        --system-divider-background-color-static-white
-    );
-    --spectrum-divider-background-color-static-black: var(
-        --system-divider-background-color-static-black
-    );
+    --spectrum-divider-background-color-static-white: var(--system-divider-background-color-static-white);
+    --spectrum-divider-background-color-static-black: var(--system-divider-background-color-static-black);
 }

--- a/packages/divider/src/spectrum-divider.css
+++ b/packages/divider/src/spectrum-divider.css
@@ -21,36 +21,36 @@ governing permissions and limitations under the License.
     --spectrum-divider-thickness: var(--spectrum-divider-thickness-medium);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-divider-thickness: var(--spectrum-divider-thickness-small);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-divider-thickness: var(--spectrum-divider-thickness-large);
     --spectrum-divider-background-color: var(--spectrum-gray-800);
 }
 
-:host([static-color='white']) {
+:host([static-color="white"]) {
     --mod-divider-background-color: var(--mod-divider-background-color-medium-static-white, var(--spectrum-divider-background-color-static-white));
 }
 
-:host([static-color='white'][size='s']) {
+:host([static-color="white"][size="s"]) {
     --mod-divider-background-color: var(--mod-divider-background-color-small-static-white, var(--spectrum-divider-background-color-static-white));
 }
 
-:host([static-color='white'][size='l']) {
+:host([static-color="white"][size="l"]) {
     --mod-divider-background-color: var(--mod-divider-background-color-large-static-white, var(--spectrum-transparent-white-800));
 }
 
-:host([static-color='black']) {
+:host([static-color="black"]) {
     --mod-divider-background-color: var(--mod-divider-background-color-medium-static-black, var(--spectrum-divider-background-color-static-black));
 }
 
-:host([static-color='black'][size='s']) {
+:host([static-color="black"][size="s"]) {
     --mod-divider-background-color: var(--mod-divider-background-color-small-static-black, var(--spectrum-divider-background-color-static-black));
 }
 
-:host([static-color='black'][size='l']) {
+:host([static-color="black"][size="l"]) {
     --mod-divider-background-color: var(--mod-divider-background-color-large-static-black, var(--spectrum-transparent-black-800));
 }
 

--- a/packages/field-group/src/field-group-overrides.css
+++ b/packages/field-group/src/field-group-overrides.css
@@ -13,7 +13,5 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     --spectrum-fieldgroup-margin: var(--system-field-group-margin);
-    --spectrum-fieldgroup-readonly-delimiter: var(
-        --system-field-group-readonly-delimiter
-    );
+    --spectrum-fieldgroup-readonly-delimiter: var(--system-field-group-readonly-delimiter);
 }

--- a/packages/field-label/src/spectrum-field-label.css
+++ b/packages/field-label/src/spectrum-field-label.css
@@ -22,7 +22,7 @@ governing permissions and limitations under the License.
     --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-medium);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-field-label-min-height: var(--spectrum-component-height-75);
     --spectrum-field-label-top-to-text: var(--spectrum-component-top-to-text-75);
     --spectrum-field-label-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
@@ -32,7 +32,7 @@ governing permissions and limitations under the License.
     --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-small);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-field-label-min-height: var(--spectrum-component-height-100);
     --spectrum-field-label-top-to-text: var(--spectrum-component-top-to-text-100);
     --spectrum-field-label-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
@@ -42,7 +42,7 @@ governing permissions and limitations under the License.
     --spectrum-field-label-text-to-asterisk: var(--spectrum-field-label-text-to-asterisk-large);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-field-label-min-height: var(--spectrum-component-height-200);
     --spectrum-field-label-top-to-text: var(--spectrum-component-top-to-text-200);
     --spectrum-field-label-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
@@ -89,8 +89,8 @@ governing permissions and limitations under the License.
     vertical-align: var(--mod-field-label-asterisk-vertical-align, baseline);
 }
 
-:host([side-aligned='start']),
-:host([side-aligned='end']) {
+:host([side-aligned="start"]),
+:host([side-aligned="end"]) {
     vertical-align: top;
     margin-block-start: var(--mod-fieldlabel-side-margin-block-start, var(--spectrum-field-label-side-margin-block-start));
     margin-block-end: 0;
@@ -98,7 +98,7 @@ governing permissions and limitations under the License.
     display: inline-block;
 }
 
-:host([side-aligned='end']) {
+:host([side-aligned="end"]) {
     text-align: end;
 }
 

--- a/packages/help-text/src/spectrum-help-text.css
+++ b/packages/help-text/src/spectrum-help-text.css
@@ -33,7 +33,7 @@ governing permissions and limitations under the License.
     display: flex;
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-helptext-min-height: var(--spectrum-component-height-75);
     --spectrum-helptext-icon-size: var(--spectrum-workflow-icon-size-75);
     --spectrum-helptext-font-size: var(--spectrum-font-size-75);
@@ -56,7 +56,7 @@ governing permissions and limitations under the License.
     --spectrum-helptext-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-helptext-min-height: var(--spectrum-component-height-100);
     --spectrum-helptext-icon-size: var(--spectrum-workflow-icon-size-200);
     --spectrum-helptext-font-size: var(--spectrum-font-size-100);
@@ -67,7 +67,7 @@ governing permissions and limitations under the License.
     --spectrum-helptext-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-helptext-min-height: var(--spectrum-component-height-200);
     --spectrum-helptext-icon-size: var(--spectrum-workflow-icon-size-300);
     --spectrum-helptext-font-size: var(--spectrum-font-size-200);
@@ -78,12 +78,12 @@ governing permissions and limitations under the License.
     --spectrum-helptext-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
 }
 
-:host([variant='neutral']) {
+:host([variant="neutral"]) {
     --spectrum-helptext-content-color-default: var(--spectrum-neutral-subdued-content-color-default);
     --spectrum-helptext-icon-color-default: var(--spectrum-neutral-subdued-content-color-default);
 }
 
-:host([variant='negative']) {
+:host([variant="negative"]) {
     --spectrum-helptext-content-color-default: var(--spectrum-negative-color-900);
     --spectrum-helptext-icon-color-default: var(--spectrum-negative-color-900);
 }
@@ -114,19 +114,19 @@ governing permissions and limitations under the License.
     padding-block-end: var(--mod-helptext-bottom-to-text, var(--spectrum-helptext-bottom-to-text));
 }
 
-:host([variant='neutral']) .text {
+:host([variant="neutral"]) .text {
     color: var(--highcontrast-helptext-content-color-default, var(--mod-helptext-content-color-default, var(--spectrum-helptext-content-color-default)));
 }
 
-:host([variant='neutral']) .icon {
+:host([variant="neutral"]) .icon {
     color: var(--highcontrast-helptext-icon-color-default, var(--mod-helptext-icon-color-default, var(--spectrum-helptext-icon-color-default)));
 }
 
-:host([variant='negative']) .text {
+:host([variant="negative"]) .text {
     color: var(--highcontrast-helptext-content-color-default, var(--mod-helptext-content-color-default, var(--spectrum-helptext-content-color-default)));
 }
 
-:host([variant='negative']) .icon {
+:host([variant="negative"]) .icon {
     color: var(--highcontrast-helptext-icon-color-default, var(--mod-helptext-icon-color-default, var(--spectrum-helptext-icon-color-default)));
 }
 

--- a/packages/icon/src/spectrum-icon.css
+++ b/packages/icon/src/spectrum-icon.css
@@ -33,26 +33,26 @@ governing permissions and limitations under the License.
     --spectrum-icon-size: var(--spectrum-workflow-icon-size-100);
 }
 
-:host([size='xxs']) {
+:host([size="xxs"]) {
     --spectrum-icon-size: var(--spectrum-workflow-icon-size-xxs);
 }
 
-:host([size='xs']) {
+:host([size="xs"]) {
     --spectrum-icon-size: var(--spectrum-workflow-icon-size-50);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-icon-size: var(--spectrum-workflow-icon-size-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-icon-size: var(--spectrum-workflow-icon-size-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-icon-size: var(--spectrum-workflow-icon-size-300);
 }
 
-:host([size='xxl']) {
+:host([size="xxl"]) {
     --spectrum-icon-size: var(--spectrum-workflow-icon-size-xxl);
 }

--- a/packages/infield-button/src/infield-button-overrides.css
+++ b/packages/infield-button/src/infield-button-overrides.css
@@ -12,40 +12,18 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-infield-button-border-width: var(
-        --system-infield-button-border-width
-    );
-    --spectrum-infield-button-border-color: var(
-        --system-infield-button-border-color
-    );
-    --spectrum-infield-button-border-radius: var(
-        --system-infield-button-border-radius
-    );
-    --spectrum-infield-button-border-radius-reset: var(
-        --system-infield-button-border-radius-reset
-    );
-    --spectrum-infield-button-stacked-top-border-radius-start-start: var(
-        --system-infield-button-stacked-top-border-radius-start-start
-    );
-    --spectrum-infield-button-stacked-bottom-border-radius-end-start: var(
-        --system-infield-button-stacked-bottom-border-radius-end-start
-    );
-    --spectrum-infield-button-background-color: var(
-        --system-infield-button-background-color
-    );
-    --spectrum-infield-button-background-color-hover: var(
-        --system-infield-button-background-color-hover
-    );
-    --spectrum-infield-button-background-color-down: var(
-        --system-infield-button-background-color-down
-    );
-    --spectrum-infield-button-background-color-key-focus: var(
-        --system-infield-button-background-color-key-focus
-    );
+    --spectrum-infield-button-border-width: var(--system-infield-button-border-width);
+    --spectrum-infield-button-border-color: var(--system-infield-button-border-color);
+    --spectrum-infield-button-border-radius: var(--system-infield-button-border-radius);
+    --spectrum-infield-button-border-radius-reset: var(--system-infield-button-border-radius-reset);
+    --spectrum-infield-button-stacked-top-border-radius-start-start: var(--system-infield-button-stacked-top-border-radius-start-start);
+    --spectrum-infield-button-stacked-bottom-border-radius-end-start: var(--system-infield-button-stacked-bottom-border-radius-end-start);
+    --spectrum-infield-button-background-color: var(--system-infield-button-background-color);
+    --spectrum-infield-button-background-color-hover: var(--system-infield-button-background-color-hover);
+    --spectrum-infield-button-background-color-down: var(--system-infield-button-background-color-down);
+    --spectrum-infield-button-background-color-key-focus: var(--system-infield-button-background-color-key-focus);
 }
 
 :host([disabled]) {
-    --spectrum-infield-button-border-color: var(
-        --system-infield-button-disabled-border-color
-    );
+    --spectrum-infield-button-border-color: var(--system-infield-button-disabled-border-color);
 }

--- a/packages/infield-button/src/spectrum-infield-button.css
+++ b/packages/infield-button/src/spectrum-infield-button.css
@@ -39,7 +39,7 @@ governing permissions and limitations under the License.
     --mod-infield-button-icon-color-key-focus: var(--mod-infield-button-icon-color-key-focus-disabled, var(--spectrum-disabled-content-color));
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-infield-button-height: var(--spectrum-component-height-75);
     --spectrum-infield-button-width: var(--spectrum-component-height-75);
     --spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-small);
@@ -47,7 +47,7 @@ governing permissions and limitations under the License.
     --spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-small);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-infield-button-height: var(--spectrum-component-height-200);
     --spectrum-infield-button-width: var(--spectrum-component-height-200);
     --spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-large);
@@ -55,7 +55,7 @@ governing permissions and limitations under the License.
     --spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-large);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-infield-button-height: var(--spectrum-component-height-300);
     --spectrum-infield-button-width: var(--spectrum-component-height-300);
     --spectrum-infield-button-stacked-fill-padding-inline: var(--spectrum-in-field-button-edge-to-disclosure-icon-stacked-extra-large);
@@ -63,23 +63,23 @@ governing permissions and limitations under the License.
     --spectrum-infield-button-stacked-fill-padding-inner: var(--spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large);
 }
 
-:host([block='end']),
-:host([block='start']) {
+:host([block="end"]),
+:host([block="start"]) {
     --mod-infield-button-width: var(--mod-infield-button-width-stacked, var(--spectrum-in-field-button-width-stacked-medium));
 }
 
-:host([block='end'][size='s']),
-:host([block='start'][size='s']) {
+:host([block="end"][size="s"]),
+:host([block="start"][size="s"]) {
     --mod-infield-button-width: var(--mod-infield-button-width-stacked, var(--spectrum-in-field-button-width-stacked-small));
 }
 
-:host([block='end'][size='l']),
-:host([block='start'][size='l']) {
+:host([block="end"][size="l"]),
+:host([block="start"][size="l"]) {
     --mod-infield-button-width: var(--mod-infield-button-width-stacked, var(--spectrum-in-field-button-width-stacked-large));
 }
 
-:host([block='end'][size='xl']),
-:host([block='start'][size='xl']) {
+:host([block="end"][size="xl"]),
+:host([block="start"][size="xl"]) {
     --mod-infield-button-width: var(--mod-infield-button-width-stacked, var(--spectrum-in-field-button-width-stacked-extra-large));
 }
 
@@ -156,16 +156,16 @@ governing permissions and limitations under the License.
     outline: none;
 }
 
-:host([block='end']),
-:host([block='start']) {
+:host([block="end"]),
+:host([block="start"]) {
     block-size: calc(var(--mod-infield-button-height, var(--spectrum-infield-button-height)) / 2);
 }
 
-:host([block='start']) {
+:host([block="start"]) {
     padding-block-end: var(--mod-infield-button-inner-edge-to-fill, var(--spectrum-infield-button-inner-edge-to-fill));
 }
 
-:host([block='end']) {
+:host([block="end"]) {
     padding-block-start: var(--mod-infield-button-inner-edge-to-fill, var(--spectrum-infield-button-inner-edge-to-fill));
 }
 
@@ -187,24 +187,24 @@ governing permissions and limitations under the License.
     display: flex;
 }
 
-:host([inline='end']) .fill {
+:host([inline="end"]) .fill {
     border-start-start-radius: var(--mod-infield-button-border-radius-reset, var(--spectrum-infield-button-border-radius-reset));
     border-end-start-radius: var(--mod-infield-button-border-radius-reset, var(--spectrum-infield-button-border-radius-reset));
 }
 
-:host([inline='start']) .fill {
+:host([inline="start"]) .fill {
     border-start-end-radius: var(--mod-infield-button-border-radius-reset, var(--spectrum-infield-button-border-radius-reset));
     border-end-end-radius: var(--mod-infield-button-border-radius-reset, var(--spectrum-infield-button-border-radius-reset));
 }
 
-:host([block='end']) .fill,
-:host([block='start']) .fill {
+:host([block="end"]) .fill,
+:host([block="start"]) .fill {
     box-sizing: border-box;
     padding-inline-start: calc(var(--mod-infield-button-stacked-fill-padding-inline, var(--spectrum-infield-button-stacked-fill-padding-inline)) - var(--mod-infield-button-edge-to-fill, var(--spectrum-infield-button-edge-to-fill)) - var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));
     padding-inline-end: calc(var(--mod-infield-button-stacked-fill-padding-inline, var(--spectrum-infield-button-stacked-fill-padding-inline)) - var(--mod-infield-button-edge-to-fill, var(--spectrum-infield-button-edge-to-fill)) - var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));
 }
 
-:host([block='start']) .fill {
+:host([block="start"]) .fill {
     border-block-end: none;
     border-start-start-radius: var(--mod-infield-button-stacked-top-border-radius-start-start, var(--spectrum-infield-button-stacked-top-border-radius-start-start));
     border-end-end-radius: var(--mod-infield-button-stacked-border-radius-reset, var(--spectrum-infield-button-stacked-border-radius-reset));
@@ -213,7 +213,7 @@ governing permissions and limitations under the License.
     padding-block-end: calc(var(--mod-infield-button-stacked-fill-padding-inner, var(--spectrum-infield-button-stacked-fill-padding-inner)) - var(--mod-infield-button-inner-edge-to-fill, var(--spectrum-infield-button-inner-edge-to-fill)));
 }
 
-:host([block='end']) .fill {
+:host([block="end"]) .fill {
     border-block-end-width: var(--mod-infield-button-stacked-bottom-border-block-end-width, var(--mod-infield-button-border-width, var(--spectrum-infield-button-border-width)));
     border-start-start-radius: var(--mod-infield-button-stacked-border-radius-reset, var(--spectrum-infield-button-stacked-border-radius-reset));
     border-start-end-radius: var(--mod-infield-button-stacked-border-radius-reset, var(--spectrum-infield-button-stacked-border-radius-reset));

--- a/packages/link/src/spectrum-link.css
+++ b/packages/link/src/spectrum-link.css
@@ -17,7 +17,7 @@ governing permissions and limitations under the License.
     }
 }
 
-:host([variant='secondary']) a {
+:host([variant="secondary"]) a {
     --mod-link-text-color: var(--mod-link-text-color-secondary-default, var(--spectrum-neutral-content-color-default));
     --mod-link-text-color-hover: var(--mod-link-text-color-secondary-hover, var(--spectrum-neutral-content-color-hover));
     --mod-link-text-color-active: var(--mod-link-text-color-secondary-active, var(--spectrum-neutral-content-color-down));
@@ -63,14 +63,14 @@ a:focus-visible {
     }
 }
 
-:host([static-color='white']) a {
+:host([static-color="white"]) a {
     --mod-link-text-color: var(--mod-link-text-color-white, var(--spectrum-white));
     --mod-link-text-color-hover: var(--mod-link-text-color-white, var(--spectrum-white));
     --mod-link-text-color-active: var(--mod-link-text-color-white, var(--spectrum-white));
     --mod-link-text-color-focus: var(--mod-link-text-color-white, var(--spectrum-white));
 }
 
-:host([static-color='black']) a {
+:host([static-color="black"]) a {
     --mod-link-text-color: var(--mod-link-text-color-black, var(--spectrum-black));
     --mod-link-text-color-hover: var(--mod-link-text-color-black, var(--spectrum-black));
     --mod-link-text-color-active: var(--mod-link-text-color-black, var(--spectrum-black));

--- a/packages/menu/src/menu-overrides.css
+++ b/packages/menu/src/menu-overrides.css
@@ -12,26 +12,12 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-menu-item-background-color-hover: var(
-        --system-menu-item-background-color-hover
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --system-menu-item-background-color-down
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --system-menu-item-background-color-key-focus
-    );
+    --spectrum-menu-item-background-color-hover: var(--system-menu-item-background-color-hover);
+    --spectrum-menu-item-background-color-down: var(--system-menu-item-background-color-down);
+    --spectrum-menu-item-background-color-key-focus: var(--system-menu-item-background-color-key-focus);
     --spectrum-menu-item-corner-radius: var(--system-menu-item-corner-radius);
-    --spectrum-menu-item-focus-indicator-shadow: var(
-        --system-menu-item-focus-indicator-shadow
-    );
-    --spectrum-menu-item-focus-indicator-offset: var(
-        --system-menu-item-focus-indicator-offset
-    );
-    --spectrum-menu-item-spacing-multiplier: var(
-        --system-menu-item-spacing-multiplier
-    );
-    --spectrum-menu-item-focus-indicator-outline-style: var(
-        --system-menu-item-focus-indicator-outline-style
-    );
+    --spectrum-menu-item-focus-indicator-shadow: var(--system-menu-item-focus-indicator-shadow);
+    --spectrum-menu-item-focus-indicator-offset: var(--system-menu-item-focus-indicator-offset);
+    --spectrum-menu-item-spacing-multiplier: var(--system-menu-item-spacing-multiplier);
+    --spectrum-menu-item-focus-indicator-outline-style: var(--system-menu-item-focus-indicator-outline-style);
 }

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -11,14 +11,14 @@ governing permissions and limitations under the License.
 */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     fill: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-label-icon-color-default, var(--spectrum-menu-item-label-icon-color-default)));
     color: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-label-icon-color-default, var(--spectrum-menu-item-label-icon-color-default)));
     grid-area: iconArea;
     align-self: start;
 }
 
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     margin-inline-end: var(--mod-menu-item-label-text-to-visual, var(--spectrum-menu-item-label-text-to-visual));
 }
 
@@ -34,10 +34,10 @@ governing permissions and limitations under the License.
     padding-inline: var(--mod-menu-item-label-inline-edge-to-content, var(--spectrum-menu-item-label-inline-edge-to-content));
     margin: calc((var(--spectrum-menu-item-focus-indicator-offset) + var(--spectrum-menu-item-focus-indicator-width)) * var(--spectrum-menu-item-spacing-multiplier));
     grid-template:
-        '. chevronAreaCollapsible . headingIconArea sectionHeadingArea . . .' 1fr
-        'selectedArea chevronAreaCollapsible checkmarkArea iconArea labelArea valueArea actionsArea chevronAreaDrillIn'
-        '. . . . descriptionArea . . .'
-        '. . . . submenuArea . . .'
+        ". chevronAreaCollapsible . headingIconArea sectionHeadingArea . . ." 1fr
+        "selectedArea chevronAreaCollapsible checkmarkArea iconArea labelArea valueArea actionsArea chevronAreaDrillIn"
+        ". . . . descriptionArea . . ."
+        ". . . . submenuArea . . ."
         / auto auto auto auto 1fr auto auto auto;
     align-items: center;
     -webkit-text-decoration: none;
@@ -71,7 +71,7 @@ governing permissions and limitations under the License.
     grid-area: submenuItemLabelArea;
 }
 
-::slotted([slot='value']) {
+::slotted([slot="value"]) {
     grid-area: submenuItemValueArea;
 }
 
@@ -86,13 +86,13 @@ governing permissions and limitations under the License.
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-content-color-focus, var(--spectrum-menu-item-label-content-color-focus)));
 }
 
-:host([focused]) > [name='description']::slotted(*),
-:host(:focus) > [name='description']::slotted(*) {
+:host([focused]) > [name="description"]::slotted(*),
+:host(:focus) > [name="description"]::slotted(*) {
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-description-color-focus, var(--spectrum-menu-item-description-color-focus)));
 }
 
-:host([focused]) > ::slotted([slot='value']),
-:host(:focus) > ::slotted([slot='value']) {
+:host([focused]) > ::slotted([slot="value"]),
+:host(:focus) > ::slotted([slot="value"]) {
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-value-color-focus, var(--spectrum-menu-item-value-color-focus)));
 }
 
@@ -122,11 +122,11 @@ governing permissions and limitations under the License.
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-content-color-down, var(--spectrum-menu-item-label-content-color-down)));
 }
 
-:host(:is(:active, [active])) > [name='description']::slotted(*) {
+:host(:is(:active, [active])) > [name="description"]::slotted(*) {
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-description-color-down, var(--spectrum-menu-item-description-color-down)));
 }
 
-:host(:is(:active, [active])) > ::slotted([slot='value']) {
+:host(:is(:active, [active])) > ::slotted([slot="value"]) {
     color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-value-color-down, var(--spectrum-menu-item-value-color-down)));
 }
 
@@ -146,24 +146,24 @@ governing permissions and limitations under the License.
 }
 
 :host([disabled]),
-:host([aria-disabled='true']) {
+:host([aria-disabled="true"]) {
     background-color: initial;
 }
 
 :host([disabled]) #label,
-:host([disabled]) ::slotted([slot='value']),
-:host([aria-disabled='true']) #label,
-:host([aria-disabled='true']) ::slotted([slot='value']) {
+:host([disabled]) ::slotted([slot="value"]),
+:host([aria-disabled="true"]) #label,
+:host([aria-disabled="true"]) ::slotted([slot="value"]) {
     color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
 }
 
-:host([disabled]) [name='description']::slotted(*),
-:host([aria-disabled='true']) [name='description']::slotted(*) {
+:host([disabled]) [name="description"]::slotted(*),
+:host([aria-disabled="true"]) [name="description"]::slotted(*) {
     color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-description-color-disabled, var(--spectrum-menu-item-description-color-disabled)));
 }
 
-:host([disabled]) ::slotted([slot='icon']),
-:host([aria-disabled='true']) ::slotted([slot='icon']) {
+:host([disabled]) ::slotted([slot="icon"]),
+:host([aria-disabled="true"]) ::slotted([slot="icon"]) {
     color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
     fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
 }
@@ -190,7 +190,7 @@ governing permissions and limitations under the License.
     grid-area: labelArea;
 }
 
-::slotted([slot='value']) {
+::slotted([slot="value"]) {
     color: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-value-color-default, var(--spectrum-menu-item-value-color-default)));
     font-size: var(--mod-menu-item-label-font-size, var(--spectrum-menu-item-label-font-size));
     grid-area: valueArea;
@@ -198,7 +198,7 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Menu-itemActions,
-::slotted([slot='value']) {
+::slotted([slot="value"]) {
     align-self: start;
     margin-inline-start: var(--mod-menu-item-label-to-value-area-min-spacing, var(--spectrum-menu-item-label-to-value-area-min-spacing));
 }
@@ -207,7 +207,7 @@ governing permissions and limitations under the License.
     grid-area: actionsArea;
 }
 
-[name='description']::slotted(*) {
+[name="description"]::slotted(*) {
     color: var(--highcontrast-menu-item-color-default, var(--mod-menu-item-description-color-default, var(--spectrum-menu-item-description-color-default)));
     font-size: var(--mod-menu-item-description-font-size, var(--spectrum-menu-item-description-font-size));
     hyphens: auto;
@@ -237,11 +237,11 @@ governing permissions and limitations under the License.
     background-color: var(--highcontrast-menu-item-background-color-default, var(--mod-menu-item-background-color-default, var(--spectrum-menu-item-background-color-default)));
 }
 
-.spectrum-Menu-item--collapsible ::slotted([slot='icon']) {
+.spectrum-Menu-item--collapsible ::slotted([slot="icon"]) {
     grid-area: headingIconArea;
 }
 
-.spectrum-Menu-item--collapsible > ::slotted([slot='icon']) {
+.spectrum-Menu-item--collapsible > ::slotted([slot="icon"]) {
     padding-block-start: var(--mod-menu-section-header-top-edge-to-text, var(--mod-menu-item-top-edge-to-text, var(--spectrum-menu-item-top-edge-to-text)));
     padding-block-end: var(--mod-menu-section-header-bottom-edge-to-text, var(--mod-menu-item-bottom-edge-to-text, var(--spectrum-menu-item-bottom-edge-to-text)));
 }
@@ -286,11 +286,11 @@ governing permissions and limitations under the License.
         color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-label-content-color-hover, var(--spectrum-menu-item-label-content-color-hover)));
     }
 
-    :host(:hover) > [name='description']::slotted(*) {
+    :host(:hover) > [name="description"]::slotted(*) {
         color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-description-color-hover, var(--spectrum-menu-item-description-color-hover)));
     }
 
-    :host(:hover) > ::slotted([slot='value']) {
+    :host(:hover) > ::slotted([slot="value"]) {
         color: var(--highcontrast-menu-item-color-focus, var(--mod-menu-item-value-color-hover, var(--spectrum-menu-item-value-color-hover)));
     }
 
@@ -310,25 +310,25 @@ governing permissions and limitations under the License.
     }
 
     :host([disabled]:hover),
-    :host([aria-disabled='true']:hover) {
+    :host([aria-disabled="true"]:hover) {
         cursor: default;
         background-color: initial;
     }
 
     :host([disabled]:hover) #label,
-    :host([disabled]:hover) ::slotted([slot='value']),
-    :host([aria-disabled='true']:hover) #label,
-    :host([aria-disabled='true']:hover) ::slotted([slot='value']) {
+    :host([disabled]:hover) ::slotted([slot="value"]),
+    :host([aria-disabled="true"]:hover) #label,
+    :host([aria-disabled="true"]:hover) ::slotted([slot="value"]) {
         color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-content-color-disabled, var(--spectrum-menu-item-label-content-color-disabled)));
     }
 
-    :host([disabled]:hover) [name='description']::slotted(*),
-    :host([aria-disabled='true']:hover) [name='description']::slotted(*) {
+    :host([disabled]:hover) [name="description"]::slotted(*),
+    :host([aria-disabled="true"]:hover) [name="description"]::slotted(*) {
         color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-description-color-disabled, var(--spectrum-menu-item-description-color-disabled)));
     }
 
-    :host([disabled]:hover) ::slotted([slot='icon']),
-    :host([aria-disabled='true']:hover) ::slotted([slot='icon']) {
+    :host([disabled]:hover) ::slotted([slot="icon"]),
+    :host([aria-disabled="true"]:hover) ::slotted([slot="icon"]) {
         color: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
         fill: var(--highcontrast-menu-item-color-disabled, var(--mod-menu-item-label-icon-color-disabled, var(--spectrum-menu-item-label-icon-color-disabled)));
     }

--- a/packages/menu/src/spectrum-menu.css
+++ b/packages/menu/src/spectrum-menu.css
@@ -100,7 +100,7 @@ governing permissions and limitations under the License.
     --spectrum-menu-item-focus-indicator-border-width: calc(var(--spectrum-menu-item-focus-indicator-width) * var(--spectrum-menu-item-focus-indicator-direction-scalar, 1));
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-menu-item-min-height: var(--spectrum-component-height-75);
     --spectrum-menu-item-icon-height: var(--spectrum-workflow-icon-size-75);
     --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-75);
@@ -120,7 +120,7 @@ governing permissions and limitations under the License.
     --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-small);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-menu-item-min-height: var(--spectrum-component-height-200);
     --spectrum-menu-item-icon-height: var(--spectrum-workflow-icon-size-200);
     --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-200);
@@ -140,7 +140,7 @@ governing permissions and limitations under the License.
     --spectrum-menu-back-icon-margin: var(--spectrum-navigational-indicator-top-to-back-icon-large);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-menu-item-min-height: var(--spectrum-component-height-300);
     --spectrum-menu-item-icon-height: var(--spectrum-workflow-icon-size-300);
     --spectrum-menu-item-icon-width: var(--spectrum-workflow-icon-size-300);
@@ -161,7 +161,7 @@ governing permissions and limitations under the License.
 }
 
 :host:dir(rtl),
-:host([dir='rtl']) {
+:host([dir="rtl"]) {
     --spectrum-menu-item-focus-indicator-direction-scalar: -1;
 }
 

--- a/packages/meter/src/meter-overrides.css
+++ b/packages/meter/src/meter-overrides.css
@@ -16,25 +16,21 @@ governing permissions and limitations under the License.
     --spectrum-meter-max-width: var(--system-meter-max-width);
     --spectrum-meter-inline-size: var(--system-meter-inline-size);
     --spectrum-meter-top-to-text: var(--system-meter-top-to-text);
-    --spectrum-meter-fill-color-positive: var(
-        --system-meter-fill-color-positive
-    );
+    --spectrum-meter-fill-color-positive: var(--system-meter-fill-color-positive);
     --spectrum-meter-fill-color-notice: var(--system-meter-fill-color-notice);
-    --spectrum-meter-fill-color-negative: var(
-        --system-meter-fill-color-negative
-    );
+    --spectrum-meter-fill-color-negative: var(--system-meter-fill-color-negative);
     --spectrum-meter-thickness: var(--system-meter-thickness);
     --spectrum-meter-font-size: var(--system-meter-font-size);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-meter-thickness: var(--system-meter-size-s-thickness);
     --spectrum-meter-inline-size: var(--system-meter-size-s-inline-size);
     --spectrum-meter-font-size: var(--system-meter-size-s-font-size);
     --spectrum-meter-top-to-text: var(--system-meter-size-s-top-to-text);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-meter-thickness: var(--system-meter-size-l-thickness);
     --spectrum-meter-inline-size: var(--system-meter-size-l-inline-size);
     --spectrum-meter-font-size: var(--system-meter-size-l-font-size);

--- a/packages/meter/src/progress-bar-overrides.css
+++ b/packages/meter/src/progress-bar-overrides.css
@@ -12,111 +12,55 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-progressbar-animation-ease-in-out-indeterminate: var(
-        --system-progress-bar-animation-ease-in-out-indeterminate
-    );
-    --spectrum-progressbar-animation-duration-indeterminate: var(
-        --system-progress-bar-animation-duration-indeterminate
-    );
-    --spectrum-progressbar-corner-radius: var(
-        --system-progress-bar-corner-radius
-    );
-    --spectrum-progressbar-fill-size-indeterminate: var(
-        --system-progress-bar-fill-size-indeterminate
-    );
+    --spectrum-progressbar-animation-ease-in-out-indeterminate: var(--system-progress-bar-animation-ease-in-out-indeterminate);
+    --spectrum-progressbar-animation-duration-indeterminate: var(--system-progress-bar-animation-duration-indeterminate);
+    --spectrum-progressbar-corner-radius: var(--system-progress-bar-corner-radius);
+    --spectrum-progressbar-fill-size-indeterminate: var(--system-progress-bar-fill-size-indeterminate);
     --spectrum-progressbar-size-2400: var(--system-progress-bar-size-2400);
     --spectrum-progressbar-size-2500: var(--system-progress-bar-size-2500);
     --spectrum-progressbar-size-2800: var(--system-progress-bar-size-2800);
-    --spectrum-progressbar-line-height-cjk: var(
-        --system-progress-bar-line-height-cjk
-    );
+    --spectrum-progressbar-line-height-cjk: var(--system-progress-bar-line-height-cjk);
     --spectrum-progressbar-min-size: var(--system-progress-bar-min-size);
     --spectrum-progressbar-max-size: var(--system-progress-bar-max-size);
     --spectrum-progressbar-line-height: var(--system-progress-bar-line-height);
-    --spectrum-progressbar-spacing-label-to-progressbar: var(
-        --system-progress-bar-spacing-label-to
-    );
-    --spectrum-progressbar-spacing-label-to-text: var(
-        --system-progress-bar-spacing-label-to-text
-    );
+    --spectrum-progressbar-spacing-label-to-progressbar: var(--system-progress-bar-spacing-label-to);
+    --spectrum-progressbar-spacing-label-to-text: var(--system-progress-bar-spacing-label-to-text);
     --spectrum-progressbar-text-color: var(--system-progress-bar-text-color);
     --spectrum-progressbar-track-color: var(--system-progress-bar-track-color);
     --spectrum-progressbar-fill-color: var(--system-progress-bar-fill-color);
-    --spectrum-progressbar-label-and-value-white: var(
-        --system-progress-bar-label-and-value-white
-    );
-    --spectrum-progressbar-track-color-white: var(
-        --system-progress-bar-track-color-white
-    );
-    --spectrum-progressbar-fill-color-white: var(
-        --system-progress-bar-fill-color-white
-    );
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-default
-    );
+    --spectrum-progressbar-label-and-value-white: var(--system-progress-bar-label-and-value-white);
+    --spectrum-progressbar-track-color-white: var(--system-progress-bar-track-color-white);
+    --spectrum-progressbar-fill-color-white: var(--system-progress-bar-fill-color-white);
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-default);
     --spectrum-progressbar-font-size: var(--system-progress-bar-font-size);
     --spectrum-progressbar-thickness: var(--system-progress-bar-thickness);
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-spacing-top-to-text
-    );
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-spacing-top-to-text);
 }
 
 .spectrum-ProgressBar--sizeM {
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-m-size-default
-    );
-    --spectrum-progressbar-font-size: var(
-        --system-progress-bar-size-m-font-size
-    );
-    --spectrum-progressbar-thickness: var(
-        --system-progress-bar-size-m-thickness
-    );
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-size-m-spacing-top-to-text
-    );
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-m-size-default);
+    --spectrum-progressbar-font-size: var(--system-progress-bar-size-m-font-size);
+    --spectrum-progressbar-thickness: var(--system-progress-bar-size-m-thickness);
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-size-m-spacing-top-to-text);
 }
 
 .spectrum-ProgressBar--sizeS {
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-s-size-default
-    );
-    --spectrum-progressbar-font-size: var(
-        --system-progress-bar-size-s-font-size
-    );
-    --spectrum-progressbar-thickness: var(
-        --system-progress-bar-size-s-thickness
-    );
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-size-s-spacing-top-to-text
-    );
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-s-size-default);
+    --spectrum-progressbar-font-size: var(--system-progress-bar-size-s-font-size);
+    --spectrum-progressbar-thickness: var(--system-progress-bar-size-s-thickness);
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-size-s-spacing-top-to-text);
 }
 
 .spectrum-ProgressBar--sizeL {
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-l-size-default
-    );
-    --spectrum-progressbar-font-size: var(
-        --system-progress-bar-size-l-font-size
-    );
-    --spectrum-progressbar-thickness: var(
-        --system-progress-bar-size-l-thickness
-    );
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-size-l-spacing-top-to-text
-    );
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-l-size-default);
+    --spectrum-progressbar-font-size: var(--system-progress-bar-size-l-font-size);
+    --spectrum-progressbar-thickness: var(--system-progress-bar-size-l-thickness);
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-size-l-spacing-top-to-text);
 }
 
 .spectrum-ProgressBar--sizeXL {
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-xl-size-default
-    );
-    --spectrum-progressbar-font-size: var(
-        --system-progress-bar-size-xl-font-size
-    );
-    --spectrum-progressbar-thickness: var(
-        --system-progress-bar-size-xl-thickness
-    );
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-size-xl-spacing-top-to-text
-    );
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-xl-size-default);
+    --spectrum-progressbar-font-size: var(--system-progress-bar-size-xl-font-size);
+    --spectrum-progressbar-thickness: var(--system-progress-bar-size-xl-thickness);
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-size-xl-spacing-top-to-text);
 }

--- a/packages/meter/src/spectrum-meter.css
+++ b/packages/meter/src/spectrum-meter.css
@@ -20,14 +20,14 @@ governing permissions and limitations under the License.
     --mod-progressbar-spacing-top-to-text: var(--spectrum-meter-top-to-text);
 }
 
-:host([variant='positive']) {
+:host([variant="positive"]) {
     --mod-progressbar-fill-color: var(--mod-meter-fill-color-positive, var(--spectrum-meter-fill-color-positive));
 }
 
-:host([variant='notice']) {
+:host([variant="notice"]) {
     --mod-progressbar-fill-color: var(--mod-meter-fill-color-notice, var(--spectrum-meter-fill-color-notice));
 }
 
-:host([variant='negative']) {
+:host([variant="negative"]) {
     --mod-progressbar-fill-color: var(--mod-meter-fill-color-negative, var(--spectrum-meter-fill-color-negative));
 }

--- a/packages/meter/src/spectrum-progress-bar.css
+++ b/packages/meter/src/spectrum-progress-bar.css
@@ -77,7 +77,7 @@ governing permissions and limitations under the License.
 }
 
 :host([indeterminate]) .fill:dir(rtl),
-:host([dir='rtl'][indeterminate]) .fill {
+:host([dir="rtl"][indeterminate]) .fill {
     animation-name: indeterminate-loop-rtl;
 }
 
@@ -104,17 +104,17 @@ governing permissions and limitations under the License.
     margin-inline-start: var(--mod-spacing-progressbar-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
 }
 
-:host([static-color='white']) .fill {
+:host([static-color="white"]) .fill {
     background: var(--mod-progressbar-fill-color-white, var(--spectrum-progressbar-fill-color-white));
 }
 
-:host([static-color='white']) .fill,
-:host([static-color='white']) .label,
-:host([static-color='white']) .percentage {
+:host([static-color="white"]) .fill,
+:host([static-color="white"]) .label,
+:host([static-color="white"]) .percentage {
     color: var(--mod-progressbar-label-and-value-white, var(--spectrum-progressbar-label-and-value-white));
 }
 
-:host([static-color='white']) .track {
+:host([static-color="white"]) .track {
     background: var(--spectrum-progressbar-track-color-white);
 }
 

--- a/packages/number-field/src/number-field-overrides.css
+++ b/packages/number-field/src/number-field-overrides.css
@@ -13,73 +13,29 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     --spectrum-stepper-border-width: var(--system-stepper-border-width);
-    --spectrum-stepper-border-color-default: var(
-        --system-stepper-border-color-default
-    );
-    --spectrum-stepper-border-color-hover: var(
-        --system-stepper-border-color-hover
-    );
-    --spectrum-stepper-border-color-focus: var(
-        --system-stepper-border-color-focus
-    );
-    --spectrum-stepper-border-color-focus-hover: var(
-        --system-stepper-border-color-focus-hover
-    );
-    --spectrum-stepper-border-color-keyboard-focus: var(
-        --system-stepper-border-color-keyboard-focus
-    );
-    --spectrum-stepper-buttons-border-style: var(
-        --system-stepper-buttons-border-style
-    );
-    --spectrum-stepper-buttons-border-width: var(
-        --system-stepper-buttons-border-width
-    );
-    --spectrum-stepper-buttons-border-color: var(
-        --system-stepper-buttons-border-color
-    );
-    --spectrum-stepper-buttons-background-color: var(
-        --system-stepper-buttons-background-color
-    );
-    --spectrum-stepper-buttons-border-color-hover: var(
-        --system-stepper-buttons-border-color-hover
-    );
-    --spectrum-stepper-buttons-border-color-focus: var(
-        --system-stepper-buttons-border-color-focus
-    );
-    --spectrum-stepper-buttons-border-color-keyboard-focus: var(
-        --system-stepper-buttons-border-color-keyboard-focus
-    );
-    --spectrum-stepper-button-border-width: var(
-        --system-stepper-button-border-width
-    );
-    --spectrum-stepper-border-color-invalid: var(
-        --system-stepper-border-color-invalid
-    );
-    --spectrum-stepper-border-color-focus-invalid: var(
-        --system-stepper-border-color-focus-invalid
-    );
-    --spectrum-stepper-border-color-focus-hover-invalid: var(
-        --system-stepper-border-color-focus-hover-invalid
-    );
-    --spectrum-stepper-border-color-keyboard-focus-invalid: var(
-        --system-stepper-border-color-keyboard-focus-invalid
-    );
-    --spectrum-stepper-border-color-disabled: var(
-        --system-stepper-border-color-disabled
-    );
-    --spectrum-stepper-button-border-width-disabled: var(
-        --system-stepper-button-border-width-disabled
-    );
-    --spectrum-stepper-buttons-background-color-disabled: var(
-        --system-stepper-buttons-background-color-disabled
-    );
+    --spectrum-stepper-border-color-default: var(--system-stepper-border-color-default);
+    --spectrum-stepper-border-color-hover: var(--system-stepper-border-color-hover);
+    --spectrum-stepper-border-color-focus: var(--system-stepper-border-color-focus);
+    --spectrum-stepper-border-color-focus-hover: var(--system-stepper-border-color-focus-hover);
+    --spectrum-stepper-border-color-keyboard-focus: var(--system-stepper-border-color-keyboard-focus);
+    --spectrum-stepper-buttons-border-style: var(--system-stepper-buttons-border-style);
+    --spectrum-stepper-buttons-border-width: var(--system-stepper-buttons-border-width);
+    --spectrum-stepper-buttons-border-color: var(--system-stepper-buttons-border-color);
+    --spectrum-stepper-buttons-background-color: var(--system-stepper-buttons-background-color);
+    --spectrum-stepper-buttons-border-color-hover: var(--system-stepper-buttons-border-color-hover);
+    --spectrum-stepper-buttons-border-color-focus: var(--system-stepper-buttons-border-color-focus);
+    --spectrum-stepper-buttons-border-color-keyboard-focus: var(--system-stepper-buttons-border-color-keyboard-focus);
+    --spectrum-stepper-button-border-width: var(--system-stepper-button-border-width);
+    --spectrum-stepper-border-color-invalid: var(--system-stepper-border-color-invalid);
+    --spectrum-stepper-border-color-focus-invalid: var(--system-stepper-border-color-focus-invalid);
+    --spectrum-stepper-border-color-focus-hover-invalid: var(--system-stepper-border-color-focus-hover-invalid);
+    --spectrum-stepper-border-color-keyboard-focus-invalid: var(--system-stepper-border-color-keyboard-focus-invalid);
+    --spectrum-stepper-border-color-disabled: var(--system-stepper-border-color-disabled);
+    --spectrum-stepper-button-border-width-disabled: var(--system-stepper-button-border-width-disabled);
+    --spectrum-stepper-buttons-background-color-disabled: var(--system-stepper-buttons-background-color-disabled);
 }
 
 :host([quiet]) #textfield {
-    --spectrum-stepper-buttons-border-style: var(
-        --system-stepper-quiet-buttons-border-style
-    );
-    --spectrum-stepper-button-edge-to-fill: var(
-        --system-stepper-quiet-button-edge-to-fill
-    );
+    --spectrum-stepper-buttons-border-style: var(--system-stepper-quiet-buttons-border-style);
+    --spectrum-stepper-button-edge-to-fill: var(--system-stepper-quiet-button-edge-to-fill);
 }

--- a/packages/number-field/src/spectrum-number-field.css
+++ b/packages/number-field/src/spectrum-number-field.css
@@ -75,22 +75,22 @@ governing permissions and limitations under the License.
 }
 
 #textfield,
-:host([size='m']) #textfield {
+:host([size="m"]) #textfield {
     --spectrum-stepper-button-width: var(--mod-stepper-button-width, var(--spectrum-in-field-button-width-stacked-medium));
     --spectrum-stepper-height: var(--mod-stepper-height, var(--spectrum-component-height-100));
 }
 
-:host([size='s']) #textfield {
+:host([size="s"]) #textfield {
     --spectrum-stepper-button-width: var(--mod-stepper-button-width, var(--spectrum-in-field-button-width-stacked-small));
     --spectrum-stepper-height: var(--mod-stepper-height, var(--spectrum-component-height-75));
 }
 
-:host([size='l']) #textfield {
+:host([size="l"]) #textfield {
     --spectrum-stepper-button-width: var(--mod-stepper-button-width, var(--spectrum-in-field-button-width-stacked-large));
     --spectrum-stepper-height: var(--mod-stepper-height, var(--spectrum-component-height-200));
 }
 
-:host([size='xl']) #textfield {
+:host([size="xl"]) #textfield {
     --spectrum-stepper-button-width: var(--mod-stepper-button-width, var(--spectrum-in-field-button-width-stacked-extra-large));
     --spectrum-stepper-height: var(--mod-stepper-height, var(--spectrum-component-height-300));
 }
@@ -259,7 +259,7 @@ governing permissions and limitations under the License.
 }
 
 #textfield:before {
-    content: '';
+    content: "";
 }
 
 .input {
@@ -308,7 +308,7 @@ governing permissions and limitations under the License.
 :host([quiet]):after {
     visibility: hidden;
     visibility: var(--mod-stepper-focus-indicator-visibility, hidden);
-    content: '';
+    content: "";
     inline-size: 100%;
     block-size: var(--spectrum-stepper-focus-indicator-width);
     background-color: var(--spectrum-stepper-focus-indicator-color);

--- a/packages/picker-button/src/picker-button-overrides.css
+++ b/packages/picker-button/src/picker-button-overrides.css
@@ -12,32 +12,14 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .root {
-    --spectrum-picker-button-background-color: var(
-        --system-picker-button-background-color
-    );
-    --spectrum-picker-button-background-color-hover: var(
-        --system-picker-button-background-color-hover
-    );
-    --spectrum-picker-button-background-color-down: var(
-        --system-picker-button-background-color-down
-    );
-    --spectrum-picker-button-background-color-key-focus: var(
-        --system-picker-button-background-color-key-focus
-    );
-    --spectrum-picker-button-border-color: var(
-        --system-picker-button-border-color
-    );
-    --spectrum-picker-button-border-radius: var(
-        --system-picker-button-border-radius
-    );
-    --spectrum-picker-button-border-radius-rounded-sided: var(
-        --system-picker-button-border-radius-rounded-sided
-    );
-    --spectrum-picker-button-border-radius-sided: var(
-        --system-picker-button-border-radius-sided
-    );
-    --spectrum-picker-button-border-width: var(
-        --system-picker-button-border-width
-    );
+    --spectrum-picker-button-background-color: var(--system-picker-button-background-color);
+    --spectrum-picker-button-background-color-hover: var(--system-picker-button-background-color-hover);
+    --spectrum-picker-button-background-color-down: var(--system-picker-button-background-color-down);
+    --spectrum-picker-button-background-color-key-focus: var(--system-picker-button-background-color-key-focus);
+    --spectrum-picker-button-border-color: var(--system-picker-button-border-color);
+    --spectrum-picker-button-border-radius: var(--system-picker-button-border-radius);
+    --spectrum-picker-button-border-radius-rounded-sided: var(--system-picker-button-border-radius-rounded-sided);
+    --spectrum-picker-button-border-radius-sided: var(--system-picker-button-border-radius-sided);
+    --spectrum-picker-button-border-width: var(--system-picker-button-border-width);
     --spectrum-picker-button-padding: var(--system-picker-button-padding);
 }

--- a/packages/picker-button/src/spectrum-picker-button.css
+++ b/packages/picker-button/src/spectrum-picker-button.css
@@ -78,7 +78,7 @@ governing permissions and limitations under the License.
     --mod-picker-button-border-color: var(--mod-picker-button-border-color-quiet, transparent);
 }
 
-:host([size='s']) .root {
+:host([size="s"]) .root {
     --spectrum-picker-button-height: var(--spectrum-component-height-75);
     --spectrum-picker-button-width: var(--spectrum-component-height-75);
     --spectrum-picker-button-label-padding: var(--spectrum-spacing-75);
@@ -86,7 +86,7 @@ governing permissions and limitations under the License.
     --spectrum-picker-button-fill-padding: var(--spectrum-field-edge-to-disclosure-icon-75);
 }
 
-:host([size='l']) .root {
+:host([size="l"]) .root {
     --spectrum-picker-button-height: var(--spectrum-component-height-200);
     --spectrum-picker-button-width: var(--spectrum-component-height-200);
     --spectrum-picker-button-label-padding: var(--spectrum-text-to-visual-200);
@@ -94,7 +94,7 @@ governing permissions and limitations under the License.
     --spectrum-picker-button-fill-padding: var(--spectrum-field-edge-to-disclosure-icon-200);
 }
 
-:host([size='xl']) .root {
+:host([size="xl"]) .root {
     --spectrum-picker-button-height: var(--spectrum-component-height-300);
     --spectrum-picker-button-width: var(--spectrum-component-height-300);
     --spectrum-picker-button-label-padding: var(--spectrum-text-to-visual-300);
@@ -154,22 +154,22 @@ governing permissions and limitations under the License.
     display: flex;
 }
 
-:host([position='right']) .spectrum-PickerButton-fill {
+:host([position="right"]) .spectrum-PickerButton-fill {
     border-start-start-radius: var(--mod-picker-button-border-radius-sided, var(--spectrum-picker-button-border-radius-sided));
     border-end-start-radius: var(--mod-picker-button-border-radius-sided, var(--spectrum-picker-button-border-radius-sided));
 }
 
-:host([position='right'][rounded]) .spectrum-PickerButton-fill {
+:host([position="right"][rounded]) .spectrum-PickerButton-fill {
     border-start-start-radius: var(--mod-picker-button-border-radius-rounded-sided, var(--spectrum-picker-button-border-radius-rounded-sided));
     border-end-start-radius: var(--mod-picker-button-border-radius-rounded-sided, var(--spectrum-picker-button-border-radius-rounded-sided));
 }
 
-:host([position='left']) .spectrum-PickerButton-fill {
+:host([position="left"]) .spectrum-PickerButton-fill {
     border-start-end-radius: var(--mod-picker-button-border-radius-sided, var(--spectrum-picker-button-border-radius-sided));
     border-end-end-radius: var(--mod-picker-button-border-radius-sided, var(--spectrum-picker-button-border-radius-sided));
 }
 
-:host([position='left'][rounded]) .spectrum-PickerButton-fill {
+:host([position="left"][rounded]) .spectrum-PickerButton-fill {
     border-start-end-radius: var(--mod-picker-button-border-radius-rounded-sided, var(--spectrum-picker-button-border-radius-rounded-sided));
     border-end-end-radius: var(--mod-picker-button-border-radius-rounded-sided, var(--spectrum-picker-button-border-radius-rounded-sided));
 }

--- a/packages/picker/src/picker-overrides.css
+++ b/packages/picker/src/picker-overrides.css
@@ -12,44 +12,18 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-picker-background-color-default: var(
-        --system-picker-background-color-default
-    );
-    --spectrum-picker-background-color-default-open: var(
-        --system-picker-background-color-default-open
-    );
-    --spectrum-picker-background-color-hover: var(
-        --system-picker-background-color-hover
-    );
-    --spectrum-picker-background-color-hover-open: var(
-        --system-picker-background-color-hover-open
-    );
-    --spectrum-picker-background-color-active: var(
-        --system-picker-background-color-active
-    );
-    --spectrum-picker-background-color-key-focus: var(
-        --system-picker-background-color-key-focus
-    );
-    --spectrum-picker-border-color-default: var(
-        --system-picker-border-color-default
-    );
-    --spectrum-picker-border-color-default-open: var(
-        --system-picker-border-color-default-open
-    );
-    --spectrum-picker-border-color-hover: var(
-        --system-picker-border-color-hover
-    );
-    --spectrum-picker-border-color-hover-open: var(
-        --system-picker-border-color-hover-open
-    );
-    --spectrum-picker-border-color-active: var(
-        --system-picker-border-color-active
-    );
-    --spectrum-picker-border-color-key-focus: var(
-        --system-picker-border-color-key-focus
-    );
-    --spectrum-picker-border-color-disabled: var(
-        --system-picker-border-color-disabled
-    );
+    --spectrum-picker-background-color-default: var(--system-picker-background-color-default);
+    --spectrum-picker-background-color-default-open: var(--system-picker-background-color-default-open);
+    --spectrum-picker-background-color-hover: var(--system-picker-background-color-hover);
+    --spectrum-picker-background-color-hover-open: var(--system-picker-background-color-hover-open);
+    --spectrum-picker-background-color-active: var(--system-picker-background-color-active);
+    --spectrum-picker-background-color-key-focus: var(--system-picker-background-color-key-focus);
+    --spectrum-picker-border-color-default: var(--system-picker-border-color-default);
+    --spectrum-picker-border-color-default-open: var(--system-picker-border-color-default-open);
+    --spectrum-picker-border-color-hover: var(--system-picker-border-color-hover);
+    --spectrum-picker-border-color-hover-open: var(--system-picker-border-color-hover-open);
+    --spectrum-picker-border-color-active: var(--system-picker-border-color-active);
+    --spectrum-picker-border-color-key-focus: var(--system-picker-border-color-key-focus);
+    --spectrum-picker-border-color-disabled: var(--system-picker-border-color-disabled);
     --spectrum-picker-border-width: var(--system-picker-border-width);
 }

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -96,7 +96,7 @@ governing permissions and limitations under the License.
     --spectrum-picker-focus-indicator-color: var(--spectrum-focus-indicator-color);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-picker-font-size: var(--spectrum-font-size-75);
     --spectrum-picker-block-size: var(--spectrum-component-height-75);
     --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
@@ -112,7 +112,7 @@ governing permissions and limitations under the License.
     --spectrum-picker-spacing-edge-to-disclosure-icon: var(--spectrum-field-end-edge-to-disclosure-icon-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-picker-font-size: var(--spectrum-font-size-200);
     --spectrum-picker-block-size: var(--spectrum-component-height-200);
     --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
@@ -128,7 +128,7 @@ governing permissions and limitations under the License.
     --spectrum-picker-spacing-edge-to-disclosure-icon: var(--spectrum-field-end-edge-to-disclosure-icon-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-picker-font-size: var(--spectrum-font-size-300);
     --spectrum-picker-block-size: var(--spectrum-component-height-300);
     --spectrum-picker-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
@@ -191,7 +191,7 @@ governing permissions and limitations under the License.
 
 #button:after {
     pointer-events: none;
-    content: '';
+    content: "";
     block-size: calc(100% + var(--mod-picker-focus-indicator-gap, var(--spectrum-picker-focus-indicator-gap)) * 2 + var(--mod-picker-border-width, var(--spectrum-picker-border-width)) * 2);
     inline-size: calc(100% + var(--mod-picker-focus-indicator-gap, var(--spectrum-picker-focus-indicator-gap)) * 2 + var(--mod-picker-border-width, var(--spectrum-picker-border-width)) * 2);
     border-style: solid;

--- a/packages/popover/src/spectrum-popover.css
+++ b/packages/popover/src/spectrum-popover.css
@@ -91,7 +91,7 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--top-left,
 :host([tip]) .spectrum-Popover--top-right,
 :host([tip]) .spectrum-Popover--top-start,
-:host([placement*='top'][tip]) {
+:host([placement*="top"][tip]) {
     margin-block-end: calc(var(--mod-popover-pointer-height, var(--spectrum-popover-pointer-height)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
@@ -99,7 +99,7 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Popover--top-left,
 :host([open]) .spectrum-Popover--top-right,
 :host([open]) .spectrum-Popover--top-start,
-:host([placement*='top'][open]) {
+:host([placement*="top"][open]) {
     transform: translateY(calc(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)) * -1)) translateZ(0);
 }
 
@@ -107,7 +107,7 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--bottom-left,
 :host([tip]) .spectrum-Popover--bottom-right,
 :host([tip]) .spectrum-Popover--bottom-start,
-:host([placement*='bottom'][tip]) {
+:host([placement*="bottom"][tip]) {
     margin-block-start: calc(var(--mod-popover-pointer-height, var(--spectrum-popover-pointer-height)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
@@ -115,31 +115,31 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Popover--bottom-left,
 :host([open]) .spectrum-Popover--bottom-right,
 :host([open]) .spectrum-Popover--bottom-start,
-:host([placement*='bottom'][open]) {
+:host([placement*="bottom"][open]) {
     transform: translateY(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance))) translateZ(0);
 }
 
 :host([tip]) .spectrum-Popover--right-bottom,
 :host([tip]) .spectrum-Popover--right-top,
-:host([placement*='right'][tip]) {
+:host([placement*="right"][tip]) {
     margin-left: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
 :host([open]) .spectrum-Popover--right-bottom,
 :host([open]) .spectrum-Popover--right-top,
-:host([placement*='right'][open]) {
+:host([placement*="right"][open]) {
     transform: translateX(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance))) translateZ(0);
 }
 
 :host([tip]) .spectrum-Popover--left-bottom,
 :host([tip]) .spectrum-Popover--left-top,
-:host([placement*='left'][tip]) {
+:host([placement*="left"][tip]) {
     margin-right: calc(var(--mod-popover-pointer-width, var(--spectrum-popover-pointer-width)) - var(--mod-popover-border-width, var(--spectrum-popover-border-width)));
 }
 
 :host([open]) .spectrum-Popover--left-bottom,
 :host([open]) .spectrum-Popover--left-top,
-:host([placement*='left'][open]) {
+:host([placement*="left"][open]) {
     transform: translateX(calc(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)) * -1)) translateZ(0);
 }
 
@@ -158,9 +158,9 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Popover--start-bottom:dir(rtl),
 :host([open]) .spectrum-Popover--start-top:dir(rtl),
 :host([open]) .spectrum-Popover--start:dir(rtl),
-:host([dir='rtl'][open]) .spectrum-Popover--start-bottom,
-:host([dir='rtl'][open]) .spectrum-Popover--start-top,
-:host([dir='rtl'][open]) .spectrum-Popover--start {
+:host([dir="rtl"][open]) .spectrum-Popover--start-bottom,
+:host([dir="rtl"][open]) .spectrum-Popover--start-top,
+:host([dir="rtl"][open]) .spectrum-Popover--start {
     transform: translateX(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance))) translateZ(0);
 }
 
@@ -179,19 +179,19 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Popover--end-bottom:dir(rtl),
 :host([open]) .spectrum-Popover--end-top:dir(rtl),
 :host([open]) .spectrum-Popover--end:dir(rtl),
-:host([dir='rtl'][open]) .spectrum-Popover--end-bottom,
-:host([dir='rtl'][open]) .spectrum-Popover--end-top,
-:host([dir='rtl'][open]) .spectrum-Popover--end {
+:host([dir="rtl"][open]) .spectrum-Popover--end-bottom,
+:host([dir="rtl"][open]) .spectrum-Popover--end-top,
+:host([dir="rtl"][open]) .spectrum-Popover--end {
     transform: translateX(calc(var(--mod-popover-animation-distance, var(--spectrum-popover-animation-distance)) * -1)) translateZ(0);
 }
 
 :host([tip]) #tip,
-:host([tip][placement*='bottom']) #tip,
+:host([tip][placement*="bottom"]) #tip,
 :host([tip]) .spectrum-Popover--bottom-end #tip,
 :host([tip]) .spectrum-Popover--bottom-left #tip,
 :host([tip]) .spectrum-Popover--bottom-right #tip,
 :host([tip]) .spectrum-Popover--bottom-start #tip,
-:host([tip][placement*='top']) #tip,
+:host([tip][placement*="top"]) #tip,
 :host([tip]) .spectrum-Popover--top-end #tip,
 :host([tip]) .spectrum-Popover--top-left #tip,
 :host([tip]) .spectrum-Popover--top-right #tip,
@@ -221,7 +221,7 @@ governing permissions and limitations under the License.
     margin-inline-end: var(--mod-popover-pointer-edge-spacing, var(--spectrum-popover-pointer-edge-spacing));
 }
 
-:host([tip][placement*='bottom']) #tip,
+:host([tip][placement*="bottom"]) #tip,
 :host([tip]) .spectrum-Popover--bottom-end #tip,
 :host([tip]) .spectrum-Popover--bottom-left #tip,
 :host([tip]) .spectrum-Popover--bottom-right #tip,
@@ -249,10 +249,10 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--end #tip,
 :host([tip]) .spectrum-Popover--end-bottom #tip,
 :host([tip]) .spectrum-Popover--end-top #tip,
-:host([tip][placement*='left']) #tip,
+:host([tip][placement*="left"]) #tip,
 :host([tip]) .spectrum-Popover--left-bottom #tip,
 :host([tip]) .spectrum-Popover--left-top #tip,
-:host([tip][placement*='right']) #tip,
+:host([tip][placement*="right"]) #tip,
 :host([tip]) .spectrum-Popover--right-bottom #tip,
 :host([tip]) .spectrum-Popover--right-top #tip,
 :host([tip]) .spectrum-Popover--start #tip,
@@ -263,14 +263,14 @@ governing permissions and limitations under the License.
     inset-block: 0;
 }
 
-:host([tip][placement*='left']) #tip,
+:host([tip][placement*="left"]) #tip,
 :host([tip]) .spectrum-Popover--left-bottom #tip,
 :host([tip]) .spectrum-Popover--left-top #tip {
     left: 100%;
     right: auto;
 }
 
-:host([tip][placement*='right']) #tip,
+:host([tip][placement*="right"]) #tip,
 :host([tip]) .spectrum-Popover--right-bottom #tip,
 :host([tip]) .spectrum-Popover--right-top #tip {
     left: auto;
@@ -301,9 +301,9 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--start #tip:dir(rtl),
 :host([tip]) .spectrum-Popover--start-bottom #tip:dir(rtl),
 :host([tip]) .spectrum-Popover--start-top #tip:dir(rtl),
-:host([dir='rtl'][tip]) .spectrum-Popover--start #tip,
-:host([dir='rtl'][tip]) .spectrum-Popover--start-bottom #tip,
-:host([dir='rtl'][tip]) .spectrum-Popover--start-top #tip {
+:host([dir="rtl"][tip]) .spectrum-Popover--start #tip,
+:host([dir="rtl"][tip]) .spectrum-Popover--start-bottom #tip,
+:host([dir="rtl"][tip]) .spectrum-Popover--start-top #tip {
     transform: none;
 }
 
@@ -317,8 +317,8 @@ governing permissions and limitations under the License.
 :host([tip]) .spectrum-Popover--end #tip:dir(rtl),
 :host([tip]) .spectrum-Popover--end-bottom #tip:dir(rtl),
 :host([tip]) .spectrum-Popover--end-top #tip:dir(rtl),
-:host([dir='rtl'][tip]) .spectrum-Popover--end #tip,
-:host([dir='rtl'][tip]) .spectrum-Popover--end-bottom #tip,
-:host([dir='rtl'][tip]) .spectrum-Popover--end-top #tip {
+:host([dir="rtl"][tip]) .spectrum-Popover--end #tip,
+:host([dir="rtl"][tip]) .spectrum-Popover--end-bottom #tip,
+:host([dir="rtl"][tip]) .spectrum-Popover--end-top #tip {
     transform: scaleX(1);
 }

--- a/packages/progress-bar/src/progress-bar-overrides.css
+++ b/packages/progress-bar/src/progress-bar-overrides.css
@@ -12,111 +12,55 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-progressbar-animation-ease-in-out-indeterminate: var(
-        --system-progress-bar-animation-ease-in-out-indeterminate
-    );
-    --spectrum-progressbar-animation-duration-indeterminate: var(
-        --system-progress-bar-animation-duration-indeterminate
-    );
-    --spectrum-progressbar-corner-radius: var(
-        --system-progress-bar-corner-radius
-    );
-    --spectrum-progressbar-fill-size-indeterminate: var(
-        --system-progress-bar-fill-size-indeterminate
-    );
+    --spectrum-progressbar-animation-ease-in-out-indeterminate: var(--system-progress-bar-animation-ease-in-out-indeterminate);
+    --spectrum-progressbar-animation-duration-indeterminate: var(--system-progress-bar-animation-duration-indeterminate);
+    --spectrum-progressbar-corner-radius: var(--system-progress-bar-corner-radius);
+    --spectrum-progressbar-fill-size-indeterminate: var(--system-progress-bar-fill-size-indeterminate);
     --spectrum-progressbar-size-2400: var(--system-progress-bar-size-2400);
     --spectrum-progressbar-size-2500: var(--system-progress-bar-size-2500);
     --spectrum-progressbar-size-2800: var(--system-progress-bar-size-2800);
-    --spectrum-progressbar-line-height-cjk: var(
-        --system-progress-bar-line-height-cjk
-    );
+    --spectrum-progressbar-line-height-cjk: var(--system-progress-bar-line-height-cjk);
     --spectrum-progressbar-min-size: var(--system-progress-bar-min-size);
     --spectrum-progressbar-max-size: var(--system-progress-bar-max-size);
     --spectrum-progressbar-line-height: var(--system-progress-bar-line-height);
-    --spectrum-progressbar-spacing-label-to-progressbar: var(
-        --system-progress-bar-spacing-label-to
-    );
-    --spectrum-progressbar-spacing-label-to-text: var(
-        --system-progress-bar-spacing-label-to-text
-    );
+    --spectrum-progressbar-spacing-label-to-progressbar: var(--system-progress-bar-spacing-label-to);
+    --spectrum-progressbar-spacing-label-to-text: var(--system-progress-bar-spacing-label-to-text);
     --spectrum-progressbar-text-color: var(--system-progress-bar-text-color);
     --spectrum-progressbar-track-color: var(--system-progress-bar-track-color);
     --spectrum-progressbar-fill-color: var(--system-progress-bar-fill-color);
-    --spectrum-progressbar-label-and-value-white: var(
-        --system-progress-bar-label-and-value-white
-    );
-    --spectrum-progressbar-track-color-white: var(
-        --system-progress-bar-track-color-white
-    );
-    --spectrum-progressbar-fill-color-white: var(
-        --system-progress-bar-fill-color-white
-    );
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-default
-    );
+    --spectrum-progressbar-label-and-value-white: var(--system-progress-bar-label-and-value-white);
+    --spectrum-progressbar-track-color-white: var(--system-progress-bar-track-color-white);
+    --spectrum-progressbar-fill-color-white: var(--system-progress-bar-fill-color-white);
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-default);
     --spectrum-progressbar-font-size: var(--system-progress-bar-font-size);
     --spectrum-progressbar-thickness: var(--system-progress-bar-thickness);
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-spacing-top-to-text
-    );
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-spacing-top-to-text);
 }
 
 :host {
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-m-size-default
-    );
-    --spectrum-progressbar-font-size: var(
-        --system-progress-bar-size-m-font-size
-    );
-    --spectrum-progressbar-thickness: var(
-        --system-progress-bar-size-m-thickness
-    );
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-size-m-spacing-top-to-text
-    );
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-m-size-default);
+    --spectrum-progressbar-font-size: var(--system-progress-bar-size-m-font-size);
+    --spectrum-progressbar-thickness: var(--system-progress-bar-size-m-thickness);
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-size-m-spacing-top-to-text);
 }
 
-:host([size='s']) {
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-s-size-default
-    );
-    --spectrum-progressbar-font-size: var(
-        --system-progress-bar-size-s-font-size
-    );
-    --spectrum-progressbar-thickness: var(
-        --system-progress-bar-size-s-thickness
-    );
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-size-s-spacing-top-to-text
-    );
+:host([size="s"]) {
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-s-size-default);
+    --spectrum-progressbar-font-size: var(--system-progress-bar-size-s-font-size);
+    --spectrum-progressbar-thickness: var(--system-progress-bar-size-s-thickness);
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-size-s-spacing-top-to-text);
 }
 
-:host([size='l']) {
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-l-size-default
-    );
-    --spectrum-progressbar-font-size: var(
-        --system-progress-bar-size-l-font-size
-    );
-    --spectrum-progressbar-thickness: var(
-        --system-progress-bar-size-l-thickness
-    );
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-size-l-spacing-top-to-text
-    );
+:host([size="l"]) {
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-l-size-default);
+    --spectrum-progressbar-font-size: var(--system-progress-bar-size-l-font-size);
+    --spectrum-progressbar-thickness: var(--system-progress-bar-size-l-thickness);
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-size-l-spacing-top-to-text);
 }
 
-:host([size='xl']) {
-    --spectrum-progressbar-size-default: var(
-        --system-progress-bar-size-xl-size-default
-    );
-    --spectrum-progressbar-font-size: var(
-        --system-progress-bar-size-xl-font-size
-    );
-    --spectrum-progressbar-thickness: var(
-        --system-progress-bar-size-xl-thickness
-    );
-    --spectrum-progressbar-spacing-top-to-text: var(
-        --system-progress-bar-size-xl-spacing-top-to-text
-    );
+:host([size="xl"]) {
+    --spectrum-progressbar-size-default: var(--system-progress-bar-size-xl-size-default);
+    --spectrum-progressbar-font-size: var(--system-progress-bar-size-xl-font-size);
+    --spectrum-progressbar-thickness: var(--system-progress-bar-size-xl-thickness);
+    --spectrum-progressbar-spacing-top-to-text: var(--system-progress-bar-size-xl-spacing-top-to-text);
 }

--- a/packages/progress-bar/src/spectrum-progress-bar.css
+++ b/packages/progress-bar/src/spectrum-progress-bar.css
@@ -77,7 +77,7 @@ governing permissions and limitations under the License.
 }
 
 :host([indeterminate]) .fill:dir(rtl),
-:host([dir='rtl'][indeterminate]) .fill {
+:host([dir="rtl"][indeterminate]) .fill {
     animation-name: indeterminate-loop-rtl;
 }
 
@@ -104,17 +104,17 @@ governing permissions and limitations under the License.
     margin-inline-start: var(--mod-spacing-progressbar-label-to-text, var(--spectrum-progressbar-spacing-label-to-text));
 }
 
-:host([static-color='white']) .fill {
+:host([static-color="white"]) .fill {
     background: var(--mod-progressbar-fill-color-white, var(--spectrum-progressbar-fill-color-white));
 }
 
-:host([static-color='white']) .fill,
-:host([static-color='white']) .label,
-:host([static-color='white']) .percentage {
+:host([static-color="white"]) .fill,
+:host([static-color="white"]) .label,
+:host([static-color="white"]) .percentage {
     color: var(--mod-progressbar-label-and-value-white, var(--spectrum-progressbar-label-and-value-white));
 }
 
-:host([static-color='white']) .track {
+:host([static-color="white"]) .track {
     background: var(--spectrum-progressbar-track-color-white);
 }
 

--- a/packages/progress-circle/src/progress-circle-overrides.css
+++ b/packages/progress-circle/src/progress-circle-overrides.css
@@ -12,13 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-progress-circle-track-border-color: var(
-        --system-progress-circle-track-border-color
-    );
-    --spectrum-progress-circle-track-border-color-over-background: var(
-        --system-progress-circle-track-border-color-over-background
-    );
-    --spectrum-progress-circle-fill-border-color-over-background: var(
-        --system-progress-circle-fill-border-color-over-background
-    );
+    --spectrum-progress-circle-track-border-color: var(--system-progress-circle-track-border-color);
+    --spectrum-progress-circle-track-border-color-over-background: var(--system-progress-circle-track-border-color-over-background);
+    --spectrum-progress-circle-fill-border-color-over-background: var(--system-progress-circle-fill-border-color-over-background);
 }

--- a/packages/progress-circle/src/spectrum-progress-circle.css
+++ b/packages/progress-circle/src/spectrum-progress-circle.css
@@ -37,7 +37,7 @@ governing permissions and limitations under the License.
     transform: translateZ(0);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-progress-circle-size: var(--spectrum-progress-circle-size-small);
     --spectrum-progress-circle-thickness: var(--spectrum-progress-circle-thickness-small);
 }
@@ -47,7 +47,7 @@ governing permissions and limitations under the License.
     --spectrum-progress-circle-thickness: var(--spectrum-progress-circle-thickness-medium);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-progress-circle-size: var(--spectrum-progress-circle-size-large);
     --spectrum-progress-circle-thickness: var(--spectrum-progress-circle-thickness-large);
 }
@@ -80,11 +80,11 @@ governing permissions and limitations under the License.
     border-color: var(--highcontrast-progress-circle-fill-border-color, var(--mod-progress-circle-fill-border-color, var(--spectrum-progress-circle-fill-border-color)));
 }
 
-:host([static-color='white']) .track {
+:host([static-color="white"]) .track {
     border-color: var(--mod-progress-circle-track-border-color-over-background, var(--spectrum-progress-circle-track-border-color-over-background));
 }
 
-:host([static-color='white']) .fill {
+:host([static-color="white"]) .fill {
     border-color: var(--highcontrast-progress-circle-fill-border-color-over-background, var(--mod-progress-circle-fill-border-color-over-background, var(--spectrum-progress-circle-fill-border-color-over-background)));
 }
 

--- a/packages/radio/src/radio-overrides.css
+++ b/packages/radio/src/radio-overrides.css
@@ -12,199 +12,95 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-radio-button-border-color-default: var(
-        --system-radio-button-border-color-default
-    );
-    --spectrum-radio-button-border-color-hover: var(
-        --system-radio-button-border-color-hover
-    );
-    --spectrum-radio-button-border-color-down: var(
-        --system-radio-button-border-color-down
-    );
-    --spectrum-radio-button-border-color-focus: var(
-        --system-radio-button-border-color-focus
-    );
-    --spectrum-radio-neutral-content-color: var(
-        --system-radio-neutral-content-color
-    );
-    --spectrum-radio-neutral-content-color-hover: var(
-        --system-radio-neutral-content-color-hover
-    );
-    --spectrum-radio-neutral-content-color-down: var(
-        --system-radio-neutral-content-color-down
-    );
-    --spectrum-radio-neutral-content-color-focus: var(
-        --system-radio-neutral-content-color-focus
-    );
-    --spectrum-radio-focus-indicator-thickness: var(
-        --system-radio-focus-indicator-thickness
-    );
-    --spectrum-radio-focus-indicator-gap: var(
-        --system-radio-focus-indicator-gap
-    );
-    --spectrum-radio-focus-indicator-color: var(
-        --system-radio-focus-indicator-color
-    );
-    --spectrum-radio-disabled-content-color: var(
-        --system-radio-disabled-content-color
-    );
-    --spectrum-radio-disabled-border-color: var(
-        --system-radio-disabled-border-color
-    );
-    --spectrum-radio-emphasized-accent-color: var(
-        --system-radio-emphasized-accent-color
-    );
-    --spectrum-radio-emphasized-accent-color-hover: var(
-        --system-radio-emphasized-accent-color-hover
-    );
-    --spectrum-radio-emphasized-accent-color-down: var(
-        --system-radio-emphasized-accent-color-down
-    );
-    --spectrum-radio-emphasized-accent-color-focus: var(
-        --system-radio-emphasized-accent-color-focus
-    );
+    --spectrum-radio-button-border-color-default: var(--system-radio-button-border-color-default);
+    --spectrum-radio-button-border-color-hover: var(--system-radio-button-border-color-hover);
+    --spectrum-radio-button-border-color-down: var(--system-radio-button-border-color-down);
+    --spectrum-radio-button-border-color-focus: var(--system-radio-button-border-color-focus);
+    --spectrum-radio-neutral-content-color: var(--system-radio-neutral-content-color);
+    --spectrum-radio-neutral-content-color-hover: var(--system-radio-neutral-content-color-hover);
+    --spectrum-radio-neutral-content-color-down: var(--system-radio-neutral-content-color-down);
+    --spectrum-radio-neutral-content-color-focus: var(--system-radio-neutral-content-color-focus);
+    --spectrum-radio-focus-indicator-thickness: var(--system-radio-focus-indicator-thickness);
+    --spectrum-radio-focus-indicator-gap: var(--system-radio-focus-indicator-gap);
+    --spectrum-radio-focus-indicator-color: var(--system-radio-focus-indicator-color);
+    --spectrum-radio-disabled-content-color: var(--system-radio-disabled-content-color);
+    --spectrum-radio-disabled-border-color: var(--system-radio-disabled-border-color);
+    --spectrum-radio-emphasized-accent-color: var(--system-radio-emphasized-accent-color);
+    --spectrum-radio-emphasized-accent-color-hover: var(--system-radio-emphasized-accent-color-hover);
+    --spectrum-radio-emphasized-accent-color-down: var(--system-radio-emphasized-accent-color-down);
+    --spectrum-radio-emphasized-accent-color-focus: var(--system-radio-emphasized-accent-color-focus);
     --spectrum-radio-border-width: var(--system-radio-border-width);
-    --spectrum-radio-button-background-color: var(
-        --system-radio-button-background-color
-    );
-    --spectrum-radio-button-checked-border-color-default: var(
-        --system-radio-button-checked-border-color-default
-    );
-    --spectrum-radio-button-checked-border-color-hover: var(
-        --system-radio-button-checked-border-color-hover
-    );
-    --spectrum-radio-button-checked-border-color-down: var(
-        --system-radio-button-checked-border-color-down
-    );
-    --spectrum-radio-button-checked-border-color-focus: var(
-        --system-radio-button-checked-border-color-focus
-    );
+    --spectrum-radio-button-background-color: var(--system-radio-button-background-color);
+    --spectrum-radio-button-checked-border-color-default: var(--system-radio-button-checked-border-color-default);
+    --spectrum-radio-button-checked-border-color-hover: var(--system-radio-button-checked-border-color-hover);
+    --spectrum-radio-button-checked-border-color-down: var(--system-radio-button-checked-border-color-down);
+    --spectrum-radio-button-checked-border-color-focus: var(--system-radio-button-checked-border-color-focus);
     --spectrum-radio-line-height: var(--system-radio-line-height);
     --spectrum-radio-animation-duration: var(--system-radio-animation-duration);
     --spectrum-radio-height: var(--system-radio-height);
-    --spectrum-radio-button-control-size: var(
-        --system-radio-button-control-size
-    );
+    --spectrum-radio-button-control-size: var(--system-radio-button-control-size);
     --spectrum-radio-text-to-control: var(--system-radio-text-to-control);
     --spectrum-radio-label-top-to-text: var(--system-radio-label-top-to-text);
-    --spectrum-radio-label-bottom-to-text: var(
-        --system-radio-label-bottom-to-text
-    );
-    --spectrum-radio-button-top-to-control: var(
-        --system-radio-button-top-to-control
-    );
+    --spectrum-radio-label-bottom-to-text: var(--system-radio-label-bottom-to-text);
+    --spectrum-radio-button-top-to-control: var(--system-radio-button-top-to-control);
     --spectrum-radio-font-size: var(--system-radio-font-size);
 }
 
 :host(:lang(ja)) {
-    --spectrum-radio-line-height-cjk: var(
-        --system-radio-lang-ja-line-height-cjk
-    );
+    --spectrum-radio-line-height-cjk: var(--system-radio-lang-ja-line-height-cjk);
 }
 
 :host(:lang(zh)) {
-    --spectrum-radio-line-height-cjk: var(
-        --system-radio-lang-zh-line-height-cjk
-    );
+    --spectrum-radio-line-height-cjk: var(--system-radio-lang-zh-line-height-cjk);
 }
 
 :host(:lang(ko)) {
-    --spectrum-radio-line-height-cjk: var(
-        --system-radio-lang-ko-line-height-cjk
-    );
+    --spectrum-radio-line-height-cjk: var(--system-radio-lang-ko-line-height-cjk);
 }
 
 :host {
     --spectrum-radio-height: var(--system-radio-size-m-height);
-    --spectrum-radio-button-control-size: var(
-        --system-radio-size-m-button-control-size
-    );
-    --spectrum-radio-text-to-control: var(
-        --system-radio-size-m-text-to-control
-    );
-    --spectrum-radio-label-top-to-text: var(
-        --system-radio-size-m-label-top-to-text
-    );
-    --spectrum-radio-label-bottom-to-text: var(
-        --system-radio-size-m-label-bottom-to-text
-    );
-    --spectrum-radio-button-top-to-control: var(
-        --system-radio-size-m-button-top-to-control
-    );
+    --spectrum-radio-button-control-size: var(--system-radio-size-m-button-control-size);
+    --spectrum-radio-text-to-control: var(--system-radio-size-m-text-to-control);
+    --spectrum-radio-label-top-to-text: var(--system-radio-size-m-label-top-to-text);
+    --spectrum-radio-label-bottom-to-text: var(--system-radio-size-m-label-bottom-to-text);
+    --spectrum-radio-button-top-to-control: var(--system-radio-size-m-button-top-to-control);
     --spectrum-radio-font-size: var(--system-radio-size-m-font-size);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-radio-height: var(--system-radio-size-s-height);
-    --spectrum-radio-button-control-size: var(
-        --system-radio-size-s-button-control-size
-    );
-    --spectrum-radio-text-to-control: var(
-        --system-radio-size-s-text-to-control
-    );
-    --spectrum-radio-label-top-to-text: var(
-        --system-radio-size-s-label-top-to-text
-    );
-    --spectrum-radio-label-bottom-to-text: var(
-        --system-radio-size-s-label-bottom-to-text
-    );
-    --spectrum-radio-button-top-to-control: var(
-        --system-radio-size-s-button-top-to-control
-    );
+    --spectrum-radio-button-control-size: var(--system-radio-size-s-button-control-size);
+    --spectrum-radio-text-to-control: var(--system-radio-size-s-text-to-control);
+    --spectrum-radio-label-top-to-text: var(--system-radio-size-s-label-top-to-text);
+    --spectrum-radio-label-bottom-to-text: var(--system-radio-size-s-label-bottom-to-text);
+    --spectrum-radio-button-top-to-control: var(--system-radio-size-s-button-top-to-control);
     --spectrum-radio-font-size: var(--system-radio-size-s-font-size);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-radio-height: var(--system-radio-size-l-height);
-    --spectrum-radio-button-control-size: var(
-        --system-radio-size-l-button-control-size
-    );
-    --spectrum-radio-text-to-control: var(
-        --system-radio-size-l-text-to-control
-    );
-    --spectrum-radio-label-top-to-text: var(
-        --system-radio-size-l-label-top-to-text
-    );
-    --spectrum-radio-label-bottom-to-text: var(
-        --system-radio-size-l-label-bottom-to-text
-    );
-    --spectrum-radio-button-top-to-control: var(
-        --system-radio-size-l-button-top-to-control
-    );
+    --spectrum-radio-button-control-size: var(--system-radio-size-l-button-control-size);
+    --spectrum-radio-text-to-control: var(--system-radio-size-l-text-to-control);
+    --spectrum-radio-label-top-to-text: var(--system-radio-size-l-label-top-to-text);
+    --spectrum-radio-label-bottom-to-text: var(--system-radio-size-l-label-bottom-to-text);
+    --spectrum-radio-button-top-to-control: var(--system-radio-size-l-button-top-to-control);
     --spectrum-radio-font-size: var(--system-radio-size-l-font-size);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-radio-height: var(--system-radio-size-xl-height);
-    --spectrum-radio-button-control-size: var(
-        --system-radio-size-xl-button-control-size
-    );
-    --spectrum-radio-text-to-control: var(
-        --system-radio-size-xl-text-to-control
-    );
-    --spectrum-radio-label-top-to-text: var(
-        --system-radio-size-xl-label-top-to-text
-    );
-    --spectrum-radio-label-bottom-to-text: var(
-        --system-radio-size-xl-label-bottom-to-text
-    );
-    --spectrum-radio-button-top-to-control: var(
-        --system-radio-size-xl-button-top-to-control
-    );
+    --spectrum-radio-button-control-size: var(--system-radio-size-xl-button-control-size);
+    --spectrum-radio-text-to-control: var(--system-radio-size-xl-text-to-control);
+    --spectrum-radio-label-top-to-text: var(--system-radio-size-xl-label-top-to-text);
+    --spectrum-radio-label-bottom-to-text: var(--system-radio-size-xl-label-bottom-to-text);
+    --spectrum-radio-button-top-to-control: var(--system-radio-size-xl-button-top-to-control);
     --spectrum-radio-font-size: var(--system-radio-size-xl-font-size);
 }
 
 :host([emphasized]) {
-    --spectrum-radio-button-checked-border-color-default: var(
-        --system-radio-emphasized-button-checked-border-color-default
-    );
-    --spectrum-radio-button-checked-border-color-hover: var(
-        --system-radio-emphasized-button-checked-border-color-hover
-    );
-    --spectrum-radio-button-checked-border-color-down: var(
-        --system-radio-emphasized-button-checked-border-color-down
-    );
-    --spectrum-radio-button-checked-border-color-focus: var(
-        --system-radio-emphasized-button-checked-border-color-focus
-    );
+    --spectrum-radio-button-checked-border-color-default: var(--system-radio-emphasized-button-checked-border-color-default);
+    --spectrum-radio-button-checked-border-color-hover: var(--system-radio-emphasized-button-checked-border-color-hover);
+    --spectrum-radio-button-checked-border-color-down: var(--system-radio-emphasized-button-checked-border-color-down);
+    --spectrum-radio-button-checked-border-color-focus: var(--system-radio-emphasized-button-checked-border-color-focus);
 }

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -201,7 +201,7 @@ governing permissions and limitations under the License.
 
 #button:before {
     z-index: 0;
-    content: '';
+    content: "";
     box-sizing: border-box;
     inline-size: var(--mod-radio-button-control-size, var(--spectrum-radio-button-control-size));
     block-size: var(--mod-radio-button-control-size, var(--spectrum-radio-button-control-size));
@@ -218,7 +218,7 @@ governing permissions and limitations under the License.
 }
 
 #button:after {
-    content: '';
+    content: "";
     transition:
         opacity var(--mod-radio-animation-duration, var(--spectrum-radio-animation-duration)) ease-out,
         margin var(--mod-radio-animation-duration, var(--spectrum-radio-animation-duration)) ease-out;
@@ -231,6 +231,6 @@ governing permissions and limitations under the License.
 }
 
 :host:dir(rtl) #button:after,
-:host([dir='rtl']) #button:after {
+:host([dir="rtl"]) #button:after {
     transform: translateX(50%) translateY(-50%);
 }

--- a/packages/search/src/search-overrides.css
+++ b/packages/search/src/search-overrides.css
@@ -12,44 +12,24 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-search-border-color-default: var(
-        --system-search-border-color-default
-    );
-    --spectrum-search-border-color-hover: var(
-        --system-search-border-color-hover
-    );
-    --spectrum-search-border-color-focus: var(
-        --system-search-border-color-focus
-    );
-    --spectrum-search-border-color-focus-hover: var(
-        --system-search-border-color-focus-hover
-    );
-    --spectrum-search-border-color-key-focus: var(
-        --system-search-border-color-key-focus
-    );
+    --spectrum-search-border-color-default: var(--system-search-border-color-default);
+    --spectrum-search-border-color-hover: var(--system-search-border-color-hover);
+    --spectrum-search-border-color-focus: var(--system-search-border-color-focus);
+    --spectrum-search-border-color-focus-hover: var(--system-search-border-color-focus-hover);
+    --spectrum-search-border-color-key-focus: var(--system-search-border-color-key-focus);
     --spectrum-search-background-color: var(--system-search-background-color);
-    --spectrum-search-background-color-disabled: var(
-        --system-search-background-color-disabled
-    );
-    --spectrum-search-border-color-disabled: var(
-        --system-search-border-color-disabled
-    );
+    --spectrum-search-background-color-disabled: var(--system-search-background-color-disabled);
+    --spectrum-search-border-color-disabled: var(--system-search-border-color-disabled);
     --spectrum-search-border-radius: var(--system-search-border-radius);
     --spectrum-search-edge-to-visual: var(--system-search-edge-to-visual);
 }
 
-:host([size='m']) #textfield {
+:host([size="m"]) #textfield {
     --spectrum-search-border-radius: var(--system-search-size-m-border-radius);
-    --spectrum-search-edge-to-visual: var(
-        --system-search-size-m-edge-to-visual
-    );
+    --spectrum-search-edge-to-visual: var(--system-search-size-m-edge-to-visual);
 }
 
 :host([quiet]) {
-    --spectrum-search-background-color-disabled: var(
-        --system-search-quiet-background-color-disabled
-    );
-    --spectrum-search-border-color-disabled: var(
-        --system-search-quiet-border-color-disabled
-    );
+    --spectrum-search-background-color-disabled: var(--system-search-quiet-background-color-disabled);
+    --spectrum-search-border-color-disabled: var(--system-search-quiet-border-color-disabled);
 }

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -66,19 +66,19 @@ governing permissions and limitations under the License.
     margin-block-start: var(--mod-search-to-help-text, var(--spectrum-search-to-help-text));
 }
 
-:host([size='s']) #textfield {
+:host([size="s"]) #textfield {
     --spectrum-search-block-size: var(--spectrum-component-height-75);
     --spectrum-search-icon-size: var(--spectrum-workflow-icon-size-75);
     --spectrum-search-text-to-icon: var(--spectrum-text-to-visual-75);
 }
 
-:host([size='l']) #textfield {
+:host([size="l"]) #textfield {
     --spectrum-search-block-size: var(--spectrum-component-height-200);
     --spectrum-search-icon-size: var(--spectrum-workflow-icon-size-200);
     --spectrum-search-text-to-icon: var(--spectrum-text-to-visual-200);
 }
 
-:host([size='xl']) #textfield {
+:host([size="xl"]) #textfield {
     --spectrum-search-block-size: var(--spectrum-component-height-300);
     --spectrum-search-icon-size: var(--spectrum-workflow-icon-size-300);
     --spectrum-search-text-to-icon: var(--spectrum-text-to-visual-300);

--- a/packages/sidenav/src/sidenav-heading-overrides.css
+++ b/packages/sidenav/src/sidenav-heading-overrides.css
@@ -12,25 +12,11 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #list {
-    --spectrum-sidenav-background-hover: var(
-        --system-side-nav-background-hover
-    );
-    --spectrum-sidenav-item-background-down: var(
-        --system-side-nav-item-background-down
-    );
-    --spectrum-sidenav-background-key-focus: var(
-        --system-side-nav-background-key-focus
-    );
-    --spectrum-sidenav-item-background-default-selected: var(
-        --system-side-nav-item-background-default-selected
-    );
-    --spectrum-sidenav-background-hover-selected: var(
-        --system-side-nav-background-hover-selected
-    );
-    --spectrum-sidenav-item-background-down-selected: var(
-        --system-side-nav-item-background-down-selected
-    );
-    --spectrum-sidenav-background-key-focus-selected: var(
-        --system-side-nav-background-key-focus-selected
-    );
+    --spectrum-sidenav-background-hover: var(--system-side-nav-background-hover);
+    --spectrum-sidenav-item-background-down: var(--system-side-nav-item-background-down);
+    --spectrum-sidenav-background-key-focus: var(--system-side-nav-background-key-focus);
+    --spectrum-sidenav-item-background-default-selected: var(--system-side-nav-item-background-default-selected);
+    --spectrum-sidenav-background-hover-selected: var(--system-side-nav-background-hover-selected);
+    --spectrum-sidenav-item-background-down-selected: var(--system-side-nav-item-background-down-selected);
+    --spectrum-sidenav-background-key-focus-selected: var(--system-side-nav-background-key-focus-selected);
 }

--- a/packages/sidenav/src/sidenav-item-overrides.css
+++ b/packages/sidenav/src/sidenav-item-overrides.css
@@ -12,25 +12,11 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #list {
-    --spectrum-sidenav-background-hover: var(
-        --system-side-nav-background-hover
-    );
-    --spectrum-sidenav-item-background-down: var(
-        --system-side-nav-item-background-down
-    );
-    --spectrum-sidenav-background-key-focus: var(
-        --system-side-nav-background-key-focus
-    );
-    --spectrum-sidenav-item-background-default-selected: var(
-        --system-side-nav-item-background-default-selected
-    );
-    --spectrum-sidenav-background-hover-selected: var(
-        --system-side-nav-background-hover-selected
-    );
-    --spectrum-sidenav-item-background-down-selected: var(
-        --system-side-nav-item-background-down-selected
-    );
-    --spectrum-sidenav-background-key-focus-selected: var(
-        --system-side-nav-background-key-focus-selected
-    );
+    --spectrum-sidenav-background-hover: var(--system-side-nav-background-hover);
+    --spectrum-sidenav-item-background-down: var(--system-side-nav-item-background-down);
+    --spectrum-sidenav-background-key-focus: var(--system-side-nav-background-key-focus);
+    --spectrum-sidenav-item-background-default-selected: var(--system-side-nav-item-background-default-selected);
+    --spectrum-sidenav-background-hover-selected: var(--system-side-nav-background-hover-selected);
+    --spectrum-sidenav-item-background-down-selected: var(--system-side-nav-item-background-down-selected);
+    --spectrum-sidenav-background-key-focus-selected: var(--system-side-nav-background-key-focus-selected);
 }

--- a/packages/sidenav/src/sidenav-overrides.css
+++ b/packages/sidenav/src/sidenav-overrides.css
@@ -12,25 +12,11 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-sidenav-background-hover: var(
-        --system-side-nav-background-hover
-    );
-    --spectrum-sidenav-item-background-down: var(
-        --system-side-nav-item-background-down
-    );
-    --spectrum-sidenav-background-key-focus: var(
-        --system-side-nav-background-key-focus
-    );
-    --spectrum-sidenav-item-background-default-selected: var(
-        --system-side-nav-item-background-default-selected
-    );
-    --spectrum-sidenav-background-hover-selected: var(
-        --system-side-nav-background-hover-selected
-    );
-    --spectrum-sidenav-item-background-down-selected: var(
-        --system-side-nav-item-background-down-selected
-    );
-    --spectrum-sidenav-background-key-focus-selected: var(
-        --system-side-nav-background-key-focus-selected
-    );
+    --spectrum-sidenav-background-hover: var(--system-side-nav-background-hover);
+    --spectrum-sidenav-item-background-down: var(--system-side-nav-item-background-down);
+    --spectrum-sidenav-background-key-focus: var(--system-side-nav-background-key-focus);
+    --spectrum-sidenav-item-background-default-selected: var(--system-side-nav-item-background-default-selected);
+    --spectrum-sidenav-background-hover-selected: var(--system-side-nav-background-hover-selected);
+    --spectrum-sidenav-item-background-down-selected: var(--system-side-nav-item-background-down-selected);
+    --spectrum-sidenav-background-key-focus-selected: var(--system-side-nav-background-key-focus-selected);
 }

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 @media (forced-colors: active) {
-    #list ::slotted([slot='icon']) {
+    #list ::slotted([slot="icon"]) {
         forced-color-adjust: preserve-parent-color;
     }
 
@@ -161,7 +161,7 @@ governing permissions and limitations under the License.
     margin-block-end: var(--mod-sidenav-bottom-to-label, var(--spectrum-sidenav-bottom-to-label));
 }
 
-#item-link ::slotted([slot='icon']) {
+#item-link ::slotted([slot="icon"]) {
     inline-size: var(--mod-sidenav-icon-size, var(--spectrum-sidenav-icon-size));
     block-size: var(--mod-sidenav-icon-size, var(--spectrum-sidenav-icon-size));
     flex-shrink: 0;
@@ -203,19 +203,19 @@ governing permissions and limitations under the License.
     line-height: var(--mod-sidenav-top-level-line-height, var(--spectrum-sidenav-top-level-line-height));
 }
 
-#item-link:not([data-level='0']) {
+#item-link:not([data-level="0"]) {
     font-weight: var(--mod-sidenav-text-font-weight, var(--spectrum-sidenav-text-font-weight));
     padding-inline-start: var(--mod-sidenav-start-to-content-second-level, var(--spectrum-sidenav-start-to-content-second-level));
 }
 
-#item-link[data-level='2'] {
+#item-link[data-level="2"] {
     padding-inline-start: var(--mod-sidenav-start-to-content-third-level, var(--spectrum-sidenav-start-to-content-third-level));
 }
 
-.spectrum-SideNav--hasIcon#item-link:not([data-level='0']) {
+.spectrum-SideNav--hasIcon#item-link:not([data-level="0"]) {
     padding-inline-start: var(--mod-sidenav-start-to-content-with-icon-second-level, var(--spectrum-sidenav-start-to-content-with-icon-second-level));
 }
 
-.spectrum-SideNav--hasIcon#item-link[data-level='2'] {
+.spectrum-SideNav--hasIcon#item-link[data-level="2"] {
     padding-inline-start: var(--mod-sidenav-start-to-content-with-icon-third-level, var(--spectrum-sidenav-start-to-content-with-icon-third-level));
 }

--- a/packages/slider/src/slider-overrides.css
+++ b/packages/slider/src/slider-overrides.css
@@ -15,68 +15,34 @@ governing permissions and limitations under the License.
     --spectrum-slider-track-color: var(--system-slider-track-color);
     --spectrum-slider-track-fill-color: var(--system-slider-track-fill-color);
     --spectrum-slider-ramp-track-color: var(--system-slider-ramp-track-color);
-    --spectrum-slider-ramp-track-color-disabled: var(
-        --system-slider-ramp-track-color-disabled
-    );
-    --spectrum-slider-handle-background-color: var(
-        --system-slider-handle-background-color
-    );
-    --spectrum-slider-handle-background-color-disabled: var(
-        --system-slider-handle-background-color-disabled
-    );
-    --spectrum-slider-ramp-handle-background-color: var(
-        --system-slider-ramp-handle-background-color
-    );
-    --spectrum-slider-ticks-handle-background-color: var(
-        --system-slider-ticks-handle-background-color
-    );
-    --spectrum-slider-handle-border-color: var(
-        --system-slider-handle-border-color
-    );
-    --spectrum-slider-handle-disabled-background-color: var(
-        --system-slider-handle-disabled-background-color
-    );
+    --spectrum-slider-ramp-track-color-disabled: var(--system-slider-ramp-track-color-disabled);
+    --spectrum-slider-handle-background-color: var(--system-slider-handle-background-color);
+    --spectrum-slider-handle-background-color-disabled: var(--system-slider-handle-background-color-disabled);
+    --spectrum-slider-ramp-handle-background-color: var(--system-slider-ramp-handle-background-color);
+    --spectrum-slider-ticks-handle-background-color: var(--system-slider-ticks-handle-background-color);
+    --spectrum-slider-handle-border-color: var(--system-slider-handle-border-color);
+    --spectrum-slider-handle-disabled-background-color: var(--system-slider-handle-disabled-background-color);
     --spectrum-slider-tick-mark-color: var(--system-slider-tick-mark-color);
-    --spectrum-slider-handle-border-color-hover: var(
-        --system-slider-handle-border-color-hover
-    );
-    --spectrum-slider-handle-border-color-down: var(
-        --system-slider-handle-border-color-down
-    );
-    --spectrum-slider-handle-border-color-key-focus: var(
-        --system-slider-handle-border-color-key-focus
-    );
-    --spectrum-slider-handle-focus-ring-color-key-focus: var(
-        --system-slider-handle-focus-ring-color-key-focus
-    );
-    --spectrum-slider-track-corner-radius: var(
-        --system-slider-track-corner-radius
-    );
-    --spectrum-slider-handle-border-radius: var(
-        --system-slider-handle-border-radius
-    );
+    --spectrum-slider-handle-border-color-hover: var(--system-slider-handle-border-color-hover);
+    --spectrum-slider-handle-border-color-down: var(--system-slider-handle-border-color-down);
+    --spectrum-slider-handle-border-color-key-focus: var(--system-slider-handle-border-color-key-focus);
+    --spectrum-slider-handle-focus-ring-color-key-focus: var(--system-slider-handle-focus-ring-color-key-focus);
+    --spectrum-slider-track-corner-radius: var(--system-slider-track-corner-radius);
+    --spectrum-slider-handle-border-radius: var(--system-slider-handle-border-radius);
 }
 
 :host {
-    --spectrum-slider-handle-border-radius: var(
-        --system-slider-size-m-handle-border-radius
-    );
+    --spectrum-slider-handle-border-radius: var(--system-slider-size-m-handle-border-radius);
 }
 
-:host([size='s']) {
-    --spectrum-slider-handle-border-radius: var(
-        --system-slider-size-s-handle-border-radius
-    );
+:host([size="s"]) {
+    --spectrum-slider-handle-border-radius: var(--system-slider-size-s-handle-border-radius);
 }
 
-:host([size='l']) {
-    --spectrum-slider-handle-border-radius: var(
-        --system-slider-size-l-handle-border-radius
-    );
+:host([size="l"]) {
+    --spectrum-slider-handle-border-radius: var(--system-slider-size-l-handle-border-radius);
 }
 
-:host([size='xl']) {
-    --spectrum-slider-handle-border-radius: var(
-        --system-slider-size-xl-handle-border-radius
-    );
+:host([size="xl"]) {
+    --spectrum-slider-handle-border-radius: var(--system-slider-size-xl-handle-border-radius);
 }

--- a/packages/slider/src/spectrum-slider.css
+++ b/packages/slider/src/spectrum-slider.css
@@ -53,7 +53,7 @@ governing permissions and limitations under the License.
 }
 
 :host:dir(rtl),
-:host([dir='rtl']) {
+:host([dir="rtl"]) {
     --spectrum-logical-rotation: matrix(-1, 0, 0, 1, 0, 0);
 }
 
@@ -61,7 +61,7 @@ governing permissions and limitations under the License.
     margin-block-start: calc(var(--mod-slider-ramp-track-height, var(--spectrum-slider-ramp-track-height)) / 2);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-slider-font-size: var(--spectrum-font-size-75);
     --spectrum-slider-handle-size: var(--spectrum-slider-handle-size-small);
     --spectrum-slider-control-height: var(--spectrum-component-height-75);
@@ -71,7 +71,7 @@ governing permissions and limitations under the License.
     --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-100);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-slider-font-size: var(--spectrum-font-size-100);
     --spectrum-slider-handle-size: var(--spectrum-slider-handle-size-large);
     --spectrum-slider-control-height: var(--spectrum-component-height-200);
@@ -82,7 +82,7 @@ governing permissions and limitations under the License.
     --spectrum-slider-value-inline-size: 18px;
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-slider-font-size: var(--spectrum-font-size-200);
     --spectrum-slider-handle-size: var(--spectrum-slider-handle-size-extra-large);
     --spectrum-slider-control-height: var(--spectrum-component-height-300);
@@ -162,7 +162,7 @@ governing permissions and limitations under the License.
 
 .fill:before,
 .track:before {
-    content: '';
+    content: "";
     block-size: 100%;
     border-start-start-radius: 0;
     border-start-end-radius: 0;
@@ -191,7 +191,7 @@ governing permissions and limitations under the License.
     inset-inline-end: var(--mod-slider-range-track-reset, var(--spectrum-slider-range-track-reset));
 }
 
-:host([variant='range']) .track ~ .track {
+:host([variant="range"]) .track ~ .track {
     padding-inline: var(--mod-slider-track-middle-handleoffset, var(--spectrum-slider-track-middle-handleoffset)) var(--mod-slider-track-middle-handleoffset, var(--spectrum-slider-track-middle-handleoffset));
     margin-inline: var(--mod-slider-range-track-reset, var(--spectrum-slider-range-track-reset));
     inset-inline: auto;
@@ -210,12 +210,12 @@ governing permissions and limitations under the License.
     padding-inline-end: calc(var(--mod-slider-controls-margin, var(--spectrum-slider-controls-margin)) + var(--spectrum-slider-handle-gap, var(--spectrum-slider-handle-gap)));
 }
 
-:host([variant='range']) #value {
+:host([variant="range"]) #value {
     -webkit-user-select: text;
     user-select: text;
 }
 
-:host([variant='range']) .track:first-of-type {
+:host([variant="range"]) .track:first-of-type {
     margin-inline-start: var(--mod-slider-track-margin-offset, var(--spectrum-slider-track-margin-offset));
     padding-inline-start: 0;
     padding-inline-end: var(--mod-slider-track-handleoffset, var(--spectrum-slider-track-handleoffset));
@@ -223,12 +223,12 @@ governing permissions and limitations under the License.
     inset-inline-end: auto;
 }
 
-:host([variant='range']) .track:first-of-type:before {
+:host([variant="range"]) .track:first-of-type:before {
     border-start-start-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
     border-end-start-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
 }
 
-:host([variant='range']) .track:last-of-type {
+:host([variant="range"]) .track:last-of-type {
     margin-inline-end: var(--mod-slider-track-margin-offset, var(--spectrum-slider-track-margin-offset));
     padding-inline-start: var(--spectrum-slider-track-handleoffset);
     padding-inline-end: 0;
@@ -236,7 +236,7 @@ governing permissions and limitations under the License.
     inset-inline-end: var(--mod-slider-range-track-reset, var(--spectrum-slider-range-track-reset));
 }
 
-:host([variant='range']) .track:last-of-type:before {
+:host([variant="range"]) .track:last-of-type:before {
     border-start-end-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
     border-end-end-radius: var(--mod-slider-track-corner-radius, var(--spectrum-slider-track-corner-radius));
 }
@@ -285,7 +285,7 @@ governing permissions and limitations under the License.
 }
 
 .handle:before {
-    content: '';
+    content: "";
     transition:
         box-shadow var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out,
         inline-size var(--mod-animation-duration-100, var(--spectrum-animation-duration-100)) ease-out,
@@ -301,7 +301,7 @@ governing permissions and limitations under the License.
 }
 
 :host:dir(rtl) .handle:before,
-:host([dir='rtl']) .handle:before {
+:host([dir="rtl"]) .handle:before {
     transform: translate(50%, -50%);
 }
 
@@ -354,22 +354,22 @@ governing permissions and limitations under the License.
 
 #value {
     cursor: default;
-    font-feature-settings: 'tnum';
+    font-feature-settings: "tnum";
     text-align: end;
     flex-grow: 0;
     margin-inline-start: var(--mod-slider-label-margin-start, var(--spectrum-slider-label-margin-start));
     padding-inline-end: 0;
 }
 
-:host([variant='tick']) .handle {
+:host([variant="tick"]) .handle {
     background-color: var(--mod-slider-tick-handle-background-color, var(--spectrum-slider-tick-handle-background-color));
 }
 
-:host([variant='tick']) #controls {
+:host([variant="tick"]) #controls {
     margin-block-start: calc(var(--spectrum-text-to-visual-75) - var(--mod-slider-tick-mark-height, var(--spectrum-slider-tick-mark-height)) / 2 - var(--mod-slider-track-thickness, var(--spectrum-slider-track-thickness)) / 2);
 }
 
-:host([variant='tick']) .tickLabel {
+:host([variant="tick"]) .tickLabel {
     margin-block-start: calc(var(--mod-slider-tick-mark-height, var(--spectrum-slider-tick-mark-height)) + var(--spectrum-text-to-visual-75));
 }
 
@@ -395,7 +395,7 @@ governing permissions and limitations under the License.
 }
 
 .tick:after {
-    content: '';
+    content: "";
     block-size: var(--mod-slider-tick-mark-height, var(--spectrum-slider-tick-mark-height));
     border-radius: var(--mod-slider-tick-mark-border-radius, var(--spectrum-slider-tick-mark-border-radius));
     display: block;
@@ -466,7 +466,7 @@ governing permissions and limitations under the License.
     color: var(--highcontrast-slider-label-text-color, var(--mod-slider-label-text-color, var(--spectrum-slider-label-text-color)));
 }
 
-:host([variant='filled']) .track:first-child:before,
+:host([variant="filled"]) .track:first-child:before,
 .fill:before {
     background: var(--highcontrast-slider-filled-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
 }
@@ -493,7 +493,7 @@ governing permissions and limitations under the License.
     border-color: var(--highcontrast-slider-handle-border-color-down, var(--mod-slider-handle-border-color-down, var(--spectrum-slider-handle-border-color-down)));
 }
 
-:host([variant='ramp']) .handle {
+:host([variant="ramp"]) .handle {
     box-shadow: 0 0 0 var(--spectrum-slider-handle-gap) var(--highcontrast-slider-ramp-handle-border-color-active, var(--mod-sectrum-slider-ramp-handle-border-color-active, var(--spectrum-slider-ramp-handle-border-color-active)));
     background: var(--mod-slider-ramp-handle-background-color, var(--highcontrast-slider-ramp-handle-background-color, var(--spectrum-slider-ramp-handle-background-color)));
 }
@@ -511,7 +511,7 @@ governing permissions and limitations under the License.
     background: var(--highcontrast-slider-handle-background-color, var(--mod-slider-handle-background-color, var(--spectrum-slider-handle-background-color)));
 }
 
-:host([variant='range']) .track:not(:first-of-type, :last-of-type):before {
+:host([variant="range"]) .track:not(:first-of-type, :last-of-type):before {
     background: var(--highcontrast-slider-filled-track-fill-color, var(--mod-slider-track-fill-color, var(--spectrum-slider-track-fill-color)));
     border-start-end-radius: 0;
     border-end-end-radius: 0;
@@ -555,7 +555,7 @@ governing permissions and limitations under the License.
 }
 
 :host([disabled]) .fill:before,
-:host([disabled][variant='filled']) .track:first-child:before {
+:host([disabled][variant="filled"]) .track:first-child:before {
     background: var(--highcontrast-slider-track-fill-color-disabled, var(--mod-slider-track-fill-color-disabled, var(--spectrum-slider-track-fill-color-disabled)));
 }
 
@@ -567,7 +567,7 @@ governing permissions and limitations under the License.
     background-color: var(--highcontrast-slider-tick-mark-color-disabled, var(--mod-slider-tick-mark-color-disabled, var(--spectrum-slider-tick-mark-color-disabled)));
 }
 
-:host([disabled][variant='range']) .track:not(:first-of-type, :last-of-type):before {
+:host([disabled][variant="range"]) .track:not(:first-of-type, :last-of-type):before {
     background: var(--highcontrast-slider-track-color-disabled, var(--mod-slider-track-color-disabled, var(--spectrum-slider-track-color-disabled)));
 }
 
@@ -598,7 +598,7 @@ governing permissions and limitations under the License.
     }
 
     .handle.handle-highlight:before,
-    :host([variant='ramp']) .handle {
+    :host([variant="ramp"]) .handle {
         forced-color-adjust: none;
     }
 

--- a/packages/split-view/src/spectrum-split-view.css
+++ b/packages/split-view/src/spectrum-split-view.css
@@ -36,7 +36,7 @@ governing permissions and limitations under the License.
 }
 
 #gripper {
-    content: '';
+    content: "";
     border-radius: var(--mod-splitview-gripper-border-radius, var(--spectrum-splitview-gripper-border-radius));
     border-style: solid;
     border-color: var(--highcontrast-splitview-handle-background-color, var(--mod-splitview-handle-background-color, var(--spectrum-splitview-handle-background-color)));
@@ -68,7 +68,7 @@ governing permissions and limitations under the License.
 
 #splitter.is-collapsed-end #gripper:before,
 #splitter.is-collapsed-start #gripper:before {
-    content: '';
+    content: "";
     inline-size: var(--mod-splitview-handle-width, var(--spectrum-splitview-handle-width));
     block-size: 100%;
     position: absolute;

--- a/packages/split-view/src/split-view-overrides.css
+++ b/packages/split-view/src/split-view-overrides.css
@@ -12,13 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-splitview-background-color: var(
-        --system-split-view-background-color
-    );
-    --spectrum-splitview-handle-background-color: var(
-        --system-split-view-handle-background-color
-    );
-    --spectrum-splitview-gripper-border-radius: var(
-        --system-split-view-gripper-border-radius
-    );
+    --spectrum-splitview-background-color: var(--system-split-view-background-color);
+    --spectrum-splitview-handle-background-color: var(--system-split-view-handle-background-color);
+    --spectrum-splitview-gripper-border-radius: var(--system-split-view-gripper-border-radius);
 }

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -22,7 +22,7 @@ governing permissions and limitations under the License.
     --spectrum-statuslight-spacing-bottom-to-label: var(--spectrum-component-bottom-to-text-100);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-statuslight-height: var(--spectrum-component-height-75);
     --spectrum-statuslight-dot-size: var(--spectrum-status-light-dot-size-small);
     --spectrum-statuslight-font-size: var(--spectrum-font-size-75);
@@ -32,7 +32,7 @@ governing permissions and limitations under the License.
     --spectrum-statuslight-spacing-bottom-to-label: var(--spectrum-component-bottom-to-text-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-statuslight-height: var(--spectrum-component-height-200);
     --spectrum-statuslight-dot-size: var(--spectrum-status-light-dot-size-large);
     --spectrum-statuslight-font-size: var(--spectrum-font-size-200);
@@ -42,7 +42,7 @@ governing permissions and limitations under the License.
     --spectrum-statuslight-spacing-bottom-to-label: var(--spectrum-component-bottom-to-text-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-statuslight-height: var(--spectrum-component-height-300);
     --spectrum-statuslight-dot-size: var(--spectrum-status-light-dot-size-extra-large);
     --spectrum-statuslight-font-size: var(--spectrum-font-size-300);
@@ -103,7 +103,7 @@ governing permissions and limitations under the License.
 
 :host:before {
     --spectrum-statuslight-spacing-computed-top-to-dot: calc(var(--mod-statuslight-spacing-top-to-dot, var(--spectrum-statuslight-spacing-top-to-dot)) - var(--mod-statuslight-spacing-top-to-label, var(--spectrum-statuslight-spacing-top-to-label)));
-    content: '';
+    content: "";
     inline-size: var(--mod-statuslight-dot-size, var(--spectrum-statuslight-dot-size));
     block-size: var(--mod-statuslight-dot-size, var(--spectrum-statuslight-dot-size));
     border-radius: var(--mod-statuslight-corner-radius, var(--spectrum-statuslight-corner-radius));
@@ -114,12 +114,12 @@ governing permissions and limitations under the License.
     display: inline-block;
 }
 
-:host([variant='neutral']) {
+:host([variant="neutral"]) {
     color: var(--highcontrast-statuslight-subdued-content-color-default, var(--mod-statuslight-subdued-content-color-default, var(--spectrum-statuslight-subdued-content-color-default)));
     font-style: italic;
 }
 
-:host([variant='neutral']):before {
+:host([variant="neutral"]):before {
     background-color: var(--mod-statuslight-semantic-neutral-color, var(--spectrum-statuslight-semantic-neutral-color));
 }
 
@@ -127,19 +127,19 @@ governing permissions and limitations under the License.
     background-color: var(--mod-statuslight-semantic-accent-color, var(--spectrum-statuslight-semantic-accent-color));
 }
 
-:host([variant='info']):before {
+:host([variant="info"]):before {
     background-color: var(--mod-statuslight-semantic-info-color, var(--spectrum-statuslight-semantic-info-color));
 }
 
-:host([variant='negative']):before {
+:host([variant="negative"]):before {
     background-color: var(--mod-statuslight-semantic-negative-color, var(--spectrum-statuslight-semantic-negative-color));
 }
 
-:host([variant='notice']):before {
+:host([variant="notice"]):before {
     background-color: var(--mod-statuslight-semantic-notice-color, var(--spectrum-statuslight-semantic-notice-color));
 }
 
-:host([variant='positive']):before {
+:host([variant="positive"]):before {
     background-color: var(--mod-statuslight-semantic-positive-color, var(--spectrum-statuslight-semantic-positive-color));
 }
 
@@ -155,15 +155,15 @@ governing permissions and limitations under the License.
     background-color: var(--mod-statuslight-nonsemantic-orange-color, var(--spectrum-statuslight-nonsemantic-orange-color));
 }
 
-:host([variant='yellow']):before {
+:host([variant="yellow"]):before {
     background-color: var(--mod-statuslight-nonsemantic-yellow-color, var(--spectrum-statuslight-nonsemantic-yellow-color));
 }
 
-:host([variant='chartreuse']):before {
+:host([variant="chartreuse"]):before {
     background-color: var(--mod-statuslight-nonsemantic-chartreuse-color, var(--spectrum-statuslight-nonsemantic-chartreuse-color));
 }
 
-:host([variant='celery']):before {
+:host([variant="celery"]):before {
     background-color: var(--mod-statuslight-nonsemantic-celery-color, var(--spectrum-statuslight-nonsemantic-celery-color));
 }
 
@@ -171,7 +171,7 @@ governing permissions and limitations under the License.
     background-color: var(--mod-statuslight-nonsemantic-green-color, var(--spectrum-statuslight-nonsemantic-green-color));
 }
 
-:host([variant='seafoam']):before {
+:host([variant="seafoam"]):before {
     background-color: var(--mod-statuslight-nonsemantic-seafoam-color, var(--spectrum-statuslight-nonsemantic-seafoam-color));
 }
 
@@ -183,19 +183,19 @@ governing permissions and limitations under the License.
     background-color: var(--mod-statuslight-nonsemantic-blue-color, var(--spectrum-statuslight-nonsemantic-blue-color));
 }
 
-:host([variant='indigo']):before {
+:host([variant="indigo"]):before {
     background-color: var(--mod-statuslight-nonsemantic-indigo-color, var(--spectrum-statuslight-nonsemantic-indigo-color));
 }
 
-:host([variant='purple']):before {
+:host([variant="purple"]):before {
     background-color: var(--mod-statuslight-nonsemantic-purple-color, var(--spectrum-statuslight-nonsemantic-purple-color));
 }
 
-:host([variant='fuchsia']):before {
+:host([variant="fuchsia"]):before {
     background-color: var(--mod-statuslight-nonsemantic-fuchsia-color, var(--spectrum-statuslight-nonsemantic-fuchsia-color));
 }
 
-:host([variant='magenta']):before {
+:host([variant="magenta"]):before {
     background-color: var(--mod-statuslight-nonsemantic-magenta-color, var(--spectrum-statuslight-nonsemantic-magenta-color));
 }
 

--- a/packages/swatch/src/spectrum-swatch-group.css
+++ b/packages/swatch/src/spectrum-swatch-group.css
@@ -19,10 +19,10 @@ governing permissions and limitations under the License.
     display: inline-flex;
 }
 
-:host([density='compact']) {
+:host([density="compact"]) {
     gap: var(--mod-swatchgroup-spacing-compact, var(--spectrum-swatchgroup-spacing-compact));
 }
 
-:host([density='spacious']) {
+:host([density="spacious"]) {
     gap: var(--mod-swatchgroup-spacing-spacious, var(--spectrum-swatchgroup-spacing-spacious));
 }

--- a/packages/swatch/src/spectrum-swatch.css
+++ b/packages/swatch/src/spectrum-swatch.css
@@ -98,14 +98,14 @@ governing permissions and limitations under the License.
 
 :host([nothing]) .fill:after {
     inline-size: var(--mod-swatch-slash-thickness, var(--spectrum-swatch-slash-thickness));
-    content: '';
+    content: "";
     block-size: 200%;
     background: var(--highcontrast-swatch-fill-foreground-color, var(--mod-swatch-slash-icon-color, var(--spectrum-swatch-slash-icon-color)));
     position: absolute;
     transform: rotate(-45deg);
 }
 
-:host([nothing][shape='rectangle']) .fill:after {
+:host([nothing][shape="rectangle"]) .fill:after {
     transform: rotate(-25deg);
 }
 
@@ -115,7 +115,7 @@ governing permissions and limitations under the License.
 }
 
 :host:before {
-    content: '';
+    content: "";
     border-width: var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected));
     border-style: solid;
     border-color: var(--highcontrast-swatch-border-color-selected, var(--mod-swatch-border-color-selected, var(--spectrum-swatch-border-color-selected)));
@@ -126,7 +126,7 @@ governing permissions and limitations under the License.
 }
 
 :host:after {
-    content: '';
+    content: "";
     inset: calc(var(--mod-swatch-focus-indicator-gap, var(--spectrum-swatch-focus-indicator-gap)) * -2);
     opacity: 0;
     border-width: var(--mod-swatch-focus-indicator-thickness, var(--spectrum-swatch-focus-indicator-thickness));
@@ -154,7 +154,7 @@ governing permissions and limitations under the License.
 }
 
 .fill:before {
-    content: '';
+    content: "";
     z-index: 0;
     box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color, var(--mod-swatch-border-color, var(--spectrum-swatch-border-color)));
     border-radius: var(--mod-swatch-border-radius, var(--spectrum-swatch-border-radius));
@@ -162,17 +162,17 @@ governing permissions and limitations under the License.
     inset: 0;
 }
 
-:host([border='none']) .fill:before,
+:host([border="none"]) .fill:before,
 .fill:before {
     background-color: initial;
     background-color: var(--spectrum-picked-color, transparent);
 }
 
-:host([border='none']) .fill:before {
+:host([border="none"]) .fill:before {
     box-shadow: none;
 }
 
-:host([border='light']) .fill:before {
+:host([border="light"]) .fill:before {
     box-shadow: inset 0 0 0 var(--mod-swatch-border-thickness, var(--spectrum-swatch-border-thickness)) var(--highcontrast-swatch-border-color-light, var(--mod-swatch-border-color-light, var(--spectrum-swatch-border-color-light)));
 }
 
@@ -200,35 +200,35 @@ governing permissions and limitations under the License.
     fill: var(--mod-swatch-icon-border-color, var(--spectrum-swatch-icon-border-color));
 }
 
-:host([shape='rectangle']) {
+:host([shape="rectangle"]) {
     inline-size: calc(var(--mod-swatch-size, var(--spectrum-swatch-size)) * 2);
 }
 
-:host([rounding='none']),
-:host([rounding='none']) .fill,
-:host([rounding='none']) .fill:before,
-:host([rounding='none'][selected]) .fill,
-:host([rounding='none'][selected]) .fill:before,
-:host([rounding='none']):after,
-:host([rounding='none']):before {
+:host([rounding="none"]),
+:host([rounding="none"]) .fill,
+:host([rounding="none"]) .fill:before,
+:host([rounding="none"][selected]) .fill,
+:host([rounding="none"][selected]) .fill:before,
+:host([rounding="none"]):after,
+:host([rounding="none"]):before {
     border-radius: 0;
 }
 
-:host([rounding='full'][selected]:not([shape='rectangle'])) .fill,
-:host([rounding='full'][selected]:not([shape='rectangle'])) .fill:before,
-:host([rounding='full']:not([shape='rectangle'])),
-:host([rounding='full']:not([shape='rectangle'])) .fill,
-:host([rounding='full']:not([shape='rectangle'])) .fill:before,
-:host([rounding='full']:not([shape='rectangle'])):after,
-:host([rounding='full']:not([shape='rectangle'])):before {
+:host([rounding="full"][selected]:not([shape="rectangle"])) .fill,
+:host([rounding="full"][selected]:not([shape="rectangle"])) .fill:before,
+:host([rounding="full"]:not([shape="rectangle"])),
+:host([rounding="full"]:not([shape="rectangle"])) .fill,
+:host([rounding="full"]:not([shape="rectangle"])) .fill:before,
+:host([rounding="full"]:not([shape="rectangle"])):after,
+:host([rounding="full"]:not([shape="rectangle"])):before {
     border-radius: 100%;
 }
 
-:host([rounding='full'][selected]:not([shape='rectangle'])) .fill {
+:host([rounding="full"][selected]:not([shape="rectangle"])) .fill {
     clip-path: circle(calc(50% - var(--mod-swatch-border-thickness-selected, var(--spectrum-swatch-border-thickness-selected)) * 2) at 50% 50%);
 }
 
-::slotted([slot='image']) {
+::slotted([slot="image"]) {
     object-fit: contain;
     inline-size: 100%;
     block-size: 100%;

--- a/packages/swatch/src/swatch-group-overrides.css
+++ b/packages/swatch/src/swatch-group-overrides.css
@@ -12,13 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-swatchgroup-spacing-compact: var(
-        --system-swatch-group-spacing-compact
-    );
-    --spectrum-swatchgroup-spacing-regular: var(
-        --system-swatch-group-spacing-regular
-    );
-    --spectrum-swatchgroup-spacing-spacious: var(
-        --system-swatch-group-spacing-spacious
-    );
+    --spectrum-swatchgroup-spacing-compact: var(--system-swatch-group-spacing-compact);
+    --spectrum-swatchgroup-spacing-regular: var(--system-swatch-group-spacing-regular);
+    --spectrum-swatchgroup-spacing-spacious: var(--system-swatch-group-spacing-spacious);
 }

--- a/packages/swatch/src/swatch-overrides.css
+++ b/packages/swatch/src/swatch-overrides.css
@@ -11,89 +11,49 @@ governing permissions and limitations under the License.
 */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-swatch-size: var(--system-swatch-size-l-size);
-    --spectrum-swatch-disabled-icon-size: var(
-        --system-swatch-size-l-disabled-icon-size
-    );
-    --spectrum-swatch-slash-thickness: var(
-        --system-swatch-size-l-slash-thickness
-    );
+    --spectrum-swatch-disabled-icon-size: var(--system-swatch-size-l-disabled-icon-size);
+    --spectrum-swatch-slash-thickness: var(--system-swatch-size-l-slash-thickness);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-swatch-size: var(--system-swatch-size-s-size);
-    --spectrum-swatch-disabled-icon-size: var(
-        --system-swatch-size-s-disabled-icon-size
-    );
-    --spectrum-swatch-slash-thickness: var(
-        --system-swatch-size-s-slash-thickness
-    );
+    --spectrum-swatch-disabled-icon-size: var(--system-swatch-size-s-disabled-icon-size);
+    --spectrum-swatch-slash-thickness: var(--system-swatch-size-s-slash-thickness);
 }
 
-:host([size='xs']) {
+:host([size="xs"]) {
     --spectrum-swatch-size: var(--system-swatch-size-xs-size);
-    --spectrum-swatch-disabled-icon-size: var(
-        --system-swatch-size-xs-disabled-icon-size
-    );
-    --spectrum-swatch-slash-thickness: var(
-        --system-swatch-size-xs-slash-thickness
-    );
+    --spectrum-swatch-disabled-icon-size: var(--system-swatch-size-xs-disabled-icon-size);
+    --spectrum-swatch-slash-thickness: var(--system-swatch-size-xs-slash-thickness);
 }
 
 :host {
     --spectrum-swatch-size: var(--system-swatch-size-m-size);
-    --spectrum-swatch-disabled-icon-size: var(
-        --system-swatch-size-m-disabled-icon-size
-    );
-    --spectrum-swatch-slash-thickness: var(
-        --system-swatch-size-m-slash-thickness
-    );
+    --spectrum-swatch-disabled-icon-size: var(--system-swatch-size-m-disabled-icon-size);
+    --spectrum-swatch-slash-thickness: var(--system-swatch-size-m-slash-thickness);
 }
 
 :host {
     --spectrum-swatch-border-radius: var(--system-swatch-border-radius);
-    --spectrum-swatch-focus-indicator-border-radius: var(
-        --system-swatch-focus-indicator-border-radius
-    );
+    --spectrum-swatch-focus-indicator-border-radius: var(--system-swatch-focus-indicator-border-radius);
     --spectrum-swatch-border-thickness: var(--system-swatch-border-thickness);
-    --spectrum-swatch-border-thickness-selected: var(
-        --system-swatch-border-thickness-selected
-    );
-    --spectrum-swatch-focus-indicator-thickness: var(
-        --system-swatch-focus-indicator-thickness
-    );
-    --spectrum-swatch-focus-indicator-gap: var(
-        --system-swatch-focus-indicator-gap
-    );
-    --spectrum-swatch-border-color-opacity: var(
-        --system-swatch-border-color-opacity
-    );
-    --spectrum-swatch-border-color-light-opacity: var(
-        --system-swatch-border-color-light-opacity
-    );
+    --spectrum-swatch-border-thickness-selected: var(--system-swatch-border-thickness-selected);
+    --spectrum-swatch-focus-indicator-thickness: var(--system-swatch-focus-indicator-thickness);
+    --spectrum-swatch-focus-indicator-gap: var(--system-swatch-focus-indicator-gap);
+    --spectrum-swatch-border-color-opacity: var(--system-swatch-border-color-opacity);
+    --spectrum-swatch-border-color-light-opacity: var(--system-swatch-border-color-light-opacity);
     --spectrum-swatch-border-color: var(--system-swatch-border-color);
     --spectrum-swatch-icon-border-color: var(--system-swatch-icon-border-color);
-    --spectrum-swatch-border-color-light: var(
-        --system-swatch-border-color-light
-    );
-    --spectrum-swatch-border-color-selected: var(
-        --system-swatch-border-color-selected
-    );
-    --spectrum-swatch-inner-border-color-selected: var(
-        --system-swatch-inner-border-color-selected
-    );
-    --spectrum-swatch-disabled-icon-color: var(
-        --system-swatch-disabled-icon-color
-    );
+    --spectrum-swatch-border-color-light: var(--system-swatch-border-color-light);
+    --spectrum-swatch-border-color-selected: var(--system-swatch-border-color-selected);
+    --spectrum-swatch-inner-border-color-selected: var(--system-swatch-inner-border-color-selected);
+    --spectrum-swatch-disabled-icon-color: var(--system-swatch-disabled-icon-color);
     --spectrum-swatch-dash-icon-color: var(--system-swatch-dash-icon-color);
     --spectrum-swatch-slash-icon-color: var(--system-swatch-slash-icon-color);
-    --spectrum-swatch-focus-indicator-color: var(
-        --system-swatch-focus-indicator-color
-    );
+    --spectrum-swatch-focus-indicator-color: var(--system-swatch-focus-indicator-color);
     --spectrum-swatch-size: var(--system-swatch-size);
-    --spectrum-swatch-disabled-icon-size: var(
-        --system-swatch-disabled-icon-size
-    );
+    --spectrum-swatch-disabled-icon-size: var(--system-swatch-disabled-icon-size);
     --spectrum-swatch-slash-thickness: var(--system-swatch-slash-thickness);
 }

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -53,7 +53,7 @@ governing permissions and limitations under the License.
     --spectrum-switch-font-size: var(--spectrum-font-size-100);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-switch-min-height: var(--spectrum-component-height-75);
     --spectrum-switch-control-width: var(--spectrum-switch-control-width-small);
     --spectrum-switch-control-height: var(--spectrum-switch-control-height-small);
@@ -63,7 +63,7 @@ governing permissions and limitations under the License.
     --spectrum-switch-font-size: var(--spectrum-font-size-75);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-switch-min-height: var(--spectrum-component-height-200);
     --spectrum-switch-control-width: var(--spectrum-switch-control-width-large);
     --spectrum-switch-control-height: var(--spectrum-switch-control-height-large);
@@ -73,7 +73,7 @@ governing permissions and limitations under the License.
     --spectrum-switch-font-size: var(--spectrum-font-size-200);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-switch-min-height: var(--spectrum-component-height-300);
     --spectrum-switch-control-width: var(--spectrum-switch-control-width-extra-large);
     --spectrum-switch-control-height: var(--spectrum-switch-control-height-extra-large);
@@ -111,7 +111,7 @@ governing permissions and limitations under the License.
 }
 
 :host([checked]) #input + #switch:dir(rtl):before,
-:host([dir='rtl'][checked]) #input + #switch:before {
+:host([dir="rtl"][checked]) #input + #switch:before {
     transform: translateX(calc((var(--mod-switch-control-width, var(--spectrum-switch-control-width)) - 100%) * -1));
 }
 
@@ -168,7 +168,7 @@ governing permissions and limitations under the License.
 
 #switch:after,
 #switch:before {
-    content: '';
+    content: "";
     display: block;
     position: absolute;
     inset-block-start: 0;

--- a/packages/switch/src/switch-overrides.css
+++ b/packages/switch/src/switch-overrides.css
@@ -12,35 +12,15 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-switch-handle-border-color-default: var(
-        --system-switch-handle-border-color-default
-    );
-    --spectrum-switch-handle-border-color-hover: var(
-        --system-switch-handle-border-color-hover
-    );
-    --spectrum-switch-handle-border-color-down: var(
-        --system-switch-handle-border-color-down
-    );
-    --spectrum-switch-handle-border-color-focus: var(
-        --system-switch-handle-border-color-focus
-    );
-    --spectrum-switch-handle-border-color-selected-default: var(
-        --system-switch-handle-border-color-selected-default
-    );
-    --spectrum-switch-handle-border-color-selected-hover: var(
-        --system-switch-handle-border-color-selected-hover
-    );
-    --spectrum-switch-handle-border-color-selected-down: var(
-        --system-switch-handle-border-color-selected-down
-    );
-    --spectrum-switch-handle-border-color-selected-focus: var(
-        --system-switch-handle-border-color-selected-focus
-    );
+    --spectrum-switch-handle-border-color-default: var(--system-switch-handle-border-color-default);
+    --spectrum-switch-handle-border-color-hover: var(--system-switch-handle-border-color-hover);
+    --spectrum-switch-handle-border-color-down: var(--system-switch-handle-border-color-down);
+    --spectrum-switch-handle-border-color-focus: var(--system-switch-handle-border-color-focus);
+    --spectrum-switch-handle-border-color-selected-default: var(--system-switch-handle-border-color-selected-default);
+    --spectrum-switch-handle-border-color-selected-hover: var(--system-switch-handle-border-color-selected-hover);
+    --spectrum-switch-handle-border-color-selected-down: var(--system-switch-handle-border-color-selected-down);
+    --spectrum-switch-handle-border-color-selected-focus: var(--system-switch-handle-border-color-selected-focus);
     --spectrum-switch-background-color: var(--system-switch-background-color);
-    --spectrum-switch-background-color-disabled: var(
-        --system-switch-background-color-disabled
-    );
-    --spectrum-switch-handle-background-color: var(
-        --system-switch-handle-background-color
-    );
+    --spectrum-switch-background-color-disabled: var(--system-switch-background-color-disabled);
+    --spectrum-switch-handle-background-color: var(--system-switch-handle-background-color);
 }

--- a/packages/table/src/spectrum-table-cell.css
+++ b/packages/table/src/spectrum-table-cell.css
@@ -17,11 +17,11 @@ governing permissions and limitations under the License.
     }
 }
 
-:host([align='center']) {
+:host([align="center"]) {
     text-align: center;
 }
 
-:host([align='end']) {
+:host([align="end"]) {
     text-align: end;
 }
 

--- a/packages/table/src/spectrum-table-head-cell.css
+++ b/packages/table/src/spectrum-table-head-cell.css
@@ -65,12 +65,12 @@ governing permissions and limitations under the License.
     --spectrum-table-icon-color: var(--highcontrast-table-icon-color-focus, var(--mod-table-icon-color-key-focus, var(--spectrum-table-icon-color-key-focus)));
 }
 
-:host([sort-direction='asc']) .sortedIcon,
-:host([sort-direction='desc']) .sortedIcon {
+:host([sort-direction="asc"]) .sortedIcon,
+:host([sort-direction="desc"]) .sortedIcon {
     display: inline-block;
 }
 
-:host([sort-direction='asc']) .sortedIcon {
+:host([sort-direction="asc"]) .sortedIcon {
     transform: rotate(-90deg);
 }
 

--- a/packages/table/src/spectrum-table-row.css
+++ b/packages/table/src/spectrum-table-row.css
@@ -194,27 +194,27 @@ governing permissions and limitations under the License.
     --spectrum-table-row-tier: 0;
 }
 
-:host([data-tier='1']) .spectrum-Table-row--collapsible {
+:host([data-tier="1"]) .spectrum-Table-row--collapsible {
     --spectrum-table-row-tier: 1;
 }
 
-:host([data-tier='2']) .spectrum-Table-row--collapsible {
+:host([data-tier="2"]) .spectrum-Table-row--collapsible {
     --spectrum-table-row-tier: 2;
 }
 
-:host([data-tier='3']) .spectrum-Table-row--collapsible {
+:host([data-tier="3"]) .spectrum-Table-row--collapsible {
     --spectrum-table-row-tier: 3;
 }
 
-:host([data-tier='4']) .spectrum-Table-row--collapsible {
+:host([data-tier="4"]) .spectrum-Table-row--collapsible {
     --spectrum-table-row-tier: 4;
 }
 
-:host([data-tier='5']) .spectrum-Table-row--collapsible {
+:host([data-tier="5"]) .spectrum-Table-row--collapsible {
     --spectrum-table-row-tier: 5;
 }
 
-:host([data-tier='6']) .spectrum-Table-row--collapsible {
+:host([data-tier="6"]) .spectrum-Table-row--collapsible {
     --spectrum-table-row-tier: 6;
 }
 

--- a/packages/table/src/spectrum-table.css
+++ b/packages/table/src/spectrum-table.css
@@ -88,7 +88,7 @@ governing permissions and limitations under the License.
 }
 
 :host:dir(rtl),
-:host([dir='rtl']) {
+:host([dir="rtl"]) {
     --spectrum-logical-rotation: matrix(-1, 0, 0, 1, 0, 0);
 }
 
@@ -113,7 +113,7 @@ governing permissions and limitations under the License.
     --spectrum-table-thumbnail-size: var(--spectrum-thumbnail-size-300);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-table-min-header-height: var(--spectrum-component-height-100);
     --spectrum-table-header-top-to-text: var(--spectrum-table-column-header-row-top-to-text-small);
     --spectrum-table-header-bottom-to-text: var(--spectrum-table-column-header-row-bottom-to-text-small);
@@ -133,7 +133,7 @@ governing permissions and limitations under the License.
     --spectrum-table-thumbnail-size: var(--spectrum-thumbnail-size-200);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-table-min-header-height: var(--spectrum-component-height-200);
     --spectrum-table-header-top-to-text: var(--spectrum-table-column-header-row-top-to-text-large);
     --spectrum-table-header-bottom-to-text: var(--spectrum-table-column-header-row-bottom-to-text-large);
@@ -153,7 +153,7 @@ governing permissions and limitations under the License.
     --spectrum-table-thumbnail-size: var(--spectrum-thumbnail-size-500);
 }
 
-:host([size='xl']) {
+:host([size="xl"]) {
     --spectrum-table-min-header-height: var(--spectrum-component-height-300);
     --spectrum-table-header-top-to-text: var(--spectrum-table-column-header-row-top-to-text-extra-large);
     --spectrum-table-header-bottom-to-text: var(--spectrum-table-column-header-row-bottom-to-text-extra-large);
@@ -173,7 +173,7 @@ governing permissions and limitations under the License.
     --spectrum-table-thumbnail-size: var(--spectrum-thumbnail-size-700);
 }
 
-:host([density='compact']) {
+:host([density="compact"]) {
     --mod-table-min-row-height: var(--mod-table-min-row-height--compact, var(--spectrum-table-row-height-medium-compact));
     --mod-table-row-top-to-text: var(--mod-table-row-top-to-text--compact, var(--spectrum-table-row-top-to-text-medium-compact));
     --mod-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--compact, var(--spectrum-table-row-bottom-to-text-medium-compact));
@@ -182,7 +182,7 @@ governing permissions and limitations under the License.
     --mod-table-thumbnail-size: var(--mod-table-thumbnail-size-compact, var(--spectrum-thumbnail-size-200));
 }
 
-:host([density='compact'][size='s']) {
+:host([density="compact"][size="s"]) {
     --mod-table-min-row-height: var(--mod-table-min-row-height--compact, var(--spectrum-table-row-height-small-compact));
     --mod-table-row-top-to-text: var(--mod-table-row-top-to-text--compact, var(--spectrum-table-row-top-to-text-small-compact));
     --mod-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--compact, var(--spectrum-table-row-bottom-to-text-small-compact));
@@ -191,7 +191,7 @@ governing permissions and limitations under the License.
     --mod-table-thumbnail-size: var(--mod-table-thumbnail-size-compact, var(--spectrum-thumbnail-size-50));
 }
 
-:host([density='compact'][size='l']) {
+:host([density="compact"][size="l"]) {
     --mod-table-min-row-height: var(--mod-table-min-row-height--compact, var(--spectrum-table-row-height-large-compact));
     --mod-table-row-top-to-text: var(--mod-table-row-top-to-text--compact, var(--spectrum-table-row-top-to-text-large-compact));
     --mod-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--compact, var(--spectrum-table-row-bottom-to-text-large-compact));
@@ -200,7 +200,7 @@ governing permissions and limitations under the License.
     --mod-table-thumbnail-size: var(--mod-table-thumbnail-size-compact, var(--spectrum-thumbnail-size-300));
 }
 
-:host([density='compact'][size='xl']) {
+:host([density="compact"][size="xl"]) {
     --mod-table-min-row-height: var(--mod-table-min-row-height--compact, var(--spectrum-table-row-height-extra-large-compact));
     --mod-table-row-top-to-text: var(--mod-table-row-top-to-text--compact, var(--spectrum-table-row-top-to-text-extra-large-compact));
     --mod-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--compact, var(--spectrum-table-row-bottom-to-text-extra-large-compact));
@@ -209,7 +209,7 @@ governing permissions and limitations under the License.
     --mod-table-thumbnail-size: var(--mod-table-thumbnail-size-compact, var(--spectrum-thumbnail-size-500));
 }
 
-:host([density='spacious']) {
+:host([density="spacious"]) {
     --mod-table-min-row-height: var(--mod-table-min-row-height--spacious, var(--spectrum-table-row-height-medium-spacious));
     --mod-table-row-top-to-text: var(--mod-table-row-top-to-text--spacious, var(--spectrum-table-row-top-to-text-medium-spacious));
     --mod-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--spacious, var(--spectrum-table-row-bottom-to-text-medium-spacious));
@@ -218,7 +218,7 @@ governing permissions and limitations under the License.
     --mod-table-thumbnail-size: var(--mod-table-thumbnail-size-spacious, var(--spectrum-thumbnail-size-500));
 }
 
-:host([density='spacious'][size='s']) {
+:host([density="spacious"][size="s"]) {
     --mod-table-min-row-height: var(--mod-table-min-row-height--spacious, var(--spectrum-table-row-height-small-spacious));
     --mod-table-row-top-to-text: var(--mod-table-row-top-to-text--spacious, var(--spectrum-table-row-top-to-text-small-spacious));
     --mod-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--spacious, var(--spectrum-table-row-bottom-to-text-small-spacious));
@@ -227,7 +227,7 @@ governing permissions and limitations under the License.
     --mod-table-thumbnail-size: var(--mod-table-thumbnail-size-spacious, var(--spectrum-thumbnail-size-300));
 }
 
-:host([density='spacious'][size='l']) {
+:host([density="spacious"][size="l"]) {
     --mod-table-min-row-height: var(--mod-table-min-row-height--spacious, var(--spectrum-table-row-height-large-spacious));
     --mod-table-row-top-to-text: var(--mod-table-row-top-to-text--spacious, var(--spectrum-table-row-top-to-text-large-spacious));
     --mod-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--spacious, var(--spectrum-table-row-bottom-to-text-large-spacious));
@@ -236,7 +236,7 @@ governing permissions and limitations under the License.
     --mod-table-thumbnail-size: var(--mod-table-thumbnail-size-spacious, var(--spectrum-thumbnail-size-700));
 }
 
-:host([density='spacious'][size='xl']) {
+:host([density="spacious"][size="xl"]) {
     --mod-table-min-row-height: var(--mod-table-min-row-height--spacious, var(--spectrum-table-row-height-extra-large-spacious));
     --mod-table-row-top-to-text: var(--mod-table-row-top-to-text--spacious, var(--spectrum-table-row-top-to-text-extra-large-spacious));
     --mod-table-row-bottom-to-text: var(--mod-table-row-bottom-to-text--spacious, var(--spectrum-table-row-bottom-to-text-extra-large-spacious));

--- a/packages/table/src/table-overrides.css
+++ b/packages/table/src/table-overrides.css
@@ -12,31 +12,17 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-table-header-background-color: var(
-        --system-table-header-background-color
-    );
+    --spectrum-table-header-background-color: var(--system-table-header-background-color);
     --spectrum-table-border-color: var(--system-table-border-color);
     --spectrum-table-divider-color: var(--system-table-divider-color);
-    --spectrum-table-row-background-color: var(
-        --system-table-row-background-color
-    );
-    --spectrum-table-summary-row-background-color: var(
-        --system-table-summary-row-background-color
-    );
-    --spectrum-table-section-header-background-color: var(
-        --system-table-section-header-background-color
-    );
+    --spectrum-table-row-background-color: var(--system-table-row-background-color);
+    --spectrum-table-summary-row-background-color: var(--system-table-summary-row-background-color);
+    --spectrum-table-section-header-background-color: var(--system-table-section-header-background-color);
     --spectrum-table-icon-color-focus: var(--system-table-icon-color-focus);
-    --spectrum-table-icon-color-focus-hover: var(
-        --system-table-icon-color-focus-hover
-    );
+    --spectrum-table-icon-color-focus-hover: var(--system-table-icon-color-focus-hover);
 }
 
 :host([quiet]) {
-    --spectrum-table-header-background-color: var(
-        --system-table-quiet-header-background-color
-    );
-    --spectrum-table-row-background-color: var(
-        --system-table-quiet-row-background-color
-    );
+    --spectrum-table-header-background-color: var(--system-table-quiet-header-background-color);
+    --spectrum-table-row-background-color: var(--system-table-quiet-row-background-color);
 }

--- a/packages/tabs/src/spectrum-tab.css
+++ b/packages/tabs/src/spectrum-tab.css
@@ -25,18 +25,18 @@ governing permissions and limitations under the License.
     position: relative;
 }
 
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     block-size: var(--mod-tabs-icon-size, var(--spectrum-tabs-icon-size));
     inline-size: var(--mod-tabs-icon-size, var(--spectrum-tabs-icon-size));
     margin-block-start: var(--mod-tabs-top-to-icon, var(--spectrum-tabs-top-to-icon));
 }
 
-[name='icon'] + #item-label {
+[name="icon"] + #item-label {
     margin-inline-start: var(--mod-tabs-icon-to-text, var(--spectrum-tabs-icon-to-text));
 }
 
 :host:before {
-    content: '';
+    content: "";
     box-sizing: border-box;
     block-size: calc(100% - var(--mod-tabs-top-to-text, var(--spectrum-tabs-top-to-text)));
     inline-size: calc(100% + var(--mod-tabs-focus-indicator-gap, var(--spectrum-tabs-focus-indicator-gap)) * 2);

--- a/packages/tabs/src/spectrum-tabs-sizes.css
+++ b/packages/tabs/src/spectrum-tabs-sizes.css
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-:host([size='s']) #list {
+:host([size="s"]) #list {
     --spectrum-tabs-item-height: var(--spectrum-tab-item-height-small);
     --spectrum-tabs-item-horizontal-spacing: var(--spectrum-tab-item-to-tab-item-horizontal-small);
     --spectrum-tabs-item-vertical-spacing: var(--spectrum-tab-item-to-tab-item-vertical-small);
@@ -25,7 +25,7 @@ governing permissions and limitations under the License.
     --spectrum-tabs-font-size: var(--spectrum-font-size-75);
 }
 
-:host([size='l']) #list {
+:host([size="l"]) #list {
     --spectrum-tabs-item-height: var(--spectrum-tab-item-height-large);
     --spectrum-tabs-item-horizontal-spacing: var(--spectrum-tab-item-to-tab-item-horizontal-large);
     --spectrum-tabs-item-vertical-spacing: var(--spectrum-tab-item-to-tab-item-vertical-large);
@@ -39,7 +39,7 @@ governing permissions and limitations under the License.
     --spectrum-tabs-font-size: var(--spectrum-font-size-200);
 }
 
-:host([size='xl']) #list {
+:host([size="xl"]) #list {
     --spectrum-tabs-item-height: var(--spectrum-tab-item-height-extra-large);
     --spectrum-tabs-item-horizontal-spacing: var(--spectrum-tab-item-to-tab-item-horizontal-extra-large);
     --spectrum-tabs-item-vertical-spacing: var(--spectrum-tab-item-to-tab-item-vertical-extra-large);
@@ -53,21 +53,21 @@ governing permissions and limitations under the License.
     --spectrum-tabs-font-size: var(--spectrum-font-size-300);
 }
 
-:host([size='s']) #list.spectrum-Tabs--compact {
+:host([size="s"]) #list.spectrum-Tabs--compact {
     --mod-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-small));
     --mod-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-small));
     --mod-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-small));
     --mod-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-small));
 }
 
-:host([size='l']) #list.spectrum-Tabs--compact {
+:host([size="l"]) #list.spectrum-Tabs--compact {
     --mod-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-large));
     --mod-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-large));
     --mod-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-large));
     --mod-tabs-top-to-icon: var(--mod-tabs-top-to-icon-compact, var(--spectrum-tab-item-top-to-workflow-icon-compact-large));
 }
 
-:host([size='xl']) #list.spectrum-Tabs--compact {
+:host([size="xl"]) #list.spectrum-Tabs--compact {
     --mod-tabs-item-height: var(--mod-tabs-item-height-compact, var(--spectrum-tab-item-compact-height-extra-large));
     --mod-tabs-top-to-text: var(--mod-tabs-top-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-extra-large));
     --mod-tabs-bottom-to-text: var(--mod-tabs-bottom-to-text-compact, var(--spectrum-tab-item-top-to-text-compact-extra-large));

--- a/packages/tabs/src/spectrum-tabs.css
+++ b/packages/tabs/src/spectrum-tabs.css
@@ -49,21 +49,21 @@ governing permissions and limitations under the License.
     --mod-tabs-selection-indicator-color: var(--mod-tabs-selection-indicator-color-emphasized, var(--spectrum-accent-content-color-default));
 }
 
-:host([direction^='vertical']) #list {
+:host([direction^="vertical"]) #list {
     --mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, right);
 }
 
-:host([direction^='vertical-right']) #list {
+:host([direction^="vertical-right"]) #list {
     --mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical-right, left);
 }
 
-:host([direction^='vertical']) #list:dir(rtl),
-:host([dir='rtl'][direction^='vertical']) #list {
+:host([direction^="vertical"]) #list:dir(rtl),
+:host([dir="rtl"][direction^="vertical"]) #list {
     --mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, left);
 }
 
-:host([direction^='vertical-right']) #list:dir(rtl),
-:host([dir='rtl'][direction^='vertical-right']) #list {
+:host([direction^="vertical-right"]) #list:dir(rtl),
+:host([dir="rtl"][direction^="vertical-right"]) #list {
     --mod-tabs-list-background-direction: var(--mod-tabs-list-background-direction-vertical, right);
 }
 
@@ -103,25 +103,25 @@ governing permissions and limitations under the License.
     inset-inline-start: 0;
 }
 
-:host([direction^='horizontal']) #list {
+:host([direction^="horizontal"]) #list {
     align-items: center;
 }
 
-:host([direction^='horizontal']) #list ::slotted(:not([slot])) {
+:host([direction^="horizontal"]) #list ::slotted(:not([slot])) {
     vertical-align: top;
 }
 
-:host([direction^='horizontal']) ::slotted(:not(:first-child)) {
+:host([direction^="horizontal"]) ::slotted(:not(:first-child)) {
     margin-inline-start: var(--mod-tabs-item-horizontal-spacing, var(--spectrum-tabs-item-horizontal-spacing));
 }
 
-:host([direction^='horizontal']) #list #selection-indicator {
+:host([direction^="horizontal"]) #list #selection-indicator {
     block-size: var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size));
     position: absolute;
     inset-block-end: 0;
 }
 
-:host([direction^='horizontal'][compact]) #list {
+:host([direction^="horizontal"][compact]) #list {
     box-sizing: initial;
     align-items: end;
 }
@@ -136,20 +136,20 @@ governing permissions and limitations under the License.
     padding-inline-start: var(--mod-tabs-start-to-item-quiet);
 }
 
-:host([direction^='vertical']) #list,
-:host([direction^='vertical-right']) #list {
+:host([direction^="vertical"]) #list,
+:host([direction^="vertical-right"]) #list {
     flex-direction: column;
     padding: 0;
     display: inline-flex;
 }
 
-:host([direction^='vertical-right'][quiet]) #list,
-:host([direction^='vertical'][quiet]) #list {
+:host([direction^="vertical-right"][quiet]) #list,
+:host([direction^="vertical"][quiet]) #list {
     border-color: #0000;
 }
 
-:host([direction^='vertical']) #list ::slotted(:not([slot])),
-:host([direction^='vertical-right']) #list ::slotted(:not([slot])) {
+:host([direction^="vertical"]) #list ::slotted(:not([slot])),
+:host([direction^="vertical-right"]) #list ::slotted(:not([slot])) {
     block-size: var(--mod-tabs-item-height, var(--spectrum-tabs-item-height));
     line-height: var(--mod-tabs-item-height, var(--spectrum-tabs-item-height));
     margin-block-end: var(--mod-tabs-item-vertical-spacing, var(--spectrum-tabs-item-vertical-spacing));
@@ -158,20 +158,20 @@ governing permissions and limitations under the License.
     padding-block: 0;
 }
 
-:host([direction^='vertical']) #list ::slotted(:not([slot])):before,
-:host([direction^='vertical-right']) #list ::slotted(:not([slot])):before {
+:host([direction^="vertical"]) #list ::slotted(:not([slot])):before,
+:host([direction^="vertical-right"]) #list ::slotted(:not([slot])):before {
     inset-inline-start: calc(var(--mod-tabs-focus-indicator-gap, var(--spectrum-tabs-focus-indicator-gap)) * -1);
 }
 
-:host([direction^='vertical']) #list #selection-indicator,
-:host([direction^='vertical-right']) #list #selection-indicator {
+:host([direction^="vertical"]) #list #selection-indicator,
+:host([direction^="vertical-right"]) #list #selection-indicator {
     inline-size: var(--mod-tabs-divider-size, var(--spectrum-tabs-divider-size));
     position: absolute;
     inset-block-start: 0;
     inset-inline-start: 0;
 }
 
-:host([direction^='vertical-right']) #list #selection-indicator {
+:host([direction^="vertical-right"]) #list #selection-indicator {
     inset-inline: auto 0;
 }
 
@@ -193,7 +193,7 @@ governing permissions and limitations under the License.
         background-color: var(--highcontrast-tabs-focus-indicator-background-color);
     }
 
-    :host([direction^='vertical'][compact]) #list #list ::slotted(:not([slot])):before {
+    :host([direction^="vertical"][compact]) #list #list ::slotted(:not([slot])):before {
         block-size: 100%;
         inset-block-start: 0;
     }

--- a/packages/tabs/src/tabs-overrides.css
+++ b/packages/tabs/src/tabs-overrides.css
@@ -13,7 +13,5 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #list {
     --spectrum-tabs-font-weight: var(--system-tabs-font-weight);
-    --spectrum-tabs-divider-background-color: var(
-        --system-tabs-divider-background-color
-    );
+    --spectrum-tabs-divider-background-color: var(--system-tabs-divider-background-color);
 }

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -73,7 +73,7 @@ governing permissions and limitations under the License.
     --spectrum-tag-clear-button-spacing-inline-end: var(--spectrum-tag-size-medium-clear-button-spacing-inline-end);
 }
 
-:host([size='s']) {
+:host([size="s"]) {
     --spectrum-tag-height: var(--spectrum-component-height-75);
     --spectrum-tag-font-size: var(--spectrum-font-size-75);
     --spectrum-tag-icon-size: var(--spectrum-workflow-icon-size-75);
@@ -92,7 +92,7 @@ governing permissions and limitations under the License.
     --spectrum-tag-clear-button-spacing-inline-end: var(--spectrum-tag-size-small-clear-button-spacing-inline-end);
 }
 
-:host([size='l']) {
+:host([size="l"]) {
     --spectrum-tag-height: var(--spectrum-component-height-200);
     --spectrum-tag-font-size: var(--spectrum-font-size-200);
     --spectrum-tag-icon-size: var(--spectrum-workflow-icon-size-200);
@@ -137,7 +137,7 @@ governing permissions and limitations under the License.
     position: relative;
 }
 
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     block-size: var(--mod-tag-icon-size, var(--spectrum-tag-icon-size));
     inline-size: var(--mod-tag-icon-size, var(--spectrum-tag-icon-size));
     flex-shrink: 0;
@@ -146,7 +146,7 @@ governing permissions and limitations under the License.
     margin-inline-end: var(--mod-tag-icon-spacing-inline-end, var(--spectrum-tag-icon-spacing-inline-end));
 }
 
-::slotted([slot='avatar']) {
+::slotted([slot="avatar"]) {
     margin-block-start: calc(var(--mod-tag-avatar-spacing-block-start, var(--spectrum-tag-avatar-spacing-block-start)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
     margin-block-end: calc(var(--mod-tag-avatar-spacing-block-end, var(--spectrum-tag-avatar-spacing-block-end)) - var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
     margin-inline-end: var(--mod-tag-avatar-spacing-inline-end, var(--spectrum-tag-avatar-spacing-inline-end));
@@ -200,7 +200,7 @@ governing permissions and limitations under the License.
 
 :host([focused]):after,
 :host(:focus-visible):after {
-    content: '';
+    content: "";
     border-color: var(--highcontrast-tag-focus-ring-color, var(--mod-tag-focus-ring-color, var(--spectrum-tag-focus-ring-color)));
     border-radius: calc(var(--mod-tag-corner-radius, var(--spectrum-tag-corner-radius)) + var(--mod-tag-focus-ring-gap, var(--spectrum-tag-focus-ring-gap)) + var(--mod-tag-border-width, var(--spectrum-tag-border-width)));
     border-width: var(--mod-tag-focus-ring-thickness, var(--spectrum-tag-focus-ring-thickness));
@@ -319,7 +319,7 @@ governing permissions and limitations under the License.
     pointer-events: none;
 }
 
-:host([disabled]) ::slotted([slot='avatar']) {
+:host([disabled]) ::slotted([slot="avatar"]) {
     opacity: var(--mod-avatar-opacity-disabled, var(--spectrum-avatar-opacity-disabled));
 }
 

--- a/packages/tags/src/tag-overrides.css
+++ b/packages/tags/src/tag-overrides.css
@@ -13,24 +13,12 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     --spectrum-tag-background-color: var(--system-tag-background-color);
-    --spectrum-tag-background-color-hover: var(
-        --system-tag-background-color-hover
-    );
-    --spectrum-tag-background-color-active: var(
-        --system-tag-background-color-active
-    );
-    --spectrum-tag-background-color-focus: var(
-        --system-tag-background-color-focus
-    );
-    --spectrum-tag-size-small-corner-radius: var(
-        --system-tag-size-small-corner-radius
-    );
-    --spectrum-tag-size-medium-corner-radius: var(
-        --system-tag-size-medium-corner-radius
-    );
-    --spectrum-tag-size-large-corner-radius: var(
-        --system-tag-size-large-corner-radius
-    );
+    --spectrum-tag-background-color-hover: var(--system-tag-background-color-hover);
+    --spectrum-tag-background-color-active: var(--system-tag-background-color-active);
+    --spectrum-tag-background-color-focus: var(--system-tag-background-color-focus);
+    --spectrum-tag-size-small-corner-radius: var(--system-tag-size-small-corner-radius);
+    --spectrum-tag-size-medium-corner-radius: var(--system-tag-size-medium-corner-radius);
+    --spectrum-tag-size-large-corner-radius: var(--system-tag-size-large-corner-radius);
     --spectrum-tag-border-color: var(--system-tag-border-color);
     --spectrum-tag-border-color-hover: var(--system-tag-border-color-hover);
     --spectrum-tag-border-color-active: var(--system-tag-border-color-active);
@@ -39,52 +27,20 @@ governing permissions and limitations under the License.
     --spectrum-tag-content-color-hover: var(--system-tag-content-color-hover);
     --spectrum-tag-content-color-active: var(--system-tag-content-color-active);
     --spectrum-tag-content-color-focus: var(--system-tag-content-color-focus);
-    --spectrum-tag-content-color-selected: var(
-        --system-tag-content-color-selected
-    );
-    --spectrum-tag-border-color-selected: var(
-        --system-tag-border-color-selected
-    );
-    --spectrum-tag-border-color-selected-hover: var(
-        --system-tag-border-color-selected-hover
-    );
-    --spectrum-tag-border-color-selected-active: var(
-        --system-tag-border-color-selected-active
-    );
-    --spectrum-tag-border-color-selected-focus: var(
-        --system-tag-border-color-selected-focus
-    );
-    --spectrum-tag-border-color-disabled: var(
-        --system-tag-border-color-disabled
-    );
-    --spectrum-tag-background-color-disabled: var(
-        --system-tag-background-color-disabled
-    );
-    --spectrum-tag-size-small-spacing-inline-start: var(
-        --system-tag-size-small-spacing-inline-start
-    );
-    --spectrum-tag-size-small-label-spacing-inline-end: var(
-        --system-tag-size-small-label-spacing-inline-end
-    );
-    --spectrum-tag-size-small-clear-button-spacing-inline-end: var(
-        --system-tag-size-small-clear-button-spacing-inline-end
-    );
-    --spectrum-tag-size-medium-spacing-inline-start: var(
-        --system-tag-size-medium-spacing-inline-start
-    );
-    --spectrum-tag-size-medium-label-spacing-inline-end: var(
-        --system-tag-size-medium-label-spacing-inline-end
-    );
-    --spectrum-tag-size-medium-clear-button-spacing-inline-end: var(
-        --system-tag-size-medium-clear-button-spacing-inline-end
-    );
-    --spectrum-tag-size-large-spacing-inline-start: var(
-        --system-tag-size-large-spacing-inline-start
-    );
-    --spectrum-tag-size-large-label-spacing-inline-end: var(
-        --system-tag-size-large-label-spacing-inline-end
-    );
-    --spectrum-tag-size-large-clear-button-spacing-inline-end: var(
-        --system-tag-size-large-clear-button-spacing-inline-end
-    );
+    --spectrum-tag-content-color-selected: var(--system-tag-content-color-selected);
+    --spectrum-tag-border-color-selected: var(--system-tag-border-color-selected);
+    --spectrum-tag-border-color-selected-hover: var(--system-tag-border-color-selected-hover);
+    --spectrum-tag-border-color-selected-active: var(--system-tag-border-color-selected-active);
+    --spectrum-tag-border-color-selected-focus: var(--system-tag-border-color-selected-focus);
+    --spectrum-tag-border-color-disabled: var(--system-tag-border-color-disabled);
+    --spectrum-tag-background-color-disabled: var(--system-tag-background-color-disabled);
+    --spectrum-tag-size-small-spacing-inline-start: var(--system-tag-size-small-spacing-inline-start);
+    --spectrum-tag-size-small-label-spacing-inline-end: var(--system-tag-size-small-label-spacing-inline-end);
+    --spectrum-tag-size-small-clear-button-spacing-inline-end: var(--system-tag-size-small-clear-button-spacing-inline-end);
+    --spectrum-tag-size-medium-spacing-inline-start: var(--system-tag-size-medium-spacing-inline-start);
+    --spectrum-tag-size-medium-label-spacing-inline-end: var(--system-tag-size-medium-label-spacing-inline-end);
+    --spectrum-tag-size-medium-clear-button-spacing-inline-end: var(--system-tag-size-medium-clear-button-spacing-inline-end);
+    --spectrum-tag-size-large-spacing-inline-start: var(--system-tag-size-large-spacing-inline-start);
+    --spectrum-tag-size-large-label-spacing-inline-end: var(--system-tag-size-large-label-spacing-inline-end);
+    --spectrum-tag-size-large-clear-button-spacing-inline-end: var(--system-tag-size-large-clear-button-spacing-inline-end);
 }

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -71,7 +71,7 @@ governing permissions and limitations under the License.
     --spectrum-text-area-min-block-size-quiet: var(--spectrum-component-height-100);
 }
 
-:host([size='s']) #textfield {
+:host([size="s"]) #textfield {
     --spectrum-textfield-height: var(--spectrum-component-height-75);
     --spectrum-textfield-label-spacing-block-quiet: var(--spectrum-field-label-to-component-quiet-small);
     --spectrum-textfield-label-spacing-inline-side-label: var(--spectrum-spacing-100);
@@ -91,7 +91,7 @@ governing permissions and limitations under the License.
     --spectrum-text-area-min-block-size-quiet: var(--spectrum-component-height-75);
 }
 
-:host([size='l']) #textfield {
+:host([size="l"]) #textfield {
     --spectrum-textfield-height: var(--spectrum-component-height-200);
     --spectrum-textfield-label-spacing-block-quiet: var(--spectrum-field-label-to-component-quiet-large);
     --spectrum-textfield-label-spacing-inline-side-label: var(--spectrum-spacing-200);
@@ -111,7 +111,7 @@ governing permissions and limitations under the License.
     --spectrum-text-area-min-block-size-quiet: var(--spectrum-component-height-200);
 }
 
-:host([size='xl']) #textfield {
+:host([size="xl"]) #textfield {
     --spectrum-textfield-height: var(--spectrum-component-height-300);
     --spectrum-textfield-label-spacing-block-quiet: var(--spectrum-field-label-to-component-quiet-extra-large);
     --spectrum-textfield-label-spacing-inline-side-label: var(--spectrum-spacing-200);
@@ -252,12 +252,12 @@ governing permissions and limitations under the License.
     margin: 0;
 }
 
-:host([type='number']) .input {
+:host([type="number"]) .input {
     -moz-appearance: textfield;
 }
 
-:host([type='number']) .input::-webkit-inner-spin-button,
-:host([type='number']) .input::-webkit-outer-spin-button {
+:host([type="number"]) .input::-webkit-inner-spin-button,
+:host([type="number"]) .input::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
 }
@@ -507,7 +507,7 @@ governing permissions and limitations under the License.
 }
 
 :host([quiet]) #textfield:after {
-    content: '';
+    content: "";
     pointer-events: none;
     inline-size: 100%;
     block-size: var(--mod-textfield-focus-indicator-width, var(--spectrum-textfield-focus-indicator-width));

--- a/packages/textfield/src/textfield-overrides.css
+++ b/packages/textfield/src/textfield-overrides.css
@@ -12,54 +12,30 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-textfield-background-color: var(
-        --system-textfield-background-color
-    );
-    --spectrum-textfield-background-color-disabled: var(
-        --system-textfield-background-color-disabled
-    );
+    --spectrum-textfield-background-color: var(--system-textfield-background-color);
+    --spectrum-textfield-background-color-disabled: var(--system-textfield-background-color-disabled);
     --spectrum-textfield-border-color: var(--system-textfield-border-color);
-    --spectrum-textfield-border-color-hover: var(
-        --system-textfield-border-color-hover
-    );
-    --spectrum-textfield-border-color-focus: var(
-        --system-textfield-border-color-focus
-    );
-    --spectrum-textfield-border-color-focus-hover: var(
-        --system-textfield-border-color-focus-hover
-    );
-    --spectrum-textfield-border-color-keyboard-focus: var(
-        --system-textfield-border-color-keyboard-focus
-    );
-    --spectrum-textfield-border-color-disabled: var(
-        --system-textfield-border-color-disabled
-    );
+    --spectrum-textfield-border-color-hover: var(--system-textfield-border-color-hover);
+    --spectrum-textfield-border-color-focus: var(--system-textfield-border-color-focus);
+    --spectrum-textfield-border-color-focus-hover: var(--system-textfield-border-color-focus-hover);
+    --spectrum-textfield-border-color-keyboard-focus: var(--system-textfield-border-color-keyboard-focus);
+    --spectrum-textfield-border-color-disabled: var(--system-textfield-border-color-disabled);
     --spectrum-textfield-border-width: var(--system-textfield-border-width);
-    --spectrum-textfield-icon-spacing-block-invalid: var(
-        --system-textfield-icon-spacing-block-invalid
-    );
+    --spectrum-textfield-icon-spacing-block-invalid: var(--system-textfield-icon-spacing-block-invalid);
 }
 
-:host([size='s']) #textfield#textfield {
-    --spectrum-textfield-icon-spacing-block-invalid: var(
-        --system-textfield-size-s-icon-spacing-block-invalid
-    );
+:host([size="s"]) #textfield#textfield {
+    --spectrum-textfield-icon-spacing-block-invalid: var(--system-textfield-size-s-icon-spacing-block-invalid);
 }
 
-:host([size='l']) #textfield#textfield {
-    --spectrum-textfield-icon-spacing-block-invalid: var(
-        --system-textfield-size-l-icon-spacing-block-invalid
-    );
+:host([size="l"]) #textfield#textfield {
+    --spectrum-textfield-icon-spacing-block-invalid: var(--system-textfield-size-l-icon-spacing-block-invalid);
 }
 
-:host([size='xl']) #textfield#textfield {
-    --spectrum-textfield-icon-spacing-block-invalid: var(
-        --system-textfield-size-xl-icon-spacing-block-invalid
-    );
+:host([size="xl"]) #textfield#textfield {
+    --spectrum-textfield-icon-spacing-block-invalid: var(--system-textfield-size-xl-icon-spacing-block-invalid);
 }
 
 :host([quiet]) #textfield {
-    --spectrum-textfield-border-color-disabled: var(
-        --system-textfield-quiet-border-color-disabled
-    );
+    --spectrum-textfield-border-color-disabled: var(--system-textfield-quiet-border-color-disabled);
 }

--- a/packages/thumbnail/src/spectrum-thumbnail.css
+++ b/packages/thumbnail/src/spectrum-thumbnail.css
@@ -12,51 +12,51 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host,
-:host([size='500']) {
+:host([size="500"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-500);
 }
 
-:host([size='50']) {
+:host([size="50"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-50);
 }
 
-:host([size='75']) {
+:host([size="75"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-75);
 }
 
-:host([size='100']) {
+:host([size="100"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-100);
 }
 
-:host([size='200']) {
+:host([size="200"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-200);
 }
 
-:host([size='300']) {
+:host([size="300"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-300);
 }
 
-:host([size='400']) {
+:host([size="400"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-400);
 }
 
-:host([size='600']) {
+:host([size="600"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-600);
 }
 
-:host([size='700']) {
+:host([size="700"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-700);
 }
 
-:host([size='800']) {
+:host([size="800"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-800);
 }
 
-:host([size='900']) {
+:host([size="900"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-900);
 }
 
-:host([size='1000']) {
+:host([size="1000"]) {
     --spectrum-thumbnail-sized-size: var(--spectrum-thumbnail-size-1000);
 }
 
@@ -91,7 +91,7 @@ governing permissions and limitations under the License.
 }
 
 :host:before {
-    content: '';
+    content: "";
     z-index: 2;
     inline-size: 100%;
     block-size: 100%;
@@ -108,7 +108,7 @@ governing permissions and limitations under the License.
 }
 
 :host([focused]):after {
-    content: '';
+    content: "";
     border-style: solid;
     border-width: var(--spectrum-thumbnail-focus-indicator-thickness);
     border-color: var(--spectrum-thumbnail-focus-indicator-color);

--- a/packages/toast/src/spectrum-toast.css
+++ b/packages/toast/src/spectrum-toast.css
@@ -62,30 +62,30 @@ governing permissions and limitations under the License.
     display: inline-flex;
 }
 
-:host([variant='negative']) {
+:host([variant="negative"]) {
     background-color: var(--mod-toast-negative-background-color-default, var(--spectrum-toast-negative-background-color-default));
 }
 
-:host([variant='negative']),
-:host([variant='negative']) .closeButton:focus-visible:not(:active) {
+:host([variant="negative"]),
+:host([variant="negative"]) .closeButton:focus-visible:not(:active) {
     color: var(--mod-toast-negative-background-color-default, var(--spectrum-toast-negative-background-color-default));
 }
 
-:host([variant='info']) {
+:host([variant="info"]) {
     background-color: var(--mod-toast-informative-background-color-default, var(--spectrum-toast-informative-background-color-default));
 }
 
-:host([variant='info']),
-:host([variant='info']) .closeButton:focus-visible:not(:active) {
+:host([variant="info"]),
+:host([variant="info"]) .closeButton:focus-visible:not(:active) {
     color: var(--mod-toast-informative-background-color-default, var(--spectrum-toast-informative-background-color-default));
 }
 
-:host([variant='positive']) {
+:host([variant="positive"]) {
     background-color: var(--mod-toast-positive-background-color-default, var(--spectrum-toast-positive-background-color-default));
 }
 
-:host([variant='positive']),
-:host([variant='positive']) .closeButton:focus-visible:not(:active) {
+:host([variant="positive"]),
+:host([variant="positive"]) .closeButton:focus-visible:not(:active) {
     color: var(--mod-toast-positive-background-color-default, var(--spectrum-toast-positive-background-color-default));
 }
 
@@ -144,13 +144,13 @@ governing permissions and limitations under the License.
     display: flex;
 }
 
-.body ::slotted([slot='action']) {
+.body ::slotted([slot="action"]) {
     margin-inline-start: auto;
     margin-inline-end: var(--mod-toast-spacing-text-and-action-button-to-divider, var(--spectrum-toast-spacing-text-and-action-button-to-divider));
 }
 
-.body ::slotted([slot='action']:dir(rtl)),
-:host([dir='rtl']) .body ::slotted([slot='action']) {
+.body ::slotted([slot="action"]:dir(rtl)),
+:host([dir="rtl"]) .body ::slotted([slot="action"]) {
     margin-inline-end: var(--mod-toast-spacing-text-and-action-button-to-divider, var(--spectrum-toast-spacing-text-and-action-button-to-divider));
 }
 

--- a/packages/toast/src/toast-overrides.css
+++ b/packages/toast/src/toast-overrides.css
@@ -12,8 +12,6 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-toast-background-color-default: var(
-        --system-toast-background-color-default
-    );
+    --spectrum-toast-background-color-default: var(--system-toast-background-color-default);
     --spectrum-toast-divider-color: var(--system-toast-divider-color);
 }

--- a/packages/tooltip/src/spectrum-tooltip.css
+++ b/packages/tooltip/src/spectrum-tooltip.css
@@ -113,15 +113,15 @@ governing permissions and limitations under the License.
     margin: 0;
 }
 
-:host([variant='info']) #tooltip {
+:host([variant="info"]) #tooltip {
     background-color: var(--highcontrast-tooltip-background-color-informative, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
 }
 
-:host([variant='positive']) #tooltip {
+:host([variant="positive"]) #tooltip {
     background-color: var(--highcontrast-tooltip-background-color-positive, var(--mod-tooltip-background-color-positive, var(--spectrum-tooltip-background-color-positive)));
 }
 
-:host([variant='negative']) #tooltip {
+:host([variant="negative"]) #tooltip {
     background-color: var(--highcontrast-tooltip-background-color-negative, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
 }
 
@@ -136,19 +136,19 @@ governing permissions and limitations under the License.
     transform: translateX(-50%);
 }
 
-:host([variant='info']) #tooltip #tip {
+:host([variant="info"]) #tooltip #tip {
     background-color: var(--highcontrast-tooltip-background-color-informative, var(--mod-tooltip-background-color-informative, var(--spectrum-tooltip-background-color-informative)));
 }
 
-:host([variant='positive']) #tooltip #tip {
+:host([variant="positive"]) #tooltip #tip {
     background-color: var(--highcontrast-tooltip-background-color-positive, var(--mod-tooltip-background-color-positive, var(--spectrum-tooltip-background-color-positive)));
 }
 
-:host([variant='negative']) #tooltip #tip {
+:host([variant="negative"]) #tooltip #tip {
     background-color: var(--highcontrast-tooltip-background-color-negative, var(--mod-tooltip-background-color-negative, var(--spectrum-tooltip-background-color-negative)));
 }
 
-:host([placement*='top']) #tooltip #tip,
+:host([placement*="top"]) #tooltip #tip,
 .spectrum-Tooltip--top-end #tip,
 .spectrum-Tooltip--top-left #tip,
 .spectrum-Tooltip--top-right #tip,
@@ -156,7 +156,7 @@ governing permissions and limitations under the License.
     inset-block-start: 100%;
 }
 
-:host([placement*='bottom']) #tooltip #tip,
+:host([placement*="bottom"]) #tooltip #tip,
 .spectrum-Tooltip--bottom-end #tip,
 .spectrum-Tooltip--bottom-left #tip,
 .spectrum-Tooltip--bottom-right #tip,
@@ -193,8 +193,8 @@ governing permissions and limitations under the License.
 
 .spectrum-Tooltip--bottom-start #tip:dir(rtl),
 .spectrum-Tooltip--top-start #tip:dir(rtl),
-:host([dir='rtl']) .spectrum-Tooltip--bottom-start #tip,
-:host([dir='rtl']) .spectrum-Tooltip--top-start #tip {
+:host([dir="rtl"]) .spectrum-Tooltip--bottom-start #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--top-start #tip {
     right: var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing));
     left: auto;
 }
@@ -206,8 +206,8 @@ governing permissions and limitations under the License.
 
 .spectrum-Tooltip--bottom-end #tip:dir(rtl),
 .spectrum-Tooltip--top-end #tip:dir(rtl),
-:host([dir='rtl']) .spectrum-Tooltip--bottom-end #tip,
-:host([dir='rtl']) .spectrum-Tooltip--top-end #tip {
+:host([dir="rtl"]) .spectrum-Tooltip--bottom-end #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--top-end #tip {
     left: var(--mod-tooltip-pointer-corner-spacing, var(--spectrum-tooltip-pointer-corner-spacing));
     right: auto;
 }
@@ -215,10 +215,10 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--end #tip,
 .spectrum-Tooltip--end-bottom #tip,
 .spectrum-Tooltip--end-top #tip,
-:host([placement*='left']) #tooltip #tip,
+:host([placement*="left"]) #tooltip #tip,
 .spectrum-Tooltip--left-bottom #tip,
 .spectrum-Tooltip--left-top #tip,
-:host([placement*='right']) #tooltip #tip,
+:host([placement*="right"]) #tooltip #tip,
 .spectrum-Tooltip--right-bottom #tip,
 .spectrum-Tooltip--right-top #tip,
 .spectrum-Tooltip--start #tip,
@@ -243,14 +243,14 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--end #tip,
 .spectrum-Tooltip--end-bottom #tip,
 .spectrum-Tooltip--end-top #tip,
-:host([placement*='right']) #tooltip #tip,
+:host([placement*="right"]) #tooltip #tip,
 .spectrum-Tooltip--right-bottom #tip,
 .spectrum-Tooltip--right-top #tip {
     clip-path: polygon(calc(100% - var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage))) 50%, calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 100%, calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 0);
     inset-inline: auto 100%;
 }
 
-:host([placement*='left']) #tooltip #tip,
+:host([placement*="left"]) #tooltip #tip,
 .spectrum-Tooltip--left-bottom #tip,
 .spectrum-Tooltip--left-top #tip,
 .spectrum-Tooltip--start #tip,
@@ -277,38 +277,38 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--end #tip:dir(rtl),
 .spectrum-Tooltip--end-bottom #tip:dir(rtl),
 .spectrum-Tooltip--end-top #tip:dir(rtl),
-:host([placement*='left']) #tooltip #tip:dir(rtl),
+:host([placement*="left"]) #tooltip #tip:dir(rtl),
 .spectrum-Tooltip--left-bottom #tip:dir(rtl),
 .spectrum-Tooltip--left-top #tip:dir(rtl),
-:host([dir='rtl']) .spectrum-Tooltip--end #tip,
-:host([dir='rtl']) .spectrum-Tooltip--end-bottom #tip,
-:host([dir='rtl']) .spectrum-Tooltip--end-top #tip,
-:host([dir='rtl'][placement*='left']) #tooltip #tip,
-:host([dir='rtl']) .spectrum-Tooltip--left-bottom #tip,
-:host([dir='rtl']) .spectrum-Tooltip--left-top #tip {
+:host([dir="rtl"]) .spectrum-Tooltip--end #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--end-bottom #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--end-top #tip,
+:host([dir="rtl"][placement*="left"]) #tooltip #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--left-bottom #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--left-top #tip {
     clip-path: polygon(calc(0% - var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 0, calc(0% - var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 100%, var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage)) 50%);
     left: 100%;
     right: auto;
 }
 
-:host([placement*='right']) #tooltip #tip:dir(rtl),
+:host([placement*="right"]) #tooltip #tip:dir(rtl),
 .spectrum-Tooltip--right-bottom #tip:dir(rtl),
 .spectrum-Tooltip--right-top #tip:dir(rtl),
 .spectrum-Tooltip--start #tip:dir(rtl),
 .spectrum-Tooltip--start-bottom #tip:dir(rtl),
 .spectrum-Tooltip--start-top #tip:dir(rtl),
-:host([dir='rtl'][placement*='right']) #tooltip #tip,
-:host([dir='rtl']) .spectrum-Tooltip--right-bottom #tip,
-:host([dir='rtl']) .spectrum-Tooltip--right-top #tip,
-:host([dir='rtl']) .spectrum-Tooltip--start #tip,
-:host([dir='rtl']) .spectrum-Tooltip--start-bottom #tip,
-:host([dir='rtl']) .spectrum-Tooltip--start-top #tip {
+:host([dir="rtl"][placement*="right"]) #tooltip #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--right-bottom #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--right-top #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--start #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--start-bottom #tip,
+:host([dir="rtl"]) .spectrum-Tooltip--start-top #tip {
     clip-path: polygon(var(--mod-tooltip-tip-height-percentage, var(--spectrum-tooltip-tip-height-percentage)) 50%, calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 100%, calc(100% + var(--mod-tooltip-tip-antialiasing-inset, var(--spectrum-tooltip-tip-antialiasing-inset))) 0);
     left: auto;
     right: 100%;
 }
 
-::slotted([slot='icon']) {
+::slotted([slot="icon"]) {
     inline-size: var(--mod-tooltip-icon-width, var(--spectrum-tooltip-icon-width));
     block-size: var(--mod-tooltip-icon-height, var(--spectrum-tooltip-icon-height));
     flex-shrink: 0;
@@ -325,7 +325,7 @@ governing permissions and limitations under the License.
 }
 
 #tooltip,
-:host([placement*='top']) #tooltip,
+:host([placement*="top"]) #tooltip,
 .spectrum-Tooltip--top-end,
 .spectrum-Tooltip--top-left,
 .spectrum-Tooltip--top-right,
@@ -337,12 +337,12 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Tooltip--top-left,
 :host([open]) .spectrum-Tooltip--top-right,
 :host([open]) .spectrum-Tooltip--top-start,
-:host([placement*='top'][open]) #tooltip,
+:host([placement*="top"][open]) #tooltip,
 :host([open]) #tooltip {
     transform: translateY(calc(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)) * -1));
 }
 
-:host([placement*='bottom']) #tooltip,
+:host([placement*="bottom"]) #tooltip,
 .spectrum-Tooltip--bottom-end,
 .spectrum-Tooltip--bottom-left,
 .spectrum-Tooltip--bottom-right,
@@ -354,11 +354,11 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Tooltip--bottom-left,
 :host([open]) .spectrum-Tooltip--bottom-right,
 :host([open]) .spectrum-Tooltip--bottom-start,
-:host([placement*='bottom'][open]) #tooltip {
+:host([placement*="bottom"][open]) #tooltip {
     transform: translateY(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)));
 }
 
-:host([placement*='right']) #tooltip,
+:host([placement*="right"]) #tooltip,
 .spectrum-Tooltip--right-bottom,
 .spectrum-Tooltip--right-top {
     margin-left: calc(var(--mod-tooltip-tip-block-size, var(--spectrum-tooltip-tip-block-size)) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin)));
@@ -366,11 +366,11 @@ governing permissions and limitations under the License.
 
 :host([open]) .spectrum-Tooltip--right-bottom,
 :host([open]) .spectrum-Tooltip--right-top,
-:host([placement*='right'][open]) #tooltip {
+:host([placement*="right"][open]) #tooltip {
     transform: translateX(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)));
 }
 
-:host([placement*='left']) #tooltip,
+:host([placement*="left"]) #tooltip,
 .spectrum-Tooltip--left-bottom,
 .spectrum-Tooltip--left-top {
     margin-right: calc(var(--mod-tooltip-tip-block-size, var(--spectrum-tooltip-tip-block-size)) + var(--mod-tooltip-margin, var(--spectrum-tooltip-margin)));
@@ -378,7 +378,7 @@ governing permissions and limitations under the License.
 
 :host([open]) .spectrum-Tooltip--left-bottom,
 :host([open]) .spectrum-Tooltip--left-top,
-:host([placement*='left'][open]) #tooltip {
+:host([placement*="left"][open]) #tooltip {
     transform: translateX(calc(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)) * -1));
 }
 
@@ -397,9 +397,9 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Tooltip--start-bottom:dir(rtl),
 :host([open]) .spectrum-Tooltip--start-top:dir(rtl),
 :host([open]) .spectrum-Tooltip--start:dir(rtl),
-:host([dir='rtl'][open]) .spectrum-Tooltip--start-bottom,
-:host([dir='rtl'][open]) .spectrum-Tooltip--start-top,
-:host([dir='rtl'][open]) .spectrum-Tooltip--start {
+:host([dir="rtl"][open]) .spectrum-Tooltip--start-bottom,
+:host([dir="rtl"][open]) .spectrum-Tooltip--start-top,
+:host([dir="rtl"][open]) .spectrum-Tooltip--start {
     transform: translateX(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)));
 }
 
@@ -418,8 +418,8 @@ governing permissions and limitations under the License.
 :host([open]) .spectrum-Tooltip--end-bottom:dir(rtl),
 :host([open]) .spectrum-Tooltip--end-top:dir(rtl),
 :host([open]) .spectrum-Tooltip--end:dir(rtl),
-:host([dir='rtl'][open]) .spectrum-Tooltip--end-bottom,
-:host([dir='rtl'][open]) .spectrum-Tooltip--end-top,
-:host([dir='rtl'][open]) .spectrum-Tooltip--end {
+:host([dir="rtl"][open]) .spectrum-Tooltip--end-bottom,
+:host([dir="rtl"][open]) .spectrum-Tooltip--end-top,
+:host([dir="rtl"][open]) .spectrum-Tooltip--end {
     transform: translateX(calc(var(--mod-tooltip-animation-distance, var(--spectrum-tooltip-animation-distance)) * -1));
 }

--- a/packages/tooltip/src/tooltip-overrides.css
+++ b/packages/tooltip/src/tooltip-overrides.css
@@ -12,7 +12,5 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #tooltip {
-    --spectrum-tooltip-backgound-color-default-neutral: var(
-        --system-tooltip-backgound-color-default-neutral
-    );
+    --spectrum-tooltip-backgound-color-default-neutral: var(--system-tooltip-backgound-color-default-neutral);
 }

--- a/tools/styles/express/spectrum-core-global.css
+++ b/tools/styles/express/spectrum-core-global.css
@@ -21,353 +21,179 @@
     --spectrum-global-color-status: Verified;
     --spectrum-global-color-version: 5.1;
     --spectrum-global-color-static-black-rgb: 0, 0, 0;
-    --spectrum-global-color-static-black: rgb(
-        var(--spectrum-global-color-static-black-rgb)
-    );
+    --spectrum-global-color-static-black: rgb(var(--spectrum-global-color-static-black-rgb));
     --spectrum-global-color-static-white-rgb: 255, 255, 255;
-    --spectrum-global-color-static-white: rgb(
-        var(--spectrum-global-color-static-white-rgb)
-    );
+    --spectrum-global-color-static-white: rgb(var(--spectrum-global-color-static-white-rgb));
     --spectrum-global-color-static-blue-rgb: 0, 87, 191;
-    --spectrum-global-color-static-blue: rgb(
-        var(--spectrum-global-color-static-blue-rgb)
-    );
+    --spectrum-global-color-static-blue: rgb(var(--spectrum-global-color-static-blue-rgb));
     --spectrum-global-color-static-gray-50-rgb: 255, 255, 255;
-    --spectrum-global-color-static-gray-50: rgb(
-        var(--spectrum-global-color-static-gray-50-rgb)
-    );
+    --spectrum-global-color-static-gray-50: rgb(var(--spectrum-global-color-static-gray-50-rgb));
     --spectrum-global-color-static-gray-75-rgb: 255, 255, 255;
-    --spectrum-global-color-static-gray-75: rgb(
-        var(--spectrum-global-color-static-gray-75-rgb)
-    );
+    --spectrum-global-color-static-gray-75: rgb(var(--spectrum-global-color-static-gray-75-rgb));
     --spectrum-global-color-static-gray-100-rgb: 255, 255, 255;
-    --spectrum-global-color-static-gray-100: rgb(
-        var(--spectrum-global-color-static-gray-100-rgb)
-    );
+    --spectrum-global-color-static-gray-100: rgb(var(--spectrum-global-color-static-gray-100-rgb));
     --spectrum-global-color-static-gray-200-rgb: 235, 235, 235;
-    --spectrum-global-color-static-gray-200: rgb(
-        var(--spectrum-global-color-static-gray-200-rgb)
-    );
+    --spectrum-global-color-static-gray-200: rgb(var(--spectrum-global-color-static-gray-200-rgb));
     --spectrum-global-color-static-gray-300-rgb: 217, 217, 217;
-    --spectrum-global-color-static-gray-300: rgb(
-        var(--spectrum-global-color-static-gray-300-rgb)
-    );
+    --spectrum-global-color-static-gray-300: rgb(var(--spectrum-global-color-static-gray-300-rgb));
     --spectrum-global-color-static-gray-400-rgb: 179, 179, 179;
-    --spectrum-global-color-static-gray-400: rgb(
-        var(--spectrum-global-color-static-gray-400-rgb)
-    );
+    --spectrum-global-color-static-gray-400: rgb(var(--spectrum-global-color-static-gray-400-rgb));
     --spectrum-global-color-static-gray-500-rgb: 146, 146, 146;
-    --spectrum-global-color-static-gray-500: rgb(
-        var(--spectrum-global-color-static-gray-500-rgb)
-    );
+    --spectrum-global-color-static-gray-500: rgb(var(--spectrum-global-color-static-gray-500-rgb));
     --spectrum-global-color-static-gray-600-rgb: 110, 110, 110;
-    --spectrum-global-color-static-gray-600: rgb(
-        var(--spectrum-global-color-static-gray-600-rgb)
-    );
+    --spectrum-global-color-static-gray-600: rgb(var(--spectrum-global-color-static-gray-600-rgb));
     --spectrum-global-color-static-gray-700-rgb: 71, 71, 71;
-    --spectrum-global-color-static-gray-700: rgb(
-        var(--spectrum-global-color-static-gray-700-rgb)
-    );
+    --spectrum-global-color-static-gray-700: rgb(var(--spectrum-global-color-static-gray-700-rgb));
     --spectrum-global-color-static-gray-800-rgb: 34, 34, 34;
-    --spectrum-global-color-static-gray-800: rgb(
-        var(--spectrum-global-color-static-gray-800-rgb)
-    );
+    --spectrum-global-color-static-gray-800: rgb(var(--spectrum-global-color-static-gray-800-rgb));
     --spectrum-global-color-static-gray-900-rgb: 0, 0, 0;
-    --spectrum-global-color-static-gray-900: rgb(
-        var(--spectrum-global-color-static-gray-900-rgb)
-    );
+    --spectrum-global-color-static-gray-900: rgb(var(--spectrum-global-color-static-gray-900-rgb));
     --spectrum-global-color-static-red-400-rgb: 237, 64, 48;
-    --spectrum-global-color-static-red-400: rgb(
-        var(--spectrum-global-color-static-red-400-rgb)
-    );
+    --spectrum-global-color-static-red-400: rgb(var(--spectrum-global-color-static-red-400-rgb));
     --spectrum-global-color-static-red-500-rgb: 217, 28, 21;
-    --spectrum-global-color-static-red-500: rgb(
-        var(--spectrum-global-color-static-red-500-rgb)
-    );
+    --spectrum-global-color-static-red-500: rgb(var(--spectrum-global-color-static-red-500-rgb));
     --spectrum-global-color-static-red-600-rgb: 187, 2, 2;
-    --spectrum-global-color-static-red-600: rgb(
-        var(--spectrum-global-color-static-red-600-rgb)
-    );
+    --spectrum-global-color-static-red-600: rgb(var(--spectrum-global-color-static-red-600-rgb));
     --spectrum-global-color-static-red-700-rgb: 154, 0, 0;
-    --spectrum-global-color-static-red-700: rgb(
-        var(--spectrum-global-color-static-red-700-rgb)
-    );
+    --spectrum-global-color-static-red-700: rgb(var(--spectrum-global-color-static-red-700-rgb));
     --spectrum-global-color-static-red-800-rgb: 124, 0, 0;
-    --spectrum-global-color-static-red-800: rgb(
-        var(--spectrum-global-color-static-red-800-rgb)
-    );
+    --spectrum-global-color-static-red-800: rgb(var(--spectrum-global-color-static-red-800-rgb));
     --spectrum-global-color-static-orange-400-rgb: 250, 139, 26;
-    --spectrum-global-color-static-orange-400: rgb(
-        var(--spectrum-global-color-static-orange-400-rgb)
-    );
+    --spectrum-global-color-static-orange-400: rgb(var(--spectrum-global-color-static-orange-400-rgb));
     --spectrum-global-color-static-orange-500-rgb: 233, 117, 0;
-    --spectrum-global-color-static-orange-500: rgb(
-        var(--spectrum-global-color-static-orange-500-rgb)
-    );
+    --spectrum-global-color-static-orange-500: rgb(var(--spectrum-global-color-static-orange-500-rgb));
     --spectrum-global-color-static-orange-600-rgb: 209, 97, 0;
-    --spectrum-global-color-static-orange-600: rgb(
-        var(--spectrum-global-color-static-orange-600-rgb)
-    );
+    --spectrum-global-color-static-orange-600: rgb(var(--spectrum-global-color-static-orange-600-rgb));
     --spectrum-global-color-static-orange-700-rgb: 182, 80, 0;
-    --spectrum-global-color-static-orange-700: rgb(
-        var(--spectrum-global-color-static-orange-700-rgb)
-    );
+    --spectrum-global-color-static-orange-700: rgb(var(--spectrum-global-color-static-orange-700-rgb));
     --spectrum-global-color-static-orange-800-rgb: 155, 64, 0;
-    --spectrum-global-color-static-orange-800: rgb(
-        var(--spectrum-global-color-static-orange-800-rgb)
-    );
+    --spectrum-global-color-static-orange-800: rgb(var(--spectrum-global-color-static-orange-800-rgb));
     --spectrum-global-color-static-yellow-200-rgb: 250, 237, 123;
-    --spectrum-global-color-static-yellow-200: rgb(
-        var(--spectrum-global-color-static-yellow-200-rgb)
-    );
+    --spectrum-global-color-static-yellow-200: rgb(var(--spectrum-global-color-static-yellow-200-rgb));
     --spectrum-global-color-static-yellow-300-rgb: 250, 224, 23;
-    --spectrum-global-color-static-yellow-300: rgb(
-        var(--spectrum-global-color-static-yellow-300-rgb)
-    );
+    --spectrum-global-color-static-yellow-300: rgb(var(--spectrum-global-color-static-yellow-300-rgb));
     --spectrum-global-color-static-yellow-400-rgb: 238, 205, 0;
-    --spectrum-global-color-static-yellow-400: rgb(
-        var(--spectrum-global-color-static-yellow-400-rgb)
-    );
+    --spectrum-global-color-static-yellow-400: rgb(var(--spectrum-global-color-static-yellow-400-rgb));
     --spectrum-global-color-static-yellow-500-rgb: 221, 185, 0;
-    --spectrum-global-color-static-yellow-500: rgb(
-        var(--spectrum-global-color-static-yellow-500-rgb)
-    );
+    --spectrum-global-color-static-yellow-500: rgb(var(--spectrum-global-color-static-yellow-500-rgb));
     --spectrum-global-color-static-yellow-600-rgb: 201, 164, 0;
-    --spectrum-global-color-static-yellow-600: rgb(
-        var(--spectrum-global-color-static-yellow-600-rgb)
-    );
+    --spectrum-global-color-static-yellow-600: rgb(var(--spectrum-global-color-static-yellow-600-rgb));
     --spectrum-global-color-static-yellow-700-rgb: 181, 144, 0;
-    --spectrum-global-color-static-yellow-700: rgb(
-        var(--spectrum-global-color-static-yellow-700-rgb)
-    );
+    --spectrum-global-color-static-yellow-700: rgb(var(--spectrum-global-color-static-yellow-700-rgb));
     --spectrum-global-color-static-yellow-800-rgb: 160, 125, 0;
-    --spectrum-global-color-static-yellow-800: rgb(
-        var(--spectrum-global-color-static-yellow-800-rgb)
-    );
+    --spectrum-global-color-static-yellow-800: rgb(var(--spectrum-global-color-static-yellow-800-rgb));
     --spectrum-global-color-static-chartreuse-300-rgb: 176, 222, 27;
-    --spectrum-global-color-static-chartreuse-300: rgb(
-        var(--spectrum-global-color-static-chartreuse-300-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-300: rgb(var(--spectrum-global-color-static-chartreuse-300-rgb));
     --spectrum-global-color-static-chartreuse-400-rgb: 157, 203, 13;
-    --spectrum-global-color-static-chartreuse-400: rgb(
-        var(--spectrum-global-color-static-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-400: rgb(var(--spectrum-global-color-static-chartreuse-400-rgb));
     --spectrum-global-color-static-chartreuse-500-rgb: 139, 182, 4;
-    --spectrum-global-color-static-chartreuse-500: rgb(
-        var(--spectrum-global-color-static-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-500: rgb(var(--spectrum-global-color-static-chartreuse-500-rgb));
     --spectrum-global-color-static-chartreuse-600-rgb: 122, 162, 0;
-    --spectrum-global-color-static-chartreuse-600: rgb(
-        var(--spectrum-global-color-static-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-600: rgb(var(--spectrum-global-color-static-chartreuse-600-rgb));
     --spectrum-global-color-static-chartreuse-700-rgb: 106, 141, 0;
-    --spectrum-global-color-static-chartreuse-700: rgb(
-        var(--spectrum-global-color-static-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-700: rgb(var(--spectrum-global-color-static-chartreuse-700-rgb));
     --spectrum-global-color-static-chartreuse-800-rgb: 90, 120, 0;
-    --spectrum-global-color-static-chartreuse-800: rgb(
-        var(--spectrum-global-color-static-chartreuse-800-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-800: rgb(var(--spectrum-global-color-static-chartreuse-800-rgb));
     --spectrum-global-color-static-celery-200-rgb: 126, 229, 114;
-    --spectrum-global-color-static-celery-200: rgb(
-        var(--spectrum-global-color-static-celery-200-rgb)
-    );
+    --spectrum-global-color-static-celery-200: rgb(var(--spectrum-global-color-static-celery-200-rgb));
     --spectrum-global-color-static-celery-300-rgb: 87, 212, 86;
-    --spectrum-global-color-static-celery-300: rgb(
-        var(--spectrum-global-color-static-celery-300-rgb)
-    );
+    --spectrum-global-color-static-celery-300: rgb(var(--spectrum-global-color-static-celery-300-rgb));
     --spectrum-global-color-static-celery-400-rgb: 48, 193, 61;
-    --spectrum-global-color-static-celery-400: rgb(
-        var(--spectrum-global-color-static-celery-400-rgb)
-    );
+    --spectrum-global-color-static-celery-400: rgb(var(--spectrum-global-color-static-celery-400-rgb));
     --spectrum-global-color-static-celery-500-rgb: 15, 172, 38;
-    --spectrum-global-color-static-celery-500: rgb(
-        var(--spectrum-global-color-static-celery-500-rgb)
-    );
+    --spectrum-global-color-static-celery-500: rgb(var(--spectrum-global-color-static-celery-500-rgb));
     --spectrum-global-color-static-celery-600-rgb: 0, 150, 20;
-    --spectrum-global-color-static-celery-600: rgb(
-        var(--spectrum-global-color-static-celery-600-rgb)
-    );
+    --spectrum-global-color-static-celery-600: rgb(var(--spectrum-global-color-static-celery-600-rgb));
     --spectrum-global-color-static-celery-700-rgb: 0, 128, 15;
-    --spectrum-global-color-static-celery-700: rgb(
-        var(--spectrum-global-color-static-celery-700-rgb)
-    );
+    --spectrum-global-color-static-celery-700: rgb(var(--spectrum-global-color-static-celery-700-rgb));
     --spectrum-global-color-static-celery-800-rgb: 0, 107, 15;
-    --spectrum-global-color-static-celery-800: rgb(
-        var(--spectrum-global-color-static-celery-800-rgb)
-    );
+    --spectrum-global-color-static-celery-800: rgb(var(--spectrum-global-color-static-celery-800-rgb));
     --spectrum-global-color-static-green-400-rgb: 29, 169, 115;
-    --spectrum-global-color-static-green-400: rgb(
-        var(--spectrum-global-color-static-green-400-rgb)
-    );
+    --spectrum-global-color-static-green-400: rgb(var(--spectrum-global-color-static-green-400-rgb));
     --spectrum-global-color-static-green-500-rgb: 0, 148, 97;
-    --spectrum-global-color-static-green-500: rgb(
-        var(--spectrum-global-color-static-green-500-rgb)
-    );
+    --spectrum-global-color-static-green-500: rgb(var(--spectrum-global-color-static-green-500-rgb));
     --spectrum-global-color-static-green-600-rgb: 0, 126, 80;
-    --spectrum-global-color-static-green-600: rgb(
-        var(--spectrum-global-color-static-green-600-rgb)
-    );
+    --spectrum-global-color-static-green-600: rgb(var(--spectrum-global-color-static-green-600-rgb));
     --spectrum-global-color-static-green-700-rgb: 0, 105, 65;
-    --spectrum-global-color-static-green-700: rgb(
-        var(--spectrum-global-color-static-green-700-rgb)
-    );
+    --spectrum-global-color-static-green-700: rgb(var(--spectrum-global-color-static-green-700-rgb));
     --spectrum-global-color-static-green-800-rgb: 0, 86, 53;
-    --spectrum-global-color-static-green-800: rgb(
-        var(--spectrum-global-color-static-green-800-rgb)
-    );
+    --spectrum-global-color-static-green-800: rgb(var(--spectrum-global-color-static-green-800-rgb));
     --spectrum-global-color-static-seafoam-200-rgb: 75, 206, 199;
-    --spectrum-global-color-static-seafoam-200: rgb(
-        var(--spectrum-global-color-static-seafoam-200-rgb)
-    );
+    --spectrum-global-color-static-seafoam-200: rgb(var(--spectrum-global-color-static-seafoam-200-rgb));
     --spectrum-global-color-static-seafoam-300-rgb: 32, 187, 180;
-    --spectrum-global-color-static-seafoam-300: rgb(
-        var(--spectrum-global-color-static-seafoam-300-rgb)
-    );
+    --spectrum-global-color-static-seafoam-300: rgb(var(--spectrum-global-color-static-seafoam-300-rgb));
     --spectrum-global-color-static-seafoam-400-rgb: 0, 166, 160;
-    --spectrum-global-color-static-seafoam-400: rgb(
-        var(--spectrum-global-color-static-seafoam-400-rgb)
-    );
+    --spectrum-global-color-static-seafoam-400: rgb(var(--spectrum-global-color-static-seafoam-400-rgb));
     --spectrum-global-color-static-seafoam-500-rgb: 0, 145, 139;
-    --spectrum-global-color-static-seafoam-500: rgb(
-        var(--spectrum-global-color-static-seafoam-500-rgb)
-    );
+    --spectrum-global-color-static-seafoam-500: rgb(var(--spectrum-global-color-static-seafoam-500-rgb));
     --spectrum-global-color-static-seafoam-600-rgb: 0, 124, 118;
-    --spectrum-global-color-static-seafoam-600: rgb(
-        var(--spectrum-global-color-static-seafoam-600-rgb)
-    );
+    --spectrum-global-color-static-seafoam-600: rgb(var(--spectrum-global-color-static-seafoam-600-rgb));
     --spectrum-global-color-static-seafoam-700-rgb: 0, 103, 99;
-    --spectrum-global-color-static-seafoam-700: rgb(
-        var(--spectrum-global-color-static-seafoam-700-rgb)
-    );
+    --spectrum-global-color-static-seafoam-700: rgb(var(--spectrum-global-color-static-seafoam-700-rgb));
     --spectrum-global-color-static-seafoam-800-rgb: 10, 83, 80;
-    --spectrum-global-color-static-seafoam-800: rgb(
-        var(--spectrum-global-color-static-seafoam-800-rgb)
-    );
+    --spectrum-global-color-static-seafoam-800: rgb(var(--spectrum-global-color-static-seafoam-800-rgb));
     --spectrum-global-color-static-blue-200-rgb: 130, 193, 251;
-    --spectrum-global-color-static-blue-200: rgb(
-        var(--spectrum-global-color-static-blue-200-rgb)
-    );
+    --spectrum-global-color-static-blue-200: rgb(var(--spectrum-global-color-static-blue-200-rgb));
     --spectrum-global-color-static-blue-300-rgb: 98, 173, 247;
-    --spectrum-global-color-static-blue-300: rgb(
-        var(--spectrum-global-color-static-blue-300-rgb)
-    );
+    --spectrum-global-color-static-blue-300: rgb(var(--spectrum-global-color-static-blue-300-rgb));
     --spectrum-global-color-static-blue-400-rgb: 66, 151, 244;
-    --spectrum-global-color-static-blue-400: rgb(
-        var(--spectrum-global-color-static-blue-400-rgb)
-    );
+    --spectrum-global-color-static-blue-400: rgb(var(--spectrum-global-color-static-blue-400-rgb));
     --spectrum-global-color-static-blue-500-rgb: 27, 127, 245;
-    --spectrum-global-color-static-blue-500: rgb(
-        var(--spectrum-global-color-static-blue-500-rgb)
-    );
+    --spectrum-global-color-static-blue-500: rgb(var(--spectrum-global-color-static-blue-500-rgb));
     --spectrum-global-color-static-blue-600-rgb: 4, 105, 227;
-    --spectrum-global-color-static-blue-600: rgb(
-        var(--spectrum-global-color-static-blue-600-rgb)
-    );
+    --spectrum-global-color-static-blue-600: rgb(var(--spectrum-global-color-static-blue-600-rgb));
     --spectrum-global-color-static-blue-700-rgb: 0, 87, 190;
-    --spectrum-global-color-static-blue-700: rgb(
-        var(--spectrum-global-color-static-blue-700-rgb)
-    );
+    --spectrum-global-color-static-blue-700: rgb(var(--spectrum-global-color-static-blue-700-rgb));
     --spectrum-global-color-static-blue-800-rgb: 0, 72, 153;
-    --spectrum-global-color-static-blue-800: rgb(
-        var(--spectrum-global-color-static-blue-800-rgb)
-    );
+    --spectrum-global-color-static-blue-800: rgb(var(--spectrum-global-color-static-blue-800-rgb));
     --spectrum-global-color-static-indigo-200-rgb: 178, 181, 255;
-    --spectrum-global-color-static-indigo-200: rgb(
-        var(--spectrum-global-color-static-indigo-200-rgb)
-    );
+    --spectrum-global-color-static-indigo-200: rgb(var(--spectrum-global-color-static-indigo-200-rgb));
     --spectrum-global-color-static-indigo-300-rgb: 155, 159, 255;
-    --spectrum-global-color-static-indigo-300: rgb(
-        var(--spectrum-global-color-static-indigo-300-rgb)
-    );
+    --spectrum-global-color-static-indigo-300: rgb(var(--spectrum-global-color-static-indigo-300-rgb));
     --spectrum-global-color-static-indigo-400-rgb: 132, 137, 253;
-    --spectrum-global-color-static-indigo-400: rgb(
-        var(--spectrum-global-color-static-indigo-400-rgb)
-    );
+    --spectrum-global-color-static-indigo-400: rgb(var(--spectrum-global-color-static-indigo-400-rgb));
     --spectrum-global-color-static-indigo-500-rgb: 109, 115, 246;
-    --spectrum-global-color-static-indigo-500: rgb(
-        var(--spectrum-global-color-static-indigo-500-rgb)
-    );
+    --spectrum-global-color-static-indigo-500: rgb(var(--spectrum-global-color-static-indigo-500-rgb));
     --spectrum-global-color-static-indigo-600-rgb: 87, 93, 232;
-    --spectrum-global-color-static-indigo-600: rgb(
-        var(--spectrum-global-color-static-indigo-600-rgb)
-    );
+    --spectrum-global-color-static-indigo-600: rgb(var(--spectrum-global-color-static-indigo-600-rgb));
     --spectrum-global-color-static-indigo-700-rgb: 68, 74, 208;
-    --spectrum-global-color-static-indigo-700: rgb(
-        var(--spectrum-global-color-static-indigo-700-rgb)
-    );
+    --spectrum-global-color-static-indigo-700: rgb(var(--spectrum-global-color-static-indigo-700-rgb));
     --spectrum-global-color-static-indigo-800-rgb: 68, 74, 208;
-    --spectrum-global-color-static-indigo-800: rgb(
-        var(--spectrum-global-color-static-indigo-800-rgb)
-    );
+    --spectrum-global-color-static-indigo-800: rgb(var(--spectrum-global-color-static-indigo-800-rgb));
     --spectrum-global-color-static-purple-400-rgb: 178, 121, 250;
-    --spectrum-global-color-static-purple-400: rgb(
-        var(--spectrum-global-color-static-purple-400-rgb)
-    );
+    --spectrum-global-color-static-purple-400: rgb(var(--spectrum-global-color-static-purple-400-rgb));
     --spectrum-global-color-static-purple-500-rgb: 161, 93, 246;
-    --spectrum-global-color-static-purple-500: rgb(
-        var(--spectrum-global-color-static-purple-500-rgb)
-    );
+    --spectrum-global-color-static-purple-500: rgb(var(--spectrum-global-color-static-purple-500-rgb));
     --spectrum-global-color-static-purple-600-rgb: 142, 67, 234;
-    --spectrum-global-color-static-purple-600: rgb(
-        var(--spectrum-global-color-static-purple-600-rgb)
-    );
+    --spectrum-global-color-static-purple-600: rgb(var(--spectrum-global-color-static-purple-600-rgb));
     --spectrum-global-color-static-purple-700-rgb: 120, 43, 216;
-    --spectrum-global-color-static-purple-700: rgb(
-        var(--spectrum-global-color-static-purple-700-rgb)
-    );
+    --spectrum-global-color-static-purple-700: rgb(var(--spectrum-global-color-static-purple-700-rgb));
     --spectrum-global-color-static-purple-800-rgb: 98, 23, 190;
-    --spectrum-global-color-static-purple-800: rgb(
-        var(--spectrum-global-color-static-purple-800-rgb)
-    );
+    --spectrum-global-color-static-purple-800: rgb(var(--spectrum-global-color-static-purple-800-rgb));
     --spectrum-global-color-static-fuchsia-400-rgb: 228, 93, 230;
-    --spectrum-global-color-static-fuchsia-400: rgb(
-        var(--spectrum-global-color-static-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-400: rgb(var(--spectrum-global-color-static-fuchsia-400-rgb));
     --spectrum-global-color-static-fuchsia-500-rgb: 211, 63, 212;
-    --spectrum-global-color-static-fuchsia-500: rgb(
-        var(--spectrum-global-color-static-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-500: rgb(var(--spectrum-global-color-static-fuchsia-500-rgb));
     --spectrum-global-color-static-fuchsia-600-rgb: 188, 39, 187;
-    --spectrum-global-color-static-fuchsia-600: rgb(
-        var(--spectrum-global-color-static-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-600: rgb(var(--spectrum-global-color-static-fuchsia-600-rgb));
     --spectrum-global-color-static-fuchsia-700-rgb: 163, 10, 163;
-    --spectrum-global-color-static-fuchsia-700: rgb(
-        var(--spectrum-global-color-static-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-700: rgb(var(--spectrum-global-color-static-fuchsia-700-rgb));
     --spectrum-global-color-static-fuchsia-800-rgb: 135, 0, 136;
-    --spectrum-global-color-static-fuchsia-800: rgb(
-        var(--spectrum-global-color-static-fuchsia-800-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-800: rgb(var(--spectrum-global-color-static-fuchsia-800-rgb));
     --spectrum-global-color-static-magenta-200-rgb: 253, 127, 175;
-    --spectrum-global-color-static-magenta-200: rgb(
-        var(--spectrum-global-color-static-magenta-200-rgb)
-    );
+    --spectrum-global-color-static-magenta-200: rgb(var(--spectrum-global-color-static-magenta-200-rgb));
     --spectrum-global-color-static-magenta-300-rgb: 242, 98, 157;
-    --spectrum-global-color-static-magenta-300: rgb(
-        var(--spectrum-global-color-static-magenta-300-rgb)
-    );
+    --spectrum-global-color-static-magenta-300: rgb(var(--spectrum-global-color-static-magenta-300-rgb));
     --spectrum-global-color-static-magenta-400-rgb: 226, 68, 135;
-    --spectrum-global-color-static-magenta-400: rgb(
-        var(--spectrum-global-color-static-magenta-400-rgb)
-    );
+    --spectrum-global-color-static-magenta-400: rgb(var(--spectrum-global-color-static-magenta-400-rgb));
     --spectrum-global-color-static-magenta-500-rgb: 205, 40, 111;
-    --spectrum-global-color-static-magenta-500: rgb(
-        var(--spectrum-global-color-static-magenta-500-rgb)
-    );
+    --spectrum-global-color-static-magenta-500: rgb(var(--spectrum-global-color-static-magenta-500-rgb));
     --spectrum-global-color-static-magenta-600-rgb: 179, 15, 89;
-    --spectrum-global-color-static-magenta-600: rgb(
-        var(--spectrum-global-color-static-magenta-600-rgb)
-    );
+    --spectrum-global-color-static-magenta-600: rgb(var(--spectrum-global-color-static-magenta-600-rgb));
     --spectrum-global-color-static-magenta-700-rgb: 149, 0, 72;
-    --spectrum-global-color-static-magenta-700: rgb(
-        var(--spectrum-global-color-static-magenta-700-rgb)
-    );
+    --spectrum-global-color-static-magenta-700: rgb(var(--spectrum-global-color-static-magenta-700-rgb));
     --spectrum-global-color-static-magenta-800-rgb: 119, 0, 58;
-    --spectrum-global-color-static-magenta-800: rgb(
-        var(--spectrum-global-color-static-magenta-800-rgb)
-    );
+    --spectrum-global-color-static-magenta-800: rgb(var(--spectrum-global-color-static-magenta-800-rgb));
     --spectrum-global-color-static-transparent-white-200: #ffffff1a;
     --spectrum-global-color-static-transparent-white-300: #ffffff40;
     --spectrum-global-color-static-transparent-white-400: #fff6;
@@ -376,9 +202,7 @@
     --spectrum-global-color-static-transparent-white-700: #fffc;
     --spectrum-global-color-static-transparent-white-800: #ffffffe6;
     --spectrum-global-color-static-transparent-white-900-rgb: 255, 255, 255;
-    --spectrum-global-color-static-transparent-white-900: rgb(
-        var(--spectrum-global-color-static-transparent-white-900-rgb)
-    );
+    --spectrum-global-color-static-transparent-white-900: rgb(var(--spectrum-global-color-static-transparent-white-900-rgb));
     --spectrum-global-color-static-transparent-black-200: #0000001a;
     --spectrum-global-color-static-transparent-black-300: #00000040;
     --spectrum-global-color-static-transparent-black-400: #0006;
@@ -387,271 +211,97 @@
     --spectrum-global-color-static-transparent-black-700: #000c;
     --spectrum-global-color-static-transparent-black-800: #000000e6;
     --spectrum-global-color-static-transparent-black-900-rgb: 0, 0, 0;
-    --spectrum-global-color-static-transparent-black-900: rgb(
-        var(--spectrum-global-color-static-transparent-black-900-rgb)
-    );
-    --spectrum-global-color-sequential-cerulean: #e9fff1, #c8f1e4, #a5e3d7,
-        #82d5ca, #68c5c1, #54b4ba, #3fa2b2, #2991ac, #2280a2, #1f6d98, #1d5c8d,
-        #1a4b83, #1a3979, #1a266f, #191264, #180057;
-    --spectrum-global-color-sequential-forest: #ffffdf, #e2f6ba, #c4eb95,
-        #a4e16d, #8dd366, #77c460, #5fb65a, #48a754, #36984f, #2c894d, #237a4a,
-        #196b47, #105c45, #094d41, #033f3e, #00313a;
-    --spectrum-global-color-sequential-rose: #fff4dd, #ffddd7, #ffc5d2, #feaecb,
-        #fa96c4, #f57ebd, #ef64b5, #e846ad, #d238a1, #bb2e96, #a3248c, #8a1b83,
-        #71167c, #560f74, #370b6e, #000968;
-    --spectrum-global-color-diverging-orange-yellow-seafoam: #580000, #79260b,
-        #9c4511, #bd651a, #dd8629, #f5ad52, #fed693, #ffffe0, #bbe4d1, #76c7be,
-        #3ea8a6, #208288, #076769, #00494b, #002c2d;
-    --spectrum-global-color-diverging-red-yellow-blue: #4a001e, #751232, #a52747,
-        #c65154, #e47961, #f0a882, #fad4ac, #ffffe0, #bce2cf, #89c0c4, #579eb9,
-        #397aa8, #1c5796, #163771, #10194d;
-    --spectrum-global-color-diverging-red-blue: #4a001e, #731331, #9f2945,
-        #cc415a, #e06e85, #ed9ab0, #f8c3d9, #faf0ff, #c6d0f2, #92b2de, #5d94cb,
-        #2f74b3, #265191, #163670, #0b194c;
-    --spectrum-semantic-cta-background-color-default: var(
-        --spectrum-global-color-static-indigo-600
-    );
-    --spectrum-semantic-cta-background-color-hover: var(
-        --spectrum-global-color-static-indigo-700
-    );
-    --spectrum-semantic-cta-background-color-down: var(
-        --spectrum-global-color-static-indigo-800
-    );
-    --spectrum-semantic-cta-background-color-key-focus: var(
-        --spectrum-global-color-static-indigo-700
-    );
-    --spectrum-semantic-emphasized-border-color-default: var(
-        --spectrum-global-color-indigo-500
-    );
-    --spectrum-semantic-emphasized-border-color-hover: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-semantic-emphasized-border-color-down: var(
-        --spectrum-global-color-indigo-700
-    );
-    --spectrum-semantic-emphasized-border-color-key-focus: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-semantic-neutral-background-color-default: var(
-        --spectrum-global-color-static-gray-800
-    );
-    --spectrum-semantic-negative-background-color: var(
-        --spectrum-global-color-static-red-600
-    );
-    --spectrum-semantic-negative-color-default: var(
-        --spectrum-global-color-red-500
-    );
-    --spectrum-semantic-negative-color-hover: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-color-dark: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-border-color: var(
-        --spectrum-global-color-red-400
-    );
-    --spectrum-semantic-negative-icon-color: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-status-color: var(
-        --spectrum-global-color-red-400
-    );
-    --spectrum-semantic-negative-text-color-large: var(
-        --spectrum-global-color-red-500
-    );
-    --spectrum-semantic-negative-text-color-small: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-text-color-small-hover: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-semantic-negative-text-color-small-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-semantic-negative-text-color-small-key-focus: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-color-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-semantic-negative-color-key-focus: var(
-        --spectrum-global-color-red-400
-    );
-    --spectrum-semantic-negative-background-color-default: var(
-        --spectrum-global-color-static-red-600
-    );
-    --spectrum-semantic-negative-background-color-hover: var(
-        --spectrum-global-color-static-red-700
-    );
-    --spectrum-semantic-negative-background-color-down: var(
-        --spectrum-global-color-static-red-800
-    );
-    --spectrum-semantic-negative-background-color-key-focus: var(
-        --spectrum-global-color-static-red-700
-    );
-    --spectrum-semantic-notice-background-color: var(
-        --spectrum-global-color-static-orange-600
-    );
-    --spectrum-semantic-notice-color-default: var(
-        --spectrum-global-color-orange-500
-    );
-    --spectrum-semantic-notice-color-dark: var(
-        --spectrum-global-color-orange-600
-    );
-    --spectrum-semantic-notice-border-color: var(
-        --spectrum-global-color-orange-400
-    );
-    --spectrum-semantic-notice-icon-color: var(
-        --spectrum-global-color-orange-600
-    );
-    --spectrum-semantic-notice-status-color: var(
-        --spectrum-global-color-orange-400
-    );
-    --spectrum-semantic-notice-text-color-large: var(
-        --spectrum-global-color-orange-500
-    );
-    --spectrum-semantic-notice-text-color-small: var(
-        --spectrum-global-color-orange-600
-    );
-    --spectrum-semantic-notice-color-down: var(
-        --spectrum-global-color-orange-700
-    );
-    --spectrum-semantic-notice-color-key-focus: var(
-        --spectrum-global-color-orange-400
-    );
-    --spectrum-semantic-notice-background-color-default: var(
-        --spectrum-global-color-static-orange-600
-    );
-    --spectrum-semantic-notice-background-color-hover: var(
-        --spectrum-global-color-static-orange-700
-    );
-    --spectrum-semantic-notice-background-color-down: var(
-        --spectrum-global-color-static-orange-800
-    );
-    --spectrum-semantic-notice-background-color-key-focus: var(
-        --spectrum-global-color-static-orange-700
-    );
-    --spectrum-semantic-positive-background-color: var(
-        --spectrum-global-color-static-green-600
-    );
-    --spectrum-semantic-positive-color-default: var(
-        --spectrum-global-color-green-500
-    );
-    --spectrum-semantic-positive-color-dark: var(
-        --spectrum-global-color-green-600
-    );
-    --spectrum-semantic-positive-border-color: var(
-        --spectrum-global-color-green-400
-    );
-    --spectrum-semantic-positive-icon-color: var(
-        --spectrum-global-color-green-600
-    );
-    --spectrum-semantic-positive-status-color: var(
-        --spectrum-global-color-green-400
-    );
-    --spectrum-semantic-positive-text-color-large: var(
-        --spectrum-global-color-green-500
-    );
-    --spectrum-semantic-positive-text-color-small: var(
-        --spectrum-global-color-green-600
-    );
-    --spectrum-semantic-positive-color-down: var(
-        --spectrum-global-color-green-700
-    );
-    --spectrum-semantic-positive-color-key-focus: var(
-        --spectrum-global-color-green-400
-    );
-    --spectrum-semantic-positive-background-color-default: var(
-        --spectrum-global-color-static-green-600
-    );
-    --spectrum-semantic-positive-background-color-hover: var(
-        --spectrum-global-color-static-green-700
-    );
-    --spectrum-semantic-positive-background-color-down: var(
-        --spectrum-global-color-static-green-800
-    );
-    --spectrum-semantic-positive-background-color-key-focus: var(
-        --spectrum-global-color-static-green-700
-    );
-    --spectrum-semantic-informative-background-color: var(
-        --spectrum-global-color-static-blue-600
-    );
-    --spectrum-semantic-informative-color-default: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-semantic-informative-color-dark: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-informative-border-color: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-semantic-informative-icon-color: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-informative-status-color: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-semantic-informative-text-color-large: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-semantic-informative-text-color-small: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-informative-color-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-semantic-informative-color-key-focus: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-semantic-informative-background-color-default: var(
-        --spectrum-global-color-static-blue-600
-    );
-    --spectrum-semantic-informative-background-color-hover: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-informative-background-color-down: var(
-        --spectrum-global-color-static-blue-800
-    );
-    --spectrum-semantic-informative-background-color-key-focus: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-neutral-background-color-hover: var(
-        --spectrum-global-color-static-gray-800
-    );
-    --spectrum-semantic-neutral-background-color-down: var(
-        --spectrum-global-color-static-gray-900
-    );
-    --spectrum-semantic-neutral-background-color-key-focus: var(
-        --spectrum-global-color-static-gray-800
-    );
-    --spectrum-semantic-presence-color-1: var(
-        --spectrum-global-color-static-red-500
-    );
-    --spectrum-semantic-presence-color-2: var(
-        --spectrum-global-color-static-orange-400
-    );
-    --spectrum-semantic-presence-color-3: var(
-        --spectrum-global-color-static-yellow-400
-    );
+    --spectrum-global-color-static-transparent-black-900: rgb(var(--spectrum-global-color-static-transparent-black-900-rgb));
+    --spectrum-global-color-sequential-cerulean: #e9fff1, #c8f1e4, #a5e3d7, #82d5ca, #68c5c1, #54b4ba, #3fa2b2, #2991ac, #2280a2, #1f6d98, #1d5c8d, #1a4b83, #1a3979, #1a266f, #191264, #180057;
+    --spectrum-global-color-sequential-forest: #ffffdf, #e2f6ba, #c4eb95, #a4e16d, #8dd366, #77c460, #5fb65a, #48a754, #36984f, #2c894d, #237a4a, #196b47, #105c45, #094d41, #033f3e, #00313a;
+    --spectrum-global-color-sequential-rose: #fff4dd, #ffddd7, #ffc5d2, #feaecb, #fa96c4, #f57ebd, #ef64b5, #e846ad, #d238a1, #bb2e96, #a3248c, #8a1b83, #71167c, #560f74, #370b6e, #000968;
+    --spectrum-global-color-diverging-orange-yellow-seafoam: #580000, #79260b, #9c4511, #bd651a, #dd8629, #f5ad52, #fed693, #ffffe0, #bbe4d1, #76c7be, #3ea8a6, #208288, #076769, #00494b, #002c2d;
+    --spectrum-global-color-diverging-red-yellow-blue: #4a001e, #751232, #a52747, #c65154, #e47961, #f0a882, #fad4ac, #ffffe0, #bce2cf, #89c0c4, #579eb9, #397aa8, #1c5796, #163771, #10194d;
+    --spectrum-global-color-diverging-red-blue: #4a001e, #731331, #9f2945, #cc415a, #e06e85, #ed9ab0, #f8c3d9, #faf0ff, #c6d0f2, #92b2de, #5d94cb, #2f74b3, #265191, #163670, #0b194c;
+    --spectrum-semantic-cta-background-color-default: var(--spectrum-global-color-static-indigo-600);
+    --spectrum-semantic-cta-background-color-hover: var(--spectrum-global-color-static-indigo-700);
+    --spectrum-semantic-cta-background-color-down: var(--spectrum-global-color-static-indigo-800);
+    --spectrum-semantic-cta-background-color-key-focus: var(--spectrum-global-color-static-indigo-700);
+    --spectrum-semantic-emphasized-border-color-default: var(--spectrum-global-color-indigo-500);
+    --spectrum-semantic-emphasized-border-color-hover: var(--spectrum-global-color-indigo-600);
+    --spectrum-semantic-emphasized-border-color-down: var(--spectrum-global-color-indigo-700);
+    --spectrum-semantic-emphasized-border-color-key-focus: var(--spectrum-global-color-indigo-600);
+    --spectrum-semantic-neutral-background-color-default: var(--spectrum-global-color-static-gray-800);
+    --spectrum-semantic-negative-background-color: var(--spectrum-global-color-static-red-600);
+    --spectrum-semantic-negative-color-default: var(--spectrum-global-color-red-500);
+    --spectrum-semantic-negative-color-hover: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-color-dark: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-border-color: var(--spectrum-global-color-red-400);
+    --spectrum-semantic-negative-icon-color: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-status-color: var(--spectrum-global-color-red-400);
+    --spectrum-semantic-negative-text-color-large: var(--spectrum-global-color-red-500);
+    --spectrum-semantic-negative-text-color-small: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-text-color-small-hover: var(--spectrum-global-color-red-700);
+    --spectrum-semantic-negative-text-color-small-down: var(--spectrum-global-color-red-700);
+    --spectrum-semantic-negative-text-color-small-key-focus: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-color-down: var(--spectrum-global-color-red-700);
+    --spectrum-semantic-negative-color-key-focus: var(--spectrum-global-color-red-400);
+    --spectrum-semantic-negative-background-color-default: var(--spectrum-global-color-static-red-600);
+    --spectrum-semantic-negative-background-color-hover: var(--spectrum-global-color-static-red-700);
+    --spectrum-semantic-negative-background-color-down: var(--spectrum-global-color-static-red-800);
+    --spectrum-semantic-negative-background-color-key-focus: var(--spectrum-global-color-static-red-700);
+    --spectrum-semantic-notice-background-color: var(--spectrum-global-color-static-orange-600);
+    --spectrum-semantic-notice-color-default: var(--spectrum-global-color-orange-500);
+    --spectrum-semantic-notice-color-dark: var(--spectrum-global-color-orange-600);
+    --spectrum-semantic-notice-border-color: var(--spectrum-global-color-orange-400);
+    --spectrum-semantic-notice-icon-color: var(--spectrum-global-color-orange-600);
+    --spectrum-semantic-notice-status-color: var(--spectrum-global-color-orange-400);
+    --spectrum-semantic-notice-text-color-large: var(--spectrum-global-color-orange-500);
+    --spectrum-semantic-notice-text-color-small: var(--spectrum-global-color-orange-600);
+    --spectrum-semantic-notice-color-down: var(--spectrum-global-color-orange-700);
+    --spectrum-semantic-notice-color-key-focus: var(--spectrum-global-color-orange-400);
+    --spectrum-semantic-notice-background-color-default: var(--spectrum-global-color-static-orange-600);
+    --spectrum-semantic-notice-background-color-hover: var(--spectrum-global-color-static-orange-700);
+    --spectrum-semantic-notice-background-color-down: var(--spectrum-global-color-static-orange-800);
+    --spectrum-semantic-notice-background-color-key-focus: var(--spectrum-global-color-static-orange-700);
+    --spectrum-semantic-positive-background-color: var(--spectrum-global-color-static-green-600);
+    --spectrum-semantic-positive-color-default: var(--spectrum-global-color-green-500);
+    --spectrum-semantic-positive-color-dark: var(--spectrum-global-color-green-600);
+    --spectrum-semantic-positive-border-color: var(--spectrum-global-color-green-400);
+    --spectrum-semantic-positive-icon-color: var(--spectrum-global-color-green-600);
+    --spectrum-semantic-positive-status-color: var(--spectrum-global-color-green-400);
+    --spectrum-semantic-positive-text-color-large: var(--spectrum-global-color-green-500);
+    --spectrum-semantic-positive-text-color-small: var(--spectrum-global-color-green-600);
+    --spectrum-semantic-positive-color-down: var(--spectrum-global-color-green-700);
+    --spectrum-semantic-positive-color-key-focus: var(--spectrum-global-color-green-400);
+    --spectrum-semantic-positive-background-color-default: var(--spectrum-global-color-static-green-600);
+    --spectrum-semantic-positive-background-color-hover: var(--spectrum-global-color-static-green-700);
+    --spectrum-semantic-positive-background-color-down: var(--spectrum-global-color-static-green-800);
+    --spectrum-semantic-positive-background-color-key-focus: var(--spectrum-global-color-static-green-700);
+    --spectrum-semantic-informative-background-color: var(--spectrum-global-color-static-blue-600);
+    --spectrum-semantic-informative-color-default: var(--spectrum-global-color-blue-500);
+    --spectrum-semantic-informative-color-dark: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-informative-border-color: var(--spectrum-global-color-blue-400);
+    --spectrum-semantic-informative-icon-color: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-informative-status-color: var(--spectrum-global-color-blue-400);
+    --spectrum-semantic-informative-text-color-large: var(--spectrum-global-color-blue-500);
+    --spectrum-semantic-informative-text-color-small: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-informative-color-down: var(--spectrum-global-color-blue-700);
+    --spectrum-semantic-informative-color-key-focus: var(--spectrum-global-color-blue-400);
+    --spectrum-semantic-informative-background-color-default: var(--spectrum-global-color-static-blue-600);
+    --spectrum-semantic-informative-background-color-hover: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-informative-background-color-down: var(--spectrum-global-color-static-blue-800);
+    --spectrum-semantic-informative-background-color-key-focus: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-neutral-background-color-hover: var(--spectrum-global-color-static-gray-800);
+    --spectrum-semantic-neutral-background-color-down: var(--spectrum-global-color-static-gray-900);
+    --spectrum-semantic-neutral-background-color-key-focus: var(--spectrum-global-color-static-gray-800);
+    --spectrum-semantic-presence-color-1: var(--spectrum-global-color-static-red-500);
+    --spectrum-semantic-presence-color-2: var(--spectrum-global-color-static-orange-400);
+    --spectrum-semantic-presence-color-3: var(--spectrum-global-color-static-yellow-400);
     --spectrum-semantic-presence-color-4-rgb: 75, 204, 162;
-    --spectrum-semantic-presence-color-4: rgb(
-        var(--spectrum-semantic-presence-color-4-rgb)
-    );
+    --spectrum-semantic-presence-color-4: rgb(var(--spectrum-semantic-presence-color-4-rgb));
     --spectrum-semantic-presence-color-5-rgb: 0, 199, 255;
-    --spectrum-semantic-presence-color-5: rgb(
-        var(--spectrum-semantic-presence-color-5-rgb)
-    );
+    --spectrum-semantic-presence-color-5: rgb(var(--spectrum-semantic-presence-color-5-rgb));
     --spectrum-semantic-presence-color-6-rgb: 0, 140, 184;
-    --spectrum-semantic-presence-color-6: rgb(
-        var(--spectrum-semantic-presence-color-6-rgb)
-    );
+    --spectrum-semantic-presence-color-6: rgb(var(--spectrum-semantic-presence-color-6-rgb));
     --spectrum-semantic-presence-color-7-rgb: 126, 75, 243;
-    --spectrum-semantic-presence-color-7: rgb(
-        var(--spectrum-semantic-presence-color-7-rgb)
-    );
-    --spectrum-semantic-presence-color-8: var(
-        --spectrum-global-color-static-fuchsia-600
-    );
+    --spectrum-semantic-presence-color-7: rgb(var(--spectrum-semantic-presence-color-7-rgb));
+    --spectrum-semantic-presence-color-8: var(--spectrum-global-color-static-fuchsia-600);
     --spectrum-global-dimension-static-percent-50: 50%;
     --spectrum-global-dimension-static-percent-70: 70%;
     --spectrum-global-dimension-static-percent-100: 100%;
@@ -723,12 +373,9 @@
     --spectrum-global-dimension-static-font-size-800: 32px;
     --spectrum-global-dimension-static-font-size-900: 36px;
     --spectrum-global-dimension-static-font-size-1000: 40px;
-    --spectrum-global-font-family-base: adobe-clean, 'Source Sans Pro',
-        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu,
-        'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-global-font-family-serif: adobe-clean-serif, 'Source Serif Pro',
-        Georgia, serif;
-    --spectrum-global-font-family-code: 'Source Code Pro', Monaco, monospace;
+    --spectrum-global-font-family-base: adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-global-font-family-serif: adobe-clean-serif, "Source Serif Pro", Georgia, serif;
+    --spectrum-global-font-family-code: "Source Code Pro", Monaco, monospace;
     --spectrum-global-font-weight-thin: 100;
     --spectrum-global-font-weight-ultra-light: 200;
     --spectrum-global-font-weight-light: 300;
@@ -750,313 +397,112 @@
     --spectrum-global-font-multiplier-0: 0em;
     --spectrum-global-font-multiplier-25: 0.25em;
     --spectrum-global-font-multiplier-75: 0.75em;
-    --spectrum-global-font-font-family-ar: myriad-arabic, adobe-clean,
-        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-global-font-font-family-he: myriad-hebrew, adobe-clean,
-        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-global-font-font-family-zh: adobe-clean-han-traditional,
-        source-han-traditional, 'MingLiu', 'Heiti TC Light', 'sans-serif';
-    --spectrum-global-font-font-family-zhhans: adobe-clean-han-simplified-c,
-        source-han-simplified-c, 'SimSun', 'Heiti SC Light', 'sans-serif';
-    --spectrum-global-font-font-family-ko: adobe-clean-han-korean,
-        source-han-korean, 'Malgun Gothic', 'Apple Gothic', 'sans-serif';
-    --spectrum-global-font-font-family-ja: adobe-clean-han-japanese,
-        'Hiragino Kaku Gothic ProN', 'ヒラギノ角ゴ ProN W3', 'Osaka', YuGothic,
-        'Yu Gothic', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', 'MS PGothic',
-        'sans-serif';
-    --spectrum-global-font-font-family-condensed: adobe-clean-han-traditional,
-        source-han-traditional, 'MingLiu', 'Heiti TC Light', adobe-clean,
-        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-alias-border-size-thin: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-border-size-thick: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-size-thicker: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-size-thickest: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thin: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-offset-thick: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-offset-thicker: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thickest: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-baseline: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-grid-gutter-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-gutter-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-gutter-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-gutter-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-gutter-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-margin-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-margin-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-margin-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-margin-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-margin-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-radial-reaction-size-default: var(
-        --spectrum-global-dimension-static-size-550
-    );
-    --spectrum-alias-focus-ring-gap: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-focus-ring-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-loupe-entry-animation-duration: var(
-        --spectrum-global-animation-duration-300
-    );
-    --spectrum-alias-loupe-exit-animation-duration: var(
-        --spectrum-global-animation-duration-300
-    );
-    --spectrum-alias-heading-text-font-weight-regular: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-heavy: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-line-height: var(
-        --spectrum-global-font-line-height-small
-    );
-    --spectrum-alias-heading-text-font-weight-regular-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-light: var(
-        --spectrum-global-font-weight-light
-    );
-    --spectrum-alias-heading-text-font-weight-light-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-heading-text-font-weight-heavy-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-quiet: var(
-        --spectrum-global-font-weight-light
-    );
-    --spectrum-alias-heading-text-font-weight-quiet-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-heading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-strong-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-margin-bottom: var(
-        --spectrum-global-font-multiplier-25
-    );
-    --spectrum-alias-subheading-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-subheading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-body-text-font-family: var(
-        --spectrum-global-font-family-base
-    );
-    --spectrum-alias-body-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-body-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-body-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-body-margin-bottom: var(
-        --spectrum-global-font-multiplier-75
-    );
-    --spectrum-alias-detail-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-detail-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-detail-text-font-weight-light: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-heading-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-article-heading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-heading-text-font-weight-quiet: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-article-heading-text-font-weight-quiet-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-article-body-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-article-body-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-subheading-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-article-subheading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-detail-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-article-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-code-text-font-family: var(
-        --spectrum-global-font-family-code
-    );
-    --spectrum-alias-code-text-font-weight-regular: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-code-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-code-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-code-margin-bottom: var(
-        --spectrum-global-font-multiplier-0
-    );
+    --spectrum-global-font-font-family-ar: myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-global-font-font-family-he: myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-global-font-font-family-zh: adobe-clean-han-traditional, source-han-traditional, "MingLiu", "Heiti TC Light", "sans-serif";
+    --spectrum-global-font-font-family-zhhans: adobe-clean-han-simplified-c, source-han-simplified-c, "SimSun", "Heiti SC Light", "sans-serif";
+    --spectrum-global-font-font-family-ko: adobe-clean-han-korean, source-han-korean, "Malgun Gothic", "Apple Gothic", "sans-serif";
+    --spectrum-global-font-font-family-ja: adobe-clean-han-japanese, "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ ProN W3", "Osaka", YuGothic, "Yu Gothic", "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", "sans-serif";
+    --spectrum-global-font-font-family-condensed: adobe-clean-han-traditional, source-han-traditional, "MingLiu", "Heiti TC Light", adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-alias-border-size-thin: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-border-size-thick: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-size-thicker: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-size-thickest: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thin: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-offset-thick: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-offset-thicker: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thickest: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-baseline: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-grid-gutter-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-gutter-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-gutter-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-gutter-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-gutter-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-margin-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-margin-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-margin-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-margin-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-margin-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-layout-region-margin-bottom-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-layout-region-margin-bottom-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-radial-reaction-size-default: var(--spectrum-global-dimension-static-size-550);
+    --spectrum-alias-focus-ring-gap: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-focus-ring-size: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-loupe-entry-animation-duration: var(--spectrum-global-animation-duration-300);
+    --spectrum-alias-loupe-exit-animation-duration: var(--spectrum-global-animation-duration-300);
+    --spectrum-alias-heading-text-font-weight-regular: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-heavy: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-line-height: var(--spectrum-global-font-line-height-small);
+    --spectrum-alias-heading-text-font-weight-regular-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-light: var(--spectrum-global-font-weight-light);
+    --spectrum-alias-heading-text-font-weight-light-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-heading-text-font-weight-heavy-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-quiet: var(--spectrum-global-font-weight-light);
+    --spectrum-alias-heading-text-font-weight-quiet-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-heading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-strong-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-margin-bottom: var(--spectrum-global-font-multiplier-25);
+    --spectrum-alias-subheading-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-subheading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-body-text-font-family: var(--spectrum-global-font-family-base);
+    --spectrum-alias-body-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-body-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-body-text-font-weight-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-body-margin-bottom: var(--spectrum-global-font-multiplier-75);
+    --spectrum-alias-detail-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-detail-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-detail-text-font-weight-light: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-detail-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-heading-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-article-heading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-heading-text-font-weight-quiet: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-article-heading-text-font-weight-quiet-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-article-body-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-article-body-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-subheading-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-article-subheading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-detail-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-article-detail-text-font-weight-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-code-text-font-family: var(--spectrum-global-font-family-code);
+    --spectrum-alias-code-text-font-weight-regular: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-code-text-font-weight-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-code-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-code-margin-bottom: var(--spectrum-global-font-multiplier-0);
     --spectrum-alias-font-family-ar: var(--spectrum-global-font-font-family-ar);
     --spectrum-alias-font-family-he: var(--spectrum-global-font-font-family-he);
     --spectrum-alias-font-family-zh: var(--spectrum-global-font-font-family-zh);
-    --spectrum-alias-font-family-zhhans: var(
-        --spectrum-global-font-font-family-zhhans
-    );
+    --spectrum-alias-font-family-zhhans: var(--spectrum-global-font-font-family-zhhans);
     --spectrum-alias-font-family-ko: var(--spectrum-global-font-font-family-ko);
     --spectrum-alias-font-family-ja: var(--spectrum-global-font-font-family-ja);
-    --spectrum-alias-font-family-condensed: var(
-        --spectrum-global-font-font-family-condensed
-    );
-    --spectrum-alias-button-text-line-height: var(
-        --spectrum-global-font-line-height-small
-    );
-    --spectrum-alias-component-text-line-height: var(
-        --spectrum-global-font-line-height-small
-    );
-    --spectrum-alias-han-component-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-serif-text-font-family: var(
-        --spectrum-global-font-family-serif
-    );
-    --spectrum-alias-han-heading-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-han-heading-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-regular-emphasis: var(
-        --spectrum-global-font-weight-extra-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-regular-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-heading-text-font-weight-quiet-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-light: var(
-        --spectrum-global-font-weight-light
-    );
-    --spectrum-alias-han-heading-text-font-weight-light-emphasis: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-han-heading-text-font-weight-light-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-heavy: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-heading-text-font-weight-heavy-emphasis: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-heading-text-font-weight-heavy-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-body-text-line-height: var(
-        --spectrum-global-font-line-height-large
-    );
-    --spectrum-alias-han-body-text-font-weight-regular: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-han-body-text-font-weight-emphasis: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-body-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-subheading-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-subheading-text-font-weight-emphasis: var(
-        --spectrum-global-font-weight-extra-bold
-    );
-    --spectrum-alias-han-subheading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-detail-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-han-detail-text-font-weight-emphasis: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
+    --spectrum-alias-font-family-condensed: var(--spectrum-global-font-font-family-condensed);
+    --spectrum-alias-button-text-line-height: var(--spectrum-global-font-line-height-small);
+    --spectrum-alias-component-text-line-height: var(--spectrum-global-font-line-height-small);
+    --spectrum-alias-han-component-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-serif-text-font-family: var(--spectrum-global-font-family-serif);
+    --spectrum-alias-han-heading-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-han-heading-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-heading-text-font-weight-regular-emphasis: var(--spectrum-global-font-weight-extra-bold);
+    --spectrum-alias-han-heading-text-font-weight-regular-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-heading-text-font-weight-quiet-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-heading-text-font-weight-light: var(--spectrum-global-font-weight-light);
+    --spectrum-alias-han-heading-text-font-weight-light-emphasis: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-han-heading-text-font-weight-light-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-heading-text-font-weight-heavy: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-heading-text-font-weight-heavy-emphasis: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-heading-text-font-weight-heavy-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-body-text-line-height: var(--spectrum-global-font-line-height-large);
+    --spectrum-alias-han-body-text-font-weight-regular: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-han-body-text-font-weight-emphasis: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-body-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-subheading-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-subheading-text-font-weight-emphasis: var(--spectrum-global-font-weight-extra-bold);
+    --spectrum-alias-han-subheading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-detail-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-han-detail-text-font-weight-emphasis: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-detail-text-font-weight-strong: var(--spectrum-global-font-weight-black);
 }
 
 :root,
@@ -1065,786 +511,278 @@
     --spectrum-alias-item-height-m: var(--spectrum-global-dimension-size-400);
     --spectrum-alias-item-height-l: var(--spectrum-global-dimension-size-500);
     --spectrum-alias-item-height-xl: var(--spectrum-global-dimension-size-600);
-    --spectrum-alias-item-rounded-border-radius-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-rounded-border-radius-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-rounded-border-radius-l: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-item-rounded-border-radius-xl: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-item-text-size-s: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-item-text-size-m: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-item-text-size-l: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-item-text-size-xl: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-item-text-padding-top-s: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-item-text-padding-top-m: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-text-padding-top-xl: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-text-padding-bottom-m: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-text-padding-bottom-l: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-text-padding-bottom-xl: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-item-icon-padding-top-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-icon-padding-top-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-icon-padding-top-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-icon-padding-top-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-icon-padding-bottom-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-icon-padding-bottom-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-icon-padding-bottom-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-icon-padding-bottom-xl: var(
-        --spectrum-global-dimension-size-160
-    );
+    --spectrum-alias-item-rounded-border-radius-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-rounded-border-radius-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-rounded-border-radius-l: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-item-rounded-border-radius-xl: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-item-text-size-s: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-item-text-size-m: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-item-text-size-l: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-item-text-size-xl: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-item-text-padding-top-s: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-item-text-padding-top-m: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-text-padding-top-xl: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-text-padding-bottom-m: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-text-padding-bottom-l: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-text-padding-bottom-xl: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-item-icon-padding-top-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-icon-padding-top-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-icon-padding-top-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-icon-padding-top-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-icon-padding-bottom-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-icon-padding-bottom-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-icon-padding-bottom-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-icon-padding-bottom-xl: var(--spectrum-global-dimension-size-160);
     --spectrum-alias-item-padding-s: var(--spectrum-global-dimension-size-115);
     --spectrum-alias-item-padding-m: var(--spectrum-global-dimension-size-150);
     --spectrum-alias-item-padding-l: var(--spectrum-global-dimension-size-185);
     --spectrum-alias-item-padding-xl: var(--spectrum-global-dimension-size-225);
-    --spectrum-alias-item-rounded-padding-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-rounded-padding-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-rounded-padding-l: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-item-rounded-padding-xl: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-item-icononly-padding-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-icononly-padding-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-icononly-padding-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-icononly-padding-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-control-gap-s: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-gap-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-gap-l: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-control-gap-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-workflow-icon-gap-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-workflow-icon-gap-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-workflow-icon-gap-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-workflow-icon-gap-xl: var(
-        --spectrum-global-dimension-size-125
-    );
+    --spectrum-alias-item-rounded-padding-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-rounded-padding-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-rounded-padding-l: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-item-rounded-padding-xl: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-item-icononly-padding-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-icononly-padding-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-icononly-padding-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-icononly-padding-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-control-gap-s: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-gap-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-gap-l: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-control-gap-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-workflow-icon-gap-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-workflow-icon-gap-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-workflow-icon-gap-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-workflow-icon-gap-xl: var(--spectrum-global-dimension-size-125);
     --spectrum-alias-item-mark-gap-s: var(--spectrum-global-dimension-size-85);
     --spectrum-alias-item-mark-gap-m: var(--spectrum-global-dimension-size-100);
     --spectrum-alias-item-mark-gap-l: var(--spectrum-global-dimension-size-115);
-    --spectrum-alias-item-mark-gap-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-ui-icon-gap-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-ui-icon-gap-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-ui-icon-gap-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-ui-icon-gap-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-clearbutton-gap-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-clearbutton-gap-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-clearbutton-gap-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-clearbutton-gap-xl: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-workflow-padding-left-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-workflow-padding-left-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-workflow-padding-left-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-rounded-workflow-padding-left-s: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-rounded-workflow-padding-left-l: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-mark-padding-top-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-item-mark-padding-top-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-mark-padding-top-xl: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-mark-padding-bottom-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-item-mark-padding-bottom-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-mark-padding-bottom-xl: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-mark-padding-left-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-mark-padding-left-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-mark-padding-left-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-control-1-size-s: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-item-control-1-size-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-control-2-size-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-item-control-2-size-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-control-2-size-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-control-2-size-xxl: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-item-control-2-border-radius-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-2-border-radius-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-control-2-border-radius-l: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-control-2-border-radius-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-2-border-radius-xxl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-2-padding-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-2-padding-m: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-2-padding-l: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-control-2-padding-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-control-3-height-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-item-control-3-height-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-control-3-height-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-control-3-border-radius-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-3-border-radius-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-control-3-border-radius-l: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-control-3-border-radius-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-3-padding-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-3-padding-m: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-3-padding-l: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-control-3-padding-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-mark-size-s: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-mark-size-l: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-item-mark-size-xl: var(
-        --spectrum-global-dimension-size-325
-    );
-    --spectrum-alias-heading-xxxl-text-size: var(
-        --spectrum-global-dimension-font-size-1300
-    );
-    --spectrum-alias-heading-xxl-text-size: var(
-        --spectrum-global-dimension-font-size-1100
-    );
-    --spectrum-alias-heading-xl-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-l-text-size: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading-m-text-size: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading-s-text-size: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-xs-text-size: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-xxs-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-xxxl-margin-top: var(
-        --spectrum-global-dimension-font-size-1200
-    );
-    --spectrum-alias-heading-xxl-margin-top: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-xl-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-l-margin-top: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading-m-margin-top: var(
-        --spectrum-global-dimension-font-size-400
-    );
-    --spectrum-alias-heading-s-margin-top: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-xs-margin-top: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-xxs-margin-top: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-heading-han-xxxl-text-size: var(
-        --spectrum-global-dimension-font-size-1300
-    );
-    --spectrum-alias-heading-han-xxl-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-han-xl-text-size: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-han-l-text-size: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading-han-m-text-size: var(
-        --spectrum-global-dimension-font-size-400
-    );
-    --spectrum-alias-heading-han-s-text-size: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-han-xs-text-size: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-han-xxs-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-han-xxxl-margin-top: var(
-        --spectrum-global-dimension-font-size-1200
-    );
-    --spectrum-alias-heading-han-xxl-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-han-xl-margin-top: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading-han-l-margin-top: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading-han-m-margin-top: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-han-s-margin-top: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-han-xs-margin-top: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-han-xxs-margin-top: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-component-border-radius: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-component-border-radius-quiet: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-component-focusring-gap: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-component-focusring-gap-emphasized: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-component-focusring-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-component-focusring-size-emphasized: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-input-focusring-gap: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-input-quiet-focusline-gap: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-radius-xsmall: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-border-radius-small: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-border-radius-regular: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-border-radius-medium: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-border-radius-large: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-border-radius-xlarge: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-focus-ring-border-radius-xsmall: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-focus-ring-border-radius-medium: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-focus-ring-border-radius-large: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-focus-ring-border-radius-xlarge: var(
-        --spectrum-global-dimension-size-350
-    );
-    --spectrum-alias-control-two-size-s: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-control-two-size-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-control-two-size-l: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-control-two-size-xl: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-control-two-size-xxl: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-control-two-border-radius-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-control-two-border-radius-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-control-two-border-radius-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-control-two-border-radius-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-control-two-border-radius-xxl: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-s: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-m: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-xl: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-xxl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-control-three-height-s: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-control-three-height-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-control-three-height-l: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-control-three-height-xl: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-control-three-width-s: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-s: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-m: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-l: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-infieldbutton-padding-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-infieldbutton-padding-m: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-infieldbutton-padding-l: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-infieldbutton-padding-xl: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-infieldbutton-border-radius: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-infieldbutton-border-radius-sided: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-infieldbutton-border-size: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-infieldbutton-fill-padding-s: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-infieldbutton-fill-padding-m: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-infieldbutton-fill-padding-l: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-infieldbutton-fill-padding-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-infieldbutton-full-height-s: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-infieldbutton-full-height-m: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-infieldbutton-full-height-l: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-infieldbutton-full-height-xl: var(
-        --spectrum-global-dimension-size-500
-    );
-    --spectrum-alias-infieldbutton-half-height-s: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-infieldbutton-half-height-m: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-infieldbutton-half-height-l: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-infieldbutton-half-height-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-stepperbutton-gap: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-stepperbutton-width-s: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-stepperbutton-width-m: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-stepperbutton-width-l: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-stepperbutton-width-xl: var(
-        --spectrum-global-dimension-size-325
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-m: var(
-        --spectrum-global-dimension-size-65
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-l: var(
-        --spectrum-global-dimension-size-65
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-xl: var(
-        --spectrum-global-dimension-size-75
-    );
+    --spectrum-alias-item-mark-gap-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-ui-icon-gap-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-ui-icon-gap-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-ui-icon-gap-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-ui-icon-gap-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-clearbutton-gap-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-clearbutton-gap-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-clearbutton-gap-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-clearbutton-gap-xl: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-workflow-padding-left-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-workflow-padding-left-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-workflow-padding-left-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-rounded-workflow-padding-left-s: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-rounded-workflow-padding-left-l: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-mark-padding-top-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-item-mark-padding-top-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-mark-padding-top-xl: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-mark-padding-bottom-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-item-mark-padding-bottom-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-mark-padding-bottom-xl: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-mark-padding-left-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-mark-padding-left-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-mark-padding-left-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-control-1-size-s: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-item-control-1-size-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-control-2-size-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-item-control-2-size-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-control-2-size-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-control-2-size-xxl: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-item-control-2-border-radius-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-2-border-radius-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-control-2-border-radius-l: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-control-2-border-radius-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-2-border-radius-xxl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-2-padding-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-2-padding-m: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-2-padding-l: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-control-2-padding-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-control-3-height-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-item-control-3-height-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-control-3-height-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-control-3-border-radius-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-3-border-radius-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-control-3-border-radius-l: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-control-3-border-radius-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-3-padding-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-3-padding-m: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-3-padding-l: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-control-3-padding-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-mark-size-s: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-mark-size-l: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-item-mark-size-xl: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-heading-xxxl-text-size: var(--spectrum-global-dimension-font-size-1300);
+    --spectrum-alias-heading-xxl-text-size: var(--spectrum-global-dimension-font-size-1100);
+    --spectrum-alias-heading-xl-text-size: var(--spectrum-global-dimension-font-size-900);
+    --spectrum-alias-heading-l-text-size: var(--spectrum-global-dimension-font-size-700);
+    --spectrum-alias-heading-m-text-size: var(--spectrum-global-dimension-font-size-500);
+    --spectrum-alias-heading-s-text-size: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-heading-xs-text-size: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-xxs-text-size: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-xxxl-margin-top: var(--spectrum-global-dimension-font-size-1200);
+    --spectrum-alias-heading-xxl-margin-top: var(--spectrum-global-dimension-font-size-900);
+    --spectrum-alias-heading-xl-margin-top: var(--spectrum-global-dimension-font-size-800);
+    --spectrum-alias-heading-l-margin-top: var(--spectrum-global-dimension-font-size-600);
+    --spectrum-alias-heading-m-margin-top: var(--spectrum-global-dimension-font-size-400);
+    --spectrum-alias-heading-s-margin-top: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-xs-margin-top: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-xxs-margin-top: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-heading-han-xxxl-text-size: var(--spectrum-global-dimension-font-size-1300);
+    --spectrum-alias-heading-han-xxl-text-size: var(--spectrum-global-dimension-font-size-900);
+    --spectrum-alias-heading-han-xl-text-size: var(--spectrum-global-dimension-font-size-800);
+    --spectrum-alias-heading-han-l-text-size: var(--spectrum-global-dimension-font-size-600);
+    --spectrum-alias-heading-han-m-text-size: var(--spectrum-global-dimension-font-size-400);
+    --spectrum-alias-heading-han-s-text-size: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-heading-han-xs-text-size: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-han-xxs-text-size: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-han-xxxl-margin-top: var(--spectrum-global-dimension-font-size-1200);
+    --spectrum-alias-heading-han-xxl-margin-top: var(--spectrum-global-dimension-font-size-800);
+    --spectrum-alias-heading-han-xl-margin-top: var(--spectrum-global-dimension-font-size-700);
+    --spectrum-alias-heading-han-l-margin-top: var(--spectrum-global-dimension-font-size-500);
+    --spectrum-alias-heading-han-m-margin-top: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-heading-han-s-margin-top: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-han-xs-margin-top: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-han-xxs-margin-top: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-component-border-radius: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-component-border-radius-quiet: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-component-focusring-gap: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-component-focusring-gap-emphasized: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-component-focusring-size: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-component-focusring-size-emphasized: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-input-focusring-gap: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-input-quiet-focusline-gap: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-radius-xsmall: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-border-radius-small: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-border-radius-regular: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-border-radius-medium: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-border-radius-large: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-border-radius-xlarge: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-focus-ring-border-radius-xsmall: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-focus-ring-border-radius-medium: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-focus-ring-border-radius-large: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-focus-ring-border-radius-xlarge: var(--spectrum-global-dimension-size-350);
+    --spectrum-alias-control-two-size-s: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-control-two-size-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-control-two-size-l: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-control-two-size-xl: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-control-two-size-xxl: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-control-two-border-radius-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-control-two-border-radius-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-control-two-border-radius-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-control-two-border-radius-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-control-two-border-radius-xxl: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-control-two-focus-ring-border-radius-s: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-control-two-focus-ring-border-radius-m: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-control-two-focus-ring-border-radius-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-control-two-focus-ring-border-radius-xl: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-control-two-focus-ring-border-radius-xxl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-control-three-height-s: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-control-three-height-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-control-three-height-l: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-control-three-height-xl: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-control-three-width-s: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-infieldbutton-icon-margin-y-s: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-infieldbutton-icon-margin-y-m: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-infieldbutton-icon-margin-y-l: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-infieldbutton-icon-margin-y-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-infieldbutton-padding-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-infieldbutton-padding-m: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-infieldbutton-padding-l: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-infieldbutton-padding-xl: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-infieldbutton-border-radius: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-infieldbutton-border-radius-sided: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-infieldbutton-border-size: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-infieldbutton-fill-padding-s: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-infieldbutton-fill-padding-m: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-infieldbutton-fill-padding-l: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-infieldbutton-fill-padding-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-infieldbutton-full-height-s: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-infieldbutton-full-height-m: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-infieldbutton-full-height-l: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-infieldbutton-full-height-xl: var(--spectrum-global-dimension-size-500);
+    --spectrum-alias-infieldbutton-half-height-s: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-infieldbutton-half-height-m: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-infieldbutton-half-height-l: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-infieldbutton-half-height-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-stepperbutton-gap: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-stepperbutton-width-s: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-stepperbutton-width-m: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-stepperbutton-width-l: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-stepperbutton-width-xl: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-stepperbutton-icon-x-offset-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-stepperbutton-icon-x-offset-m: var(--spectrum-global-dimension-size-65);
+    --spectrum-alias-stepperbutton-icon-x-offset-l: var(--spectrum-global-dimension-size-65);
+    --spectrum-alias-stepperbutton-icon-x-offset-xl: var(--spectrum-global-dimension-size-75);
     --spectrum-alias-stepperbutton-icon-y-offset-top-s: 0;
-    --spectrum-alias-stepperbutton-icon-y-offset-top-m: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-l: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-xl: var(
-        --spectrum-global-dimension-size-10
-    );
+    --spectrum-alias-stepperbutton-icon-y-offset-top-m: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-l: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-xl: var(--spectrum-global-dimension-size-10);
     --spectrum-alias-stepperbutton-icon-y-offset-bottom-s: 0;
     --spectrum-alias-stepperbutton-icon-y-offset-bottom-m: 0;
     --spectrum-alias-stepperbutton-icon-y-offset-bottom-l: 0;
     --spectrum-alias-stepperbutton-icon-y-offset-bottom-xl: 0;
-    --spectrum-alias-stepperbutton-radius-touching: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-clearbutton-icon-margin-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-clearbutton-icon-margin-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-clearbutton-icon-margin-l: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-clearbutton-icon-margin-xl: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-clearbutton-border-radius: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-m: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-xl: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-m: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-xl: var(
-        --spectrum-global-dimension-size-150
-    );
+    --spectrum-alias-stepperbutton-radius-touching: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-clearbutton-icon-margin-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-clearbutton-icon-margin-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-clearbutton-icon-margin-l: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-clearbutton-icon-margin-xl: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-clearbutton-border-radius: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-pickerbutton-icononly-padding-x-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-pickerbutton-icononly-padding-x-m: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-pickerbutton-icononly-padding-x-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-pickerbutton-icononly-padding-x-xl: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-pickerbutton-icon-margin-y-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-pickerbutton-icon-margin-y-m: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-pickerbutton-icon-margin-y-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-pickerbutton-icon-margin-y-xl: var(--spectrum-global-dimension-size-150);
     --spectrum-alias-pickerbutton-label-padding-y-s: 0;
-    --spectrum-alias-pickerbutton-label-padding-y-m: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-l: var(
-        --spectrum-global-dimension-size-65
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-xl: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-pickerbutton-border-radius-rounded: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-pickerbutton-border-radius-rounded-sided: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-search-border-radius: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-combobox-quiet-button-offset-x: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-thumbnail-border-radius-small: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-focus-ring-gap-small: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-focus-ring-size-small: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-input-border-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-avatar-border-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-actiongroup-button-gap: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-actiongroup-button-gap-compact: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-actiongroup-button-gap-quiet: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-actiongroup-button-gap-quiet-compact: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-search-padding-left-s: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-search-padding-left-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-search-padding-left-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-search-padding-left-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-tag-border-radius: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-tag-border-size-default: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-tag-border-size-disabled: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-tag-border-size-key-focus: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-tag-padding-right-s: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-tag-padding-right-m: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-tag-padding-right-l: var(
-        --spectrum-global-dimension-size-175
-    );
+    --spectrum-alias-pickerbutton-label-padding-y-m: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-pickerbutton-label-padding-y-l: var(--spectrum-global-dimension-size-65);
+    --spectrum-alias-pickerbutton-label-padding-y-xl: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-pickerbutton-border-radius-rounded: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-pickerbutton-border-radius-rounded-sided: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-search-border-radius: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-combobox-quiet-button-offset-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-thumbnail-border-radius-small: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-focus-ring-gap-small: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-focus-ring-size-small: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-input-border-size: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-avatar-border-size: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-actiongroup-button-gap: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-actiongroup-button-gap-compact: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-actiongroup-button-gap-quiet: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-actiongroup-button-gap-quiet-compact: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-search-padding-left-s: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-search-padding-left-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-search-padding-left-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-search-padding-left-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-tag-border-radius: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-tag-border-size-default: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-tag-border-size-disabled: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-tag-border-size-key-focus: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-tag-padding-right-s: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-tag-padding-right-m: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-tag-padding-right-l: var(--spectrum-global-dimension-size-175);
     --spectrum-alias-tag-height-s: var(--spectrum-global-dimension-size-250);
     --spectrum-alias-tag-height-m: var(--spectrum-global-dimension-size-300);
     --spectrum-alias-tag-height-l: var(--spectrum-global-dimension-size-400);
-    --spectrum-alias-tag-font-size-s: var(
-        --spectrum-global-dimension-font-size-50
-    );
-    --spectrum-alias-tag-font-size-m: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-tag-font-size-l: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-tag-text-padding-top-m: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-tag-text-padding-top-l: var(
-        --spectrum-global-dimension-size-85
-    );
+    --spectrum-alias-tag-font-size-s: var(--spectrum-global-dimension-font-size-50);
+    --spectrum-alias-tag-font-size-m: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-tag-font-size-l: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-tag-text-padding-top-m: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-tag-text-padding-top-l: var(--spectrum-global-dimension-size-85);
     --spectrum-alias-tag-icon-size-s: var(--spectrum-global-dimension-size-175);
     --spectrum-alias-tag-icon-size-m: var(--spectrum-global-dimension-size-200);
-    --spectrum-alias-tag-icon-margin-top-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-tag-icon-margin-top-m: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-tag-icon-margin-top-l: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-tag-clearbutton-width-s: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-tag-clearbutton-width-m: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-tag-clearbutton-width-l: var(
-        --spectrum-global-dimension-size-350
-    );
-    --spectrum-alias-tag-clearbutton-icon-margin-s: var(
-        --spectrum-global-dimension-size-30
-    );
-    --spectrum-alias-tag-clearbutton-icon-margin-m: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-tag-clearbutton-icon-margin-l: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-tag-focusring-border-radius: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-tag-focusring-gap: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-colorloupe-width: var(
-        --spectrum-global-dimension-static-size-450
-    );
-    --spectrum-alias-colorloupe-height: var(
-        --spectrum-global-dimension-static-size-550
-    );
+    --spectrum-alias-tag-icon-margin-top-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-tag-icon-margin-top-m: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-tag-icon-margin-top-l: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-tag-clearbutton-width-s: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-tag-clearbutton-width-m: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-tag-clearbutton-width-l: var(--spectrum-global-dimension-size-350);
+    --spectrum-alias-tag-clearbutton-icon-margin-s: var(--spectrum-global-dimension-size-30);
+    --spectrum-alias-tag-clearbutton-icon-margin-m: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-tag-clearbutton-icon-margin-l: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-tag-focusring-border-radius: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-tag-focusring-gap: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-colorloupe-width: var(--spectrum-global-dimension-static-size-450);
+    --spectrum-alias-colorloupe-height: var(--spectrum-global-dimension-static-size-550);
     --spectrum-alias-search-border-radius-quiet: 0;
     --spectrum-alias-percent-50: 50%;
     --spectrum-alias-percent-70: 70%;
@@ -1857,497 +795,183 @@
     --spectrum-alias-grid-columns: 12;
     --spectrum-alias-grid-fluid-width: 100%;
     --spectrum-alias-grid-fixed-max-width: 1280px;
-    --spectrum-alias-border-size-thin: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-border-size-thick: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-size-thicker: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-size-thickest: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thin: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-offset-thick: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-offset-thicker: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thickest: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-baseline: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-grid-gutter-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-gutter-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-gutter-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-gutter-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-gutter-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-margin-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-margin-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-margin-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-margin-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-margin-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-radial-reaction-size-default: var(
-        --spectrum-global-dimension-static-size-550
-    );
-    --spectrum-alias-focus-ring-gap: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-focus-ring-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
+    --spectrum-alias-border-size-thin: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-border-size-thick: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-size-thicker: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-size-thickest: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thin: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-offset-thick: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-offset-thicker: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thickest: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-baseline: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-grid-gutter-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-gutter-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-gutter-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-gutter-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-gutter-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-margin-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-margin-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-margin-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-margin-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-margin-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-layout-region-margin-bottom-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-layout-region-margin-bottom-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-radial-reaction-size-default: var(--spectrum-global-dimension-static-size-550);
+    --spectrum-alias-focus-ring-gap: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-focus-ring-size: var(--spectrum-global-dimension-static-size-25);
     --spectrum-alias-dropshadow-blur: var(--spectrum-global-dimension-size-50);
-    --spectrum-alias-dropshadow-offset-y: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-font-size-default: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-layout-label-gap-size: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-pill-button-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-pill-button-text-baseline: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-single-line-height: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-single-line-width: var(
-        --spectrum-global-dimension-size-2400
-    );
-    --spectrum-alias-workflow-icon-size-s: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-workflow-icon-size-m: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-workflow-icon-size-xl: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-ui-icon-alert-size-75: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-ui-icon-alert-size-100: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-ui-icon-alert-size-200: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-ui-icon-alert-size-300: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-ui-icon-triplegripper-size-100-height: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-ui-icon-doublegripper-size-100-width: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-ui-icon-singlegripper-size-100-width: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-75: var(
-        --spectrum-global-dimension-size-65
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-200: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-ui-icon-asterisk-size-75: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-asterisk-size-100: var(
-        --spectrum-global-dimension-size-100
-    );
+    --spectrum-alias-dropshadow-offset-y: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-font-size-default: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-layout-label-gap-size: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-pill-button-text-size: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-pill-button-text-baseline: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-single-line-height: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-single-line-width: var(--spectrum-global-dimension-size-2400);
+    --spectrum-alias-workflow-icon-size-s: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-workflow-icon-size-m: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-workflow-icon-size-xl: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-ui-icon-alert-size-75: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-ui-icon-alert-size-100: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-ui-icon-alert-size-200: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-ui-icon-alert-size-300: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-ui-icon-triplegripper-size-100-height: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-ui-icon-doublegripper-size-100-width: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-ui-icon-singlegripper-size-100-width: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-ui-icon-cornertriangle-size-75: var(--spectrum-global-dimension-size-65);
+    --spectrum-alias-ui-icon-cornertriangle-size-200: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-ui-icon-asterisk-size-75: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-asterisk-size-100: var(--spectrum-global-dimension-size-100);
     --spectrum-alias-avatar-size-50: var(--spectrum-global-dimension-size-200);
     --spectrum-alias-avatar-size-75: var(--spectrum-global-dimension-size-225);
     --spectrum-alias-avatar-size-200: var(--spectrum-global-dimension-size-275);
     --spectrum-alias-avatar-size-300: var(--spectrum-global-dimension-size-325);
     --spectrum-alias-avatar-size-500: var(--spectrum-global-dimension-size-400);
     --spectrum-alias-avatar-size-700: var(--spectrum-global-dimension-size-500);
-    --spectrum-alias-tag-border-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-tag-icon-margin-right-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-tag-icon-margin-right-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-tag-icon-margin-right-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-tag-focusring-size: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-tag-focusring-gap-selected: var(
-        --spectrum-global-dimension-size-25
-    );
+    --spectrum-alias-tag-border-size: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-tag-icon-margin-right-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-tag-icon-margin-right-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-tag-icon-margin-right-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-tag-focusring-size: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-tag-focusring-gap-selected: var(--spectrum-global-dimension-size-25);
 }
 
 :root,
 :host {
     --spectrum-alias-colorhandle-outer-border-color: #0000006b;
-    --spectrum-alias-component-text-color-selected-default: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-component-text-color-selected-hover: var(
-        --spectrum-alias-component-text-color-selected-default
-    );
-    --spectrum-alias-component-text-color-selected-down: var(
-        --spectrum-alias-component-text-color-selected-default
-    );
-    --spectrum-alias-component-text-color-selected-key-focus: var(
-        --spectrum-alias-component-text-color-selected-default
-    );
-    --spectrum-alias-component-text-color-selected-mouse-focus: var(
-        --spectrum-alias-component-text-color-selected-default
-    );
-    --spectrum-alias-component-icon-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-component-icon-color-selected: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-component-background-color-default: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-hover: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-component-background-color-down: var(
-        --spectrum-global-color-gray-400
-    );
-    --spectrum-alias-component-background-color-key-focus: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-component-background-color-quiet-hover: var(
-        --spectrum-alias-component-background-color-hover
-    );
-    --spectrum-alias-component-background-color-quiet-down: var(
-        --spectrum-alias-component-background-color-down
-    );
-    --spectrum-alias-component-background-color-quiet-key-focus: var(
-        --spectrum-alias-component-background-color-key-focus
-    );
-    --spectrum-alias-component-background-color-selected-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-component-background-color-selected-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-component-background-color-selected-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-component-background-color-selected-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-component-border-color-default: var(
-        --spectrum-alias-component-background-color-default
-    );
-    --spectrum-alias-component-border-color-hover: var(
-        --spectrum-alias-component-background-color-hover
-    );
-    --spectrum-alias-component-border-color-down: var(
-        --spectrum-alias-component-background-color-down
-    );
-    --spectrum-alias-component-border-color-key-focus: var(
-        --spectrum-alias-component-background-color-key-focus
-    );
-    --spectrum-alias-component-border-color-selected-default: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-border-color-selected-hover: var(
-        --spectrum-alias-component-background-color-selected-hover
-    );
-    --spectrum-alias-component-border-color-selected-down: var(
-        --spectrum-alias-component-background-color-selected-down
-    );
-    --spectrum-alias-component-border-color-selected-key-focus: var(
-        --spectrum-alias-component-background-color-selected-key-focus
-    );
-    --spectrum-alias-component-border-color-quiet-key-focus: var(
-        --spectrum-alias-component-background-color-quiet-default
-    );
-    --spectrum-alias-component-border-color-quiet-selected-default: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-border-color-quiet-selected-hover: var(
-        --spectrum-alias-component-background-color-quiet-selected-hover
-    );
-    --spectrum-alias-component-border-color-quiet-selected-down: var(
-        --spectrum-alias-component-background-color-quiet-selected-down
-    );
-    --spectrum-alias-component-border-color-quiet-selected-key-focus: var(
-        --spectrum-alias-component-background-color-quiet-selected-key-focus
-    );
-    --spectrum-alias-toggle-background-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-background-color-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-toggle-background-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-toggle-background-color-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-default: var(
-        --spectrum-global-color-indigo-500
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-hover: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-down: var(
-        --spectrum-global-color-indigo-700
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-key-focus: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-alias-toggle-border-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-border-color-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-toggle-border-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-toggle-border-color-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tag-border-color-default: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-tag-border-color-hover: var(
-        --spectrum-global-color-gray-400
-    );
-    --spectrum-alias-tag-border-color-down: var(
-        --spectrum-global-color-gray-500
-    );
-    --spectrum-alias-tag-border-color-key-focus: var(
-        --spectrum-global-color-gray-400
-    );
-    --spectrum-alias-tag-border-color-disabled-default: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-tag-border-color-error-key-focus: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-focusring-border-color-key-focus: var(
-        --spectrum-alias-focus-ring-color
-    );
-    --spectrum-alias-tag-background-color-disabled: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-tag-background-color-default: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-tag-background-color-hover: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-tag-background-color-down: var(
-        --spectrum-global-color-gray-400
-    );
-    --spectrum-alias-tag-background-color-key-focus: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-tag-background-color-error-default: var(
-        --spectrum-alias-tag-background-color-default
-    );
-    --spectrum-alias-tag-background-color-error-hover: var(
-        --spectrum-alias-tag-background-color-hover
-    );
-    --spectrum-alias-tag-background-color-error-down: var(
-        --spectrum-alias-tag-background-color-down
-    );
-    --spectrum-alias-tag-background-color-error-key-focus: var(
-        --spectrum-alias-tag-background-color-key-focus
-    );
-    --spectrum-alias-avatar-border-color-disabled: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected-default: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-avatar-border-color-selected-hover: var(
-        --spectrum-alias-component-background-color-selected-hover
-    );
-    --spectrum-alias-avatar-border-color-selected-down: var(
-        --spectrum-alias-component-background-color-selected-hover
-    );
-    --spectrum-alias-avatar-border-color-selected-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-link-primary-text-color-default: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-alias-link-primary-text-color-hover: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-alias-link-primary-text-color-down: var(
-        --spectrum-global-color-indigo-700
-    );
-    --spectrum-alias-link-primary-text-color-key-focus: var(
-        --spectrum-alias-text-color-key-focus
-    );
-    --spectrum-alias-link-secondary-text-color-default: var(
-        --spectrum-alias-text-color
-    );
-    --spectrum-alias-link-secondary-text-color-hover: var(
-        --spectrum-alias-link-primary-text-color-hover
-    );
-    --spectrum-alias-link-secondary-text-color-down: var(
-        --spectrum-alias-link-primary-text-color-down
-    );
-    --spectrum-alias-link-secondary-text-color-key-focus: var(
-        --spectrum-alias-link-primary-text-color-key-focus
-    );
-    --spectrum-alias-button-primary-background-color-default: var(
-        --spectrum-alias-button-primary-border-color-default
-    );
-    --spectrum-alias-button-primary-text-color-default: var(
-        --spectrum-alias-button-primary-text-color-hover
-    );
-    --spectrum-alias-button-primary-icon-color-default: var(
-        --spectrum-alias-button-primary-text-color-default
-    );
-    --spectrum-alias-button-secondary-background-color-default: var(
-        --spectrum-alias-button-secondary-border-color-default
-    );
-    --spectrum-alias-button-secondary-text-color-default: var(
-        --spectrum-alias-button-secondary-text-color-hover
-    );
-    --spectrum-alias-button-secondary-icon-color-default: var(
-        --spectrum-alias-button-secondary-text-color-default
-    );
-    --spectrum-alias-button-negative-background-color-default: var(
-        --spectrum-alias-button-negative-border-color-default
-    );
-    --spectrum-alias-button-negative-text-color-default: var(
-        --spectrum-alias-button-negative-text-color-hover
-    );
-    --spectrum-alias-button-negative-icon-color-default: var(
-        --spectrum-alias-button-negative-text-color-default
-    );
-    --spectrum-alias-input-border-color-default: var(
-        --spectrum-alias-border-color
-    );
-    --spectrum-alias-input-border-color-hover: var(
-        --spectrum-alias-border-color-hover
-    );
-    --spectrum-alias-input-border-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-input-border-color-mouse-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-input-border-color-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-input-border-color-invalid-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-yellow-background-color-default: var(
-        --spectrum-global-color-static-yellow-400
-    );
-    --spectrum-alias-yellow-background-color-hover: var(
-        --spectrum-global-color-static-yellow-500
-    );
-    --spectrum-alias-yellow-background-color-key-focus: var(
-        --spectrum-global-color-static-yellow-500
-    );
-    --spectrum-alias-yellow-background-color-down: var(
-        --spectrum-global-color-static-yellow-600
-    );
+    --spectrum-alias-component-text-color-selected-default: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-component-text-color-selected-hover: var(--spectrum-alias-component-text-color-selected-default);
+    --spectrum-alias-component-text-color-selected-down: var(--spectrum-alias-component-text-color-selected-default);
+    --spectrum-alias-component-text-color-selected-key-focus: var(--spectrum-alias-component-text-color-selected-default);
+    --spectrum-alias-component-text-color-selected-mouse-focus: var(--spectrum-alias-component-text-color-selected-default);
+    --spectrum-alias-component-icon-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-component-icon-color-selected: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-component-background-color-default: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-hover: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-component-background-color-down: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-component-background-color-key-focus: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-component-background-color-quiet-hover: var(--spectrum-alias-component-background-color-hover);
+    --spectrum-alias-component-background-color-quiet-down: var(--spectrum-alias-component-background-color-down);
+    --spectrum-alias-component-background-color-quiet-key-focus: var(--spectrum-alias-component-background-color-key-focus);
+    --spectrum-alias-component-background-color-selected-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-component-background-color-selected-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-component-background-color-selected-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-component-background-color-selected-key-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-component-border-color-default: var(--spectrum-alias-component-background-color-default);
+    --spectrum-alias-component-border-color-hover: var(--spectrum-alias-component-background-color-hover);
+    --spectrum-alias-component-border-color-down: var(--spectrum-alias-component-background-color-down);
+    --spectrum-alias-component-border-color-key-focus: var(--spectrum-alias-component-background-color-key-focus);
+    --spectrum-alias-component-border-color-selected-default: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-border-color-selected-hover: var(--spectrum-alias-component-background-color-selected-hover);
+    --spectrum-alias-component-border-color-selected-down: var(--spectrum-alias-component-background-color-selected-down);
+    --spectrum-alias-component-border-color-selected-key-focus: var(--spectrum-alias-component-background-color-selected-key-focus);
+    --spectrum-alias-component-border-color-quiet-key-focus: var(--spectrum-alias-component-background-color-quiet-default);
+    --spectrum-alias-component-border-color-quiet-selected-default: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-border-color-quiet-selected-hover: var(--spectrum-alias-component-background-color-quiet-selected-hover);
+    --spectrum-alias-component-border-color-quiet-selected-down: var(--spectrum-alias-component-background-color-quiet-selected-down);
+    --spectrum-alias-component-border-color-quiet-selected-key-focus: var(--spectrum-alias-component-background-color-quiet-selected-key-focus);
+    --spectrum-alias-toggle-background-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-background-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-background-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-background-color-key-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-background-color-emphasized-selected-default: var(--spectrum-global-color-indigo-500);
+    --spectrum-alias-toggle-background-color-emphasized-selected-hover: var(--spectrum-global-color-indigo-600);
+    --spectrum-alias-toggle-background-color-emphasized-selected-down: var(--spectrum-global-color-indigo-700);
+    --spectrum-alias-toggle-background-color-emphasized-selected-key-focus: var(--spectrum-global-color-indigo-600);
+    --spectrum-alias-toggle-border-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-border-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-border-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-border-color-key-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tag-border-color-default: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-tag-border-color-hover: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-tag-border-color-down: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-tag-border-color-key-focus: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-tag-border-color-disabled-default: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-tag-border-color-error-key-focus: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-focusring-border-color-key-focus: var(--spectrum-alias-focus-ring-color);
+    --spectrum-alias-tag-background-color-disabled: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-tag-background-color-default: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-tag-background-color-hover: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-tag-background-color-down: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-tag-background-color-key-focus: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-tag-background-color-error-default: var(--spectrum-alias-tag-background-color-default);
+    --spectrum-alias-tag-background-color-error-hover: var(--spectrum-alias-tag-background-color-hover);
+    --spectrum-alias-tag-background-color-error-down: var(--spectrum-alias-tag-background-color-down);
+    --spectrum-alias-tag-background-color-error-key-focus: var(--spectrum-alias-tag-background-color-key-focus);
+    --spectrum-alias-avatar-border-color-disabled: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected-default: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-avatar-border-color-selected-hover: var(--spectrum-alias-component-background-color-selected-hover);
+    --spectrum-alias-avatar-border-color-selected-down: var(--spectrum-alias-component-background-color-selected-hover);
+    --spectrum-alias-avatar-border-color-selected-key-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-link-primary-text-color-default: var(--spectrum-global-color-indigo-600);
+    --spectrum-alias-link-primary-text-color-hover: var(--spectrum-global-color-indigo-600);
+    --spectrum-alias-link-primary-text-color-down: var(--spectrum-global-color-indigo-700);
+    --spectrum-alias-link-primary-text-color-key-focus: var(--spectrum-alias-text-color-key-focus);
+    --spectrum-alias-link-secondary-text-color-default: var(--spectrum-alias-text-color);
+    --spectrum-alias-link-secondary-text-color-hover: var(--spectrum-alias-link-primary-text-color-hover);
+    --spectrum-alias-link-secondary-text-color-down: var(--spectrum-alias-link-primary-text-color-down);
+    --spectrum-alias-link-secondary-text-color-key-focus: var(--spectrum-alias-link-primary-text-color-key-focus);
+    --spectrum-alias-button-primary-background-color-default: var(--spectrum-alias-button-primary-border-color-default);
+    --spectrum-alias-button-primary-text-color-default: var(--spectrum-alias-button-primary-text-color-hover);
+    --spectrum-alias-button-primary-icon-color-default: var(--spectrum-alias-button-primary-text-color-default);
+    --spectrum-alias-button-secondary-background-color-default: var(--spectrum-alias-button-secondary-border-color-default);
+    --spectrum-alias-button-secondary-text-color-default: var(--spectrum-alias-button-secondary-text-color-hover);
+    --spectrum-alias-button-secondary-icon-color-default: var(--spectrum-alias-button-secondary-text-color-default);
+    --spectrum-alias-button-negative-background-color-default: var(--spectrum-alias-button-negative-border-color-default);
+    --spectrum-alias-button-negative-text-color-default: var(--spectrum-alias-button-negative-text-color-hover);
+    --spectrum-alias-button-negative-icon-color-default: var(--spectrum-alias-button-negative-text-color-default);
+    --spectrum-alias-input-border-color-default: var(--spectrum-alias-border-color);
+    --spectrum-alias-input-border-color-hover: var(--spectrum-alias-border-color-hover);
+    --spectrum-alias-input-border-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-input-border-color-mouse-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-input-border-color-key-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-input-border-color-invalid-key-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-yellow-background-color-default: var(--spectrum-global-color-static-yellow-400);
+    --spectrum-alias-yellow-background-color-hover: var(--spectrum-global-color-static-yellow-500);
+    --spectrum-alias-yellow-background-color-key-focus: var(--spectrum-global-color-static-yellow-500);
+    --spectrum-alias-yellow-background-color-down: var(--spectrum-global-color-static-yellow-600);
     --spectrum-alias-infieldbutton-background-color: transparent;
     --spectrum-alias-infieldbutton-fill-border-color-default: transparent;
     --spectrum-alias-infieldbutton-fill-border-color-hover: transparent;
     --spectrum-alias-infieldbutton-fill-border-color-down: transparent;
     --spectrum-alias-infieldbutton-fill-border-color-mouse-focus: transparent;
     --spectrum-alias-infieldbutton-fill-border-color-key-focus: transparent;
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-default: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down: var(
-        --spectrum-global-color-gray-400
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-disabled: var(
-        --spectrum-alias-component-background-color-disabled
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-default: var(
-        --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-default
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-hover: var(
-        --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-down: var(
-        --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-key-focus: var(
-        --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus
-    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-default: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-disabled: var(--spectrum-alias-component-background-color-disabled);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-default: var(--spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-default);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-hover: var(--spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-down: var(--spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-key-focus: var(--spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus);
     --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-disabled: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-default: transparent;
-    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover: var(
-        --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down: var(
-        --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus: var(
-        --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus
-    );
+    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover: var(--spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover);
+    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down: var(--spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down);
+    --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus: var(--spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus);
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-disabled: transparent;
     --spectrum-alias-actionbutton-staticBlack-border-color-default: transparent;
     --spectrum-alias-actionbutton-staticBlack-background-color-default: #0000001a;
@@ -2374,872 +998,324 @@
     --spectrum-alias-actionbutton-staticWhite-border-color-disabled-selected: transparent;
     --spectrum-alias-actionbutton-staticWhite-background-color-disabled-selected: #ffffff1a;
     --spectrum-alias-track-color-default: var(--spectrum-global-color-gray-300);
-    --spectrum-alias-thumbnail-darksquare-background-color: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-thumbnail-lightsquare-background-color: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-tabs-divider-background-color-default: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-tabs-divider-background-color-quiet: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-tabitem-text-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-tabitem-text-color-hover: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tabitem-text-color-down: var(
-        --spectrum-alias-text-color-down
-    );
-    --spectrum-alias-tabitem-text-color-key-focus: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tabitem-text-color-mouse-focus: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tabitem-text-color-selected-default: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tabitem-text-color-selected-hover: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-down: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-key-focus: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-mouse-focus: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-default: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-hover: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-down: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-key-focus: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-mouse-focus: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-selection-indicator-color-default: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tabitem-selection-indicator-color-emphasized: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-icon-color-disabled: var(
-        --spectrum-alias-text-color-disabled
-    );
-    --spectrum-alias-tabitem-icon-color-default: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-icon-color-hover: var(
-        --spectrum-alias-tabitem-text-color-hover
-    );
-    --spectrum-alias-tabitem-icon-color-down: var(
-        --spectrum-alias-tabitem-text-color-down
-    );
-    --spectrum-alias-tabitem-icon-color-key-focus: var(
-        --spectrum-alias-tabitem-text-color-hover
-    );
-    --spectrum-alias-tabitem-icon-color-mouse-focus: var(
-        --spectrum-alias-tabitem-text-color-down
-    );
-    --spectrum-alias-tabitem-icon-color-selected: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-icon-color-emphasized: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-icon-color-emphasized-selected: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-global-color-indigo-500
-    );
+    --spectrum-alias-thumbnail-darksquare-background-color: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-thumbnail-lightsquare-background-color: var(--spectrum-global-color-static-white);
+    --spectrum-alias-tabs-divider-background-color-default: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-tabs-divider-background-color-quiet: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-tabitem-text-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-tabitem-text-color-hover: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tabitem-text-color-down: var(--spectrum-alias-text-color-down);
+    --spectrum-alias-tabitem-text-color-key-focus: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tabitem-text-color-mouse-focus: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tabitem-text-color-selected-default: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tabitem-text-color-selected-hover: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected-down: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected-key-focus: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected-mouse-focus: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-default: var(--spectrum-global-color-indigo-600);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-hover: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-down: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-key-focus: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-mouse-focus: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-selection-indicator-color-default: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tabitem-selection-indicator-color-emphasized: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-icon-color-disabled: var(--spectrum-alias-text-color-disabled);
+    --spectrum-alias-tabitem-icon-color-default: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-icon-color-hover: var(--spectrum-alias-tabitem-text-color-hover);
+    --spectrum-alias-tabitem-icon-color-down: var(--spectrum-alias-tabitem-text-color-down);
+    --spectrum-alias-tabitem-icon-color-key-focus: var(--spectrum-alias-tabitem-text-color-hover);
+    --spectrum-alias-tabitem-icon-color-mouse-focus: var(--spectrum-alias-tabitem-text-color-down);
+    --spectrum-alias-tabitem-icon-color-selected: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-icon-color-emphasized: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-icon-color-emphasized-selected: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-assetcard-selectionindicator-background-color-ordered: var(--spectrum-global-color-indigo-500);
     --spectrum-alias-assetcard-overlay-background-color: #6d73f633;
-    --spectrum-alias-assetcard-border-color-selected: var(
-        --spectrum-global-color-indigo-500
-    );
-    --spectrum-alias-assetcard-border-color-selected-hover: var(
-        --spectrum-global-color-indigo-500
-    );
-    --spectrum-alias-assetcard-border-color-selected-down: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-alias-transparent-blue-background-color-mouse-focus: var(
-        --spectrum-alias-transparent-blue-background-color-hover
-    );
-    --spectrum-alias-transparent-blue-background-color: var(
-        --spectrum-alias-component-text-color-default
-    );
+    --spectrum-alias-assetcard-border-color-selected: var(--spectrum-global-color-indigo-500);
+    --spectrum-alias-assetcard-border-color-selected-hover: var(--spectrum-global-color-indigo-500);
+    --spectrum-alias-assetcard-border-color-selected-down: var(--spectrum-global-color-indigo-600);
+    --spectrum-alias-transparent-blue-background-color-mouse-focus: var(--spectrum-alias-transparent-blue-background-color-hover);
+    --spectrum-alias-transparent-blue-background-color: var(--spectrum-alias-component-text-color-default);
     --spectrum-alias-transparent-red-background-color-hover: #9a000026;
     --spectrum-alias-transparent-red-background-color-down: #7c00004d;
-    --spectrum-alias-transparent-red-background-color-key-focus: var(
-        --spectrum-alias-transparent-red-background-color-hover
-    );
-    --spectrum-alias-transparent-red-background-color-mouse-focus: var(
-        --spectrum-alias-transparent-red-background-color-hover
-    );
-    --spectrum-alias-transparent-red-background-color: var(
-        --spectrum-alias-component-text-color-default
-    );
-    --spectrum-alias-component-text-color-disabled: var(
-        --spectrum-global-color-gray-500
-    );
-    --spectrum-alias-component-text-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-component-text-color-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-component-text-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-component-text-color-key-focus: var(
-        --spectrum-alias-component-text-color-hover
-    );
-    --spectrum-alias-component-text-color-mouse-focus: var(
-        --spectrum-alias-component-text-color-hover
-    );
-    --spectrum-alias-component-text-color: var(
-        --spectrum-alias-component-text-color-default
-    );
-    --spectrum-alias-component-text-color-selected: var(
-        --spectrum-alias-component-text-color-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-default: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-hover: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-down: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-key-focus: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-mouse-focus: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-error-default: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-component-text-color-error-hover: var(
-        --spectrum-semantic-negative-text-color-small-hover
-    );
-    --spectrum-alias-component-text-color-error-down: var(
-        --spectrum-semantic-negative-text-color-small-down
-    );
-    --spectrum-alias-component-text-color-error-key-focus: var(
-        --spectrum-semantic-negative-text-color-small-key-focus
-    );
-    --spectrum-alias-component-text-color-error-mouse-focus: var(
-        --spectrum-semantic-negative-text-color-small-key-focus
-    );
-    --spectrum-alias-component-text-color-error: var(
-        --spectrum-alias-component-text-color-error-default
-    );
-    --spectrum-alias-component-icon-color-disabled: var(
-        --spectrum-alias-icon-color-disabled
-    );
-    --spectrum-alias-component-icon-color-hover: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-component-icon-color-down: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-component-icon-color-key-focus: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-component-icon-color-mouse-focus: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-component-icon-color: var(
-        --spectrum-alias-component-icon-color-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-default: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-hover: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-down: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-key-focus: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-background-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-quiet-disabled: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet-selected-disabled: var(
-        --spectrum-alias-component-background-color-disabled
-    );
-    --spectrum-alias-component-background-color: var(
-        --spectrum-alias-component-background-color-default
-    );
-    --spectrum-alias-component-background-color-selected: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-background-color-quiet-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet: var(
-        --spectrum-alias-component-background-color-quiet-default
-    );
-    --spectrum-alias-component-background-color-quiet-selected-default: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-background-color-quiet-selected-hover: var(
-        --spectrum-alias-component-background-color-selected-hover
-    );
-    --spectrum-alias-component-background-color-quiet-selected-down: var(
-        --spectrum-alias-component-background-color-selected-down
-    );
-    --spectrum-alias-component-background-color-quiet-selected-key-focus: var(
-        --spectrum-alias-component-background-color-selected-key-focus
-    );
-    --spectrum-alias-component-background-color-quiet-selected: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-default: var(
-        --spectrum-semantic-cta-background-color-default
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-hover: var(
-        --spectrum-semantic-cta-background-color-hover
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-down: var(
-        --spectrum-semantic-cta-background-color-down
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-key-focus: var(
-        --spectrum-semantic-cta-background-color-key-focus
-    );
-    --spectrum-alias-component-background-color-emphasized-selected: var(
-        --spectrum-alias-component-background-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-border-color-disabled: var(
-        --spectrum-alias-border-color-disabled
-    );
-    --spectrum-alias-component-border-color-quiet-disabled: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color: var(
-        --spectrum-alias-component-border-color-default
-    );
-    --spectrum-alias-component-border-color-selected: var(
-        --spectrum-alias-component-border-color-selected-default
-    );
-    --spectrum-alias-component-border-color-quiet-default: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-quiet-hover: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-quiet-down: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-quiet: var(
-        --spectrum-alias-component-border-color-quiet-default
-    );
-    --spectrum-alias-component-border-color-quiet-selected: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-default: var(
-        --spectrum-semantic-cta-background-color-default
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-hover: var(
-        --spectrum-semantic-cta-background-color-hover
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-down: var(
-        --spectrum-semantic-cta-background-color-down
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-key-focus: var(
-        --spectrum-semantic-cta-background-color-key-focus
-    );
-    --spectrum-alias-component-border-color-emphasized-selected: var(
-        --spectrum-alias-component-border-color-emphasized-selected-default
-    );
-    --spectrum-alias-tag-border-color-error-default: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-border-color-error-hover: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-border-color-error-down: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-border-color-error-selected: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-border-color-selected: var(
-        --spectrum-alias-tag-background-color-selected-default
-    );
-    --spectrum-alias-tag-border-color: var(
-        --spectrum-alias-tag-border-color-default
-    );
-    --spectrum-alias-tag-border-color-disabled: var(
-        --spectrum-alias-border-color-disabled
-    );
-    --spectrum-alias-tag-border-color-error: var(
-        --spectrum-alias-tag-border-color-error-default
-    );
-    --spectrum-alias-tag-text-color-default: var(
-        --spectrum-alias-label-text-color
-    );
-    --spectrum-alias-tag-text-color-hover: var(
-        --spectrum-alias-text-color-hover
-    );
+    --spectrum-alias-transparent-red-background-color-key-focus: var(--spectrum-alias-transparent-red-background-color-hover);
+    --spectrum-alias-transparent-red-background-color-mouse-focus: var(--spectrum-alias-transparent-red-background-color-hover);
+    --spectrum-alias-transparent-red-background-color: var(--spectrum-alias-component-text-color-default);
+    --spectrum-alias-component-text-color-disabled: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-component-text-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-component-text-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-component-text-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-component-text-color-key-focus: var(--spectrum-alias-component-text-color-hover);
+    --spectrum-alias-component-text-color-mouse-focus: var(--spectrum-alias-component-text-color-hover);
+    --spectrum-alias-component-text-color: var(--spectrum-alias-component-text-color-default);
+    --spectrum-alias-component-text-color-selected: var(--spectrum-alias-component-text-color-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-default: var(--spectrum-global-color-static-white);
+    --spectrum-alias-component-text-color-emphasized-selected-hover: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-down: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-key-focus: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-mouse-focus: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-error-default: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-component-text-color-error-hover: var(--spectrum-semantic-negative-text-color-small-hover);
+    --spectrum-alias-component-text-color-error-down: var(--spectrum-semantic-negative-text-color-small-down);
+    --spectrum-alias-component-text-color-error-key-focus: var(--spectrum-semantic-negative-text-color-small-key-focus);
+    --spectrum-alias-component-text-color-error-mouse-focus: var(--spectrum-semantic-negative-text-color-small-key-focus);
+    --spectrum-alias-component-text-color-error: var(--spectrum-alias-component-text-color-error-default);
+    --spectrum-alias-component-icon-color-disabled: var(--spectrum-alias-icon-color-disabled);
+    --spectrum-alias-component-icon-color-hover: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-component-icon-color-down: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-component-icon-color-key-focus: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-component-icon-color-mouse-focus: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-component-icon-color: var(--spectrum-alias-component-icon-color-default);
+    --spectrum-alias-component-icon-color-emphasized-selected-default: var(--spectrum-global-color-static-white);
+    --spectrum-alias-component-icon-color-emphasized-selected-hover: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-icon-color-emphasized-selected-down: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-icon-color-emphasized-selected-key-focus: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-icon-color-emphasized-selected: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-background-color-disabled: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-quiet-disabled: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet-selected-disabled: var(--spectrum-alias-component-background-color-disabled);
+    --spectrum-alias-component-background-color: var(--spectrum-alias-component-background-color-default);
+    --spectrum-alias-component-background-color-selected: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-background-color-quiet-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet: var(--spectrum-alias-component-background-color-quiet-default);
+    --spectrum-alias-component-background-color-quiet-selected-default: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-background-color-quiet-selected-hover: var(--spectrum-alias-component-background-color-selected-hover);
+    --spectrum-alias-component-background-color-quiet-selected-down: var(--spectrum-alias-component-background-color-selected-down);
+    --spectrum-alias-component-background-color-quiet-selected-key-focus: var(--spectrum-alias-component-background-color-selected-key-focus);
+    --spectrum-alias-component-background-color-quiet-selected: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-background-color-emphasized-selected-default: var(--spectrum-semantic-cta-background-color-default);
+    --spectrum-alias-component-background-color-emphasized-selected-hover: var(--spectrum-semantic-cta-background-color-hover);
+    --spectrum-alias-component-background-color-emphasized-selected-down: var(--spectrum-semantic-cta-background-color-down);
+    --spectrum-alias-component-background-color-emphasized-selected-key-focus: var(--spectrum-semantic-cta-background-color-key-focus);
+    --spectrum-alias-component-background-color-emphasized-selected: var(--spectrum-alias-component-background-color-emphasized-selected-default);
+    --spectrum-alias-component-border-color-disabled: var(--spectrum-alias-border-color-disabled);
+    --spectrum-alias-component-border-color-quiet-disabled: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color: var(--spectrum-alias-component-border-color-default);
+    --spectrum-alias-component-border-color-selected: var(--spectrum-alias-component-border-color-selected-default);
+    --spectrum-alias-component-border-color-quiet-default: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-quiet-hover: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-quiet-down: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-quiet: var(--spectrum-alias-component-border-color-quiet-default);
+    --spectrum-alias-component-border-color-quiet-selected: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-border-color-emphasized-selected-default: var(--spectrum-semantic-cta-background-color-default);
+    --spectrum-alias-component-border-color-emphasized-selected-hover: var(--spectrum-semantic-cta-background-color-hover);
+    --spectrum-alias-component-border-color-emphasized-selected-down: var(--spectrum-semantic-cta-background-color-down);
+    --spectrum-alias-component-border-color-emphasized-selected-key-focus: var(--spectrum-semantic-cta-background-color-key-focus);
+    --spectrum-alias-component-border-color-emphasized-selected: var(--spectrum-alias-component-border-color-emphasized-selected-default);
+    --spectrum-alias-tag-border-color-error-default: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-border-color-error-hover: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-border-color-error-down: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-border-color-error-selected: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-border-color-selected: var(--spectrum-alias-tag-background-color-selected-default);
+    --spectrum-alias-tag-border-color: var(--spectrum-alias-tag-border-color-default);
+    --spectrum-alias-tag-border-color-disabled: var(--spectrum-alias-border-color-disabled);
+    --spectrum-alias-tag-border-color-error: var(--spectrum-alias-tag-border-color-error-default);
+    --spectrum-alias-tag-text-color-default: var(--spectrum-alias-label-text-color);
+    --spectrum-alias-tag-text-color-hover: var(--spectrum-alias-text-color-hover);
     --spectrum-alias-tag-text-color-down: var(--spectrum-alias-text-color-down);
-    --spectrum-alias-tag-text-color-key-focus: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tag-text-color-disabled: var(
-        --spectrum-global-color-gray-500
-    );
-    --spectrum-alias-tag-text-color: var(
-        --spectrum-alias-tag-text-color-default
-    );
-    --spectrum-alias-tag-text-color-error-default: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-alias-tag-text-color-error-hover: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-tag-text-color-error-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-tag-text-color-error-key-focus: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-tag-text-color-error: var(
-        --spectrum-alias-tag-text-color-error-default
-    );
-    --spectrum-alias-tag-text-color-selected: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-alias-tag-text-color-key-focus: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tag-text-color-disabled: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-tag-text-color: var(--spectrum-alias-tag-text-color-default);
+    --spectrum-alias-tag-text-color-error-default: var(--spectrum-global-color-red-600);
+    --spectrum-alias-tag-text-color-error-hover: var(--spectrum-global-color-red-700);
+    --spectrum-alias-tag-text-color-error-down: var(--spectrum-global-color-red-700);
+    --spectrum-alias-tag-text-color-error-key-focus: var(--spectrum-global-color-red-700);
+    --spectrum-alias-tag-text-color-error: var(--spectrum-alias-tag-text-color-error-default);
+    --spectrum-alias-tag-text-color-selected: var(--spectrum-global-color-gray-50);
     --spectrum-alias-tag-icon-color-default: var(--spectrum-alias-icon-color);
-    --spectrum-alias-tag-icon-color-hover: var(
-        --spectrum-alias-icon-color-hover
-    );
+    --spectrum-alias-tag-icon-color-hover: var(--spectrum-alias-icon-color-hover);
     --spectrum-alias-tag-icon-color-down: var(--spectrum-alias-icon-color-down);
-    --spectrum-alias-tag-icon-color-key-focus: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-tag-icon-color-disabled: var(
-        --spectrum-alias-icon-color-disabled
-    );
-    --spectrum-alias-tag-icon-color: var(
-        --spectrum-alias-tag-icon-color-default
-    );
+    --spectrum-alias-tag-icon-color-key-focus: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-tag-icon-color-disabled: var(--spectrum-alias-icon-color-disabled);
+    --spectrum-alias-tag-icon-color: var(--spectrum-alias-tag-icon-color-default);
     --spectrum-alias-tag-icon-color-error: var(--spectrum-global-color-red-600);
-    --spectrum-alias-tag-icon-color-selected: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color: var(
-        --spectrum-alias-tag-background-color-default
-    );
-    --spectrum-alias-tag-background-color-error: var(
-        --spectrum-alias-tag-background-color-error-default
-    );
-    --spectrum-alias-tag-background-color-error-selected-default: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-background-color-error-selected-hover: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-background-color-error-selected-down: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-background-color-error-selected-key-focus: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-alias-tag-background-color-error-selected: var(
-        --spectrum-alias-tag-background-color-error-selected-default
-    );
-    --spectrum-alias-tag-background-color-selected-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-tag-background-color-selected-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-tag-background-color-selected-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tag-background-color-selected-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tag-background-color-selected: var(
-        --spectrum-alias-tag-background-color-selected-default
-    );
+    --spectrum-alias-tag-icon-color-selected: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color: var(--spectrum-alias-tag-background-color-default);
+    --spectrum-alias-tag-background-color-error: var(--spectrum-alias-tag-background-color-error-default);
+    --spectrum-alias-tag-background-color-error-selected-default: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-background-color-error-selected-hover: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-background-color-error-selected-down: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-background-color-error-selected-key-focus: var(--spectrum-global-color-red-600);
+    --spectrum-alias-tag-background-color-error-selected: var(--spectrum-alias-tag-background-color-error-selected-default);
+    --spectrum-alias-tag-background-color-selected-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-tag-background-color-selected-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-tag-background-color-selected-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tag-background-color-selected-key-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tag-background-color-selected: var(--spectrum-alias-tag-background-color-selected-default);
     --spectrum-alias-tag-focusring-border-color-default: transparent;
     --spectrum-alias-tag-focusring-border-color-disabled: transparent;
-    --spectrum-alias-tag-focusring-border-color-selected-key-focus: var(
-        --spectrum-alias-focus-ring-color
-    );
-    --spectrum-alias-tag-focusring-border-color: var(
-        --spectrum-alias-tag-focusring-border-color-default
-    );
-    --spectrum-alias-avatar-border-color: var(
-        --spectrum-alias-avatar-border-color-default
-    );
-    --spectrum-alias-avatar-border-color-selected: var(
-        --spectrum-alias-avatar-border-color-selected-default
-    );
-    --spectrum-alias-toggle-background-color: var(
-        --spectrum-alias-toggle-background-color-default
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected: var(
-        --spectrum-alias-toggle-background-color-emphasized-selected-default
-    );
-    --spectrum-alias-toggle-border-color: var(
-        --spectrum-alias-toggle-border-color-default
-    );
-    --spectrum-alias-toggle-icon-color-selected: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-toggle-icon-color-emphasized-selected: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-button-primary-background-color-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-background-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-button-primary-background-color-key-focus: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-background-color: var(
-        --spectrum-alias-button-primary-background-color-default
-    );
-    --spectrum-alias-button-primary-border-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-border-color-hover: var(
-        --spectrum-alias-button-primary-background-color-hover
-    );
-    --spectrum-alias-button-primary-border-color-down: var(
-        --spectrum-alias-button-primary-background-color-down
-    );
-    --spectrum-alias-button-primary-border-color-key-focus: var(
-        --spectrum-alias-button-primary-background-color-key-focus
-    );
-    --spectrum-alias-button-primary-border-color: var(
-        --spectrum-alias-button-primary-border-color-default
-    );
-    --spectrum-alias-button-primary-text-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-primary-text-color-down: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-primary-text-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-primary-text-color: var(
-        --spectrum-alias-button-primary-text-color-default
-    );
-    --spectrum-alias-button-primary-icon-color-hover: var(
-        --spectrum-alias-button-primary-text-color-hover
-    );
-    --spectrum-alias-button-primary-icon-color-down: var(
-        --spectrum-alias-button-primary-text-color-down
-    );
-    --spectrum-alias-button-primary-icon-color-key-focus: var(
-        --spectrum-alias-button-primary-text-color-key-focus
-    );
-    --spectrum-alias-button-primary-icon-color: var(
-        --spectrum-alias-button-primary-icon-color-default
-    );
-    --spectrum-alias-button-secondary-background-color-hover: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-background-color-down: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-secondary-background-color-key-focus: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-background-color: var(
-        --spectrum-alias-button-secondary-background-color-default
-    );
-    --spectrum-alias-button-secondary-border-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-border-color-hover: var(
-        --spectrum-alias-button-secondary-background-color-hover
-    );
-    --spectrum-alias-button-secondary-border-color-down: var(
-        --spectrum-alias-button-secondary-background-color-down
-    );
-    --spectrum-alias-button-secondary-border-color-key-focus: var(
-        --spectrum-alias-button-secondary-background-color-key-focus
-    );
-    --spectrum-alias-button-secondary-border-color: var(
-        --spectrum-alias-button-secondary-border-color-default
-    );
-    --spectrum-alias-button-secondary-text-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-secondary-text-color-down: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-secondary-text-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-secondary-text-color: var(
-        --spectrum-alias-button-secondary-text-color-default
-    );
-    --spectrum-alias-button-secondary-icon-color-hover: var(
-        --spectrum-alias-button-secondary-text-color-hover
-    );
-    --spectrum-alias-button-secondary-icon-color-down: var(
-        --spectrum-alias-button-secondary-text-color-down
-    );
-    --spectrum-alias-button-secondary-icon-color-key-focus: var(
-        --spectrum-alias-button-secondary-text-color-key-focus
-    );
-    --spectrum-alias-button-secondary-icon-color: var(
-        --spectrum-alias-button-secondary-icon-color-default
-    );
-    --spectrum-alias-button-negative-background-color-hover: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-background-color-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-button-negative-background-color-key-focus: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-background-color: var(
-        --spectrum-alias-button-negative-background-color-default
-    );
-    --spectrum-alias-button-negative-border-color-default: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-border-color-hover: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-border-color-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-button-negative-border-color-key-focus: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-border-color: var(
-        --spectrum-alias-button-negative-border-color-default
-    );
-    --spectrum-alias-button-negative-text-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-negative-text-color-down: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-negative-text-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-negative-text-color: var(
-        --spectrum-alias-button-negative-text-color-default
-    );
-    --spectrum-alias-button-negative-icon-color-hover: var(
-        --spectrum-alias-button-negative-text-color-hover
-    );
-    --spectrum-alias-button-negative-icon-color-down: var(
-        --spectrum-alias-button-negative-text-color-down
-    );
-    --spectrum-alias-button-negative-icon-color-key-focus: var(
-        --spectrum-alias-button-negative-text-color-key-focus
-    );
-    --spectrum-alias-button-negative-icon-color: var(
-        --spectrum-alias-button-negative-icon-color-default
-    );
-    --spectrum-alias-input-border-color-disabled: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-input-border-color-quiet-disabled: var(
-        --spectrum-alias-border-color-mid
-    );
-    --spectrum-alias-input-border-color: var(
-        --spectrum-alias-input-border-color-default
-    );
-    --spectrum-alias-input-border-color-invalid-default: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-input-border-color-invalid-hover: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-input-border-color-invalid-down: var(
-        --spectrum-semantic-negative-color-down
-    );
-    --spectrum-alias-input-border-color-invalid-mouse-focus: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-input-border-color-invalid: var(
-        --spectrum-alias-input-border-color-invalid-default
-    );
-    --spectrum-alias-background-color-yellow-default: var(
-        --spectrum-global-color-static-yellow-300
-    );
-    --spectrum-alias-background-color-yellow-hover: var(
-        --spectrum-global-color-static-yellow-400
-    );
-    --spectrum-alias-background-color-yellow-key-focus: var(
-        --spectrum-global-color-static-yellow-400
-    );
-    --spectrum-alias-background-color-yellow-down: var(
-        --spectrum-global-color-static-yellow-500
-    );
-    --spectrum-alias-background-color-yellow: var(
-        --spectrum-alias-background-color-yellow-default
-    );
+    --spectrum-alias-tag-focusring-border-color-selected-key-focus: var(--spectrum-alias-focus-ring-color);
+    --spectrum-alias-tag-focusring-border-color: var(--spectrum-alias-tag-focusring-border-color-default);
+    --spectrum-alias-avatar-border-color: var(--spectrum-alias-avatar-border-color-default);
+    --spectrum-alias-avatar-border-color-selected: var(--spectrum-alias-avatar-border-color-selected-default);
+    --spectrum-alias-toggle-background-color: var(--spectrum-alias-toggle-background-color-default);
+    --spectrum-alias-toggle-background-color-emphasized-selected: var(--spectrum-alias-toggle-background-color-emphasized-selected-default);
+    --spectrum-alias-toggle-border-color: var(--spectrum-alias-toggle-border-color-default);
+    --spectrum-alias-toggle-icon-color-selected: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-toggle-icon-color-emphasized-selected: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-button-primary-background-color-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-background-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-button-primary-background-color-key-focus: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-background-color: var(--spectrum-alias-button-primary-background-color-default);
+    --spectrum-alias-button-primary-border-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-border-color-hover: var(--spectrum-alias-button-primary-background-color-hover);
+    --spectrum-alias-button-primary-border-color-down: var(--spectrum-alias-button-primary-background-color-down);
+    --spectrum-alias-button-primary-border-color-key-focus: var(--spectrum-alias-button-primary-background-color-key-focus);
+    --spectrum-alias-button-primary-border-color: var(--spectrum-alias-button-primary-border-color-default);
+    --spectrum-alias-button-primary-text-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-primary-text-color-down: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-primary-text-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-primary-text-color: var(--spectrum-alias-button-primary-text-color-default);
+    --spectrum-alias-button-primary-icon-color-hover: var(--spectrum-alias-button-primary-text-color-hover);
+    --spectrum-alias-button-primary-icon-color-down: var(--spectrum-alias-button-primary-text-color-down);
+    --spectrum-alias-button-primary-icon-color-key-focus: var(--spectrum-alias-button-primary-text-color-key-focus);
+    --spectrum-alias-button-primary-icon-color: var(--spectrum-alias-button-primary-icon-color-default);
+    --spectrum-alias-button-secondary-background-color-hover: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-background-color-down: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-secondary-background-color-key-focus: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-background-color: var(--spectrum-alias-button-secondary-background-color-default);
+    --spectrum-alias-button-secondary-border-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-border-color-hover: var(--spectrum-alias-button-secondary-background-color-hover);
+    --spectrum-alias-button-secondary-border-color-down: var(--spectrum-alias-button-secondary-background-color-down);
+    --spectrum-alias-button-secondary-border-color-key-focus: var(--spectrum-alias-button-secondary-background-color-key-focus);
+    --spectrum-alias-button-secondary-border-color: var(--spectrum-alias-button-secondary-border-color-default);
+    --spectrum-alias-button-secondary-text-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-secondary-text-color-down: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-secondary-text-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-secondary-text-color: var(--spectrum-alias-button-secondary-text-color-default);
+    --spectrum-alias-button-secondary-icon-color-hover: var(--spectrum-alias-button-secondary-text-color-hover);
+    --spectrum-alias-button-secondary-icon-color-down: var(--spectrum-alias-button-secondary-text-color-down);
+    --spectrum-alias-button-secondary-icon-color-key-focus: var(--spectrum-alias-button-secondary-text-color-key-focus);
+    --spectrum-alias-button-secondary-icon-color: var(--spectrum-alias-button-secondary-icon-color-default);
+    --spectrum-alias-button-negative-background-color-hover: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-background-color-down: var(--spectrum-global-color-red-700);
+    --spectrum-alias-button-negative-background-color-key-focus: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-background-color: var(--spectrum-alias-button-negative-background-color-default);
+    --spectrum-alias-button-negative-border-color-default: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-border-color-hover: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-border-color-down: var(--spectrum-global-color-red-700);
+    --spectrum-alias-button-negative-border-color-key-focus: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-border-color: var(--spectrum-alias-button-negative-border-color-default);
+    --spectrum-alias-button-negative-text-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-negative-text-color-down: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-negative-text-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-negative-text-color: var(--spectrum-alias-button-negative-text-color-default);
+    --spectrum-alias-button-negative-icon-color-hover: var(--spectrum-alias-button-negative-text-color-hover);
+    --spectrum-alias-button-negative-icon-color-down: var(--spectrum-alias-button-negative-text-color-down);
+    --spectrum-alias-button-negative-icon-color-key-focus: var(--spectrum-alias-button-negative-text-color-key-focus);
+    --spectrum-alias-button-negative-icon-color: var(--spectrum-alias-button-negative-icon-color-default);
+    --spectrum-alias-input-border-color-disabled: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-input-border-color-quiet-disabled: var(--spectrum-alias-border-color-mid);
+    --spectrum-alias-input-border-color: var(--spectrum-alias-input-border-color-default);
+    --spectrum-alias-input-border-color-invalid-default: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-input-border-color-invalid-hover: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-input-border-color-invalid-down: var(--spectrum-semantic-negative-color-down);
+    --spectrum-alias-input-border-color-invalid-mouse-focus: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-input-border-color-invalid: var(--spectrum-alias-input-border-color-invalid-default);
+    --spectrum-alias-background-color-yellow-default: var(--spectrum-global-color-static-yellow-300);
+    --spectrum-alias-background-color-yellow-hover: var(--spectrum-global-color-static-yellow-400);
+    --spectrum-alias-background-color-yellow-key-focus: var(--spectrum-global-color-static-yellow-400);
+    --spectrum-alias-background-color-yellow-down: var(--spectrum-global-color-static-yellow-500);
+    --spectrum-alias-background-color-yellow: var(--spectrum-alias-background-color-yellow-default);
     --spectrum-alias-infieldbutton-fill-loudnessLow-border-color-disabled: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessMedium-border-color-disabled: transparent;
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-border-color-disabled: var(
-        --spectrum-alias-component-background-color-disabled
-    );
-    --spectrum-alias-tabitem-text-color: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-text-color-selected: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-icon-color: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-background-color-default: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-border-color-disabled: var(--spectrum-alias-component-background-color-disabled);
+    --spectrum-alias-tabitem-text-color: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-text-color-selected: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-icon-color: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-background-color-default: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-disabled: var(--spectrum-global-color-gray-200);
     --spectrum-alias-background-color-transparent: transparent;
     --spectrum-alias-background-color-overbackground-down: #fff3;
     --spectrum-alias-background-color-quiet-overbackground-hover: #ffffff1a;
     --spectrum-alias-background-color-quiet-overbackground-down: #fff3;
     --spectrum-alias-background-color-overbackground-disabled: #ffffff1a;
     --spectrum-alias-background-color-quickactions-overlay: #0003;
-    --spectrum-alias-placeholder-text-color: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-placeholder-text-color-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-placeholder-text-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-placeholder-text-color-selected: var(
-        --spectrum-global-color-gray-800
-    );
+    --spectrum-alias-placeholder-text-color: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-placeholder-text-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-placeholder-text-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-placeholder-text-color-selected: var(--spectrum-global-color-gray-800);
     --spectrum-alias-label-text-color: var(--spectrum-global-color-gray-700);
     --spectrum-alias-text-color: var(--spectrum-global-color-gray-800);
     --spectrum-alias-text-color-hover: var(--spectrum-global-color-gray-900);
     --spectrum-alias-text-color-down: var(--spectrum-global-color-gray-900);
-    --spectrum-alias-text-color-key-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-text-color-mouse-focus: var(
-        --spectrum-global-color-blue-600
-    );
+    --spectrum-alias-text-color-key-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-text-color-mouse-focus: var(--spectrum-global-color-blue-600);
     --spectrum-alias-text-color-disabled: var(--spectrum-global-color-gray-500);
     --spectrum-alias-text-color-invalid: var(--spectrum-global-color-red-500);
     --spectrum-alias-text-color-selected: var(--spectrum-global-color-blue-600);
-    --spectrum-alias-text-color-selected-neutral: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-text-color-overbackground: var(
-        --spectrum-global-color-static-white
-    );
+    --spectrum-alias-text-color-selected-neutral: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-text-color-overbackground: var(--spectrum-global-color-static-white);
     --spectrum-alias-text-color-overbackground-disabled: #fff3;
     --spectrum-alias-text-color-quiet-overbackground-disabled: #fff3;
     --spectrum-alias-heading-text-color: var(--spectrum-global-color-gray-900);
-    --spectrum-alias-link-primary-text-color: var(
-        --spectrum-alias-link-primary-text-color-default
-    );
-    --spectrum-alias-link-secondary-text-color: var(
-        --spectrum-alias-link-secondary-text-color-default
-    );
+    --spectrum-alias-link-primary-text-color: var(--spectrum-alias-link-primary-text-color-default);
+    --spectrum-alias-link-secondary-text-color: var(--spectrum-alias-link-secondary-text-color-default);
     --spectrum-alias-border-color: var(--spectrum-global-color-gray-400);
     --spectrum-alias-border-color-hover: var(--spectrum-global-color-gray-500);
     --spectrum-alias-border-color-down: var(--spectrum-global-color-gray-500);
-    --spectrum-alias-border-color-key-focus: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-alias-border-color-mouse-focus: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-alias-border-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-border-color-extralight: var(
-        --spectrum-global-color-gray-100
-    );
+    --spectrum-alias-border-color-key-focus: var(--spectrum-global-color-blue-400);
+    --spectrum-alias-border-color-mouse-focus: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-border-color-disabled: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-border-color-extralight: var(--spectrum-global-color-gray-100);
     --spectrum-alias-border-color-light: var(--spectrum-global-color-gray-200);
     --spectrum-alias-border-color-mid: var(--spectrum-global-color-gray-300);
     --spectrum-alias-border-color-dark: var(--spectrum-global-color-gray-400);
-    --spectrum-alias-border-color-darker-default: var(
-        --spectrum-global-color-gray-600
-    );
-    --spectrum-alias-border-color-darker-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-border-color-darker-down: var(
-        --spectrum-global-color-gray-900
-    );
+    --spectrum-alias-border-color-darker-default: var(--spectrum-global-color-gray-600);
+    --spectrum-alias-border-color-darker-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-border-color-darker-down: var(--spectrum-global-color-gray-900);
     --spectrum-alias-border-color-transparent: transparent;
     --spectrum-alias-border-color-translucent-dark: #0000000d;
     --spectrum-alias-border-color-translucent-darker: #0000001a;
     --spectrum-alias-focus-color: var(--spectrum-global-color-blue-400);
     --spectrum-alias-focus-ring-color: var(--spectrum-alias-focus-color);
-    --spectrum-alias-track-fill-color-overbackground: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-track-color-disabled: var(
-        --spectrum-global-color-gray-300
-    );
+    --spectrum-alias-track-fill-color-overbackground: var(--spectrum-global-color-static-white);
+    --spectrum-alias-track-color-disabled: var(--spectrum-global-color-gray-300);
     --spectrum-alias-track-color-overbackground: #fff3;
     --spectrum-alias-icon-color: var(--spectrum-global-color-gray-700);
-    --spectrum-alias-icon-color-overbackground: var(
-        --spectrum-global-color-static-white
-    );
+    --spectrum-alias-icon-color-overbackground: var(--spectrum-global-color-static-white);
     --spectrum-alias-icon-color-hover: var(--spectrum-global-color-gray-900);
     --spectrum-alias-icon-color-down: var(--spectrum-global-color-gray-900);
-    --spectrum-alias-icon-color-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
+    --spectrum-alias-icon-color-key-focus: var(--spectrum-global-color-gray-900);
     --spectrum-alias-icon-color-disabled: var(--spectrum-global-color-gray-400);
     --spectrum-alias-icon-color-overbackground-disabled: #fff3;
     --spectrum-alias-icon-color-quiet-overbackground-disabled: #ffffff26;
-    --spectrum-alias-icon-color-selected-neutral: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-icon-color-selected-neutral-subdued: var(
-        --spectrum-global-color-gray-800
-    );
+    --spectrum-alias-icon-color-selected-neutral: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-icon-color-selected-neutral-subdued: var(--spectrum-global-color-gray-800);
     --spectrum-alias-icon-color-selected: var(--spectrum-global-color-blue-500);
-    --spectrum-alias-icon-color-selected-hover: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-icon-color-selected-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-alias-icon-color-selected-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-image-opacity-disabled: var(
-        --spectrum-global-color-opacity-30
-    );
-    --spectrum-alias-toolbar-background-color: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-code-highlight-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-code-highlight-background-color: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-code-highlight-color-keyword: var(
-        --spectrum-global-color-fuchsia-600
-    );
-    --spectrum-alias-code-highlight-color-section: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-alias-code-highlight-color-literal: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-code-highlight-color-attribute: var(
-        --spectrum-global-color-seafoam-600
-    );
-    --spectrum-alias-code-highlight-color-class: var(
-        --spectrum-global-color-magenta-600
-    );
-    --spectrum-alias-code-highlight-color-variable: var(
-        --spectrum-global-color-purple-600
-    );
-    --spectrum-alias-code-highlight-color-title: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-alias-code-highlight-color-string: var(
-        --spectrum-global-color-fuchsia-600
-    );
-    --spectrum-alias-code-highlight-color-function: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-code-highlight-color-comment: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-categorical-color-1: var(
-        --spectrum-global-color-static-seafoam-200
-    );
-    --spectrum-alias-categorical-color-2: var(
-        --spectrum-global-color-static-indigo-700
-    );
-    --spectrum-alias-categorical-color-3: var(
-        --spectrum-global-color-static-orange-500
-    );
-    --spectrum-alias-categorical-color-4: var(
-        --spectrum-global-color-static-magenta-500
-    );
-    --spectrum-alias-categorical-color-5: var(
-        --spectrum-global-color-static-indigo-200
-    );
-    --spectrum-alias-categorical-color-6: var(
-        --spectrum-global-color-static-celery-200
-    );
-    --spectrum-alias-categorical-color-7: var(
-        --spectrum-global-color-static-blue-500
-    );
-    --spectrum-alias-categorical-color-8: var(
-        --spectrum-global-color-static-purple-800
-    );
-    --spectrum-alias-categorical-color-9: var(
-        --spectrum-global-color-static-yellow-500
-    );
-    --spectrum-alias-categorical-color-10: var(
-        --spectrum-global-color-static-orange-700
-    );
-    --spectrum-alias-categorical-color-11: var(
-        --spectrum-global-color-static-green-600
-    );
-    --spectrum-alias-categorical-color-12: var(
-        --spectrum-global-color-static-chartreuse-300
-    );
-    --spectrum-alias-categorical-color-13: var(
-        --spectrum-global-color-static-blue-200
-    );
-    --spectrum-alias-categorical-color-14: var(
-        --spectrum-global-color-static-fuchsia-500
-    );
-    --spectrum-alias-categorical-color-15: var(
-        --spectrum-global-color-static-magenta-200
-    );
-    --spectrum-alias-categorical-color-16: var(
-        --spectrum-global-color-static-yellow-200
-    );
+    --spectrum-alias-icon-color-selected-hover: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-icon-color-selected-down: var(--spectrum-global-color-blue-700);
+    --spectrum-alias-icon-color-selected-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-image-opacity-disabled: var(--spectrum-global-color-opacity-30);
+    --spectrum-alias-toolbar-background-color: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-code-highlight-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-code-highlight-background-color: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-code-highlight-color-keyword: var(--spectrum-global-color-fuchsia-600);
+    --spectrum-alias-code-highlight-color-section: var(--spectrum-global-color-red-600);
+    --spectrum-alias-code-highlight-color-literal: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-code-highlight-color-attribute: var(--spectrum-global-color-seafoam-600);
+    --spectrum-alias-code-highlight-color-class: var(--spectrum-global-color-magenta-600);
+    --spectrum-alias-code-highlight-color-variable: var(--spectrum-global-color-purple-600);
+    --spectrum-alias-code-highlight-color-title: var(--spectrum-global-color-indigo-600);
+    --spectrum-alias-code-highlight-color-string: var(--spectrum-global-color-fuchsia-600);
+    --spectrum-alias-code-highlight-color-function: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-code-highlight-color-comment: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-categorical-color-1: var(--spectrum-global-color-static-seafoam-200);
+    --spectrum-alias-categorical-color-2: var(--spectrum-global-color-static-indigo-700);
+    --spectrum-alias-categorical-color-3: var(--spectrum-global-color-static-orange-500);
+    --spectrum-alias-categorical-color-4: var(--spectrum-global-color-static-magenta-500);
+    --spectrum-alias-categorical-color-5: var(--spectrum-global-color-static-indigo-200);
+    --spectrum-alias-categorical-color-6: var(--spectrum-global-color-static-celery-200);
+    --spectrum-alias-categorical-color-7: var(--spectrum-global-color-static-blue-500);
+    --spectrum-alias-categorical-color-8: var(--spectrum-global-color-static-purple-800);
+    --spectrum-alias-categorical-color-9: var(--spectrum-global-color-static-yellow-500);
+    --spectrum-alias-categorical-color-10: var(--spectrum-global-color-static-orange-700);
+    --spectrum-alias-categorical-color-11: var(--spectrum-global-color-static-green-600);
+    --spectrum-alias-categorical-color-12: var(--spectrum-global-color-static-chartreuse-300);
+    --spectrum-alias-categorical-color-13: var(--spectrum-global-color-static-blue-200);
+    --spectrum-alias-categorical-color-14: var(--spectrum-global-color-static-fuchsia-500);
+    --spectrum-alias-categorical-color-15: var(--spectrum-global-color-static-magenta-200);
+    --spectrum-alias-categorical-color-16: var(--spectrum-global-color-static-yellow-200);
 }

--- a/tools/styles/express/spectrum-scale-large.css
+++ b/tools/styles/express/spectrum-scale-large.css
@@ -69,209 +69,79 @@
     --spectrum-global-dimension-font-size-1100: 55px;
     --spectrum-global-dimension-font-size-1200: 62px;
     --spectrum-global-dimension-font-size-1300: 70px;
-    --spectrum-alias-item-text-padding-top-l: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-text-padding-bottom-s: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-item-workflow-padding-left-m: var(
-        --spectrum-global-dimension-static-size-150
-    );
+    --spectrum-alias-item-text-padding-top-l: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-text-padding-bottom-s: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-item-workflow-padding-left-m: var(--spectrum-global-dimension-static-size-150);
     --spectrum-alias-item-rounded-workflow-padding-left-m: 17px;
     --spectrum-alias-item-rounded-workflow-padding-left-xl: 27px;
-    --spectrum-alias-item-mark-padding-top-m: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-item-mark-padding-bottom-m: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-item-mark-padding-left-m: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-control-1-size-l: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-control-1-size-xl: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-control-2-size-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-control-3-height-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-control-3-width-s: var(
-        --spectrum-global-dimension-size-325
-    );
-    --spectrum-alias-item-control-3-width-m: var(
-        --spectrum-global-dimension-static-size-450
-    );
+    --spectrum-alias-item-mark-padding-top-m: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-item-mark-padding-bottom-m: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-item-mark-padding-left-m: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-control-1-size-l: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-control-1-size-xl: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-control-2-size-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-control-3-height-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-control-3-width-s: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-item-control-3-width-m: var(--spectrum-global-dimension-static-size-450);
     --spectrum-alias-item-control-3-width-l: 41px;
     --spectrum-alias-item-control-3-width-xl: 46px;
-    --spectrum-alias-item-mark-size-m: var(
-        --spectrum-global-dimension-static-size-325
-    );
-    --spectrum-alias-component-focusring-border-radius: var(
-        --spectrum-alias-focus-ring-border-radius-regular
-    );
-    --spectrum-alias-focus-ring-border-radius-small: var(
-        --spectrum-global-dimension-size-75
-    );
+    --spectrum-alias-item-mark-size-m: var(--spectrum-global-dimension-static-size-325);
+    --spectrum-alias-component-focusring-border-radius: var(--spectrum-alias-focus-ring-border-radius-regular);
+    --spectrum-alias-focus-ring-border-radius-small: var(--spectrum-global-dimension-size-75);
     --spectrum-alias-focus-ring-border-radius-regular: 12px;
     --spectrum-alias-control-three-width-m: 34px;
     --spectrum-alias-control-three-width-l: 38px;
-    --spectrum-alias-control-three-width-xl: var(
-        --spectrum-global-dimension-static-size-550
-    );
-    --spectrum-alias-tag-text-padding-top-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-tag-icon-size-l: var(
-        --spectrum-global-dimension-static-size-275
-    );
-    --spectrum-alias-focus-ring-radius-default: var(
-        --spectrum-global-dimension-static-size-115
-    );
-    --spectrum-alias-workflow-icon-size-l: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-ui-icon-chevron-size-75: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-chevron-size-100: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-chevron-size-200: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-chevron-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-chevron-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-chevron-size-500: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-checkmark-size-50: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-checkmark-size-75: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-checkmark-size-100: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-checkmark-size-200: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-checkmark-size-500: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-checkmark-size-600: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-ui-icon-dash-size-50: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-dash-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-dash-size-100: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-dash-size-200: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-dash-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-dash-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-dash-size-500: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-dash-size-600: var(
-        --spectrum-global-dimension-static-size-275
-    );
-    --spectrum-alias-ui-icon-cross-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-cross-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-cross-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-cross-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-cross-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-cross-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-cross-size-600: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-arrow-size-75: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-arrow-size-100: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-arrow-size-200: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-arrow-size-500: var(
-        --spectrum-global-dimension-static-size-275
-    );
-    --spectrum-alias-ui-icon-arrow-size-600: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-asterisk-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-asterisk-size-300: var(
-        --spectrum-global-dimension-static-size-150
-    );
+    --spectrum-alias-control-three-width-xl: var(--spectrum-global-dimension-static-size-550);
+    --spectrum-alias-tag-text-padding-top-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-tag-icon-size-l: var(--spectrum-global-dimension-static-size-275);
+    --spectrum-alias-focus-ring-radius-default: var(--spectrum-global-dimension-static-size-115);
+    --spectrum-alias-workflow-icon-size-l: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-ui-icon-chevron-size-75: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-chevron-size-100: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-chevron-size-200: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-chevron-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-chevron-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-chevron-size-500: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-checkmark-size-50: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-checkmark-size-75: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-checkmark-size-100: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-checkmark-size-200: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-checkmark-size-500: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-checkmark-size-600: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-ui-icon-dash-size-50: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-dash-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-dash-size-100: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-dash-size-200: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-dash-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-dash-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-dash-size-500: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-dash-size-600: var(--spectrum-global-dimension-static-size-275);
+    --spectrum-alias-ui-icon-cross-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-cross-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-cross-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-cross-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-cross-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-cross-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-cross-size-600: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-arrow-size-75: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-arrow-size-100: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-arrow-size-200: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-arrow-size-500: var(--spectrum-global-dimension-static-size-275);
+    --spectrum-alias-ui-icon-arrow-size-600: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-asterisk-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-asterisk-size-300: var(--spectrum-global-dimension-static-size-150);
     --spectrum-alias-avatar-size-100: 26px;
     --spectrum-alias-avatar-size-400: 36px;
     --spectrum-alias-avatar-size-600: 46px;
-    --spectrum-dialog-confirm-title-text-size: var(
-        --spectrum-alias-heading-xs-text-size
-    );
-    --spectrum-dialog-confirm-description-text-size: var(
-        --spectrum-global-dimension-font-size-75
-    );
+    --spectrum-dialog-confirm-title-text-size: var(--spectrum-alias-heading-xs-text-size);
+    --spectrum-dialog-confirm-description-text-size: var(--spectrum-global-dimension-font-size-75);
 }

--- a/tools/styles/express/spectrum-scale-medium.css
+++ b/tools/styles/express/spectrum-scale-medium.css
@@ -69,213 +69,79 @@
     --spectrum-global-dimension-font-size-1100: 45px;
     --spectrum-global-dimension-font-size-1200: 50px;
     --spectrum-global-dimension-font-size-1300: 60px;
-    --spectrum-alias-item-text-padding-top-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-text-padding-bottom-s: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-item-workflow-padding-left-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-rounded-workflow-padding-left-m: var(
-        --spectrum-global-dimension-size-175
-    );
+    --spectrum-alias-item-text-padding-top-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-text-padding-bottom-s: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-item-workflow-padding-left-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-rounded-workflow-padding-left-m: var(--spectrum-global-dimension-size-175);
     --spectrum-alias-item-rounded-workflow-padding-left-xl: 21px;
-    --spectrum-alias-item-mark-padding-top-m: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-item-mark-padding-bottom-m: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-item-mark-padding-left-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-1-size-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-1-size-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-2-size-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-control-3-height-s: var(
-        --spectrum-global-dimension-size-150
-    );
+    --spectrum-alias-item-mark-padding-top-m: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-item-mark-padding-bottom-m: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-item-mark-padding-left-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-1-size-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-1-size-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-2-size-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-control-3-height-s: var(--spectrum-global-dimension-size-150);
     --spectrum-alias-item-control-3-width-s: 23px;
-    --spectrum-alias-item-control-3-width-m: var(
-        --spectrum-global-dimension-static-size-325
-    );
+    --spectrum-alias-item-control-3-width-m: var(--spectrum-global-dimension-static-size-325);
     --spectrum-alias-item-control-3-width-l: 29px;
     --spectrum-alias-item-control-3-width-xl: 33px;
-    --spectrum-alias-item-mark-size-m: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-component-focusring-border-radius: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-focus-ring-border-radius-small: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-focus-ring-border-radius-regular: var(
-        --spectrum-global-dimension-size-125
-    );
+    --spectrum-alias-item-mark-size-m: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-component-focusring-border-radius: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-focus-ring-border-radius-small: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-focus-ring-border-radius-regular: var(--spectrum-global-dimension-size-125);
     --spectrum-alias-control-three-width-m: 28px;
-    --spectrum-alias-control-three-width-l: var(
-        --spectrum-global-dimension-static-size-450
-    );
-    --spectrum-alias-control-three-width-xl: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-tag-text-padding-top-s: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-tag-icon-size-l: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-focus-ring-radius-default: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-workflow-icon-size-l: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-chevron-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-chevron-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-chevron-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-chevron-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-chevron-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-chevron-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-50: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-checkmark-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-checkmark-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-checkmark-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-checkmark-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-checkmark-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-600: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-dash-size-50: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-dash-size-75: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-dash-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-dash-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-dash-size-300: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-dash-size-400: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-dash-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-dash-size-600: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-cross-size-75: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-cross-size-100: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-cross-size-200: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-cross-size-300: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-cross-size-400: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-cross-size-500: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-cross-size-600: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-arrow-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-arrow-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-arrow-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-arrow-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-500: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-arrow-size-600: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-ui-icon-asterisk-size-200: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-asterisk-size-300: var(
-        --spectrum-global-dimension-static-size-125
-    );
+    --spectrum-alias-control-three-width-l: var(--spectrum-global-dimension-static-size-450);
+    --spectrum-alias-control-three-width-xl: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-tag-text-padding-top-s: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-tag-icon-size-l: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-focus-ring-radius-default: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-workflow-icon-size-l: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-chevron-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-chevron-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-chevron-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-chevron-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-chevron-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-chevron-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-50: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-checkmark-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-checkmark-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-checkmark-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-checkmark-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-checkmark-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-600: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-dash-size-50: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-dash-size-75: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-dash-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-dash-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-dash-size-300: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-dash-size-400: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-dash-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-dash-size-600: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-cross-size-75: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-cross-size-100: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-cross-size-200: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-cross-size-300: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-cross-size-400: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-cross-size-500: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-cross-size-600: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-arrow-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-arrow-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-arrow-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-arrow-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-500: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-arrow-size-600: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-ui-icon-asterisk-size-200: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-asterisk-size-300: var(--spectrum-global-dimension-static-size-125);
     --spectrum-alias-avatar-size-100: var(--spectrum-global-dimension-size-250);
     --spectrum-alias-avatar-size-400: var(--spectrum-global-dimension-size-350);
     --spectrum-alias-avatar-size-600: var(--spectrum-global-dimension-size-450);
-    --spectrum-dialog-confirm-title-text-size: var(
-        --spectrum-alias-heading-s-text-size
-    );
-    --spectrum-dialog-confirm-description-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
+    --spectrum-dialog-confirm-title-text-size: var(--spectrum-alias-heading-s-text-size);
+    --spectrum-dialog-confirm-description-text-size: var(--spectrum-global-dimension-font-size-100);
 }

--- a/tools/styles/express/spectrum-theme-dark.css
+++ b/tools/styles/express/spectrum-theme-dark.css
@@ -23,241 +23,123 @@
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 34, 184, 51;
-    --spectrum-global-color-celery-400: rgb(
-        var(--spectrum-global-color-celery-400-rgb)
-    );
+    --spectrum-global-color-celery-400: rgb(var(--spectrum-global-color-celery-400-rgb));
     --spectrum-global-color-celery-500-rgb: 68, 202, 73;
-    --spectrum-global-color-celery-500: rgb(
-        var(--spectrum-global-color-celery-500-rgb)
-    );
+    --spectrum-global-color-celery-500: rgb(var(--spectrum-global-color-celery-500-rgb));
     --spectrum-global-color-celery-600-rgb: 105, 220, 99;
-    --spectrum-global-color-celery-600: rgb(
-        var(--spectrum-global-color-celery-600-rgb)
-    );
+    --spectrum-global-color-celery-600: rgb(var(--spectrum-global-color-celery-600-rgb));
     --spectrum-global-color-celery-700-rgb: 142, 235, 127;
-    --spectrum-global-color-celery-700: rgb(
-        var(--spectrum-global-color-celery-700-rgb)
-    );
+    --spectrum-global-color-celery-700: rgb(var(--spectrum-global-color-celery-700-rgb));
     --spectrum-global-color-chartreuse-400-rgb: 148, 192, 8;
-    --spectrum-global-color-chartreuse-400: rgb(
-        var(--spectrum-global-color-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-chartreuse-400: rgb(var(--spectrum-global-color-chartreuse-400-rgb));
     --spectrum-global-color-chartreuse-500-rgb: 166, 211, 18;
-    --spectrum-global-color-chartreuse-500: rgb(
-        var(--spectrum-global-color-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-chartreuse-500: rgb(var(--spectrum-global-color-chartreuse-500-rgb));
     --spectrum-global-color-chartreuse-600-rgb: 184, 229, 37;
-    --spectrum-global-color-chartreuse-600: rgb(
-        var(--spectrum-global-color-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-chartreuse-600: rgb(var(--spectrum-global-color-chartreuse-600-rgb));
     --spectrum-global-color-chartreuse-700-rgb: 205, 245, 71;
-    --spectrum-global-color-chartreuse-700: rgb(
-        var(--spectrum-global-color-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-chartreuse-700: rgb(var(--spectrum-global-color-chartreuse-700-rgb));
     --spectrum-global-color-yellow-400-rgb: 228, 194, 0;
-    --spectrum-global-color-yellow-400: rgb(
-        var(--spectrum-global-color-yellow-400-rgb)
-    );
+    --spectrum-global-color-yellow-400: rgb(var(--spectrum-global-color-yellow-400-rgb));
     --spectrum-global-color-yellow-500-rgb: 244, 213, 0;
-    --spectrum-global-color-yellow-500: rgb(
-        var(--spectrum-global-color-yellow-500-rgb)
-    );
+    --spectrum-global-color-yellow-500: rgb(var(--spectrum-global-color-yellow-500-rgb));
     --spectrum-global-color-yellow-600-rgb: 249, 232, 92;
-    --spectrum-global-color-yellow-600: rgb(
-        var(--spectrum-global-color-yellow-600-rgb)
-    );
+    --spectrum-global-color-yellow-600: rgb(var(--spectrum-global-color-yellow-600-rgb));
     --spectrum-global-color-yellow-700-rgb: 252, 246, 187;
-    --spectrum-global-color-yellow-700: rgb(
-        var(--spectrum-global-color-yellow-700-rgb)
-    );
+    --spectrum-global-color-yellow-700: rgb(var(--spectrum-global-color-yellow-700-rgb));
     --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
-    --spectrum-global-color-magenta-400: rgb(
-        var(--spectrum-global-color-magenta-400-rgb)
-    );
+    --spectrum-global-color-magenta-400: rgb(var(--spectrum-global-color-magenta-400-rgb));
     --spectrum-global-color-magenta-500-rgb: 237, 87, 149;
-    --spectrum-global-color-magenta-500: rgb(
-        var(--spectrum-global-color-magenta-500-rgb)
-    );
+    --spectrum-global-color-magenta-500: rgb(var(--spectrum-global-color-magenta-500-rgb));
     --spectrum-global-color-magenta-600-rgb: 249, 114, 167;
-    --spectrum-global-color-magenta-600: rgb(
-        var(--spectrum-global-color-magenta-600-rgb)
-    );
+    --spectrum-global-color-magenta-600: rgb(var(--spectrum-global-color-magenta-600-rgb));
     --spectrum-global-color-magenta-700-rgb: 255, 143, 185;
-    --spectrum-global-color-magenta-700: rgb(
-        var(--spectrum-global-color-magenta-700-rgb)
-    );
+    --spectrum-global-color-magenta-700: rgb(var(--spectrum-global-color-magenta-700-rgb));
     --spectrum-global-color-fuchsia-400-rgb: 205, 57, 206;
-    --spectrum-global-color-fuchsia-400: rgb(
-        var(--spectrum-global-color-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-fuchsia-400: rgb(var(--spectrum-global-color-fuchsia-400-rgb));
     --spectrum-global-color-fuchsia-500-rgb: 223, 81, 224;
-    --spectrum-global-color-fuchsia-500: rgb(
-        var(--spectrum-global-color-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-fuchsia-500: rgb(var(--spectrum-global-color-fuchsia-500-rgb));
     --spectrum-global-color-fuchsia-600-rgb: 235, 110, 236;
-    --spectrum-global-color-fuchsia-600: rgb(
-        var(--spectrum-global-color-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-fuchsia-600: rgb(var(--spectrum-global-color-fuchsia-600-rgb));
     --spectrum-global-color-fuchsia-700-rgb: 244, 140, 242;
-    --spectrum-global-color-fuchsia-700: rgb(
-        var(--spectrum-global-color-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-fuchsia-700: rgb(var(--spectrum-global-color-fuchsia-700-rgb));
     --spectrum-global-color-purple-400-rgb: 157, 87, 243;
-    --spectrum-global-color-purple-400: rgb(
-        var(--spectrum-global-color-purple-400-rgb)
-    );
+    --spectrum-global-color-purple-400: rgb(var(--spectrum-global-color-purple-400-rgb));
     --spectrum-global-color-purple-500-rgb: 172, 111, 249;
-    --spectrum-global-color-purple-500: rgb(
-        var(--spectrum-global-color-purple-500-rgb)
-    );
+    --spectrum-global-color-purple-500: rgb(var(--spectrum-global-color-purple-500-rgb));
     --spectrum-global-color-purple-600-rgb: 187, 135, 251;
-    --spectrum-global-color-purple-600: rgb(
-        var(--spectrum-global-color-purple-600-rgb)
-    );
+    --spectrum-global-color-purple-600: rgb(var(--spectrum-global-color-purple-600-rgb));
     --spectrum-global-color-purple-700-rgb: 202, 159, 252;
-    --spectrum-global-color-purple-700: rgb(
-        var(--spectrum-global-color-purple-700-rgb)
-    );
+    --spectrum-global-color-purple-700: rgb(var(--spectrum-global-color-purple-700-rgb));
     --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
-    --spectrum-global-color-indigo-400: rgb(
-        var(--spectrum-global-color-indigo-400-rgb)
-    );
+    --spectrum-global-color-indigo-400: rgb(var(--spectrum-global-color-indigo-400-rgb));
     --spectrum-global-color-indigo-500-rgb: 124, 129, 251;
-    --spectrum-global-color-indigo-500: rgb(
-        var(--spectrum-global-color-indigo-500-rgb)
-    );
+    --spectrum-global-color-indigo-500: rgb(var(--spectrum-global-color-indigo-500-rgb));
     --spectrum-global-color-indigo-600-rgb: 145, 149, 255;
-    --spectrum-global-color-indigo-600: rgb(
-        var(--spectrum-global-color-indigo-600-rgb)
-    );
+    --spectrum-global-color-indigo-600: rgb(var(--spectrum-global-color-indigo-600-rgb));
     --spectrum-global-color-indigo-700-rgb: 167, 170, 255;
-    --spectrum-global-color-indigo-700: rgb(
-        var(--spectrum-global-color-indigo-700-rgb)
-    );
+    --spectrum-global-color-indigo-700: rgb(var(--spectrum-global-color-indigo-700-rgb));
     --spectrum-global-color-seafoam-400-rgb: 0, 158, 152;
-    --spectrum-global-color-seafoam-400: rgb(
-        var(--spectrum-global-color-seafoam-400-rgb)
-    );
+    --spectrum-global-color-seafoam-400: rgb(var(--spectrum-global-color-seafoam-400-rgb));
     --spectrum-global-color-seafoam-500-rgb: 3, 178, 171;
-    --spectrum-global-color-seafoam-500: rgb(
-        var(--spectrum-global-color-seafoam-500-rgb)
-    );
+    --spectrum-global-color-seafoam-500: rgb(var(--spectrum-global-color-seafoam-500-rgb));
     --spectrum-global-color-seafoam-600-rgb: 54, 197, 189;
-    --spectrum-global-color-seafoam-600: rgb(
-        var(--spectrum-global-color-seafoam-600-rgb)
-    );
+    --spectrum-global-color-seafoam-600: rgb(var(--spectrum-global-color-seafoam-600-rgb));
     --spectrum-global-color-seafoam-700-rgb: 93, 214, 207;
-    --spectrum-global-color-seafoam-700: rgb(
-        var(--spectrum-global-color-seafoam-700-rgb)
-    );
+    --spectrum-global-color-seafoam-700: rgb(var(--spectrum-global-color-seafoam-700-rgb));
     --spectrum-global-color-red-400-rgb: 234, 56, 41;
-    --spectrum-global-color-red-400: rgb(
-        var(--spectrum-global-color-red-400-rgb)
-    );
+    --spectrum-global-color-red-400: rgb(var(--spectrum-global-color-red-400-rgb));
     --spectrum-global-color-red-500-rgb: 246, 88, 67;
-    --spectrum-global-color-red-500: rgb(
-        var(--spectrum-global-color-red-500-rgb)
-    );
+    --spectrum-global-color-red-500: rgb(var(--spectrum-global-color-red-500-rgb));
     --spectrum-global-color-red-600-rgb: 255, 117, 94;
-    --spectrum-global-color-red-600: rgb(
-        var(--spectrum-global-color-red-600-rgb)
-    );
+    --spectrum-global-color-red-600: rgb(var(--spectrum-global-color-red-600-rgb));
     --spectrum-global-color-red-700-rgb: 255, 149, 129;
-    --spectrum-global-color-red-700: rgb(
-        var(--spectrum-global-color-red-700-rgb)
-    );
+    --spectrum-global-color-red-700: rgb(var(--spectrum-global-color-red-700-rgb));
     --spectrum-global-color-orange-400-rgb: 244, 129, 12;
-    --spectrum-global-color-orange-400: rgb(
-        var(--spectrum-global-color-orange-400-rgb)
-    );
+    --spectrum-global-color-orange-400: rgb(var(--spectrum-global-color-orange-400-rgb));
     --spectrum-global-color-orange-500-rgb: 254, 154, 46;
-    --spectrum-global-color-orange-500: rgb(
-        var(--spectrum-global-color-orange-500-rgb)
-    );
+    --spectrum-global-color-orange-500: rgb(var(--spectrum-global-color-orange-500-rgb));
     --spectrum-global-color-orange-600-rgb: 255, 181, 88;
-    --spectrum-global-color-orange-600: rgb(
-        var(--spectrum-global-color-orange-600-rgb)
-    );
+    --spectrum-global-color-orange-600: rgb(var(--spectrum-global-color-orange-600-rgb));
     --spectrum-global-color-orange-700-rgb: 253, 206, 136;
-    --spectrum-global-color-orange-700: rgb(
-        var(--spectrum-global-color-orange-700-rgb)
-    );
+    --spectrum-global-color-orange-700: rgb(var(--spectrum-global-color-orange-700-rgb));
     --spectrum-global-color-green-400-rgb: 18, 162, 108;
-    --spectrum-global-color-green-400: rgb(
-        var(--spectrum-global-color-green-400-rgb)
-    );
+    --spectrum-global-color-green-400: rgb(var(--spectrum-global-color-green-400-rgb));
     --spectrum-global-color-green-500-rgb: 43, 180, 125;
-    --spectrum-global-color-green-500: rgb(
-        var(--spectrum-global-color-green-500-rgb)
-    );
+    --spectrum-global-color-green-500: rgb(var(--spectrum-global-color-green-500-rgb));
     --spectrum-global-color-green-600-rgb: 67, 199, 143;
-    --spectrum-global-color-green-600: rgb(
-        var(--spectrum-global-color-green-600-rgb)
-    );
+    --spectrum-global-color-green-600: rgb(var(--spectrum-global-color-green-600-rgb));
     --spectrum-global-color-green-700-rgb: 94, 217, 162;
-    --spectrum-global-color-green-700: rgb(
-        var(--spectrum-global-color-green-700-rgb)
-    );
+    --spectrum-global-color-green-700: rgb(var(--spectrum-global-color-green-700-rgb));
     --spectrum-global-color-blue-400-rgb: 52, 143, 244;
-    --spectrum-global-color-blue-400: rgb(
-        var(--spectrum-global-color-blue-400-rgb)
-    );
+    --spectrum-global-color-blue-400: rgb(var(--spectrum-global-color-blue-400-rgb));
     --spectrum-global-color-blue-500-rgb: 84, 163, 246;
-    --spectrum-global-color-blue-500: rgb(
-        var(--spectrum-global-color-blue-500-rgb)
-    );
+    --spectrum-global-color-blue-500: rgb(var(--spectrum-global-color-blue-500-rgb));
     --spectrum-global-color-blue-600-rgb: 114, 183, 249;
-    --spectrum-global-color-blue-600: rgb(
-        var(--spectrum-global-color-blue-600-rgb)
-    );
+    --spectrum-global-color-blue-600: rgb(var(--spectrum-global-color-blue-600-rgb));
     --spectrum-global-color-blue-700-rgb: 143, 202, 252;
-    --spectrum-global-color-blue-700: rgb(
-        var(--spectrum-global-color-blue-700-rgb)
-    );
+    --spectrum-global-color-blue-700: rgb(var(--spectrum-global-color-blue-700-rgb));
     --spectrum-global-color-gray-50-rgb: 29, 29, 29;
-    --spectrum-global-color-gray-50: rgb(
-        var(--spectrum-global-color-gray-50-rgb)
-    );
+    --spectrum-global-color-gray-50: rgb(var(--spectrum-global-color-gray-50-rgb));
     --spectrum-global-color-gray-75-rgb: 38, 38, 38;
-    --spectrum-global-color-gray-75: rgb(
-        var(--spectrum-global-color-gray-75-rgb)
-    );
+    --spectrum-global-color-gray-75: rgb(var(--spectrum-global-color-gray-75-rgb));
     --spectrum-global-color-gray-100-rgb: 50, 50, 50;
-    --spectrum-global-color-gray-100: rgb(
-        var(--spectrum-global-color-gray-100-rgb)
-    );
+    --spectrum-global-color-gray-100: rgb(var(--spectrum-global-color-gray-100-rgb));
     --spectrum-global-color-gray-200-rgb: 63, 63, 63;
-    --spectrum-global-color-gray-200: rgb(
-        var(--spectrum-global-color-gray-200-rgb)
-    );
+    --spectrum-global-color-gray-200: rgb(var(--spectrum-global-color-gray-200-rgb));
     --spectrum-global-color-gray-300-rgb: 84, 84, 84;
-    --spectrum-global-color-gray-300: rgb(
-        var(--spectrum-global-color-gray-300-rgb)
-    );
+    --spectrum-global-color-gray-300: rgb(var(--spectrum-global-color-gray-300-rgb));
     --spectrum-global-color-gray-400-rgb: 112, 112, 112;
-    --spectrum-global-color-gray-400: rgb(
-        var(--spectrum-global-color-gray-400-rgb)
-    );
+    --spectrum-global-color-gray-400: rgb(var(--spectrum-global-color-gray-400-rgb));
     --spectrum-global-color-gray-500-rgb: 144, 144, 144;
-    --spectrum-global-color-gray-500: rgb(
-        var(--spectrum-global-color-gray-500-rgb)
-    );
+    --spectrum-global-color-gray-500: rgb(var(--spectrum-global-color-gray-500-rgb));
     --spectrum-global-color-gray-600-rgb: 178, 178, 178;
-    --spectrum-global-color-gray-600: rgb(
-        var(--spectrum-global-color-gray-600-rgb)
-    );
+    --spectrum-global-color-gray-600: rgb(var(--spectrum-global-color-gray-600-rgb));
     --spectrum-global-color-gray-700-rgb: 209, 209, 209;
-    --spectrum-global-color-gray-700: rgb(
-        var(--spectrum-global-color-gray-700-rgb)
-    );
+    --spectrum-global-color-gray-700: rgb(var(--spectrum-global-color-gray-700-rgb));
     --spectrum-global-color-gray-800-rgb: 235, 235, 235;
-    --spectrum-global-color-gray-800: rgb(
-        var(--spectrum-global-color-gray-800-rgb)
-    );
+    --spectrum-global-color-gray-800: rgb(var(--spectrum-global-color-gray-800-rgb));
     --spectrum-global-color-gray-900-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-900: rgb(
-        var(--spectrum-global-color-gray-900-rgb)
-    );
+    --spectrum-global-color-gray-900: rgb(var(--spectrum-global-color-gray-900-rgb));
     --spectrum-alias-avatar-border-color-default: #ffffff1a;
     --spectrum-alias-avatar-border-color-hover: #ffffff40;
     --spectrum-alias-avatar-border-color-down: #fff6;
@@ -268,15 +150,9 @@
     --spectrum-alias-transparent-blue-background-color-down: #a7aaff26;
     --spectrum-alias-transparent-blue-background-color-key-focus: #9195ff26;
     --spectrum-alias-border-color-selected: #ffffffe6;
-    --spectrum-alias-background-color-primary: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-secondary: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-background-color-tertiary: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-alias-background-color-primary: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-secondary: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-background-color-tertiary: var(--spectrum-global-color-gray-50);
     --spectrum-alias-background-color-modal-overlay: #00000080;
     --spectrum-alias-dropshadow-color: #00000080;
     --spectrum-alias-background-color-hover-overlay: #ffffff0f;
@@ -288,13 +164,7 @@
     --spectrum-alias-background-color-quickactions: #323232e6;
     --spectrum-alias-border-color-translucent: #ffffff1a;
     --spectrum-alias-radial-reaction-color-default: #ebebeb99;
-    --spectrum-alias-pasteboard-background-color: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-appframe-border-color: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-appframe-separator-color: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-alias-pasteboard-background-color: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-appframe-border-color: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-appframe-separator-color: var(--spectrum-global-color-gray-50);
 }

--- a/tools/styles/express/spectrum-theme-light.css
+++ b/tools/styles/express/spectrum-theme-light.css
@@ -23,241 +23,123 @@
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 39, 187, 54;
-    --spectrum-global-color-celery-400: rgb(
-        var(--spectrum-global-color-celery-400-rgb)
-    );
+    --spectrum-global-color-celery-400: rgb(var(--spectrum-global-color-celery-400-rgb));
     --spectrum-global-color-celery-500-rgb: 7, 167, 33;
-    --spectrum-global-color-celery-500: rgb(
-        var(--spectrum-global-color-celery-500-rgb)
-    );
+    --spectrum-global-color-celery-500: rgb(var(--spectrum-global-color-celery-500-rgb));
     --spectrum-global-color-celery-600-rgb: 0, 145, 18;
-    --spectrum-global-color-celery-600: rgb(
-        var(--spectrum-global-color-celery-600-rgb)
-    );
+    --spectrum-global-color-celery-600: rgb(var(--spectrum-global-color-celery-600-rgb));
     --spectrum-global-color-celery-700-rgb: 0, 124, 15;
-    --spectrum-global-color-celery-700: rgb(
-        var(--spectrum-global-color-celery-700-rgb)
-    );
+    --spectrum-global-color-celery-700: rgb(var(--spectrum-global-color-celery-700-rgb));
     --spectrum-global-color-chartreuse-400-rgb: 152, 197, 10;
-    --spectrum-global-color-chartreuse-400: rgb(
-        var(--spectrum-global-color-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-chartreuse-400: rgb(var(--spectrum-global-color-chartreuse-400-rgb));
     --spectrum-global-color-chartreuse-500-rgb: 135, 177, 3;
-    --spectrum-global-color-chartreuse-500: rgb(
-        var(--spectrum-global-color-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-chartreuse-500: rgb(var(--spectrum-global-color-chartreuse-500-rgb));
     --spectrum-global-color-chartreuse-600-rgb: 118, 156, 0;
-    --spectrum-global-color-chartreuse-600: rgb(
-        var(--spectrum-global-color-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-chartreuse-600: rgb(var(--spectrum-global-color-chartreuse-600-rgb));
     --spectrum-global-color-chartreuse-700-rgb: 103, 136, 0;
-    --spectrum-global-color-chartreuse-700: rgb(
-        var(--spectrum-global-color-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-chartreuse-700: rgb(var(--spectrum-global-color-chartreuse-700-rgb));
     --spectrum-global-color-yellow-400-rgb: 232, 198, 0;
-    --spectrum-global-color-yellow-400: rgb(
-        var(--spectrum-global-color-yellow-400-rgb)
-    );
+    --spectrum-global-color-yellow-400: rgb(var(--spectrum-global-color-yellow-400-rgb));
     --spectrum-global-color-yellow-500-rgb: 215, 179, 0;
-    --spectrum-global-color-yellow-500: rgb(
-        var(--spectrum-global-color-yellow-500-rgb)
-    );
+    --spectrum-global-color-yellow-500: rgb(var(--spectrum-global-color-yellow-500-rgb));
     --spectrum-global-color-yellow-600-rgb: 196, 159, 0;
-    --spectrum-global-color-yellow-600: rgb(
-        var(--spectrum-global-color-yellow-600-rgb)
-    );
+    --spectrum-global-color-yellow-600: rgb(var(--spectrum-global-color-yellow-600-rgb));
     --spectrum-global-color-yellow-700-rgb: 176, 140, 0;
-    --spectrum-global-color-yellow-700: rgb(
-        var(--spectrum-global-color-yellow-700-rgb)
-    );
+    --spectrum-global-color-yellow-700: rgb(var(--spectrum-global-color-yellow-700-rgb));
     --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
-    --spectrum-global-color-magenta-400: rgb(
-        var(--spectrum-global-color-magenta-400-rgb)
-    );
+    --spectrum-global-color-magenta-400: rgb(var(--spectrum-global-color-magenta-400-rgb));
     --spectrum-global-color-magenta-500-rgb: 200, 34, 105;
-    --spectrum-global-color-magenta-500: rgb(
-        var(--spectrum-global-color-magenta-500-rgb)
-    );
+    --spectrum-global-color-magenta-500: rgb(var(--spectrum-global-color-magenta-500-rgb));
     --spectrum-global-color-magenta-600-rgb: 173, 9, 85;
-    --spectrum-global-color-magenta-600: rgb(
-        var(--spectrum-global-color-magenta-600-rgb)
-    );
+    --spectrum-global-color-magenta-600: rgb(var(--spectrum-global-color-magenta-600-rgb));
     --spectrum-global-color-magenta-700-rgb: 142, 0, 69;
-    --spectrum-global-color-magenta-700: rgb(
-        var(--spectrum-global-color-magenta-700-rgb)
-    );
+    --spectrum-global-color-magenta-700: rgb(var(--spectrum-global-color-magenta-700-rgb));
     --spectrum-global-color-fuchsia-400-rgb: 205, 58, 206;
-    --spectrum-global-color-fuchsia-400: rgb(
-        var(--spectrum-global-color-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-fuchsia-400: rgb(var(--spectrum-global-color-fuchsia-400-rgb));
     --spectrum-global-color-fuchsia-500-rgb: 182, 34, 183;
-    --spectrum-global-color-fuchsia-500: rgb(
-        var(--spectrum-global-color-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-fuchsia-500: rgb(var(--spectrum-global-color-fuchsia-500-rgb));
     --spectrum-global-color-fuchsia-600-rgb: 157, 3, 158;
-    --spectrum-global-color-fuchsia-600: rgb(
-        var(--spectrum-global-color-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-fuchsia-600: rgb(var(--spectrum-global-color-fuchsia-600-rgb));
     --spectrum-global-color-fuchsia-700-rgb: 128, 0, 129;
-    --spectrum-global-color-fuchsia-700: rgb(
-        var(--spectrum-global-color-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-fuchsia-700: rgb(var(--spectrum-global-color-fuchsia-700-rgb));
     --spectrum-global-color-purple-400-rgb: 157, 87, 244;
-    --spectrum-global-color-purple-400: rgb(
-        var(--spectrum-global-color-purple-400-rgb)
-    );
+    --spectrum-global-color-purple-400: rgb(var(--spectrum-global-color-purple-400-rgb));
     --spectrum-global-color-purple-500-rgb: 137, 61, 231;
-    --spectrum-global-color-purple-500: rgb(
-        var(--spectrum-global-color-purple-500-rgb)
-    );
+    --spectrum-global-color-purple-500: rgb(var(--spectrum-global-color-purple-500-rgb));
     --spectrum-global-color-purple-600-rgb: 115, 38, 211;
-    --spectrum-global-color-purple-600: rgb(
-        var(--spectrum-global-color-purple-600-rgb)
-    );
+    --spectrum-global-color-purple-600: rgb(var(--spectrum-global-color-purple-600-rgb));
     --spectrum-global-color-purple-700-rgb: 93, 19, 183;
-    --spectrum-global-color-purple-700: rgb(
-        var(--spectrum-global-color-purple-700-rgb)
-    );
+    --spectrum-global-color-purple-700: rgb(var(--spectrum-global-color-purple-700-rgb));
     --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
-    --spectrum-global-color-indigo-400: rgb(
-        var(--spectrum-global-color-indigo-400-rgb)
-    );
+    --spectrum-global-color-indigo-400: rgb(var(--spectrum-global-color-indigo-400-rgb));
     --spectrum-global-color-indigo-500-rgb: 82, 88, 228;
-    --spectrum-global-color-indigo-500: rgb(
-        var(--spectrum-global-color-indigo-500-rgb)
-    );
+    --spectrum-global-color-indigo-500: rgb(var(--spectrum-global-color-indigo-500-rgb));
     --spectrum-global-color-indigo-600-rgb: 64, 70, 202;
-    --spectrum-global-color-indigo-600: rgb(
-        var(--spectrum-global-color-indigo-600-rgb)
-    );
+    --spectrum-global-color-indigo-600: rgb(var(--spectrum-global-color-indigo-600-rgb));
     --spectrum-global-color-indigo-700-rgb: 50, 54, 168;
-    --spectrum-global-color-indigo-700: rgb(
-        var(--spectrum-global-color-indigo-700-rgb)
-    );
+    --spectrum-global-color-indigo-700: rgb(var(--spectrum-global-color-indigo-700-rgb));
     --spectrum-global-color-seafoam-400-rgb: 0, 161, 154;
-    --spectrum-global-color-seafoam-400: rgb(
-        var(--spectrum-global-color-seafoam-400-rgb)
-    );
+    --spectrum-global-color-seafoam-400: rgb(var(--spectrum-global-color-seafoam-400-rgb));
     --spectrum-global-color-seafoam-500-rgb: 0, 140, 135;
-    --spectrum-global-color-seafoam-500: rgb(
-        var(--spectrum-global-color-seafoam-500-rgb)
-    );
+    --spectrum-global-color-seafoam-500: rgb(var(--spectrum-global-color-seafoam-500-rgb));
     --spectrum-global-color-seafoam-600-rgb: 0, 119, 114;
-    --spectrum-global-color-seafoam-600: rgb(
-        var(--spectrum-global-color-seafoam-600-rgb)
-    );
+    --spectrum-global-color-seafoam-600: rgb(var(--spectrum-global-color-seafoam-600-rgb));
     --spectrum-global-color-seafoam-700-rgb: 0, 99, 95;
-    --spectrum-global-color-seafoam-700: rgb(
-        var(--spectrum-global-color-seafoam-700-rgb)
-    );
+    --spectrum-global-color-seafoam-700: rgb(var(--spectrum-global-color-seafoam-700-rgb));
     --spectrum-global-color-red-400-rgb: 234, 56, 41;
-    --spectrum-global-color-red-400: rgb(
-        var(--spectrum-global-color-red-400-rgb)
-    );
+    --spectrum-global-color-red-400: rgb(var(--spectrum-global-color-red-400-rgb));
     --spectrum-global-color-red-500-rgb: 211, 21, 16;
-    --spectrum-global-color-red-500: rgb(
-        var(--spectrum-global-color-red-500-rgb)
-    );
+    --spectrum-global-color-red-500: rgb(var(--spectrum-global-color-red-500-rgb));
     --spectrum-global-color-red-600-rgb: 180, 0, 0;
-    --spectrum-global-color-red-600: rgb(
-        var(--spectrum-global-color-red-600-rgb)
-    );
+    --spectrum-global-color-red-600: rgb(var(--spectrum-global-color-red-600-rgb));
     --spectrum-global-color-red-700-rgb: 147, 0, 0;
-    --spectrum-global-color-red-700: rgb(
-        var(--spectrum-global-color-red-700-rgb)
-    );
+    --spectrum-global-color-red-700: rgb(var(--spectrum-global-color-red-700-rgb));
     --spectrum-global-color-orange-400-rgb: 246, 133, 17;
-    --spectrum-global-color-orange-400: rgb(
-        var(--spectrum-global-color-orange-400-rgb)
-    );
+    --spectrum-global-color-orange-400: rgb(var(--spectrum-global-color-orange-400-rgb));
     --spectrum-global-color-orange-500-rgb: 228, 111, 0;
-    --spectrum-global-color-orange-500: rgb(
-        var(--spectrum-global-color-orange-500-rgb)
-    );
+    --spectrum-global-color-orange-500: rgb(var(--spectrum-global-color-orange-500-rgb));
     --spectrum-global-color-orange-600-rgb: 203, 93, 0;
-    --spectrum-global-color-orange-600: rgb(
-        var(--spectrum-global-color-orange-600-rgb)
-    );
+    --spectrum-global-color-orange-600: rgb(var(--spectrum-global-color-orange-600-rgb));
     --spectrum-global-color-orange-700-rgb: 177, 76, 0;
-    --spectrum-global-color-orange-700: rgb(
-        var(--spectrum-global-color-orange-700-rgb)
-    );
+    --spectrum-global-color-orange-700: rgb(var(--spectrum-global-color-orange-700-rgb));
     --spectrum-global-color-green-400-rgb: 0, 143, 93;
-    --spectrum-global-color-green-400: rgb(
-        var(--spectrum-global-color-green-400-rgb)
-    );
+    --spectrum-global-color-green-400: rgb(var(--spectrum-global-color-green-400-rgb));
     --spectrum-global-color-green-500-rgb: 0, 122, 77;
-    --spectrum-global-color-green-500: rgb(
-        var(--spectrum-global-color-green-500-rgb)
-    );
+    --spectrum-global-color-green-500: rgb(var(--spectrum-global-color-green-500-rgb));
     --spectrum-global-color-green-600-rgb: 0, 101, 62;
-    --spectrum-global-color-green-600: rgb(
-        var(--spectrum-global-color-green-600-rgb)
-    );
+    --spectrum-global-color-green-600: rgb(var(--spectrum-global-color-green-600-rgb));
     --spectrum-global-color-green-700-rgb: 0, 81, 50;
-    --spectrum-global-color-green-700: rgb(
-        var(--spectrum-global-color-green-700-rgb)
-    );
+    --spectrum-global-color-green-700: rgb(var(--spectrum-global-color-green-700-rgb));
     --spectrum-global-color-blue-400-rgb: 20, 122, 243;
-    --spectrum-global-color-blue-400: rgb(
-        var(--spectrum-global-color-blue-400-rgb)
-    );
+    --spectrum-global-color-blue-400: rgb(var(--spectrum-global-color-blue-400-rgb));
     --spectrum-global-color-blue-500-rgb: 2, 101, 220;
-    --spectrum-global-color-blue-500: rgb(
-        var(--spectrum-global-color-blue-500-rgb)
-    );
+    --spectrum-global-color-blue-500: rgb(var(--spectrum-global-color-blue-500-rgb));
     --spectrum-global-color-blue-600-rgb: 0, 84, 182;
-    --spectrum-global-color-blue-600: rgb(
-        var(--spectrum-global-color-blue-600-rgb)
-    );
+    --spectrum-global-color-blue-600: rgb(var(--spectrum-global-color-blue-600-rgb));
     --spectrum-global-color-blue-700-rgb: 0, 68, 145;
-    --spectrum-global-color-blue-700: rgb(
-        var(--spectrum-global-color-blue-700-rgb)
-    );
+    --spectrum-global-color-blue-700: rgb(var(--spectrum-global-color-blue-700-rgb));
     --spectrum-global-color-gray-50-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-50: rgb(
-        var(--spectrum-global-color-gray-50-rgb)
-    );
+    --spectrum-global-color-gray-50: rgb(var(--spectrum-global-color-gray-50-rgb));
     --spectrum-global-color-gray-75-rgb: 253, 253, 253;
-    --spectrum-global-color-gray-75: rgb(
-        var(--spectrum-global-color-gray-75-rgb)
-    );
+    --spectrum-global-color-gray-75: rgb(var(--spectrum-global-color-gray-75-rgb));
     --spectrum-global-color-gray-100-rgb: 248, 248, 248;
-    --spectrum-global-color-gray-100: rgb(
-        var(--spectrum-global-color-gray-100-rgb)
-    );
+    --spectrum-global-color-gray-100: rgb(var(--spectrum-global-color-gray-100-rgb));
     --spectrum-global-color-gray-200-rgb: 230, 230, 230;
-    --spectrum-global-color-gray-200: rgb(
-        var(--spectrum-global-color-gray-200-rgb)
-    );
+    --spectrum-global-color-gray-200: rgb(var(--spectrum-global-color-gray-200-rgb));
     --spectrum-global-color-gray-300-rgb: 213, 213, 213;
-    --spectrum-global-color-gray-300: rgb(
-        var(--spectrum-global-color-gray-300-rgb)
-    );
+    --spectrum-global-color-gray-300: rgb(var(--spectrum-global-color-gray-300-rgb));
     --spectrum-global-color-gray-400-rgb: 177, 177, 177;
-    --spectrum-global-color-gray-400: rgb(
-        var(--spectrum-global-color-gray-400-rgb)
-    );
+    --spectrum-global-color-gray-400: rgb(var(--spectrum-global-color-gray-400-rgb));
     --spectrum-global-color-gray-500-rgb: 144, 144, 144;
-    --spectrum-global-color-gray-500: rgb(
-        var(--spectrum-global-color-gray-500-rgb)
-    );
+    --spectrum-global-color-gray-500: rgb(var(--spectrum-global-color-gray-500-rgb));
     --spectrum-global-color-gray-600-rgb: 109, 109, 109;
-    --spectrum-global-color-gray-600: rgb(
-        var(--spectrum-global-color-gray-600-rgb)
-    );
+    --spectrum-global-color-gray-600: rgb(var(--spectrum-global-color-gray-600-rgb));
     --spectrum-global-color-gray-700-rgb: 70, 70, 70;
-    --spectrum-global-color-gray-700: rgb(
-        var(--spectrum-global-color-gray-700-rgb)
-    );
+    --spectrum-global-color-gray-700: rgb(var(--spectrum-global-color-gray-700-rgb));
     --spectrum-global-color-gray-800-rgb: 34, 34, 34;
-    --spectrum-global-color-gray-800: rgb(
-        var(--spectrum-global-color-gray-800-rgb)
-    );
+    --spectrum-global-color-gray-800: rgb(var(--spectrum-global-color-gray-800-rgb));
     --spectrum-global-color-gray-900-rgb: 0, 0, 0;
-    --spectrum-global-color-gray-900: rgb(
-        var(--spectrum-global-color-gray-900-rgb)
-    );
+    --spectrum-global-color-gray-900: rgb(var(--spectrum-global-color-gray-900-rgb));
     --spectrum-alias-avatar-border-color-default: #0000001a;
     --spectrum-alias-avatar-border-color-hover: #00000040;
     --spectrum-alias-avatar-border-color-down: #0006;
@@ -268,15 +150,9 @@
     --spectrum-alias-transparent-blue-background-color-down: #3236a826;
     --spectrum-alias-transparent-blue-background-color-key-focus: #4046ca26;
     --spectrum-alias-border-color-selected: #000000e6;
-    --spectrum-alias-background-color-primary: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-background-color-secondary: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-tertiary: var(
-        --spectrum-global-color-gray-300
-    );
+    --spectrum-alias-background-color-primary: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-background-color-secondary: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-tertiary: var(--spectrum-global-color-gray-300);
     --spectrum-alias-background-color-modal-overlay: #0006;
     --spectrum-alias-dropshadow-color: #00000026;
     --spectrum-alias-background-color-hover-overlay: #0000000a;
@@ -288,13 +164,7 @@
     --spectrum-alias-background-color-quickactions: #f8f8f8e6;
     --spectrum-alias-border-color-translucent: #0000001a;
     --spectrum-alias-radial-reaction-color-default: #2229;
-    --spectrum-alias-pasteboard-background-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-appframe-border-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-appframe-separator-color: var(
-        --spectrum-global-color-gray-300
-    );
+    --spectrum-alias-pasteboard-background-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-appframe-border-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-appframe-separator-color: var(--spectrum-global-color-gray-300);
 }

--- a/tools/styles/fonts.css
+++ b/tools/styles/fonts.css
@@ -13,130 +13,58 @@
 }
 
 .spectrum-Typography .spectrum-Heading {
-    --spectrum-heading-margin-start: calc(
-        var(--mod-heading-font-size, var(--spectrum-heading-font-size)) *
-            var(--spectrum-heading-margin-top-multiplier)
-    );
-    --spectrum-heading-margin-end: calc(
-        var(--mod-heading-font-size, var(--spectrum-heading-font-size)) *
-            var(--spectrum-heading-margin-bottom-multiplier)
-    );
+    --spectrum-heading-margin-start: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-top-multiplier));
+    --spectrum-heading-margin-end: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-bottom-multiplier));
 }
 
 .spectrum-Typography .spectrum-Body {
-    --spectrum-body-margin-end: calc(
-        var(--mod-body-font-size, var(--spectrum-body-font-size)) *
-            var(--spectrum-body-margin-multiplier)
-    );
+    --spectrum-body-margin-end: calc(var(--mod-body-font-size, var(--spectrum-body-font-size)) * var(--spectrum-body-margin-multiplier));
 }
 
 .spectrum-Typography .spectrum-Detail {
-    --spectrum-detail-margin-start: calc(
-        var(--mod-detail-font-size, var(--spectrum-detail-font-size)) *
-            var(--spectrum-detail-margin-top-multiplier)
-    );
-    --spectrum-detail-margin-end: calc(
-        var(--mod-detail-font-size, var(--spectrum-detail-font-size)) *
-            var(--spectrum-detail-margin-bottom-multiplier)
-    );
+    --spectrum-detail-margin-start: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-top-multiplier));
+    --spectrum-detail-margin-end: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-bottom-multiplier));
 }
 
 .spectrum-Heading {
-    font-family: var(
-        --mod-heading-sans-serif-font-family,
-        var(--spectrum-heading-sans-serif-font-family)
-    );
-    font-style: var(
-        --mod-heading-sans-serif-font-style,
-        var(--spectrum-heading-sans-serif-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-font-weight,
-        var(--spectrum-heading-sans-serif-font-weight)
-    );
+    font-family: var(--mod-heading-sans-serif-font-family, var(--spectrum-heading-sans-serif-font-family));
+    font-style: var(--mod-heading-sans-serif-font-style, var(--spectrum-heading-sans-serif-font-style));
+    font-weight: var(--mod-heading-sans-serif-font-weight, var(--spectrum-heading-sans-serif-font-weight));
     font-size: var(--mod-heading-font-size, var(--spectrum-heading-font-size));
-    color: var(
-        --highcontrast-heading-font-color,
-        var(--mod-heading-font-color, var(--spectrum-heading-font-color))
-    );
-    line-height: var(
-        --mod-heading-line-height,
-        var(--spectrum-heading-line-height)
-    );
-    margin-block-start: var(
-        --mod-heading-margin-start,
-        var(--spectrum-heading-margin-start, 0)
-    );
-    margin-block-end: var(
-        --mod-heading-margin-end,
-        var(--spectrum-heading-margin-end, 0)
-    );
+    color: var(--highcontrast-heading-font-color, var(--mod-heading-font-color, var(--spectrum-heading-font-color)));
+    line-height: var(--mod-heading-line-height, var(--spectrum-heading-line-height));
+    margin-block-start: var(--mod-heading-margin-start, var(--spectrum-heading-margin-start, 0));
+    margin-block-end: var(--mod-heading-margin-end, var(--spectrum-heading-margin-end, 0));
 }
 
 .spectrum-Heading .spectrum-Heading-strong,
 .spectrum-Heading strong {
-    font-style: var(
-        --mod-heading-sans-serif-strong-font-style,
-        var(--spectrum-heading-sans-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-strong-font-weight,
-        var(--spectrum-heading-sans-serif-strong-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-strong-font-style, var(--spectrum-heading-sans-serif-strong-font-style));
+    font-weight: var(--mod-heading-sans-serif-strong-font-weight, var(--spectrum-heading-sans-serif-strong-font-weight));
 }
 
 .spectrum-Heading .spectrum-Heading-emphasized,
 .spectrum-Heading em {
-    font-style: var(
-        --mod-heading-sans-serif-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-emphasized-font-style, var(--spectrum-heading-sans-serif-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-emphasized-font-weight, var(--spectrum-heading-sans-serif-emphasized-font-weight));
 }
 
 .spectrum-Heading .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading em strong,
 .spectrum-Heading strong em {
-    font-style: var(
-        --mod-heading-sans-serif-strong-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-strong-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-strong-emphasized-font-style, var(--spectrum-heading-sans-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-strong-emphasized-font-weight, var(--spectrum-heading-sans-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading:lang(ja),
 .spectrum-Heading:lang(ko),
 .spectrum-Heading:lang(zh) {
-    font-family: var(
-        --mod-heading-cjk-font-family,
-        var(--spectrum-heading-cjk-font-family)
-    );
-    font-style: var(
-        --mod-heading-cjk-font-style,
-        var(--spectrum-heading-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-font-weight,
-        var(--spectrum-heading-cjk-font-weight)
-    );
-    font-size: var(
-        --mod-heading-cjk-font-size,
-        var(--spectrum-heading-cjk-font-size)
-    );
-    line-height: var(
-        --mod-heading-cjk-line-height,
-        var(--spectrum-heading-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-heading-cjk-letter-spacing,
-        var(--spectrum-heading-cjk-letter-spacing)
-    );
+    font-family: var(--mod-heading-cjk-font-family, var(--spectrum-heading-cjk-font-family));
+    font-style: var(--mod-heading-cjk-font-style, var(--spectrum-heading-cjk-font-style));
+    font-weight: var(--mod-heading-cjk-font-weight, var(--spectrum-heading-cjk-font-weight));
+    font-size: var(--mod-heading-cjk-font-size, var(--spectrum-heading-cjk-font-size));
+    line-height: var(--mod-heading-cjk-line-height, var(--spectrum-heading-cjk-line-height));
+    letter-spacing: var(--mod-heading-cjk-letter-spacing, var(--spectrum-heading-cjk-letter-spacing));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-emphasized,
@@ -145,14 +73,8 @@
 .spectrum-Heading:lang(ko) em,
 .spectrum-Heading:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-emphasized-font-style,
-        var(--spectrum-heading-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-emphasized-font-weight,
-        var(--spectrum-heading-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-emphasized-font-style, var(--spectrum-heading-cjk-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-emphasized-font-weight, var(--spectrum-heading-cjk-emphasized-font-weight));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-strong,
@@ -161,14 +83,8 @@
 .spectrum-Heading:lang(ko) strong,
 .spectrum-Heading:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-strong-font-style,
-        var(--spectrum-heading-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-strong-font-weight,
-        var(--spectrum-heading-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-strong-font-style, var(--spectrum-heading-cjk-strong-font-style));
+    font-weight: var(--mod-heading-cjk-strong-font-weight, var(--spectrum-heading-cjk-strong-font-weight));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
@@ -180,75 +96,39 @@
 .spectrum-Heading:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading:lang(zh) em strong,
 .spectrum-Heading:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-strong-emphasized-font-style, var(--spectrum-heading-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-strong-emphasized-font-weight, var(--spectrum-heading-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-font-style,
-        var(--spectrum-heading-sans-serif-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-font-style, var(--spectrum-heading-sans-serif-heavy-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-font-weight, var(--spectrum-heading-sans-serif-heavy-font-weight));
 }
 
 .spectrum-Heading--heavy .spectrum-Heading-strong,
 .spectrum-Heading--heavy strong {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-strong-font-style,
-        var(--spectrum-heading-sans-serif-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-strong-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-strong-font-style, var(--spectrum-heading-sans-serif-heavy-strong-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-strong-font-weight, var(--spectrum-heading-sans-serif-heavy-strong-font-weight));
 }
 
 .spectrum-Heading--heavy .spectrum-Heading-emphasized,
 .spectrum-Heading--heavy em {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-emphasized-font-style, var(--spectrum-heading-sans-serif-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-emphasized-font-weight, var(--spectrum-heading-sans-serif-heavy-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy em strong,
 .spectrum-Heading--heavy strong em {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-strong-emphasized-font-style, var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-strong-emphasized-font-weight, var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja),
 .spectrum-Heading--heavy:lang(ko),
 .spectrum-Heading--heavy:lang(zh) {
-    font-style: var(
-        --mod-heading-cjk-heavy-font-style,
-        var(--spectrum-heading-cjk-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-font-weight,
-        var(--spectrum-heading-cjk-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-font-style, var(--spectrum-heading-cjk-heavy-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-font-weight, var(--spectrum-heading-cjk-heavy-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja) .spectrum-Heading-emphasized,
@@ -257,14 +137,8 @@
 .spectrum-Heading--heavy:lang(ko) em,
 .spectrum-Heading--heavy:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-heavy-emphasized-font-style,
-        var(--spectrum-heading-cjk-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-emphasized-font-weight,
-        var(--spectrum-heading-cjk-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-emphasized-font-style, var(--spectrum-heading-cjk-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-emphasized-font-weight, var(--spectrum-heading-cjk-heavy-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja) .spectrum-Heading-strong,
@@ -273,97 +147,52 @@
 .spectrum-Heading--heavy:lang(ko) strong,
 .spectrum-Heading--heavy:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading--heavy:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-heavy-strong-font-style,
-        var(--spectrum-heading-cjk-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-strong-font-weight,
-        var(--spectrum-heading-cjk-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-strong-font-style, var(--spectrum-heading-cjk-heavy-strong-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-strong-font-weight, var(--spectrum-heading-cjk-heavy-strong-font-weight));
 }
 
-.spectrum-Heading--heavy:lang(ja)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(ja) em strong,
 .spectrum-Heading--heavy:lang(ja) strong em,
-.spectrum-Heading--heavy:lang(ko)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(ko) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(ko) em strong,
 .spectrum-Heading--heavy:lang(ko) strong em,
-.spectrum-Heading--heavy:lang(zh)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(zh) em strong,
 .spectrum-Heading--heavy:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-strong-emphasized-font-style, var(--spectrum-heading-cjk-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-strong-emphasized-font-weight, var(--spectrum-heading-cjk-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--light {
-    font-style: var(
-        --mod-heading-sans-serif-light-font-style,
-        var(--spectrum-heading-sans-serif-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-font-weight,
-        var(--spectrum-heading-sans-serif-light-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-font-style, var(--spectrum-heading-sans-serif-light-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-font-weight, var(--spectrum-heading-sans-serif-light-font-weight));
 }
 
 .spectrum-Heading--light .spectrum-Heading-emphasized,
 .spectrum-Heading--light em {
-    font-style: var(
-        --mod-heading-sans-serif-light-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-emphasized-font-style, var(--spectrum-heading-sans-serif-light-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-emphasized-font-weight, var(--spectrum-heading-sans-serif-light-emphasized-font-weight));
 }
 
 .spectrum-Heading--light .spectrum-Heading-strong,
 .spectrum-Heading--light strong {
-    font-style: var(
-        --mod-heading-sans-serif-light-strong-font-style,
-        var(--spectrum-heading-sans-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-strong-font-weight,
-        var(--spectrum-heading-sans-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-strong-font-style, var(--spectrum-heading-sans-serif-light-strong-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-strong-font-weight, var(--spectrum-heading-sans-serif-light-strong-font-weight));
 }
 
 .spectrum-Heading--light .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light em strong,
 .spectrum-Heading--light strong em {
-    font-style: var(
-        --mod-heading-sans-serif-light-strong-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-strong-emphasized-font-style, var(--spectrum-heading-sans-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-strong-emphasized-font-weight, var(--spectrum-heading-sans-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja),
 .spectrum-Heading--light:lang(ko),
 .spectrum-Heading--light:lang(zh) {
-    font-style: var(
-        --mod-heading-cjk-light-font-style,
-        var(--spectrum-heading-cjk-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-font-weight,
-        var(--spectrum-heading-cjk-light-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-font-style, var(--spectrum-heading-cjk-light-font-style));
+    font-weight: var(--mod-heading-cjk-light-font-weight, var(--spectrum-heading-cjk-light-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja) .spectrum-Heading-strong,
@@ -372,14 +201,8 @@
 .spectrum-Heading--light:lang(ko) strong,
 .spectrum-Heading--light:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading--light:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-light-strong-font-style,
-        var(--spectrum-heading-cjk-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-strong-font-weight,
-        var(--spectrum-heading-cjk-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-strong-font-style, var(--spectrum-heading-cjk-light-strong-font-style));
+    font-weight: var(--mod-heading-cjk-light-strong-font-weight, var(--spectrum-heading-cjk-light-strong-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja) .spectrum-Heading-emphasized,
@@ -388,277 +211,134 @@
 .spectrum-Heading--light:lang(ko) em,
 .spectrum-Heading--light:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-light-emphasized-font-style,
-        var(--spectrum-heading-cjk-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-emphasized-font-weight,
-        var(--spectrum-heading-cjk-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-emphasized-font-style, var(--spectrum-heading-cjk-light-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-light-emphasized-font-weight, var(--spectrum-heading-cjk-light-emphasized-font-weight));
 }
 
-.spectrum-Heading--light:lang(ja)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(ja) em strong,
 .spectrum-Heading--light:lang(ja) strong em,
-.spectrum-Heading--light:lang(ko)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(ko) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(ko) em strong,
 .spectrum-Heading--light:lang(ko) strong em,
-.spectrum-Heading--light:lang(zh)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(zh) em strong,
 .spectrum-Heading--light:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-light-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-strong-emphasized-font-style, var(--spectrum-heading-cjk-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-light-strong-emphasized-font-weight, var(--spectrum-heading-cjk-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif {
-    font-family: var(
-        --mod-heading-serif-font-family,
-        var(--spectrum-heading-serif-font-family)
-    );
-    font-style: var(
-        --mod-heading-serif-font-style,
-        var(--spectrum-heading-serif-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-font-weight,
-        var(--spectrum-heading-serif-font-weight)
-    );
+    font-family: var(--mod-heading-serif-font-family, var(--spectrum-heading-serif-font-family));
+    font-style: var(--mod-heading-serif-font-style, var(--spectrum-heading-serif-font-style));
+    font-weight: var(--mod-heading-serif-font-weight, var(--spectrum-heading-serif-font-weight));
 }
 
 .spectrum-Heading--serif .spectrum-Heading-emphasized,
 .spectrum-Heading--serif em {
-    font-style: var(
-        --mod-heading-serif-emphasized-font-style,
-        var(--spectrum-heading-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-emphasized-font-weight,
-        var(--spectrum-heading-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-emphasized-font-style, var(--spectrum-heading-serif-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-emphasized-font-weight, var(--spectrum-heading-serif-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif .spectrum-Heading-strong,
 .spectrum-Heading--serif strong {
-    font-style: var(
-        --mod-heading-serif-strong-font-style,
-        var(--spectrum-heading-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-strong-font-weight,
-        var(--spectrum-heading-serif-strong-font-weight)
-    );
+    font-style: var(--mod-heading-serif-strong-font-style, var(--spectrum-heading-serif-strong-font-style));
+    font-weight: var(--mod-heading-serif-strong-font-weight, var(--spectrum-heading-serif-strong-font-weight));
 }
 
 .spectrum-Heading--serif .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--serif em strong,
 .spectrum-Heading--serif strong em {
-    font-style: var(
-        --mod-heading-serif-strong-emphasized-font-style,
-        var(--spectrum-heading-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-strong-emphasized-font-weight,
-        var(--spectrum-heading-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-strong-emphasized-font-style, var(--spectrum-heading-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-strong-emphasized-font-weight, var(--spectrum-heading-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--heavy {
-    font-style: var(
-        --mod-heading-serif-heavy-font-style,
-        var(--spectrum-heading-serif-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-font-weight,
-        var(--spectrum-heading-serif-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-font-style, var(--spectrum-heading-serif-heavy-font-style));
+    font-weight: var(--mod-heading-serif-heavy-font-weight, var(--spectrum-heading-serif-heavy-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--heavy .spectrum-Heading-strong,
 .spectrum-Heading--serif.spectrum-Heading--heavy strong {
-    font-style: var(
-        --mod-heading-serif-heavy-strong-font-style,
-        var(--spectrum-heading-serif-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-strong-font-weight,
-        var(--spectrum-heading-serif-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-strong-font-style, var(--spectrum-heading-serif-heavy-strong-font-style));
+    font-weight: var(--mod-heading-serif-heavy-strong-font-weight, var(--spectrum-heading-serif-heavy-strong-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--heavy .spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--heavy em {
-    font-style: var(
-        --mod-heading-serif-heavy-emphasized-font-style,
-        var(--spectrum-heading-serif-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-emphasized-font-weight,
-        var(--spectrum-heading-serif-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-emphasized-font-style, var(--spectrum-heading-serif-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-heavy-emphasized-font-weight, var(--spectrum-heading-serif-heavy-emphasized-font-weight));
 }
 
-.spectrum-Heading--serif.spectrum-Heading--heavy
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--serif.spectrum-Heading--heavy .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--heavy em strong,
 .spectrum-Heading--serif.spectrum-Heading--heavy strong em {
-    font-style: var(
-        --mod-heading-serif-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-serif-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-serif-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-strong-emphasized-font-style, var(--spectrum-heading-serif-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-heavy-strong-emphasized-font-weight, var(--spectrum-heading-serif-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--light {
-    font-style: var(
-        --mod-heading-serif-light-font-style,
-        var(--spectrum-heading-serif-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-font-weight,
-        var(--spectrum-heading-serif-light-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-font-style, var(--spectrum-heading-serif-light-font-style));
+    font-weight: var(--mod-heading-serif-light-font-weight, var(--spectrum-heading-serif-light-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--light .spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--light em {
-    font-style: var(
-        --mod-heading-serif-light-emphasized-font-style,
-        var(--spectrum-heading-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-emphasized-font-weight,
-        var(--spectrum-heading-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-emphasized-font-style, var(--spectrum-heading-serif-light-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-light-emphasized-font-weight, var(--spectrum-heading-serif-light-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--light .spectrum-Heading-strong,
 .spectrum-Heading--serif.spectrum-Heading--light strong {
-    font-style: var(
-        --mod-heading-serif-light-strong-font-style,
-        var(--spectrum-heading-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-strong-font-weight,
-        var(--spectrum-heading-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-strong-font-style, var(--spectrum-heading-serif-light-strong-font-style));
+    font-weight: var(--mod-heading-serif-light-strong-font-weight, var(--spectrum-heading-serif-light-strong-font-weight));
 }
 
-.spectrum-Heading--serif.spectrum-Heading--light
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--serif.spectrum-Heading--light .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--light em strong,
 .spectrum-Heading--serif.spectrum-Heading--light strong em {
-    font-style: var(
-        --mod-heading-serif-light-strong-emphasized-font-style,
-        var(--spectrum-heading-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-strong-emphasized-font-style, var(--spectrum-heading-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-light-strong-emphasized-font-weight, var(--spectrum-heading-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Body {
-    font-family: var(
-        --mod-body-sans-serif-font-family,
-        var(--spectrum-body-sans-serif-font-family)
-    );
-    font-style: var(
-        --mod-body-sans-serif-font-style,
-        var(--spectrum-body-sans-serif-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-font-weight,
-        var(--spectrum-body-sans-serif-font-weight)
-    );
+    font-family: var(--mod-body-sans-serif-font-family, var(--spectrum-body-sans-serif-font-family));
+    font-style: var(--mod-body-sans-serif-font-style, var(--spectrum-body-sans-serif-font-style));
+    font-weight: var(--mod-body-sans-serif-font-weight, var(--spectrum-body-sans-serif-font-weight));
     font-size: var(--mod-body-font-size, var(--spectrum-body-font-size));
-    color: var(
-        --highcontrast-body-font-color,
-        var(--mod-body-font-color, var(--spectrum-body-font-color))
-    );
+    color: var(--highcontrast-body-font-color, var(--mod-body-font-color, var(--spectrum-body-font-color)));
     line-height: var(--mod-body-line-height, var(--spectrum-body-line-height));
-    margin-block-start: var(
-        --mod-body-margin-start,
-        var(--mod-body-margin, var(--spectrum-body-margin-start, 0))
-    );
-    margin-block-end: var(
-        --mod-body-margin-end,
-        var(--mod-body-margin, var(--spectrum-body-margin-end, 0))
-    );
+    margin-block-start: var(--mod-body-margin-start, var(--mod-body-margin, var(--spectrum-body-margin-start, 0)));
+    margin-block-end: var(--mod-body-margin-end, var(--mod-body-margin, var(--spectrum-body-margin-end, 0)));
 }
 
 .spectrum-Body .spectrum-Body-strong,
 .spectrum-Body strong {
-    font-style: var(
-        --mod-body-sans-serif-strong-font-style,
-        var(--spectrum-body-sans-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-strong-font-weight,
-        var(--spectrum-body-sans-serif-strong-font-weight)
-    );
+    font-style: var(--mod-body-sans-serif-strong-font-style, var(--spectrum-body-sans-serif-strong-font-style));
+    font-weight: var(--mod-body-sans-serif-strong-font-weight, var(--spectrum-body-sans-serif-strong-font-weight));
 }
 
 .spectrum-Body .spectrum-Body-emphasized,
 .spectrum-Body em {
-    font-style: var(
-        --mod-body-sans-serif-emphasized-font-style,
-        var(--spectrum-body-sans-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-emphasized-font-weight,
-        var(--spectrum-body-sans-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-sans-serif-emphasized-font-style, var(--spectrum-body-sans-serif-emphasized-font-style));
+    font-weight: var(--mod-body-sans-serif-emphasized-font-weight, var(--spectrum-body-sans-serif-emphasized-font-weight));
 }
 
 .spectrum-Body .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body em strong,
 .spectrum-Body strong em {
-    font-style: var(
-        --mod-body-sans-serif-strong-emphasized-font-style,
-        var(--spectrum-body-sans-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-strong-emphasized-font-weight,
-        var(--spectrum-body-sans-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-sans-serif-strong-emphasized-font-style, var(--spectrum-body-sans-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-body-sans-serif-strong-emphasized-font-weight, var(--spectrum-body-sans-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Body:lang(ja),
 .spectrum-Body:lang(ko),
 .spectrum-Body:lang(zh) {
-    font-family: var(
-        --mod-body-cjk-font-family,
-        var(--spectrum-body-cjk-font-family)
-    );
-    font-style: var(
-        --mod-body-cjk-font-style,
-        var(--spectrum-body-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-font-weight,
-        var(--spectrum-body-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-body-cjk-line-height,
-        var(--spectrum-body-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-body-cjk-letter-spacing,
-        var(--spectrum-body-cjk-letter-spacing)
-    );
+    font-family: var(--mod-body-cjk-font-family, var(--spectrum-body-cjk-font-family));
+    font-style: var(--mod-body-cjk-font-style, var(--spectrum-body-cjk-font-style));
+    font-weight: var(--mod-body-cjk-font-weight, var(--spectrum-body-cjk-font-weight));
+    line-height: var(--mod-body-cjk-line-height, var(--spectrum-body-cjk-line-height));
+    letter-spacing: var(--mod-body-cjk-letter-spacing, var(--spectrum-body-cjk-letter-spacing));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-strong,
@@ -667,14 +347,8 @@
 .spectrum-Body:lang(ko) strong,
 .spectrum-Body:lang(zh) .spectrum-Body-strong,
 .spectrum-Body:lang(zh) strong {
-    font-style: var(
-        --mod-body-cjk-strong-font-style,
-        var(--spectrum-body-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-strong-font-weight,
-        var(--spectrum-body-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-body-cjk-strong-font-style, var(--spectrum-body-cjk-strong-font-style));
+    font-weight: var(--mod-body-cjk-strong-font-weight, var(--spectrum-body-cjk-strong-font-weight));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-emphasized,
@@ -683,14 +357,8 @@
 .spectrum-Body:lang(ko) em,
 .spectrum-Body:lang(zh) .spectrum-Body-emphasized,
 .spectrum-Body:lang(zh) em {
-    font-style: var(
-        --mod-body-cjk-emphasized-font-style,
-        var(--spectrum-body-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-emphasized-font-weight,
-        var(--spectrum-body-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-cjk-emphasized-font-style, var(--spectrum-body-cjk-emphasized-font-style));
+    font-weight: var(--mod-body-cjk-emphasized-font-weight, var(--spectrum-body-cjk-emphasized-font-weight));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-strong.spectrum-Body-emphasized,
@@ -702,161 +370,74 @@
 .spectrum-Body:lang(zh) .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body:lang(zh) em strong,
 .spectrum-Body:lang(zh) strong em {
-    font-style: var(
-        --mod-body-cjk-strong-emphasized-font-style,
-        var(--spectrum-body-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-strong-emphasized-font-weight,
-        var(--spectrum-body-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-cjk-strong-emphasized-font-style, var(--spectrum-body-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-body-cjk-strong-emphasized-font-weight, var(--spectrum-body-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Body--serif {
-    font-family: var(
-        --mod-body-serif-font-family,
-        var(--spectrum-body-serif-font-family)
-    );
-    font-weight: var(
-        --mod-body-serif-font-weight,
-        var(--spectrum-body-serif-font-weight)
-    );
-    font-style: var(
-        --mod-body-serif-font-style,
-        var(--spectrum-body-serif-font-style)
-    );
+    font-family: var(--mod-body-serif-font-family, var(--spectrum-body-serif-font-family));
+    font-weight: var(--mod-body-serif-font-weight, var(--spectrum-body-serif-font-weight));
+    font-style: var(--mod-body-serif-font-style, var(--spectrum-body-serif-font-style));
 }
 
 .spectrum-Body--serif .spectrum-Body-strong,
 .spectrum-Body--serif strong {
-    font-style: var(
-        --mod-body-serif-strong-font-style,
-        var(--spectrum-body-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-serif-strong-font-weight,
-        var(--spectrum-body-serif-strong-font-weight)
-    );
+    font-style: var(--mod-body-serif-strong-font-style, var(--spectrum-body-serif-strong-font-style));
+    font-weight: var(--mod-body-serif-strong-font-weight, var(--spectrum-body-serif-strong-font-weight));
 }
 
 .spectrum-Body--serif .spectrum-Body-emphasized,
 .spectrum-Body--serif em {
-    font-style: var(
-        --mod-body-serif-emphasized-font-style,
-        var(--spectrum-body-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-serif-emphasized-font-weight,
-        var(--spectrum-body-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-serif-emphasized-font-style, var(--spectrum-body-serif-emphasized-font-style));
+    font-weight: var(--mod-body-serif-emphasized-font-weight, var(--spectrum-body-serif-emphasized-font-weight));
 }
 
 .spectrum-Body--serif .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body--serif em strong,
 .spectrum-Body--serif strong em {
-    font-style: var(
-        --mod-body-serif-strong-emphasized-font-style,
-        var(--spectrum-body-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-serif-strong-emphasized-font-weight,
-        var(--spectrum-body-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-serif-strong-emphasized-font-style, var(--spectrum-body-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-body-serif-strong-emphasized-font-weight, var(--spectrum-body-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail {
-    font-family: var(
-        --mod-detail-sans-serif-font-family,
-        var(--spectrum-detail-sans-serif-font-family)
-    );
-    font-style: var(
-        --mod-detail-sans-serif-font-style,
-        var(--spectrum-detail-sans-serif-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-font-weight,
-        var(--spectrum-detail-sans-serif-font-weight)
-    );
+    font-family: var(--mod-detail-sans-serif-font-family, var(--spectrum-detail-sans-serif-font-family));
+    font-style: var(--mod-detail-sans-serif-font-style, var(--spectrum-detail-sans-serif-font-style));
+    font-weight: var(--mod-detail-sans-serif-font-weight, var(--spectrum-detail-sans-serif-font-weight));
     font-size: var(--mod-detail-font-size, var(--spectrum-detail-font-size));
-    color: var(
-        --highcontrast-detail-font-color,
-        var(--mod-detail-font-color, var(--spectrum-detail-font-color))
-    );
-    line-height: var(
-        --mod-detail-line-height,
-        var(--spectrum-detail-line-height)
-    );
-    letter-spacing: var(
-        --mod-detail-letter-spacing,
-        var(--spectrum-detail-letter-spacing)
-    );
+    color: var(--highcontrast-detail-font-color, var(--mod-detail-font-color, var(--spectrum-detail-font-color)));
+    line-height: var(--mod-detail-line-height, var(--spectrum-detail-line-height));
+    letter-spacing: var(--mod-detail-letter-spacing, var(--spectrum-detail-letter-spacing));
     text-transform: uppercase;
-    margin-block-start: var(
-        --mod-detail-margin-start,
-        var(--spectrum-detail-margin-start, 0)
-    );
-    margin-block-end: var(
-        --mod-detail-margin-end,
-        var(--spectrum-detail-margin-end, 0)
-    );
+    margin-block-start: var(--mod-detail-margin-start, var(--spectrum-detail-margin-start, 0));
+    margin-block-end: var(--mod-detail-margin-end, var(--spectrum-detail-margin-end, 0));
 }
 
 .spectrum-Detail .spectrum-Detail-strong,
 .spectrum-Detail strong {
-    font-style: var(
-        --mod-detail-sans-serif-strong-font-style,
-        var(--spectrum-detail-sans-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-strong-font-weight,
-        var(--spectrum-detail-sans-serif-strong-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-strong-font-style, var(--spectrum-detail-sans-serif-strong-font-style));
+    font-weight: var(--mod-detail-sans-serif-strong-font-weight, var(--spectrum-detail-sans-serif-strong-font-weight));
 }
 
 .spectrum-Detail .spectrum-Detail-emphasized,
 .spectrum-Detail em {
-    font-style: var(
-        --mod-detail-sans-serif-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-emphasized-font-style, var(--spectrum-detail-sans-serif-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-emphasized-font-weight, var(--spectrum-detail-sans-serif-emphasized-font-weight));
 }
 
 .spectrum-Detail .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail em strong,
 .spectrum-Detail strong em {
-    font-style: var(
-        --mod-detail-sans-serif-strong-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-strong-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-strong-emphasized-font-style, var(--spectrum-detail-sans-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-strong-emphasized-font-weight, var(--spectrum-detail-sans-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail:lang(ja),
 .spectrum-Detail:lang(ko),
 .spectrum-Detail:lang(zh) {
-    font-family: var(
-        --mod-detail-cjk-font-family,
-        var(--spectrum-detail-cjk-font-family)
-    );
-    font-style: var(
-        --mod-detail-cjk-font-style,
-        var(--spectrum-detail-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-font-weight,
-        var(--spectrum-detail-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-detail-cjk-line-height,
-        var(--spectrum-detail-cjk-line-height)
-    );
+    font-family: var(--mod-detail-cjk-font-family, var(--spectrum-detail-cjk-font-family));
+    font-style: var(--mod-detail-cjk-font-style, var(--spectrum-detail-cjk-font-style));
+    font-weight: var(--mod-detail-cjk-font-weight, var(--spectrum-detail-cjk-font-weight));
+    line-height: var(--mod-detail-cjk-line-height, var(--spectrum-detail-cjk-line-height));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-strong,
@@ -865,14 +446,8 @@
 .spectrum-Detail:lang(ko) strong,
 .spectrum-Detail:lang(zh) .spectrum-Detail-strong,
 .spectrum-Detail:lang(zh) strong {
-    font-style: var(
-        --mod-detail-cjk-strong-font-style,
-        var(--spectrum-detail-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-strong-font-weight,
-        var(--spectrum-detail-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-strong-font-style, var(--spectrum-detail-cjk-strong-font-style));
+    font-weight: var(--mod-detail-cjk-strong-font-weight, var(--spectrum-detail-cjk-strong-font-weight));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-emphasized,
@@ -881,14 +456,8 @@
 .spectrum-Detail:lang(ko) em,
 .spectrum-Detail:lang(zh) .spectrum-Detail-emphasized,
 .spectrum-Detail:lang(zh) em {
-    font-style: var(
-        --mod-detail-cjk-emphasized-font-style,
-        var(--spectrum-detail-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-emphasized-font-weight,
-        var(--spectrum-detail-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-emphasized-font-style, var(--spectrum-detail-cjk-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-emphasized-font-weight, var(--spectrum-detail-cjk-emphasized-font-weight));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-strong.spectrum-Detail-emphasized,
@@ -900,127 +469,64 @@
 .spectrum-Detail:lang(zh) .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail:lang(zh) em strong,
 .spectrum-Detail:lang(zh) strong em {
-    font-style: var(
-        --mod-detail-cjk-strong-emphasized-font-style,
-        var(--spectrum-detail-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-strong-emphasized-font-weight,
-        var(--spectrum-detail-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-strong-emphasized-font-style, var(--spectrum-detail-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-strong-emphasized-font-weight, var(--spectrum-detail-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--serif {
-    font-family: var(
-        --mod-detail-serif-font-family,
-        var(--spectrum-detail-serif-font-family)
-    );
-    font-style: var(
-        --mod-detail-serif-font-style,
-        var(--spectrum-detail-serif-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-font-weight,
-        var(--spectrum-detail-serif-font-weight)
-    );
+    font-family: var(--mod-detail-serif-font-family, var(--spectrum-detail-serif-font-family));
+    font-style: var(--mod-detail-serif-font-style, var(--spectrum-detail-serif-font-style));
+    font-weight: var(--mod-detail-serif-font-weight, var(--spectrum-detail-serif-font-weight));
 }
 
 .spectrum-Detail--serif .spectrum-Detail-strong,
 .spectrum-Detail--serif strong {
-    font-style: var(
-        --mod-detail-serif-strong-font-style,
-        var(--spectrum-detail-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-strong-font-weight,
-        var(--spectrum-detail-serif-strong-font-weight)
-    );
+    font-style: var(--mod-detail-serif-strong-font-style, var(--spectrum-detail-serif-strong-font-style));
+    font-weight: var(--mod-detail-serif-strong-font-weight, var(--spectrum-detail-serif-strong-font-weight));
 }
 
 .spectrum-Detail--serif .spectrum-Detail-emphasized,
 .spectrum-Detail--serif em {
-    font-style: var(
-        --mod-detail-serif-emphasized-font-style,
-        var(--spectrum-detail-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-emphasized-font-weight,
-        var(--spectrum-detail-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-emphasized-font-style, var(--spectrum-detail-serif-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-emphasized-font-weight, var(--spectrum-detail-serif-emphasized-font-weight));
 }
 
 .spectrum-Detail--serif .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail--serif em strong,
 .spectrum-Detail--serif strong em {
-    font-style: var(
-        --mod-detail-serif-strong-emphasized-font-style,
-        var(--spectrum-detail-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-strong-emphasized-font-weight,
-        var(--spectrum-detail-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-strong-emphasized-font-style, var(--spectrum-detail-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-strong-emphasized-font-weight, var(--spectrum-detail-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--light {
-    font-style: var(
-        --mod-detail-sans-serif-light-font-style,
-        var(--spectrum-detail-sans-serif-light-font-style)
-    );
-    font-weight: var(
-        --spectrum-detail-sans-serif-light-font-weight,
-        var(--spectrum-detail-sans-serif-light-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-font-style, var(--spectrum-detail-sans-serif-light-font-style));
+    font-weight: var(--spectrum-detail-sans-serif-light-font-weight, var(--spectrum-detail-sans-serif-light-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-strong,
 .spectrum-Detail--light strong {
-    font-style: var(
-        --mod-detail-sans-serif-light-strong-font-style,
-        var(--spectrum-detail-sans-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-strong-font-weight,
-        var(--spectrum-detail-sans-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-strong-font-style, var(--spectrum-detail-sans-serif-light-strong-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-strong-font-weight, var(--spectrum-detail-sans-serif-light-strong-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-emphasized,
 .spectrum-Detail--light em {
-    font-style: var(
-        --mod-detail-sans-serif-light-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-emphasized-font-style, var(--spectrum-detail-sans-serif-light-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-emphasized-font-weight, var(--spectrum-detail-sans-serif-light-emphasized-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-strong.spectrum-Body-emphasized,
 .spectrum-Detail--light em strong,
 .spectrum-Detail--light strong em {
-    font-style: var(
-        --mod-detail-sans-serif-light-strong-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-strong-emphasized-font-style, var(--spectrum-detail-sans-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-strong-emphasized-font-weight, var(--spectrum-detail-sans-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja),
 .spectrum-Detail--light:lang(ko),
 .spectrum-Detail--light:lang(zh) {
-    font-style: var(
-        --mod-detail-cjk-light-font-style,
-        var(--spectrum-detail-cjk-light-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-font-weight,
-        var(--spectrum-detail-cjk-light-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-font-style, var(--spectrum-detail-cjk-light-font-style));
+    font-weight: var(--mod-detail-cjk-light-font-weight, var(--spectrum-detail-cjk-light-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja) .spectrum-Detail-strong,
@@ -1029,14 +535,8 @@
 .spectrum-Detail--light:lang(ko) strong,
 .spectrum-Detail--light:lang(zh) .spectrum-Detail-strong,
 .spectrum-Detail--light:lang(zh) strong {
-    font-style: var(
-        --mod-detail-cjk-light-strong-font-style,
-        var(--spectrum-detail-cjk-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-strong-font-weight,
-        var(--spectrum-detail-cjk-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-strong-font-style, var(--spectrum-detail-cjk-light-strong-font-style));
+    font-weight: var(--mod-detail-cjk-light-strong-font-weight, var(--spectrum-detail-cjk-light-strong-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja) .spectrum-Detail-emphasized,
@@ -1045,79 +545,39 @@
 .spectrum-Detail--light:lang(ko) em,
 .spectrum-Detail--light:lang(zh) .spectrum-Detail-emphasized,
 .spectrum-Detail--light:lang(zh) em {
-    font-style: var(
-        --mod-detail-cjk-light-emphasized-font-style,
-        var(--spectrum-detail-cjk-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-emphasized-font-weight,
-        var(--spectrum-detail-cjk-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-emphasized-font-style, var(--spectrum-detail-cjk-light-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-light-emphasized-font-weight, var(--spectrum-detail-cjk-light-emphasized-font-weight));
 }
 
-.spectrum-Detail--light:lang(ja)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized,
-.spectrum-Detail--light:lang(ko)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized,
-.spectrum-Detail--light:lang(zh)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized {
-    font-style: var(
-        --mod-detail-cjk-light-strong-emphasized-font-style,
-        var(--spectrum-detail-cjk-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-cjk-light-strong-emphasized-font-weight)
-    );
+.spectrum-Detail--light:lang(ja) .spectrum-Detail-strong.spectrum-Detail-emphasized,
+.spectrum-Detail--light:lang(ko) .spectrum-Detail-strong.spectrum-Detail-emphasized,
+.spectrum-Detail--light:lang(zh) .spectrum-Detail-strong.spectrum-Detail-emphasized {
+    font-style: var(--mod-detail-cjk-light-strong-emphasized-font-style, var(--spectrum-detail-cjk-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-light-strong-emphasized-font-weight, var(--spectrum-detail-cjk-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--serif.spectrum-Detail--light {
-    font-style: var(
-        --mod-detail-serif-light-font-style,
-        var(--spectrum-detail-serif-light-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-font-weight,
-        var(--spectrum-detail-serif-light-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-font-style, var(--spectrum-detail-serif-light-font-style));
+    font-weight: var(--mod-detail-serif-light-font-weight, var(--spectrum-detail-serif-light-font-weight));
 }
 
 .spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-strong,
 .spectrum-Detail--serif.spectrum-Detail--light strong {
-    font-style: var(
-        --mod-detail-serif-light-strong-font-style,
-        var(--spectrum-detail-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-strong-font-weight,
-        var(--spectrum-detail-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-strong-font-style, var(--spectrum-detail-serif-light-strong-font-style));
+    font-weight: var(--mod-detail-serif-light-strong-font-weight, var(--spectrum-detail-serif-light-strong-font-weight));
 }
 
 .spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-emphasized,
 .spectrum-Detail--serif.spectrum-Detail--light em {
-    font-style: var(
-        --mod-detail-serif-light-emphasized-font-style,
-        var(--spectrum-detail-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-emphasized-font-weight,
-        var(--spectrum-detail-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-emphasized-font-style, var(--spectrum-detail-serif-light-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-light-emphasized-font-weight, var(--spectrum-detail-serif-light-emphasized-font-weight));
 }
 
-.spectrum-Detail--serif.spectrum-Detail--light
-    .spectrum-Detail-strong.spectrum-Body-emphasized,
+.spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-strong.spectrum-Body-emphasized,
 .spectrum-Detail--serif.spectrum-Detail--light em strong,
 .spectrum-Detail--serif.spectrum-Detail--light strong em {
-    font-style: var(
-        --mod-detail-serif-light-strong-emphasized-font-style,
-        var(--spectrum-detail-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-strong-emphasized-font-style, var(--spectrum-detail-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-light-strong-emphasized-font-weight, var(--spectrum-detail-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Code {
@@ -1126,80 +586,38 @@
     font-weight: var(--mod-code-font-weight, var(--spectrum-code-font-weight));
     font-size: var(--mod-code-font-size, var(--spectrum-code-font-size));
     line-height: var(--mod-code-line-height, var(--spectrum-code-line-height));
-    color: var(
-        --highcontrast-code-font-color,
-        var(--mod-code-font-color, var(--spectrum-code-font-color))
-    );
-    margin-block-start: var(
-        --mod-code-margin-start,
-        var(--spectrum-code-margin-end, 0)
-    );
-    margin-block-end: var(
-        --mod-code-margin-end,
-        var(--spectrum-code-margin-end, 0)
-    );
+    color: var(--highcontrast-code-font-color, var(--mod-code-font-color, var(--spectrum-code-font-color)));
+    margin-block-start: var(--mod-code-margin-start, var(--spectrum-code-margin-end, 0));
+    margin-block-end: var(--mod-code-margin-end, var(--spectrum-code-margin-end, 0));
 }
 
 .spectrum-Code .spectrum-Code-strong,
 .spectrum-Code strong {
-    font-style: var(
-        --mod-code-strong-font-style,
-        var(--spectrum-code-strong-font-style)
-    );
-    font-weight: var(
-        --mod-code-strong-font-weight,
-        var(--spectrum-code-strong-font-weight)
-    );
+    font-style: var(--mod-code-strong-font-style, var(--spectrum-code-strong-font-style));
+    font-weight: var(--mod-code-strong-font-weight, var(--spectrum-code-strong-font-weight));
 }
 
 .spectrum-Code .spectrum-Code-emphasized,
 .spectrum-Code em {
-    font-style: var(
-        --mod-code-emphasized-font-style,
-        var(--spectrum-code-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-emphasized-font-weight,
-        var(--spectrum-code-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-emphasized-font-style, var(--spectrum-code-emphasized-font-style));
+    font-weight: var(--mod-code-emphasized-font-weight, var(--spectrum-code-emphasized-font-weight));
 }
 
 .spectrum-Code .spectrum-Code-strong.spectrum-Code-emphasized,
 .spectrum-Code em strong,
 .spectrum-Code strong em {
-    font-style: var(
-        --mod-code-strong-emphasized-font-style,
-        var(--spectrum-code-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-strong-emphasized-font-weight,
-        var(--spectrum-code-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-strong-emphasized-font-style, var(--spectrum-code-strong-emphasized-font-style));
+    font-weight: var(--mod-code-strong-emphasized-font-weight, var(--spectrum-code-strong-emphasized-font-weight));
 }
 
 .spectrum-Code:lang(ja),
 .spectrum-Code:lang(ko),
 .spectrum-Code:lang(zh) {
-    font-family: var(
-        --mod-code-cjk-font-family,
-        var(--spectrum-code-cjk-font-family)
-    );
-    font-style: var(
-        --mod-code-cjk-font-style,
-        var(--spectrum-code-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-font-weight,
-        var(--spectrum-code-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-code-cjk-line-height,
-        var(--spectrum-code-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-code-cjk-letter-spacing,
-        var(--spectrum-code-cjk-letter-spacing)
-    );
+    font-family: var(--mod-code-cjk-font-family, var(--spectrum-code-cjk-font-family));
+    font-style: var(--mod-code-cjk-font-style, var(--spectrum-code-cjk-font-style));
+    font-weight: var(--mod-code-cjk-font-weight, var(--spectrum-code-cjk-font-weight));
+    line-height: var(--mod-code-cjk-line-height, var(--spectrum-code-cjk-line-height));
+    letter-spacing: var(--mod-code-cjk-letter-spacing, var(--spectrum-code-cjk-letter-spacing));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-strong,
@@ -1208,14 +626,8 @@
 .spectrum-Code:lang(ko) strong,
 .spectrum-Code:lang(zh) .spectrum-Code-strong,
 .spectrum-Code:lang(zh) strong {
-    font-style: var(
-        --mod-code-cjk-strong-font-style,
-        var(--spectrum-code-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-strong-font-weight,
-        var(--spectrum-code-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-code-cjk-strong-font-style, var(--spectrum-code-cjk-strong-font-style));
+    font-weight: var(--mod-code-cjk-strong-font-weight, var(--spectrum-code-cjk-strong-font-weight));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-emphasized,
@@ -1224,14 +636,8 @@
 .spectrum-Code:lang(ko) em,
 .spectrum-Code:lang(zh) .spectrum-Code-emphasized,
 .spectrum-Code:lang(zh) em {
-    font-style: var(
-        --mod-code-cjk-emphasized-font-style,
-        var(--spectrum-code-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-emphasized-font-weight,
-        var(--spectrum-code-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-cjk-emphasized-font-style, var(--spectrum-code-cjk-emphasized-font-style));
+    font-weight: var(--mod-code-cjk-emphasized-font-weight, var(--spectrum-code-cjk-emphasized-font-weight));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-strong.spectrum-Code-emphasized,
@@ -1243,27 +649,15 @@
 .spectrum-Code:lang(zh) .spectrum-Code-strong.spectrum-Code-emphasized,
 .spectrum-Code:lang(zh) em strong,
 .spectrum-Code:lang(zh) strong em {
-    font-style: var(
-        --mod-code-cjk-strong-emphasized-font-style,
-        var(--spectrum-code-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-strong-emphasized-font-weight,
-        var(--spectrum-code-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-cjk-strong-emphasized-font-style, var(--spectrum-code-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-code-cjk-strong-emphasized-font-weight, var(--spectrum-code-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading {
-    --spectrum-heading-sans-serif-font-family: var(
-        --system-heading-sans-serif-font-family
-    );
-    --spectrum-heading-serif-font-family: var(
-        --system-heading-serif-font-family
-    );
+    --spectrum-heading-sans-serif-font-family: var(--system-heading-sans-serif-font-family);
+    --spectrum-heading-serif-font-family: var(--system-heading-serif-font-family);
     --spectrum-heading-cjk-font-family: var(--system-heading-cjk-font-family);
-    --spectrum-heading-cjk-letter-spacing: var(
-        --system-heading-cjk-letter-spacing
-    );
+    --spectrum-heading-cjk-letter-spacing: var(--system-heading-cjk-letter-spacing);
     --spectrum-heading-font-color: var(--system-heading-font-color);
     --spectrum-heading-font-size: var(--system-heading-font-size);
     --spectrum-heading-cjk-font-size: var(--system-heading-cjk-font-size);
@@ -1271,64 +665,46 @@
 
 .spectrum-Heading--sizeXXS {
     --spectrum-heading-font-size: var(--system-heading-size-xxs-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xxs-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xxs-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXS {
     --spectrum-heading-font-size: var(--system-heading-size-xs-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xs-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xs-cjk-font-size);
 }
 
 .spectrum-Heading--sizeS {
     --spectrum-heading-font-size: var(--system-heading-size-s-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-s-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-s-cjk-font-size);
 }
 
 .spectrum-Heading--sizeM {
     --spectrum-heading-font-size: var(--system-heading-size-m-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-m-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-m-cjk-font-size);
 }
 
 .spectrum-Heading--sizeL {
     --spectrum-heading-font-size: var(--system-heading-size-l-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-l-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-l-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXL {
     --spectrum-heading-font-size: var(--system-heading-size-xl-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xl-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xl-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXXL {
     --spectrum-heading-font-size: var(--system-heading-size-xxl-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xxl-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xxl-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXXXL {
     --spectrum-heading-font-size: var(--system-heading-size-xxxl-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xxxl-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xxxl-cjk-font-size);
 }
 
 .spectrum-Body {
-    --spectrum-body-sans-serif-font-family: var(
-        --system-body-sans-serif-font-family
-    );
+    --spectrum-body-sans-serif-font-family: var(--system-body-sans-serif-font-family);
     --spectrum-body-serif-font-family: var(--system-body-serif-font-family);
     --spectrum-body-cjk-font-family: var(--system-body-cjk-font-family);
     --spectrum-body-cjk-letter-spacing: var(--system-body-cjk-letter-spacing);
@@ -1365,9 +741,7 @@
 }
 
 .spectrum-Detail {
-    --spectrum-detail-sans-serif-font-family: var(
-        --system-detail-sans-serif-font-family
-    );
+    --spectrum-detail-sans-serif-font-family: var(--system-detail-sans-serif-font-family);
     --spectrum-detail-serif-font-family: var(--system-detail-serif-font-family);
     --spectrum-detail-cjk-font-family: var(--system-detail-cjk-font-family);
     --spectrum-detail-font-color: var(--system-detail-font-color);

--- a/tools/styles/spectrum-core-global.css
+++ b/tools/styles/spectrum-core-global.css
@@ -21,353 +21,179 @@
     --spectrum-global-color-status: Verified;
     --spectrum-global-color-version: 5.1;
     --spectrum-global-color-static-black-rgb: 0, 0, 0;
-    --spectrum-global-color-static-black: rgb(
-        var(--spectrum-global-color-static-black-rgb)
-    );
+    --spectrum-global-color-static-black: rgb(var(--spectrum-global-color-static-black-rgb));
     --spectrum-global-color-static-white-rgb: 255, 255, 255;
-    --spectrum-global-color-static-white: rgb(
-        var(--spectrum-global-color-static-white-rgb)
-    );
+    --spectrum-global-color-static-white: rgb(var(--spectrum-global-color-static-white-rgb));
     --spectrum-global-color-static-blue-rgb: 0, 87, 191;
-    --spectrum-global-color-static-blue: rgb(
-        var(--spectrum-global-color-static-blue-rgb)
-    );
+    --spectrum-global-color-static-blue: rgb(var(--spectrum-global-color-static-blue-rgb));
     --spectrum-global-color-static-gray-50-rgb: 255, 255, 255;
-    --spectrum-global-color-static-gray-50: rgb(
-        var(--spectrum-global-color-static-gray-50-rgb)
-    );
+    --spectrum-global-color-static-gray-50: rgb(var(--spectrum-global-color-static-gray-50-rgb));
     --spectrum-global-color-static-gray-75-rgb: 255, 255, 255;
-    --spectrum-global-color-static-gray-75: rgb(
-        var(--spectrum-global-color-static-gray-75-rgb)
-    );
+    --spectrum-global-color-static-gray-75: rgb(var(--spectrum-global-color-static-gray-75-rgb));
     --spectrum-global-color-static-gray-100-rgb: 255, 255, 255;
-    --spectrum-global-color-static-gray-100: rgb(
-        var(--spectrum-global-color-static-gray-100-rgb)
-    );
+    --spectrum-global-color-static-gray-100: rgb(var(--spectrum-global-color-static-gray-100-rgb));
     --spectrum-global-color-static-gray-200-rgb: 235, 235, 235;
-    --spectrum-global-color-static-gray-200: rgb(
-        var(--spectrum-global-color-static-gray-200-rgb)
-    );
+    --spectrum-global-color-static-gray-200: rgb(var(--spectrum-global-color-static-gray-200-rgb));
     --spectrum-global-color-static-gray-300-rgb: 217, 217, 217;
-    --spectrum-global-color-static-gray-300: rgb(
-        var(--spectrum-global-color-static-gray-300-rgb)
-    );
+    --spectrum-global-color-static-gray-300: rgb(var(--spectrum-global-color-static-gray-300-rgb));
     --spectrum-global-color-static-gray-400-rgb: 179, 179, 179;
-    --spectrum-global-color-static-gray-400: rgb(
-        var(--spectrum-global-color-static-gray-400-rgb)
-    );
+    --spectrum-global-color-static-gray-400: rgb(var(--spectrum-global-color-static-gray-400-rgb));
     --spectrum-global-color-static-gray-500-rgb: 146, 146, 146;
-    --spectrum-global-color-static-gray-500: rgb(
-        var(--spectrum-global-color-static-gray-500-rgb)
-    );
+    --spectrum-global-color-static-gray-500: rgb(var(--spectrum-global-color-static-gray-500-rgb));
     --spectrum-global-color-static-gray-600-rgb: 110, 110, 110;
-    --spectrum-global-color-static-gray-600: rgb(
-        var(--spectrum-global-color-static-gray-600-rgb)
-    );
+    --spectrum-global-color-static-gray-600: rgb(var(--spectrum-global-color-static-gray-600-rgb));
     --spectrum-global-color-static-gray-700-rgb: 71, 71, 71;
-    --spectrum-global-color-static-gray-700: rgb(
-        var(--spectrum-global-color-static-gray-700-rgb)
-    );
+    --spectrum-global-color-static-gray-700: rgb(var(--spectrum-global-color-static-gray-700-rgb));
     --spectrum-global-color-static-gray-800-rgb: 34, 34, 34;
-    --spectrum-global-color-static-gray-800: rgb(
-        var(--spectrum-global-color-static-gray-800-rgb)
-    );
+    --spectrum-global-color-static-gray-800: rgb(var(--spectrum-global-color-static-gray-800-rgb));
     --spectrum-global-color-static-gray-900-rgb: 0, 0, 0;
-    --spectrum-global-color-static-gray-900: rgb(
-        var(--spectrum-global-color-static-gray-900-rgb)
-    );
+    --spectrum-global-color-static-gray-900: rgb(var(--spectrum-global-color-static-gray-900-rgb));
     --spectrum-global-color-static-red-400-rgb: 237, 64, 48;
-    --spectrum-global-color-static-red-400: rgb(
-        var(--spectrum-global-color-static-red-400-rgb)
-    );
+    --spectrum-global-color-static-red-400: rgb(var(--spectrum-global-color-static-red-400-rgb));
     --spectrum-global-color-static-red-500-rgb: 217, 28, 21;
-    --spectrum-global-color-static-red-500: rgb(
-        var(--spectrum-global-color-static-red-500-rgb)
-    );
+    --spectrum-global-color-static-red-500: rgb(var(--spectrum-global-color-static-red-500-rgb));
     --spectrum-global-color-static-red-600-rgb: 187, 2, 2;
-    --spectrum-global-color-static-red-600: rgb(
-        var(--spectrum-global-color-static-red-600-rgb)
-    );
+    --spectrum-global-color-static-red-600: rgb(var(--spectrum-global-color-static-red-600-rgb));
     --spectrum-global-color-static-red-700-rgb: 154, 0, 0;
-    --spectrum-global-color-static-red-700: rgb(
-        var(--spectrum-global-color-static-red-700-rgb)
-    );
+    --spectrum-global-color-static-red-700: rgb(var(--spectrum-global-color-static-red-700-rgb));
     --spectrum-global-color-static-red-800-rgb: 124, 0, 0;
-    --spectrum-global-color-static-red-800: rgb(
-        var(--spectrum-global-color-static-red-800-rgb)
-    );
+    --spectrum-global-color-static-red-800: rgb(var(--spectrum-global-color-static-red-800-rgb));
     --spectrum-global-color-static-orange-400-rgb: 250, 139, 26;
-    --spectrum-global-color-static-orange-400: rgb(
-        var(--spectrum-global-color-static-orange-400-rgb)
-    );
+    --spectrum-global-color-static-orange-400: rgb(var(--spectrum-global-color-static-orange-400-rgb));
     --spectrum-global-color-static-orange-500-rgb: 233, 117, 0;
-    --spectrum-global-color-static-orange-500: rgb(
-        var(--spectrum-global-color-static-orange-500-rgb)
-    );
+    --spectrum-global-color-static-orange-500: rgb(var(--spectrum-global-color-static-orange-500-rgb));
     --spectrum-global-color-static-orange-600-rgb: 209, 97, 0;
-    --spectrum-global-color-static-orange-600: rgb(
-        var(--spectrum-global-color-static-orange-600-rgb)
-    );
+    --spectrum-global-color-static-orange-600: rgb(var(--spectrum-global-color-static-orange-600-rgb));
     --spectrum-global-color-static-orange-700-rgb: 182, 80, 0;
-    --spectrum-global-color-static-orange-700: rgb(
-        var(--spectrum-global-color-static-orange-700-rgb)
-    );
+    --spectrum-global-color-static-orange-700: rgb(var(--spectrum-global-color-static-orange-700-rgb));
     --spectrum-global-color-static-orange-800-rgb: 155, 64, 0;
-    --spectrum-global-color-static-orange-800: rgb(
-        var(--spectrum-global-color-static-orange-800-rgb)
-    );
+    --spectrum-global-color-static-orange-800: rgb(var(--spectrum-global-color-static-orange-800-rgb));
     --spectrum-global-color-static-yellow-200-rgb: 250, 237, 123;
-    --spectrum-global-color-static-yellow-200: rgb(
-        var(--spectrum-global-color-static-yellow-200-rgb)
-    );
+    --spectrum-global-color-static-yellow-200: rgb(var(--spectrum-global-color-static-yellow-200-rgb));
     --spectrum-global-color-static-yellow-300-rgb: 250, 224, 23;
-    --spectrum-global-color-static-yellow-300: rgb(
-        var(--spectrum-global-color-static-yellow-300-rgb)
-    );
+    --spectrum-global-color-static-yellow-300: rgb(var(--spectrum-global-color-static-yellow-300-rgb));
     --spectrum-global-color-static-yellow-400-rgb: 238, 205, 0;
-    --spectrum-global-color-static-yellow-400: rgb(
-        var(--spectrum-global-color-static-yellow-400-rgb)
-    );
+    --spectrum-global-color-static-yellow-400: rgb(var(--spectrum-global-color-static-yellow-400-rgb));
     --spectrum-global-color-static-yellow-500-rgb: 221, 185, 0;
-    --spectrum-global-color-static-yellow-500: rgb(
-        var(--spectrum-global-color-static-yellow-500-rgb)
-    );
+    --spectrum-global-color-static-yellow-500: rgb(var(--spectrum-global-color-static-yellow-500-rgb));
     --spectrum-global-color-static-yellow-600-rgb: 201, 164, 0;
-    --spectrum-global-color-static-yellow-600: rgb(
-        var(--spectrum-global-color-static-yellow-600-rgb)
-    );
+    --spectrum-global-color-static-yellow-600: rgb(var(--spectrum-global-color-static-yellow-600-rgb));
     --spectrum-global-color-static-yellow-700-rgb: 181, 144, 0;
-    --spectrum-global-color-static-yellow-700: rgb(
-        var(--spectrum-global-color-static-yellow-700-rgb)
-    );
+    --spectrum-global-color-static-yellow-700: rgb(var(--spectrum-global-color-static-yellow-700-rgb));
     --spectrum-global-color-static-yellow-800-rgb: 160, 125, 0;
-    --spectrum-global-color-static-yellow-800: rgb(
-        var(--spectrum-global-color-static-yellow-800-rgb)
-    );
+    --spectrum-global-color-static-yellow-800: rgb(var(--spectrum-global-color-static-yellow-800-rgb));
     --spectrum-global-color-static-chartreuse-300-rgb: 176, 222, 27;
-    --spectrum-global-color-static-chartreuse-300: rgb(
-        var(--spectrum-global-color-static-chartreuse-300-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-300: rgb(var(--spectrum-global-color-static-chartreuse-300-rgb));
     --spectrum-global-color-static-chartreuse-400-rgb: 157, 203, 13;
-    --spectrum-global-color-static-chartreuse-400: rgb(
-        var(--spectrum-global-color-static-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-400: rgb(var(--spectrum-global-color-static-chartreuse-400-rgb));
     --spectrum-global-color-static-chartreuse-500-rgb: 139, 182, 4;
-    --spectrum-global-color-static-chartreuse-500: rgb(
-        var(--spectrum-global-color-static-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-500: rgb(var(--spectrum-global-color-static-chartreuse-500-rgb));
     --spectrum-global-color-static-chartreuse-600-rgb: 122, 162, 0;
-    --spectrum-global-color-static-chartreuse-600: rgb(
-        var(--spectrum-global-color-static-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-600: rgb(var(--spectrum-global-color-static-chartreuse-600-rgb));
     --spectrum-global-color-static-chartreuse-700-rgb: 106, 141, 0;
-    --spectrum-global-color-static-chartreuse-700: rgb(
-        var(--spectrum-global-color-static-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-700: rgb(var(--spectrum-global-color-static-chartreuse-700-rgb));
     --spectrum-global-color-static-chartreuse-800-rgb: 90, 120, 0;
-    --spectrum-global-color-static-chartreuse-800: rgb(
-        var(--spectrum-global-color-static-chartreuse-800-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-800: rgb(var(--spectrum-global-color-static-chartreuse-800-rgb));
     --spectrum-global-color-static-celery-200-rgb: 126, 229, 114;
-    --spectrum-global-color-static-celery-200: rgb(
-        var(--spectrum-global-color-static-celery-200-rgb)
-    );
+    --spectrum-global-color-static-celery-200: rgb(var(--spectrum-global-color-static-celery-200-rgb));
     --spectrum-global-color-static-celery-300-rgb: 87, 212, 86;
-    --spectrum-global-color-static-celery-300: rgb(
-        var(--spectrum-global-color-static-celery-300-rgb)
-    );
+    --spectrum-global-color-static-celery-300: rgb(var(--spectrum-global-color-static-celery-300-rgb));
     --spectrum-global-color-static-celery-400-rgb: 48, 193, 61;
-    --spectrum-global-color-static-celery-400: rgb(
-        var(--spectrum-global-color-static-celery-400-rgb)
-    );
+    --spectrum-global-color-static-celery-400: rgb(var(--spectrum-global-color-static-celery-400-rgb));
     --spectrum-global-color-static-celery-500-rgb: 15, 172, 38;
-    --spectrum-global-color-static-celery-500: rgb(
-        var(--spectrum-global-color-static-celery-500-rgb)
-    );
+    --spectrum-global-color-static-celery-500: rgb(var(--spectrum-global-color-static-celery-500-rgb));
     --spectrum-global-color-static-celery-600-rgb: 0, 150, 20;
-    --spectrum-global-color-static-celery-600: rgb(
-        var(--spectrum-global-color-static-celery-600-rgb)
-    );
+    --spectrum-global-color-static-celery-600: rgb(var(--spectrum-global-color-static-celery-600-rgb));
     --spectrum-global-color-static-celery-700-rgb: 0, 128, 15;
-    --spectrum-global-color-static-celery-700: rgb(
-        var(--spectrum-global-color-static-celery-700-rgb)
-    );
+    --spectrum-global-color-static-celery-700: rgb(var(--spectrum-global-color-static-celery-700-rgb));
     --spectrum-global-color-static-celery-800-rgb: 0, 107, 15;
-    --spectrum-global-color-static-celery-800: rgb(
-        var(--spectrum-global-color-static-celery-800-rgb)
-    );
+    --spectrum-global-color-static-celery-800: rgb(var(--spectrum-global-color-static-celery-800-rgb));
     --spectrum-global-color-static-green-400-rgb: 29, 169, 115;
-    --spectrum-global-color-static-green-400: rgb(
-        var(--spectrum-global-color-static-green-400-rgb)
-    );
+    --spectrum-global-color-static-green-400: rgb(var(--spectrum-global-color-static-green-400-rgb));
     --spectrum-global-color-static-green-500-rgb: 0, 148, 97;
-    --spectrum-global-color-static-green-500: rgb(
-        var(--spectrum-global-color-static-green-500-rgb)
-    );
+    --spectrum-global-color-static-green-500: rgb(var(--spectrum-global-color-static-green-500-rgb));
     --spectrum-global-color-static-green-600-rgb: 0, 126, 80;
-    --spectrum-global-color-static-green-600: rgb(
-        var(--spectrum-global-color-static-green-600-rgb)
-    );
+    --spectrum-global-color-static-green-600: rgb(var(--spectrum-global-color-static-green-600-rgb));
     --spectrum-global-color-static-green-700-rgb: 0, 105, 65;
-    --spectrum-global-color-static-green-700: rgb(
-        var(--spectrum-global-color-static-green-700-rgb)
-    );
+    --spectrum-global-color-static-green-700: rgb(var(--spectrum-global-color-static-green-700-rgb));
     --spectrum-global-color-static-green-800-rgb: 0, 86, 53;
-    --spectrum-global-color-static-green-800: rgb(
-        var(--spectrum-global-color-static-green-800-rgb)
-    );
+    --spectrum-global-color-static-green-800: rgb(var(--spectrum-global-color-static-green-800-rgb));
     --spectrum-global-color-static-seafoam-200-rgb: 75, 206, 199;
-    --spectrum-global-color-static-seafoam-200: rgb(
-        var(--spectrum-global-color-static-seafoam-200-rgb)
-    );
+    --spectrum-global-color-static-seafoam-200: rgb(var(--spectrum-global-color-static-seafoam-200-rgb));
     --spectrum-global-color-static-seafoam-300-rgb: 32, 187, 180;
-    --spectrum-global-color-static-seafoam-300: rgb(
-        var(--spectrum-global-color-static-seafoam-300-rgb)
-    );
+    --spectrum-global-color-static-seafoam-300: rgb(var(--spectrum-global-color-static-seafoam-300-rgb));
     --spectrum-global-color-static-seafoam-400-rgb: 0, 166, 160;
-    --spectrum-global-color-static-seafoam-400: rgb(
-        var(--spectrum-global-color-static-seafoam-400-rgb)
-    );
+    --spectrum-global-color-static-seafoam-400: rgb(var(--spectrum-global-color-static-seafoam-400-rgb));
     --spectrum-global-color-static-seafoam-500-rgb: 0, 145, 139;
-    --spectrum-global-color-static-seafoam-500: rgb(
-        var(--spectrum-global-color-static-seafoam-500-rgb)
-    );
+    --spectrum-global-color-static-seafoam-500: rgb(var(--spectrum-global-color-static-seafoam-500-rgb));
     --spectrum-global-color-static-seafoam-600-rgb: 0, 124, 118;
-    --spectrum-global-color-static-seafoam-600: rgb(
-        var(--spectrum-global-color-static-seafoam-600-rgb)
-    );
+    --spectrum-global-color-static-seafoam-600: rgb(var(--spectrum-global-color-static-seafoam-600-rgb));
     --spectrum-global-color-static-seafoam-700-rgb: 0, 103, 99;
-    --spectrum-global-color-static-seafoam-700: rgb(
-        var(--spectrum-global-color-static-seafoam-700-rgb)
-    );
+    --spectrum-global-color-static-seafoam-700: rgb(var(--spectrum-global-color-static-seafoam-700-rgb));
     --spectrum-global-color-static-seafoam-800-rgb: 10, 83, 80;
-    --spectrum-global-color-static-seafoam-800: rgb(
-        var(--spectrum-global-color-static-seafoam-800-rgb)
-    );
+    --spectrum-global-color-static-seafoam-800: rgb(var(--spectrum-global-color-static-seafoam-800-rgb));
     --spectrum-global-color-static-blue-200-rgb: 130, 193, 251;
-    --spectrum-global-color-static-blue-200: rgb(
-        var(--spectrum-global-color-static-blue-200-rgb)
-    );
+    --spectrum-global-color-static-blue-200: rgb(var(--spectrum-global-color-static-blue-200-rgb));
     --spectrum-global-color-static-blue-300-rgb: 98, 173, 247;
-    --spectrum-global-color-static-blue-300: rgb(
-        var(--spectrum-global-color-static-blue-300-rgb)
-    );
+    --spectrum-global-color-static-blue-300: rgb(var(--spectrum-global-color-static-blue-300-rgb));
     --spectrum-global-color-static-blue-400-rgb: 66, 151, 244;
-    --spectrum-global-color-static-blue-400: rgb(
-        var(--spectrum-global-color-static-blue-400-rgb)
-    );
+    --spectrum-global-color-static-blue-400: rgb(var(--spectrum-global-color-static-blue-400-rgb));
     --spectrum-global-color-static-blue-500-rgb: 27, 127, 245;
-    --spectrum-global-color-static-blue-500: rgb(
-        var(--spectrum-global-color-static-blue-500-rgb)
-    );
+    --spectrum-global-color-static-blue-500: rgb(var(--spectrum-global-color-static-blue-500-rgb));
     --spectrum-global-color-static-blue-600-rgb: 4, 105, 227;
-    --spectrum-global-color-static-blue-600: rgb(
-        var(--spectrum-global-color-static-blue-600-rgb)
-    );
+    --spectrum-global-color-static-blue-600: rgb(var(--spectrum-global-color-static-blue-600-rgb));
     --spectrum-global-color-static-blue-700-rgb: 0, 87, 190;
-    --spectrum-global-color-static-blue-700: rgb(
-        var(--spectrum-global-color-static-blue-700-rgb)
-    );
+    --spectrum-global-color-static-blue-700: rgb(var(--spectrum-global-color-static-blue-700-rgb));
     --spectrum-global-color-static-blue-800-rgb: 0, 72, 153;
-    --spectrum-global-color-static-blue-800: rgb(
-        var(--spectrum-global-color-static-blue-800-rgb)
-    );
+    --spectrum-global-color-static-blue-800: rgb(var(--spectrum-global-color-static-blue-800-rgb));
     --spectrum-global-color-static-indigo-200-rgb: 178, 181, 255;
-    --spectrum-global-color-static-indigo-200: rgb(
-        var(--spectrum-global-color-static-indigo-200-rgb)
-    );
+    --spectrum-global-color-static-indigo-200: rgb(var(--spectrum-global-color-static-indigo-200-rgb));
     --spectrum-global-color-static-indigo-300-rgb: 155, 159, 255;
-    --spectrum-global-color-static-indigo-300: rgb(
-        var(--spectrum-global-color-static-indigo-300-rgb)
-    );
+    --spectrum-global-color-static-indigo-300: rgb(var(--spectrum-global-color-static-indigo-300-rgb));
     --spectrum-global-color-static-indigo-400-rgb: 132, 137, 253;
-    --spectrum-global-color-static-indigo-400: rgb(
-        var(--spectrum-global-color-static-indigo-400-rgb)
-    );
+    --spectrum-global-color-static-indigo-400: rgb(var(--spectrum-global-color-static-indigo-400-rgb));
     --spectrum-global-color-static-indigo-500-rgb: 109, 115, 246;
-    --spectrum-global-color-static-indigo-500: rgb(
-        var(--spectrum-global-color-static-indigo-500-rgb)
-    );
+    --spectrum-global-color-static-indigo-500: rgb(var(--spectrum-global-color-static-indigo-500-rgb));
     --spectrum-global-color-static-indigo-600-rgb: 87, 93, 232;
-    --spectrum-global-color-static-indigo-600: rgb(
-        var(--spectrum-global-color-static-indigo-600-rgb)
-    );
+    --spectrum-global-color-static-indigo-600: rgb(var(--spectrum-global-color-static-indigo-600-rgb));
     --spectrum-global-color-static-indigo-700-rgb: 68, 74, 208;
-    --spectrum-global-color-static-indigo-700: rgb(
-        var(--spectrum-global-color-static-indigo-700-rgb)
-    );
+    --spectrum-global-color-static-indigo-700: rgb(var(--spectrum-global-color-static-indigo-700-rgb));
     --spectrum-global-color-static-indigo-800-rgb: 68, 74, 208;
-    --spectrum-global-color-static-indigo-800: rgb(
-        var(--spectrum-global-color-static-indigo-800-rgb)
-    );
+    --spectrum-global-color-static-indigo-800: rgb(var(--spectrum-global-color-static-indigo-800-rgb));
     --spectrum-global-color-static-purple-400-rgb: 178, 121, 250;
-    --spectrum-global-color-static-purple-400: rgb(
-        var(--spectrum-global-color-static-purple-400-rgb)
-    );
+    --spectrum-global-color-static-purple-400: rgb(var(--spectrum-global-color-static-purple-400-rgb));
     --spectrum-global-color-static-purple-500-rgb: 161, 93, 246;
-    --spectrum-global-color-static-purple-500: rgb(
-        var(--spectrum-global-color-static-purple-500-rgb)
-    );
+    --spectrum-global-color-static-purple-500: rgb(var(--spectrum-global-color-static-purple-500-rgb));
     --spectrum-global-color-static-purple-600-rgb: 142, 67, 234;
-    --spectrum-global-color-static-purple-600: rgb(
-        var(--spectrum-global-color-static-purple-600-rgb)
-    );
+    --spectrum-global-color-static-purple-600: rgb(var(--spectrum-global-color-static-purple-600-rgb));
     --spectrum-global-color-static-purple-700-rgb: 120, 43, 216;
-    --spectrum-global-color-static-purple-700: rgb(
-        var(--spectrum-global-color-static-purple-700-rgb)
-    );
+    --spectrum-global-color-static-purple-700: rgb(var(--spectrum-global-color-static-purple-700-rgb));
     --spectrum-global-color-static-purple-800-rgb: 98, 23, 190;
-    --spectrum-global-color-static-purple-800: rgb(
-        var(--spectrum-global-color-static-purple-800-rgb)
-    );
+    --spectrum-global-color-static-purple-800: rgb(var(--spectrum-global-color-static-purple-800-rgb));
     --spectrum-global-color-static-fuchsia-400-rgb: 228, 93, 230;
-    --spectrum-global-color-static-fuchsia-400: rgb(
-        var(--spectrum-global-color-static-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-400: rgb(var(--spectrum-global-color-static-fuchsia-400-rgb));
     --spectrum-global-color-static-fuchsia-500-rgb: 211, 63, 212;
-    --spectrum-global-color-static-fuchsia-500: rgb(
-        var(--spectrum-global-color-static-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-500: rgb(var(--spectrum-global-color-static-fuchsia-500-rgb));
     --spectrum-global-color-static-fuchsia-600-rgb: 188, 39, 187;
-    --spectrum-global-color-static-fuchsia-600: rgb(
-        var(--spectrum-global-color-static-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-600: rgb(var(--spectrum-global-color-static-fuchsia-600-rgb));
     --spectrum-global-color-static-fuchsia-700-rgb: 163, 10, 163;
-    --spectrum-global-color-static-fuchsia-700: rgb(
-        var(--spectrum-global-color-static-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-700: rgb(var(--spectrum-global-color-static-fuchsia-700-rgb));
     --spectrum-global-color-static-fuchsia-800-rgb: 135, 0, 136;
-    --spectrum-global-color-static-fuchsia-800: rgb(
-        var(--spectrum-global-color-static-fuchsia-800-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-800: rgb(var(--spectrum-global-color-static-fuchsia-800-rgb));
     --spectrum-global-color-static-magenta-200-rgb: 253, 127, 175;
-    --spectrum-global-color-static-magenta-200: rgb(
-        var(--spectrum-global-color-static-magenta-200-rgb)
-    );
+    --spectrum-global-color-static-magenta-200: rgb(var(--spectrum-global-color-static-magenta-200-rgb));
     --spectrum-global-color-static-magenta-300-rgb: 242, 98, 157;
-    --spectrum-global-color-static-magenta-300: rgb(
-        var(--spectrum-global-color-static-magenta-300-rgb)
-    );
+    --spectrum-global-color-static-magenta-300: rgb(var(--spectrum-global-color-static-magenta-300-rgb));
     --spectrum-global-color-static-magenta-400-rgb: 226, 68, 135;
-    --spectrum-global-color-static-magenta-400: rgb(
-        var(--spectrum-global-color-static-magenta-400-rgb)
-    );
+    --spectrum-global-color-static-magenta-400: rgb(var(--spectrum-global-color-static-magenta-400-rgb));
     --spectrum-global-color-static-magenta-500-rgb: 205, 40, 111;
-    --spectrum-global-color-static-magenta-500: rgb(
-        var(--spectrum-global-color-static-magenta-500-rgb)
-    );
+    --spectrum-global-color-static-magenta-500: rgb(var(--spectrum-global-color-static-magenta-500-rgb));
     --spectrum-global-color-static-magenta-600-rgb: 179, 15, 89;
-    --spectrum-global-color-static-magenta-600: rgb(
-        var(--spectrum-global-color-static-magenta-600-rgb)
-    );
+    --spectrum-global-color-static-magenta-600: rgb(var(--spectrum-global-color-static-magenta-600-rgb));
     --spectrum-global-color-static-magenta-700-rgb: 149, 0, 72;
-    --spectrum-global-color-static-magenta-700: rgb(
-        var(--spectrum-global-color-static-magenta-700-rgb)
-    );
+    --spectrum-global-color-static-magenta-700: rgb(var(--spectrum-global-color-static-magenta-700-rgb));
     --spectrum-global-color-static-magenta-800-rgb: 119, 0, 58;
-    --spectrum-global-color-static-magenta-800: rgb(
-        var(--spectrum-global-color-static-magenta-800-rgb)
-    );
+    --spectrum-global-color-static-magenta-800: rgb(var(--spectrum-global-color-static-magenta-800-rgb));
     --spectrum-global-color-static-transparent-white-200: #ffffff1a;
     --spectrum-global-color-static-transparent-white-300: #ffffff40;
     --spectrum-global-color-static-transparent-white-400: #fff6;
@@ -376,9 +202,7 @@
     --spectrum-global-color-static-transparent-white-700: #fffc;
     --spectrum-global-color-static-transparent-white-800: #ffffffe6;
     --spectrum-global-color-static-transparent-white-900-rgb: 255, 255, 255;
-    --spectrum-global-color-static-transparent-white-900: rgb(
-        var(--spectrum-global-color-static-transparent-white-900-rgb)
-    );
+    --spectrum-global-color-static-transparent-white-900: rgb(var(--spectrum-global-color-static-transparent-white-900-rgb));
     --spectrum-global-color-static-transparent-black-200: #0000001a;
     --spectrum-global-color-static-transparent-black-300: #00000040;
     --spectrum-global-color-static-transparent-black-400: #0006;
@@ -387,271 +211,97 @@
     --spectrum-global-color-static-transparent-black-700: #000c;
     --spectrum-global-color-static-transparent-black-800: #000000e6;
     --spectrum-global-color-static-transparent-black-900-rgb: 0, 0, 0;
-    --spectrum-global-color-static-transparent-black-900: rgb(
-        var(--spectrum-global-color-static-transparent-black-900-rgb)
-    );
-    --spectrum-global-color-sequential-cerulean: #e9fff1, #c8f1e4, #a5e3d7,
-        #82d5ca, #68c5c1, #54b4ba, #3fa2b2, #2991ac, #2280a2, #1f6d98, #1d5c8d,
-        #1a4b83, #1a3979, #1a266f, #191264, #180057;
-    --spectrum-global-color-sequential-forest: #ffffdf, #e2f6ba, #c4eb95,
-        #a4e16d, #8dd366, #77c460, #5fb65a, #48a754, #36984f, #2c894d, #237a4a,
-        #196b47, #105c45, #094d41, #033f3e, #00313a;
-    --spectrum-global-color-sequential-rose: #fff4dd, #ffddd7, #ffc5d2, #feaecb,
-        #fa96c4, #f57ebd, #ef64b5, #e846ad, #d238a1, #bb2e96, #a3248c, #8a1b83,
-        #71167c, #560f74, #370b6e, #000968;
-    --spectrum-global-color-diverging-orange-yellow-seafoam: #580000, #79260b,
-        #9c4511, #bd651a, #dd8629, #f5ad52, #fed693, #ffffe0, #bbe4d1, #76c7be,
-        #3ea8a6, #208288, #076769, #00494b, #002c2d;
-    --spectrum-global-color-diverging-red-yellow-blue: #4a001e, #751232, #a52747,
-        #c65154, #e47961, #f0a882, #fad4ac, #ffffe0, #bce2cf, #89c0c4, #579eb9,
-        #397aa8, #1c5796, #163771, #10194d;
-    --spectrum-global-color-diverging-red-blue: #4a001e, #731331, #9f2945,
-        #cc415a, #e06e85, #ed9ab0, #f8c3d9, #faf0ff, #c6d0f2, #92b2de, #5d94cb,
-        #2f74b3, #265191, #163670, #0b194c;
-    --spectrum-semantic-negative-background-color: var(
-        --spectrum-global-color-static-red-600
-    );
-    --spectrum-semantic-negative-color-default: var(
-        --spectrum-global-color-red-500
-    );
-    --spectrum-semantic-negative-color-hover: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-color-dark: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-border-color: var(
-        --spectrum-global-color-red-400
-    );
-    --spectrum-semantic-negative-icon-color: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-status-color: var(
-        --spectrum-global-color-red-400
-    );
-    --spectrum-semantic-negative-text-color-large: var(
-        --spectrum-global-color-red-500
-    );
-    --spectrum-semantic-negative-text-color-small: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-text-color-small-hover: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-semantic-negative-text-color-small-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-semantic-negative-text-color-small-key-focus: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-color-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-semantic-negative-color-key-focus: var(
-        --spectrum-global-color-red-400
-    );
-    --spectrum-semantic-negative-background-color-default: var(
-        --spectrum-global-color-static-red-600
-    );
-    --spectrum-semantic-negative-background-color-hover: var(
-        --spectrum-global-color-static-red-700
-    );
-    --spectrum-semantic-negative-background-color-down: var(
-        --spectrum-global-color-static-red-800
-    );
-    --spectrum-semantic-negative-background-color-key-focus: var(
-        --spectrum-global-color-static-red-700
-    );
-    --spectrum-semantic-notice-background-color: var(
-        --spectrum-global-color-static-orange-600
-    );
-    --spectrum-semantic-notice-color-default: var(
-        --spectrum-global-color-orange-500
-    );
-    --spectrum-semantic-notice-color-dark: var(
-        --spectrum-global-color-orange-600
-    );
-    --spectrum-semantic-notice-border-color: var(
-        --spectrum-global-color-orange-400
-    );
-    --spectrum-semantic-notice-icon-color: var(
-        --spectrum-global-color-orange-600
-    );
-    --spectrum-semantic-notice-status-color: var(
-        --spectrum-global-color-orange-400
-    );
-    --spectrum-semantic-notice-text-color-large: var(
-        --spectrum-global-color-orange-500
-    );
-    --spectrum-semantic-notice-text-color-small: var(
-        --spectrum-global-color-orange-600
-    );
-    --spectrum-semantic-notice-color-down: var(
-        --spectrum-global-color-orange-700
-    );
-    --spectrum-semantic-notice-color-key-focus: var(
-        --spectrum-global-color-orange-400
-    );
-    --spectrum-semantic-notice-background-color-default: var(
-        --spectrum-global-color-static-orange-600
-    );
-    --spectrum-semantic-notice-background-color-hover: var(
-        --spectrum-global-color-static-orange-700
-    );
-    --spectrum-semantic-notice-background-color-down: var(
-        --spectrum-global-color-static-orange-800
-    );
-    --spectrum-semantic-notice-background-color-key-focus: var(
-        --spectrum-global-color-static-orange-700
-    );
-    --spectrum-semantic-positive-background-color: var(
-        --spectrum-global-color-static-green-600
-    );
-    --spectrum-semantic-positive-color-default: var(
-        --spectrum-global-color-green-500
-    );
-    --spectrum-semantic-positive-color-dark: var(
-        --spectrum-global-color-green-600
-    );
-    --spectrum-semantic-positive-border-color: var(
-        --spectrum-global-color-green-400
-    );
-    --spectrum-semantic-positive-icon-color: var(
-        --spectrum-global-color-green-600
-    );
-    --spectrum-semantic-positive-status-color: var(
-        --spectrum-global-color-green-400
-    );
-    --spectrum-semantic-positive-text-color-large: var(
-        --spectrum-global-color-green-500
-    );
-    --spectrum-semantic-positive-text-color-small: var(
-        --spectrum-global-color-green-600
-    );
-    --spectrum-semantic-positive-color-down: var(
-        --spectrum-global-color-green-700
-    );
-    --spectrum-semantic-positive-color-key-focus: var(
-        --spectrum-global-color-green-400
-    );
-    --spectrum-semantic-positive-background-color-default: var(
-        --spectrum-global-color-static-green-600
-    );
-    --spectrum-semantic-positive-background-color-hover: var(
-        --spectrum-global-color-static-green-700
-    );
-    --spectrum-semantic-positive-background-color-down: var(
-        --spectrum-global-color-static-green-800
-    );
-    --spectrum-semantic-positive-background-color-key-focus: var(
-        --spectrum-global-color-static-green-700
-    );
-    --spectrum-semantic-informative-background-color: var(
-        --spectrum-global-color-static-blue-600
-    );
-    --spectrum-semantic-informative-color-default: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-semantic-informative-color-dark: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-informative-border-color: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-semantic-informative-icon-color: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-informative-status-color: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-semantic-informative-text-color-large: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-semantic-informative-text-color-small: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-informative-color-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-semantic-informative-color-key-focus: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-semantic-informative-background-color-default: var(
-        --spectrum-global-color-static-blue-600
-    );
-    --spectrum-semantic-informative-background-color-hover: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-informative-background-color-down: var(
-        --spectrum-global-color-static-blue-800
-    );
-    --spectrum-semantic-informative-background-color-key-focus: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-cta-background-color-default: var(
-        --spectrum-global-color-static-blue-600
-    );
-    --spectrum-semantic-cta-background-color-hover: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-cta-background-color-down: var(
-        --spectrum-global-color-static-blue-800
-    );
-    --spectrum-semantic-cta-background-color-key-focus: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-emphasized-border-color-default: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-semantic-emphasized-border-color-hover: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-emphasized-border-color-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-semantic-emphasized-border-color-key-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-neutral-background-color-default: var(
-        --spectrum-global-color-static-gray-700
-    );
-    --spectrum-semantic-neutral-background-color-hover: var(
-        --spectrum-global-color-static-gray-800
-    );
-    --spectrum-semantic-neutral-background-color-down: var(
-        --spectrum-global-color-static-gray-900
-    );
-    --spectrum-semantic-neutral-background-color-key-focus: var(
-        --spectrum-global-color-static-gray-800
-    );
-    --spectrum-semantic-presence-color-1: var(
-        --spectrum-global-color-static-red-500
-    );
-    --spectrum-semantic-presence-color-2: var(
-        --spectrum-global-color-static-orange-400
-    );
-    --spectrum-semantic-presence-color-3: var(
-        --spectrum-global-color-static-yellow-400
-    );
+    --spectrum-global-color-static-transparent-black-900: rgb(var(--spectrum-global-color-static-transparent-black-900-rgb));
+    --spectrum-global-color-sequential-cerulean: #e9fff1, #c8f1e4, #a5e3d7, #82d5ca, #68c5c1, #54b4ba, #3fa2b2, #2991ac, #2280a2, #1f6d98, #1d5c8d, #1a4b83, #1a3979, #1a266f, #191264, #180057;
+    --spectrum-global-color-sequential-forest: #ffffdf, #e2f6ba, #c4eb95, #a4e16d, #8dd366, #77c460, #5fb65a, #48a754, #36984f, #2c894d, #237a4a, #196b47, #105c45, #094d41, #033f3e, #00313a;
+    --spectrum-global-color-sequential-rose: #fff4dd, #ffddd7, #ffc5d2, #feaecb, #fa96c4, #f57ebd, #ef64b5, #e846ad, #d238a1, #bb2e96, #a3248c, #8a1b83, #71167c, #560f74, #370b6e, #000968;
+    --spectrum-global-color-diverging-orange-yellow-seafoam: #580000, #79260b, #9c4511, #bd651a, #dd8629, #f5ad52, #fed693, #ffffe0, #bbe4d1, #76c7be, #3ea8a6, #208288, #076769, #00494b, #002c2d;
+    --spectrum-global-color-diverging-red-yellow-blue: #4a001e, #751232, #a52747, #c65154, #e47961, #f0a882, #fad4ac, #ffffe0, #bce2cf, #89c0c4, #579eb9, #397aa8, #1c5796, #163771, #10194d;
+    --spectrum-global-color-diverging-red-blue: #4a001e, #731331, #9f2945, #cc415a, #e06e85, #ed9ab0, #f8c3d9, #faf0ff, #c6d0f2, #92b2de, #5d94cb, #2f74b3, #265191, #163670, #0b194c;
+    --spectrum-semantic-negative-background-color: var(--spectrum-global-color-static-red-600);
+    --spectrum-semantic-negative-color-default: var(--spectrum-global-color-red-500);
+    --spectrum-semantic-negative-color-hover: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-color-dark: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-border-color: var(--spectrum-global-color-red-400);
+    --spectrum-semantic-negative-icon-color: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-status-color: var(--spectrum-global-color-red-400);
+    --spectrum-semantic-negative-text-color-large: var(--spectrum-global-color-red-500);
+    --spectrum-semantic-negative-text-color-small: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-text-color-small-hover: var(--spectrum-global-color-red-700);
+    --spectrum-semantic-negative-text-color-small-down: var(--spectrum-global-color-red-700);
+    --spectrum-semantic-negative-text-color-small-key-focus: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-color-down: var(--spectrum-global-color-red-700);
+    --spectrum-semantic-negative-color-key-focus: var(--spectrum-global-color-red-400);
+    --spectrum-semantic-negative-background-color-default: var(--spectrum-global-color-static-red-600);
+    --spectrum-semantic-negative-background-color-hover: var(--spectrum-global-color-static-red-700);
+    --spectrum-semantic-negative-background-color-down: var(--spectrum-global-color-static-red-800);
+    --spectrum-semantic-negative-background-color-key-focus: var(--spectrum-global-color-static-red-700);
+    --spectrum-semantic-notice-background-color: var(--spectrum-global-color-static-orange-600);
+    --spectrum-semantic-notice-color-default: var(--spectrum-global-color-orange-500);
+    --spectrum-semantic-notice-color-dark: var(--spectrum-global-color-orange-600);
+    --spectrum-semantic-notice-border-color: var(--spectrum-global-color-orange-400);
+    --spectrum-semantic-notice-icon-color: var(--spectrum-global-color-orange-600);
+    --spectrum-semantic-notice-status-color: var(--spectrum-global-color-orange-400);
+    --spectrum-semantic-notice-text-color-large: var(--spectrum-global-color-orange-500);
+    --spectrum-semantic-notice-text-color-small: var(--spectrum-global-color-orange-600);
+    --spectrum-semantic-notice-color-down: var(--spectrum-global-color-orange-700);
+    --spectrum-semantic-notice-color-key-focus: var(--spectrum-global-color-orange-400);
+    --spectrum-semantic-notice-background-color-default: var(--spectrum-global-color-static-orange-600);
+    --spectrum-semantic-notice-background-color-hover: var(--spectrum-global-color-static-orange-700);
+    --spectrum-semantic-notice-background-color-down: var(--spectrum-global-color-static-orange-800);
+    --spectrum-semantic-notice-background-color-key-focus: var(--spectrum-global-color-static-orange-700);
+    --spectrum-semantic-positive-background-color: var(--spectrum-global-color-static-green-600);
+    --spectrum-semantic-positive-color-default: var(--spectrum-global-color-green-500);
+    --spectrum-semantic-positive-color-dark: var(--spectrum-global-color-green-600);
+    --spectrum-semantic-positive-border-color: var(--spectrum-global-color-green-400);
+    --spectrum-semantic-positive-icon-color: var(--spectrum-global-color-green-600);
+    --spectrum-semantic-positive-status-color: var(--spectrum-global-color-green-400);
+    --spectrum-semantic-positive-text-color-large: var(--spectrum-global-color-green-500);
+    --spectrum-semantic-positive-text-color-small: var(--spectrum-global-color-green-600);
+    --spectrum-semantic-positive-color-down: var(--spectrum-global-color-green-700);
+    --spectrum-semantic-positive-color-key-focus: var(--spectrum-global-color-green-400);
+    --spectrum-semantic-positive-background-color-default: var(--spectrum-global-color-static-green-600);
+    --spectrum-semantic-positive-background-color-hover: var(--spectrum-global-color-static-green-700);
+    --spectrum-semantic-positive-background-color-down: var(--spectrum-global-color-static-green-800);
+    --spectrum-semantic-positive-background-color-key-focus: var(--spectrum-global-color-static-green-700);
+    --spectrum-semantic-informative-background-color: var(--spectrum-global-color-static-blue-600);
+    --spectrum-semantic-informative-color-default: var(--spectrum-global-color-blue-500);
+    --spectrum-semantic-informative-color-dark: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-informative-border-color: var(--spectrum-global-color-blue-400);
+    --spectrum-semantic-informative-icon-color: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-informative-status-color: var(--spectrum-global-color-blue-400);
+    --spectrum-semantic-informative-text-color-large: var(--spectrum-global-color-blue-500);
+    --spectrum-semantic-informative-text-color-small: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-informative-color-down: var(--spectrum-global-color-blue-700);
+    --spectrum-semantic-informative-color-key-focus: var(--spectrum-global-color-blue-400);
+    --spectrum-semantic-informative-background-color-default: var(--spectrum-global-color-static-blue-600);
+    --spectrum-semantic-informative-background-color-hover: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-informative-background-color-down: var(--spectrum-global-color-static-blue-800);
+    --spectrum-semantic-informative-background-color-key-focus: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-cta-background-color-default: var(--spectrum-global-color-static-blue-600);
+    --spectrum-semantic-cta-background-color-hover: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-cta-background-color-down: var(--spectrum-global-color-static-blue-800);
+    --spectrum-semantic-cta-background-color-key-focus: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-emphasized-border-color-default: var(--spectrum-global-color-blue-500);
+    --spectrum-semantic-emphasized-border-color-hover: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-emphasized-border-color-down: var(--spectrum-global-color-blue-700);
+    --spectrum-semantic-emphasized-border-color-key-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-neutral-background-color-default: var(--spectrum-global-color-static-gray-700);
+    --spectrum-semantic-neutral-background-color-hover: var(--spectrum-global-color-static-gray-800);
+    --spectrum-semantic-neutral-background-color-down: var(--spectrum-global-color-static-gray-900);
+    --spectrum-semantic-neutral-background-color-key-focus: var(--spectrum-global-color-static-gray-800);
+    --spectrum-semantic-presence-color-1: var(--spectrum-global-color-static-red-500);
+    --spectrum-semantic-presence-color-2: var(--spectrum-global-color-static-orange-400);
+    --spectrum-semantic-presence-color-3: var(--spectrum-global-color-static-yellow-400);
     --spectrum-semantic-presence-color-4-rgb: 75, 204, 162;
-    --spectrum-semantic-presence-color-4: rgb(
-        var(--spectrum-semantic-presence-color-4-rgb)
-    );
+    --spectrum-semantic-presence-color-4: rgb(var(--spectrum-semantic-presence-color-4-rgb));
     --spectrum-semantic-presence-color-5-rgb: 0, 199, 255;
-    --spectrum-semantic-presence-color-5: rgb(
-        var(--spectrum-semantic-presence-color-5-rgb)
-    );
+    --spectrum-semantic-presence-color-5: rgb(var(--spectrum-semantic-presence-color-5-rgb));
     --spectrum-semantic-presence-color-6-rgb: 0, 140, 184;
-    --spectrum-semantic-presence-color-6: rgb(
-        var(--spectrum-semantic-presence-color-6-rgb)
-    );
+    --spectrum-semantic-presence-color-6: rgb(var(--spectrum-semantic-presence-color-6-rgb));
     --spectrum-semantic-presence-color-7-rgb: 126, 75, 243;
-    --spectrum-semantic-presence-color-7: rgb(
-        var(--spectrum-semantic-presence-color-7-rgb)
-    );
-    --spectrum-semantic-presence-color-8: var(
-        --spectrum-global-color-static-fuchsia-600
-    );
+    --spectrum-semantic-presence-color-7: rgb(var(--spectrum-semantic-presence-color-7-rgb));
+    --spectrum-semantic-presence-color-8: var(--spectrum-global-color-static-fuchsia-600);
     --spectrum-global-dimension-static-percent-50: 50%;
     --spectrum-global-dimension-static-percent-70: 70%;
     --spectrum-global-dimension-static-percent-100: 100%;
@@ -723,12 +373,9 @@
     --spectrum-global-dimension-static-font-size-800: 32px;
     --spectrum-global-dimension-static-font-size-900: 36px;
     --spectrum-global-dimension-static-font-size-1000: 40px;
-    --spectrum-global-font-family-base: adobe-clean, 'Source Sans Pro',
-        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu,
-        'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-global-font-family-serif: adobe-clean-serif, 'Source Serif Pro',
-        Georgia, serif;
-    --spectrum-global-font-family-code: 'Source Code Pro', Monaco, monospace;
+    --spectrum-global-font-family-base: adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-global-font-family-serif: adobe-clean-serif, "Source Serif Pro", Georgia, serif;
+    --spectrum-global-font-family-code: "Source Code Pro", Monaco, monospace;
     --spectrum-global-font-weight-thin: 100;
     --spectrum-global-font-weight-ultra-light: 200;
     --spectrum-global-font-weight-light: 300;
@@ -750,313 +397,112 @@
     --spectrum-global-font-multiplier-0: 0em;
     --spectrum-global-font-multiplier-25: 0.25em;
     --spectrum-global-font-multiplier-75: 0.75em;
-    --spectrum-global-font-font-family-ar: myriad-arabic, adobe-clean,
-        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-global-font-font-family-he: myriad-hebrew, adobe-clean,
-        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-global-font-font-family-zh: adobe-clean-han-traditional,
-        source-han-traditional, 'MingLiu', 'Heiti TC Light', 'sans-serif';
-    --spectrum-global-font-font-family-zhhans: adobe-clean-han-simplified-c,
-        source-han-simplified-c, 'SimSun', 'Heiti SC Light', 'sans-serif';
-    --spectrum-global-font-font-family-ko: adobe-clean-han-korean,
-        source-han-korean, 'Malgun Gothic', 'Apple Gothic', 'sans-serif';
-    --spectrum-global-font-font-family-ja: adobe-clean-han-japanese,
-        'Hiragino Kaku Gothic ProN', 'ヒラギノ角ゴ ProN W3', 'Osaka', YuGothic,
-        'Yu Gothic', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', 'MS PGothic',
-        'sans-serif';
-    --spectrum-global-font-font-family-condensed: adobe-clean-han-traditional,
-        source-han-traditional, 'MingLiu', 'Heiti TC Light', adobe-clean,
-        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-alias-border-size-thin: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-border-size-thick: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-size-thicker: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-size-thickest: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thin: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-offset-thick: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-offset-thicker: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thickest: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-baseline: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-grid-gutter-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-gutter-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-gutter-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-gutter-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-gutter-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-margin-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-margin-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-margin-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-margin-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-margin-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-radial-reaction-size-default: var(
-        --spectrum-global-dimension-static-size-550
-    );
-    --spectrum-alias-focus-ring-gap: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-focus-ring-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-loupe-entry-animation-duration: var(
-        --spectrum-global-animation-duration-300
-    );
-    --spectrum-alias-loupe-exit-animation-duration: var(
-        --spectrum-global-animation-duration-300
-    );
-    --spectrum-alias-heading-text-line-height: var(
-        --spectrum-global-font-line-height-small
-    );
-    --spectrum-alias-heading-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-heading-text-font-weight-regular-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-light: var(
-        --spectrum-global-font-weight-light
-    );
-    --spectrum-alias-heading-text-font-weight-light-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-heading-text-font-weight-heavy: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-heavy-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-quiet: var(
-        --spectrum-global-font-weight-light
-    );
-    --spectrum-alias-heading-text-font-weight-quiet-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-heading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-strong-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-margin-bottom: var(
-        --spectrum-global-font-multiplier-25
-    );
-    --spectrum-alias-subheading-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-subheading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-body-text-font-family: var(
-        --spectrum-global-font-family-base
-    );
-    --spectrum-alias-body-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-body-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-body-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-body-margin-bottom: var(
-        --spectrum-global-font-multiplier-75
-    );
-    --spectrum-alias-detail-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-detail-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-detail-text-font-weight-light: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-heading-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-article-heading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-heading-text-font-weight-quiet: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-article-heading-text-font-weight-quiet-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-article-body-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-article-body-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-subheading-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-article-subheading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-detail-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-article-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-code-text-font-family: var(
-        --spectrum-global-font-family-code
-    );
-    --spectrum-alias-code-text-font-weight-regular: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-code-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-code-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-code-margin-bottom: var(
-        --spectrum-global-font-multiplier-0
-    );
+    --spectrum-global-font-font-family-ar: myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-global-font-font-family-he: myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-global-font-font-family-zh: adobe-clean-han-traditional, source-han-traditional, "MingLiu", "Heiti TC Light", "sans-serif";
+    --spectrum-global-font-font-family-zhhans: adobe-clean-han-simplified-c, source-han-simplified-c, "SimSun", "Heiti SC Light", "sans-serif";
+    --spectrum-global-font-font-family-ko: adobe-clean-han-korean, source-han-korean, "Malgun Gothic", "Apple Gothic", "sans-serif";
+    --spectrum-global-font-font-family-ja: adobe-clean-han-japanese, "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ ProN W3", "Osaka", YuGothic, "Yu Gothic", "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", "sans-serif";
+    --spectrum-global-font-font-family-condensed: adobe-clean-han-traditional, source-han-traditional, "MingLiu", "Heiti TC Light", adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-alias-border-size-thin: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-border-size-thick: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-size-thicker: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-size-thickest: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thin: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-offset-thick: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-offset-thicker: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thickest: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-baseline: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-grid-gutter-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-gutter-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-gutter-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-gutter-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-gutter-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-margin-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-margin-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-margin-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-margin-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-margin-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-layout-region-margin-bottom-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-layout-region-margin-bottom-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-radial-reaction-size-default: var(--spectrum-global-dimension-static-size-550);
+    --spectrum-alias-focus-ring-gap: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-focus-ring-size: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-loupe-entry-animation-duration: var(--spectrum-global-animation-duration-300);
+    --spectrum-alias-loupe-exit-animation-duration: var(--spectrum-global-animation-duration-300);
+    --spectrum-alias-heading-text-line-height: var(--spectrum-global-font-line-height-small);
+    --spectrum-alias-heading-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-heading-text-font-weight-regular-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-light: var(--spectrum-global-font-weight-light);
+    --spectrum-alias-heading-text-font-weight-light-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-heading-text-font-weight-heavy: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-heavy-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-quiet: var(--spectrum-global-font-weight-light);
+    --spectrum-alias-heading-text-font-weight-quiet-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-heading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-strong-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-margin-bottom: var(--spectrum-global-font-multiplier-25);
+    --spectrum-alias-subheading-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-subheading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-body-text-font-family: var(--spectrum-global-font-family-base);
+    --spectrum-alias-body-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-body-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-body-text-font-weight-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-body-margin-bottom: var(--spectrum-global-font-multiplier-75);
+    --spectrum-alias-detail-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-detail-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-detail-text-font-weight-light: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-detail-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-heading-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-article-heading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-heading-text-font-weight-quiet: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-article-heading-text-font-weight-quiet-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-article-body-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-article-body-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-subheading-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-article-subheading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-detail-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-article-detail-text-font-weight-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-code-text-font-family: var(--spectrum-global-font-family-code);
+    --spectrum-alias-code-text-font-weight-regular: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-code-text-font-weight-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-code-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-code-margin-bottom: var(--spectrum-global-font-multiplier-0);
     --spectrum-alias-font-family-ar: var(--spectrum-global-font-font-family-ar);
     --spectrum-alias-font-family-he: var(--spectrum-global-font-font-family-he);
     --spectrum-alias-font-family-zh: var(--spectrum-global-font-font-family-zh);
-    --spectrum-alias-font-family-zhhans: var(
-        --spectrum-global-font-font-family-zhhans
-    );
+    --spectrum-alias-font-family-zhhans: var(--spectrum-global-font-font-family-zhhans);
     --spectrum-alias-font-family-ko: var(--spectrum-global-font-font-family-ko);
     --spectrum-alias-font-family-ja: var(--spectrum-global-font-font-family-ja);
-    --spectrum-alias-font-family-condensed: var(
-        --spectrum-global-font-font-family-condensed
-    );
-    --spectrum-alias-button-text-line-height: var(
-        --spectrum-global-font-line-height-small
-    );
-    --spectrum-alias-component-text-line-height: var(
-        --spectrum-global-font-line-height-small
-    );
-    --spectrum-alias-han-component-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-serif-text-font-family: var(
-        --spectrum-global-font-family-serif
-    );
-    --spectrum-alias-han-heading-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-han-heading-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-regular-emphasis: var(
-        --spectrum-global-font-weight-extra-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-regular-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-heading-text-font-weight-quiet-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-light: var(
-        --spectrum-global-font-weight-light
-    );
-    --spectrum-alias-han-heading-text-font-weight-light-emphasis: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-han-heading-text-font-weight-light-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-heavy: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-heading-text-font-weight-heavy-emphasis: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-heading-text-font-weight-heavy-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-body-text-line-height: var(
-        --spectrum-global-font-line-height-large
-    );
-    --spectrum-alias-han-body-text-font-weight-regular: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-han-body-text-font-weight-emphasis: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-body-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-subheading-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-subheading-text-font-weight-emphasis: var(
-        --spectrum-global-font-weight-extra-bold
-    );
-    --spectrum-alias-han-subheading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-detail-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-han-detail-text-font-weight-emphasis: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
+    --spectrum-alias-font-family-condensed: var(--spectrum-global-font-font-family-condensed);
+    --spectrum-alias-button-text-line-height: var(--spectrum-global-font-line-height-small);
+    --spectrum-alias-component-text-line-height: var(--spectrum-global-font-line-height-small);
+    --spectrum-alias-han-component-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-serif-text-font-family: var(--spectrum-global-font-family-serif);
+    --spectrum-alias-han-heading-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-han-heading-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-heading-text-font-weight-regular-emphasis: var(--spectrum-global-font-weight-extra-bold);
+    --spectrum-alias-han-heading-text-font-weight-regular-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-heading-text-font-weight-quiet-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-heading-text-font-weight-light: var(--spectrum-global-font-weight-light);
+    --spectrum-alias-han-heading-text-font-weight-light-emphasis: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-han-heading-text-font-weight-light-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-heading-text-font-weight-heavy: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-heading-text-font-weight-heavy-emphasis: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-heading-text-font-weight-heavy-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-body-text-line-height: var(--spectrum-global-font-line-height-large);
+    --spectrum-alias-han-body-text-font-weight-regular: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-han-body-text-font-weight-emphasis: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-body-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-subheading-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-subheading-text-font-weight-emphasis: var(--spectrum-global-font-weight-extra-bold);
+    --spectrum-alias-han-subheading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-detail-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-han-detail-text-font-weight-emphasis: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-detail-text-font-weight-strong: var(--spectrum-global-font-weight-black);
 }
 
 :root,
@@ -1065,652 +511,232 @@
     --spectrum-alias-item-height-m: var(--spectrum-global-dimension-size-400);
     --spectrum-alias-item-height-l: var(--spectrum-global-dimension-size-500);
     --spectrum-alias-item-height-xl: var(--spectrum-global-dimension-size-600);
-    --spectrum-alias-item-rounded-border-radius-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-rounded-border-radius-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-rounded-border-radius-l: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-item-rounded-border-radius-xl: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-item-text-size-s: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-item-text-size-m: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-item-text-size-l: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-item-text-size-xl: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-item-text-padding-top-s: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-item-text-padding-top-m: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-text-padding-top-xl: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-text-padding-bottom-m: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-text-padding-bottom-l: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-text-padding-bottom-xl: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-item-icon-padding-top-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-icon-padding-top-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-icon-padding-top-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-icon-padding-top-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-icon-padding-bottom-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-icon-padding-bottom-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-icon-padding-bottom-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-icon-padding-bottom-xl: var(
-        --spectrum-global-dimension-size-160
-    );
+    --spectrum-alias-item-rounded-border-radius-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-rounded-border-radius-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-rounded-border-radius-l: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-item-rounded-border-radius-xl: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-item-text-size-s: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-item-text-size-m: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-item-text-size-l: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-item-text-size-xl: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-item-text-padding-top-s: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-item-text-padding-top-m: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-text-padding-top-xl: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-text-padding-bottom-m: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-text-padding-bottom-l: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-text-padding-bottom-xl: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-item-icon-padding-top-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-icon-padding-top-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-icon-padding-top-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-icon-padding-top-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-icon-padding-bottom-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-icon-padding-bottom-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-icon-padding-bottom-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-icon-padding-bottom-xl: var(--spectrum-global-dimension-size-160);
     --spectrum-alias-item-padding-s: var(--spectrum-global-dimension-size-115);
     --spectrum-alias-item-padding-m: var(--spectrum-global-dimension-size-150);
     --spectrum-alias-item-padding-l: var(--spectrum-global-dimension-size-185);
     --spectrum-alias-item-padding-xl: var(--spectrum-global-dimension-size-225);
-    --spectrum-alias-item-rounded-padding-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-rounded-padding-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-rounded-padding-l: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-item-rounded-padding-xl: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-item-icononly-padding-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-icononly-padding-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-icononly-padding-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-icononly-padding-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-control-gap-s: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-gap-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-gap-l: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-control-gap-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-workflow-icon-gap-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-workflow-icon-gap-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-workflow-icon-gap-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-workflow-icon-gap-xl: var(
-        --spectrum-global-dimension-size-125
-    );
+    --spectrum-alias-item-rounded-padding-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-rounded-padding-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-rounded-padding-l: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-item-rounded-padding-xl: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-item-icononly-padding-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-icononly-padding-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-icononly-padding-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-icononly-padding-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-control-gap-s: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-gap-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-gap-l: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-control-gap-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-workflow-icon-gap-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-workflow-icon-gap-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-workflow-icon-gap-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-workflow-icon-gap-xl: var(--spectrum-global-dimension-size-125);
     --spectrum-alias-item-mark-gap-s: var(--spectrum-global-dimension-size-85);
     --spectrum-alias-item-mark-gap-m: var(--spectrum-global-dimension-size-100);
     --spectrum-alias-item-mark-gap-l: var(--spectrum-global-dimension-size-115);
-    --spectrum-alias-item-mark-gap-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-ui-icon-gap-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-ui-icon-gap-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-ui-icon-gap-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-ui-icon-gap-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-clearbutton-gap-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-clearbutton-gap-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-clearbutton-gap-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-clearbutton-gap-xl: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-workflow-padding-left-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-workflow-padding-left-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-workflow-padding-left-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-rounded-workflow-padding-left-s: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-rounded-workflow-padding-left-l: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-mark-padding-top-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-item-mark-padding-top-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-mark-padding-top-xl: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-mark-padding-bottom-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-item-mark-padding-bottom-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-mark-padding-bottom-xl: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-mark-padding-left-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-mark-padding-left-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-mark-padding-left-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-control-1-size-s: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-item-control-1-size-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-control-2-size-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-item-control-2-size-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-control-2-size-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-control-2-size-xxl: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-item-control-2-border-radius-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-2-border-radius-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-control-2-border-radius-l: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-control-2-border-radius-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-2-border-radius-xxl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-2-padding-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-2-padding-m: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-2-padding-l: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-control-2-padding-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-control-3-height-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-item-control-3-height-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-control-3-height-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-control-3-border-radius-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-3-border-radius-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-control-3-border-radius-l: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-control-3-border-radius-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-3-padding-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-3-padding-m: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-3-padding-l: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-control-3-padding-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-mark-size-s: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-mark-size-l: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-item-mark-size-xl: var(
-        --spectrum-global-dimension-size-325
-    );
-    --spectrum-alias-heading-xxxl-text-size: var(
-        --spectrum-global-dimension-font-size-1300
-    );
-    --spectrum-alias-heading-xxl-text-size: var(
-        --spectrum-global-dimension-font-size-1100
-    );
-    --spectrum-alias-heading-xl-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-l-text-size: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading-m-text-size: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading-s-text-size: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-xs-text-size: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-xxs-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-xxxl-margin-top: var(
-        --spectrum-global-dimension-font-size-1200
-    );
-    --spectrum-alias-heading-xxl-margin-top: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-xl-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-l-margin-top: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading-m-margin-top: var(
-        --spectrum-global-dimension-font-size-400
-    );
-    --spectrum-alias-heading-s-margin-top: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-xs-margin-top: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-xxs-margin-top: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-heading-han-xxxl-text-size: var(
-        --spectrum-global-dimension-font-size-1300
-    );
-    --spectrum-alias-heading-han-xxl-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-han-xl-text-size: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-han-l-text-size: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading-han-m-text-size: var(
-        --spectrum-global-dimension-font-size-400
-    );
-    --spectrum-alias-heading-han-s-text-size: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-han-xs-text-size: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-han-xxs-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-han-xxxl-margin-top: var(
-        --spectrum-global-dimension-font-size-1200
-    );
-    --spectrum-alias-heading-han-xxl-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-han-xl-margin-top: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading-han-l-margin-top: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading-han-m-margin-top: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-han-s-margin-top: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-han-xs-margin-top: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-han-xxs-margin-top: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-component-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-component-border-radius-quiet: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-component-focusring-gap: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-component-focusring-gap-emphasized: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-component-focusring-size: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-component-focusring-size-emphasized: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-input-border-size: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-input-focusring-gap: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-input-quiet-focusline-gap: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-control-two-size-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-control-two-size-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-control-two-size-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-control-two-size-xxl: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-control-two-border-radius-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-control-two-border-radius-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-control-two-border-radius-l: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-control-two-border-radius-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-control-two-border-radius-xxl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-s: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-m: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-l: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-xxl: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-control-three-height-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-control-three-height-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-control-three-height-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-infieldbutton-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
+    --spectrum-alias-item-mark-gap-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-ui-icon-gap-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-ui-icon-gap-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-ui-icon-gap-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-ui-icon-gap-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-clearbutton-gap-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-clearbutton-gap-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-clearbutton-gap-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-clearbutton-gap-xl: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-workflow-padding-left-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-workflow-padding-left-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-workflow-padding-left-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-rounded-workflow-padding-left-s: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-rounded-workflow-padding-left-l: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-mark-padding-top-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-item-mark-padding-top-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-mark-padding-top-xl: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-mark-padding-bottom-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-item-mark-padding-bottom-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-mark-padding-bottom-xl: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-mark-padding-left-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-mark-padding-left-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-mark-padding-left-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-control-1-size-s: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-item-control-1-size-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-control-2-size-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-item-control-2-size-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-control-2-size-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-control-2-size-xxl: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-item-control-2-border-radius-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-2-border-radius-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-control-2-border-radius-l: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-control-2-border-radius-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-2-border-radius-xxl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-2-padding-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-2-padding-m: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-2-padding-l: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-control-2-padding-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-control-3-height-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-item-control-3-height-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-control-3-height-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-control-3-border-radius-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-3-border-radius-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-control-3-border-radius-l: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-control-3-border-radius-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-3-padding-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-3-padding-m: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-3-padding-l: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-control-3-padding-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-mark-size-s: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-mark-size-l: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-item-mark-size-xl: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-heading-xxxl-text-size: var(--spectrum-global-dimension-font-size-1300);
+    --spectrum-alias-heading-xxl-text-size: var(--spectrum-global-dimension-font-size-1100);
+    --spectrum-alias-heading-xl-text-size: var(--spectrum-global-dimension-font-size-900);
+    --spectrum-alias-heading-l-text-size: var(--spectrum-global-dimension-font-size-700);
+    --spectrum-alias-heading-m-text-size: var(--spectrum-global-dimension-font-size-500);
+    --spectrum-alias-heading-s-text-size: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-heading-xs-text-size: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-xxs-text-size: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-xxxl-margin-top: var(--spectrum-global-dimension-font-size-1200);
+    --spectrum-alias-heading-xxl-margin-top: var(--spectrum-global-dimension-font-size-900);
+    --spectrum-alias-heading-xl-margin-top: var(--spectrum-global-dimension-font-size-800);
+    --spectrum-alias-heading-l-margin-top: var(--spectrum-global-dimension-font-size-600);
+    --spectrum-alias-heading-m-margin-top: var(--spectrum-global-dimension-font-size-400);
+    --spectrum-alias-heading-s-margin-top: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-xs-margin-top: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-xxs-margin-top: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-heading-han-xxxl-text-size: var(--spectrum-global-dimension-font-size-1300);
+    --spectrum-alias-heading-han-xxl-text-size: var(--spectrum-global-dimension-font-size-900);
+    --spectrum-alias-heading-han-xl-text-size: var(--spectrum-global-dimension-font-size-800);
+    --spectrum-alias-heading-han-l-text-size: var(--spectrum-global-dimension-font-size-600);
+    --spectrum-alias-heading-han-m-text-size: var(--spectrum-global-dimension-font-size-400);
+    --spectrum-alias-heading-han-s-text-size: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-heading-han-xs-text-size: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-han-xxs-text-size: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-han-xxxl-margin-top: var(--spectrum-global-dimension-font-size-1200);
+    --spectrum-alias-heading-han-xxl-margin-top: var(--spectrum-global-dimension-font-size-800);
+    --spectrum-alias-heading-han-xl-margin-top: var(--spectrum-global-dimension-font-size-700);
+    --spectrum-alias-heading-han-l-margin-top: var(--spectrum-global-dimension-font-size-500);
+    --spectrum-alias-heading-han-m-margin-top: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-heading-han-s-margin-top: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-han-xs-margin-top: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-han-xxs-margin-top: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-component-border-radius: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-component-border-radius-quiet: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-component-focusring-gap: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-component-focusring-gap-emphasized: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-component-focusring-size: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-component-focusring-size-emphasized: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-input-border-size: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-input-focusring-gap: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-input-quiet-focusline-gap: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-control-two-size-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-control-two-size-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-control-two-size-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-control-two-size-xxl: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-control-two-border-radius-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-control-two-border-radius-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-control-two-border-radius-l: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-control-two-border-radius-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-control-two-border-radius-xxl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-control-two-focus-ring-border-radius-s: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-control-two-focus-ring-border-radius-m: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-control-two-focus-ring-border-radius-l: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-control-two-focus-ring-border-radius-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-control-two-focus-ring-border-radius-xxl: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-control-three-height-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-control-three-height-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-control-three-height-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-infieldbutton-icon-margin-y-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-infieldbutton-icon-margin-y-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-infieldbutton-icon-margin-y-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-infieldbutton-icon-margin-y-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-infieldbutton-border-radius: var(--spectrum-global-dimension-size-50);
     --spectrum-alias-infieldbutton-border-radius-sided: 0;
-    --spectrum-alias-infieldbutton-border-size: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-infieldbutton-fill-padding-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-infieldbutton-fill-padding-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-infieldbutton-fill-padding-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-infieldbutton-fill-padding-xl: var(
-        --spectrum-global-dimension-size-160
-    );
+    --spectrum-alias-infieldbutton-border-size: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-infieldbutton-fill-padding-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-infieldbutton-fill-padding-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-infieldbutton-fill-padding-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-infieldbutton-fill-padding-xl: var(--spectrum-global-dimension-size-160);
     --spectrum-alias-infieldbutton-padding-s: 0;
     --spectrum-alias-infieldbutton-padding-m: 0;
     --spectrum-alias-infieldbutton-padding-l: 0;
     --spectrum-alias-infieldbutton-padding-xl: 0;
-    --spectrum-alias-infieldbutton-full-height-s: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-infieldbutton-full-height-m: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-infieldbutton-full-height-l: var(
-        --spectrum-global-dimension-size-500
-    );
-    --spectrum-alias-infieldbutton-full-height-xl: var(
-        --spectrum-global-dimension-size-600
-    );
-    --spectrum-alias-infieldbutton-half-height-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-infieldbutton-half-height-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-infieldbutton-half-height-l: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-infieldbutton-half-height-xl: var(
-        --spectrum-global-dimension-size-300
-    );
+    --spectrum-alias-infieldbutton-full-height-s: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-infieldbutton-full-height-m: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-infieldbutton-full-height-l: var(--spectrum-global-dimension-size-500);
+    --spectrum-alias-infieldbutton-full-height-xl: var(--spectrum-global-dimension-size-600);
+    --spectrum-alias-infieldbutton-half-height-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-infieldbutton-half-height-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-infieldbutton-half-height-l: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-infieldbutton-half-height-xl: var(--spectrum-global-dimension-size-300);
     --spectrum-alias-stepperbutton-gap: 0;
-    --spectrum-alias-stepperbutton-width-s: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-stepperbutton-width-m: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-stepperbutton-width-l: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-stepperbutton-width-xl: var(
-        --spectrum-global-dimension-size-450
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-xl: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-s: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-m: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-l: var(
-        --spectrum-global-dimension-size-65
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-xl: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-bottom-s: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-bottom-m: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-bottom-l: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-bottom-xl: var(
-        --spectrum-global-dimension-size-50
-    );
+    --spectrum-alias-stepperbutton-width-s: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-stepperbutton-width-m: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-stepperbutton-width-l: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-stepperbutton-width-xl: var(--spectrum-global-dimension-size-450);
+    --spectrum-alias-stepperbutton-icon-x-offset-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-stepperbutton-icon-x-offset-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-stepperbutton-icon-x-offset-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-stepperbutton-icon-x-offset-xl: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-s: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-m: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-l: var(--spectrum-global-dimension-size-65);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-xl: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-s: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-m: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-l: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-xl: var(--spectrum-global-dimension-size-50);
     --spectrum-alias-stepperbutton-radius-touching: 0;
-    --spectrum-alias-clearbutton-icon-margin-s: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-clearbutton-icon-margin-m: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-clearbutton-icon-margin-l: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-clearbutton-icon-margin-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-clearbutton-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-xl: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-xl: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-m: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-xl: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-pickerbutton-border-radius-rounded: var(
-        --spectrum-global-dimension-size-50
-    );
+    --spectrum-alias-clearbutton-icon-margin-s: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-clearbutton-icon-margin-m: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-clearbutton-icon-margin-l: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-clearbutton-icon-margin-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-clearbutton-border-radius: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-pickerbutton-icononly-padding-x-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-pickerbutton-icononly-padding-x-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-pickerbutton-icononly-padding-x-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-pickerbutton-icononly-padding-x-xl: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-pickerbutton-icon-margin-y-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-pickerbutton-icon-margin-y-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-pickerbutton-icon-margin-y-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-pickerbutton-icon-margin-y-xl: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-pickerbutton-label-padding-y-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-pickerbutton-label-padding-y-m: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-pickerbutton-label-padding-y-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-pickerbutton-label-padding-y-xl: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-pickerbutton-border-radius-rounded: var(--spectrum-global-dimension-size-50);
     --spectrum-alias-pickerbutton-border-radius-rounded-sided: 0;
-    --spectrum-alias-search-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
+    --spectrum-alias-search-border-radius: var(--spectrum-global-dimension-size-50);
     --spectrum-alias-search-border-radius-quiet: 0;
-    --spectrum-alias-combobox-quiet-button-offset-x: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-thumbnail-border-radius-small: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-actiongroup-button-gap: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-actiongroup-button-gap-compact: var(
-        --spectrum-global-dimension-size-0
-    );
-    --spectrum-alias-actiongroup-button-gap-quiet: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-actiongroup-button-gap-quiet-compact: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-search-padding-left-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-search-padding-left-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-search-padding-left-xl: var(
-        --spectrum-global-dimension-size-185
-    );
+    --spectrum-alias-combobox-quiet-button-offset-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-thumbnail-border-radius-small: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-actiongroup-button-gap: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-actiongroup-button-gap-compact: var(--spectrum-global-dimension-size-0);
+    --spectrum-alias-actiongroup-button-gap-quiet: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-actiongroup-button-gap-quiet-compact: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-search-padding-left-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-search-padding-left-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-search-padding-left-xl: var(--spectrum-global-dimension-size-185);
     --spectrum-alias-percent-50: 50%;
     --spectrum-alias-percent-70: 70%;
     --spectrum-alias-percent-100: 100%;
@@ -1722,297 +748,111 @@
     --spectrum-alias-grid-columns: 12;
     --spectrum-alias-grid-fluid-width: 100%;
     --spectrum-alias-grid-fixed-max-width: 1280px;
-    --spectrum-alias-border-size-thin: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-border-size-thick: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-size-thicker: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-size-thickest: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thin: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-offset-thick: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-offset-thicker: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thickest: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-baseline: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-grid-gutter-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-gutter-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-gutter-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-gutter-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-gutter-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-margin-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-margin-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-margin-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-margin-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-margin-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-radial-reaction-size-default: var(
-        --spectrum-global-dimension-static-size-550
-    );
-    --spectrum-alias-focus-ring-gap: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-focus-ring-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-focus-ring-gap-small: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-focus-ring-size-small: var(
-        --spectrum-global-dimension-static-size-10
-    );
+    --spectrum-alias-border-size-thin: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-border-size-thick: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-size-thicker: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-size-thickest: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thin: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-offset-thick: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-offset-thicker: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thickest: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-baseline: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-grid-gutter-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-gutter-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-gutter-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-gutter-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-gutter-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-margin-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-margin-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-margin-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-margin-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-margin-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-layout-region-margin-bottom-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-layout-region-margin-bottom-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-radial-reaction-size-default: var(--spectrum-global-dimension-static-size-550);
+    --spectrum-alias-focus-ring-gap: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-focus-ring-size: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-focus-ring-gap-small: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-focus-ring-size-small: var(--spectrum-global-dimension-static-size-10);
     --spectrum-alias-dropshadow-blur: var(--spectrum-global-dimension-size-50);
-    --spectrum-alias-dropshadow-offset-y: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-font-size-default: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-layout-label-gap-size: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-pill-button-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-pill-button-text-baseline: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-border-radius-xsmall: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-border-radius-small: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-border-radius-regular: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-border-radius-medium: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-border-radius-large: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-border-radius-xlarge: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-focus-ring-border-radius-xsmall: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-focus-ring-border-radius-small: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-focus-ring-border-radius-medium: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-focus-ring-border-radius-large: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-focus-ring-border-radius-xlarge: var(
-        --spectrum-global-dimension-size-350
-    );
-    --spectrum-alias-single-line-height: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-single-line-width: var(
-        --spectrum-global-dimension-size-2400
-    );
-    --spectrum-alias-workflow-icon-size-s: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-workflow-icon-size-m: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-workflow-icon-size-xl: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-ui-icon-alert-size-75: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-ui-icon-alert-size-100: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-ui-icon-alert-size-200: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-ui-icon-alert-size-300: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-ui-icon-triplegripper-size-100-height: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-ui-icon-doublegripper-size-100-width: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-ui-icon-singlegripper-size-100-width: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-75: var(
-        --spectrum-global-dimension-size-65
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-200: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-ui-icon-asterisk-size-75: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-asterisk-size-100: var(
-        --spectrum-global-dimension-size-100
-    );
+    --spectrum-alias-dropshadow-offset-y: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-font-size-default: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-layout-label-gap-size: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-pill-button-text-size: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-pill-button-text-baseline: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-border-radius-xsmall: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-border-radius-small: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-border-radius-regular: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-border-radius-medium: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-border-radius-large: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-border-radius-xlarge: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-focus-ring-border-radius-xsmall: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-focus-ring-border-radius-small: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-focus-ring-border-radius-medium: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-focus-ring-border-radius-large: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-focus-ring-border-radius-xlarge: var(--spectrum-global-dimension-size-350);
+    --spectrum-alias-single-line-height: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-single-line-width: var(--spectrum-global-dimension-size-2400);
+    --spectrum-alias-workflow-icon-size-s: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-workflow-icon-size-m: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-workflow-icon-size-xl: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-ui-icon-alert-size-75: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-ui-icon-alert-size-100: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-ui-icon-alert-size-200: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-ui-icon-alert-size-300: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-ui-icon-triplegripper-size-100-height: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-ui-icon-doublegripper-size-100-width: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-ui-icon-singlegripper-size-100-width: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-ui-icon-cornertriangle-size-75: var(--spectrum-global-dimension-size-65);
+    --spectrum-alias-ui-icon-cornertriangle-size-200: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-ui-icon-asterisk-size-75: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-asterisk-size-100: var(--spectrum-global-dimension-size-100);
     --spectrum-alias-avatar-size-50: var(--spectrum-global-dimension-size-200);
     --spectrum-alias-avatar-size-75: var(--spectrum-global-dimension-size-225);
     --spectrum-alias-avatar-size-200: var(--spectrum-global-dimension-size-275);
     --spectrum-alias-avatar-size-300: var(--spectrum-global-dimension-size-325);
     --spectrum-alias-avatar-size-500: var(--spectrum-global-dimension-size-400);
     --spectrum-alias-avatar-size-700: var(--spectrum-global-dimension-size-500);
-    --spectrum-alias-avatar-border-size: var(
-        --spectrum-global-dimension-size-0
-    );
-    --spectrum-alias-tag-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-tag-border-size-default: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-tag-border-size-key-focus: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-tag-border-size-disabled: var(
-        --spectrum-global-dimension-size-0
-    );
-    --spectrum-alias-tag-border-size: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-tag-padding-right-s: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-tag-padding-right-m: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-tag-padding-right-l: var(
-        --spectrum-global-dimension-size-185
-    );
+    --spectrum-alias-avatar-border-size: var(--spectrum-global-dimension-size-0);
+    --spectrum-alias-tag-border-radius: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-tag-border-size-default: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-tag-border-size-key-focus: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-tag-border-size-disabled: var(--spectrum-global-dimension-size-0);
+    --spectrum-alias-tag-border-size: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-tag-padding-right-s: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-tag-padding-right-m: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-tag-padding-right-l: var(--spectrum-global-dimension-size-185);
     --spectrum-alias-tag-height-s: var(--spectrum-global-dimension-size-300);
     --spectrum-alias-tag-height-m: var(--spectrum-global-dimension-size-400);
     --spectrum-alias-tag-height-l: var(--spectrum-global-dimension-size-500);
-    --spectrum-alias-tag-font-size-s: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-tag-font-size-m: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-tag-font-size-l: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-tag-text-padding-top-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-tag-text-padding-top-m: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-tag-text-padding-top-l: var(
-        --spectrum-global-dimension-size-115
-    );
+    --spectrum-alias-tag-font-size-s: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-tag-font-size-m: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-tag-font-size-l: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-tag-text-padding-top-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-tag-text-padding-top-m: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-tag-text-padding-top-l: var(--spectrum-global-dimension-size-115);
     --spectrum-alias-tag-icon-size-s: var(--spectrum-global-dimension-size-200);
     --spectrum-alias-tag-icon-size-m: var(--spectrum-global-dimension-size-225);
-    --spectrum-alias-tag-icon-margin-top-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-tag-icon-margin-top-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-tag-icon-margin-top-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-tag-icon-margin-right-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-tag-icon-margin-right-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-tag-icon-margin-right-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-tag-clearbutton-width-s: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-tag-clearbutton-width-m: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-tag-clearbutton-width-l: var(
-        --spectrum-global-dimension-size-500
-    );
-    --spectrum-alias-tag-clearbutton-icon-margin-s: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-tag-clearbutton-icon-margin-m: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-tag-clearbutton-icon-margin-l: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-tag-focusring-size: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-tag-focusring-gap: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-tag-focusring-gap-selected: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-colorloupe-width: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-colorloupe-height: var(
-        --spectrum-global-dimension-static-size-800
-    );
+    --spectrum-alias-tag-icon-margin-top-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-tag-icon-margin-top-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-tag-icon-margin-top-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-tag-icon-margin-right-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-tag-icon-margin-right-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-tag-icon-margin-right-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-tag-clearbutton-width-s: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-tag-clearbutton-width-m: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-tag-clearbutton-width-l: var(--spectrum-global-dimension-size-500);
+    --spectrum-alias-tag-clearbutton-icon-margin-s: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-tag-clearbutton-icon-margin-m: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-tag-clearbutton-icon-margin-l: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-tag-focusring-size: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-tag-focusring-gap: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-tag-focusring-gap-selected: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-colorloupe-width: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-colorloupe-height: var(--spectrum-global-dimension-static-size-800);
 }
 
 :root,
@@ -2020,848 +860,298 @@
     --spectrum-alias-colorhandle-outer-border-color: #0000006b;
     --spectrum-alias-transparent-blue-background-color-hover: #0057be26;
     --spectrum-alias-transparent-blue-background-color-down: #0048994d;
-    --spectrum-alias-transparent-blue-background-color-key-focus: var(
-        --spectrum-alias-transparent-blue-background-color-hover
-    );
-    --spectrum-alias-transparent-blue-background-color-mouse-focus: var(
-        --spectrum-alias-transparent-blue-background-color-hover
-    );
-    --spectrum-alias-transparent-blue-background-color: var(
-        --spectrum-alias-component-text-color-default
-    );
+    --spectrum-alias-transparent-blue-background-color-key-focus: var(--spectrum-alias-transparent-blue-background-color-hover);
+    --spectrum-alias-transparent-blue-background-color-mouse-focus: var(--spectrum-alias-transparent-blue-background-color-hover);
+    --spectrum-alias-transparent-blue-background-color: var(--spectrum-alias-component-text-color-default);
     --spectrum-alias-transparent-red-background-color-hover: #9a000026;
     --spectrum-alias-transparent-red-background-color-down: #7c00004d;
-    --spectrum-alias-transparent-red-background-color-key-focus: var(
-        --spectrum-alias-transparent-red-background-color-hover
-    );
-    --spectrum-alias-transparent-red-background-color-mouse-focus: var(
-        --spectrum-alias-transparent-red-background-color-hover
-    );
-    --spectrum-alias-transparent-red-background-color: var(
-        --spectrum-alias-component-text-color-default
-    );
-    --spectrum-alias-component-text-color-disabled: var(
-        --spectrum-global-color-gray-500
-    );
-    --spectrum-alias-component-text-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-component-text-color-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-component-text-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-component-text-color-key-focus: var(
-        --spectrum-alias-component-text-color-hover
-    );
-    --spectrum-alias-component-text-color-mouse-focus: var(
-        --spectrum-alias-component-text-color-hover
-    );
-    --spectrum-alias-component-text-color: var(
-        --spectrum-alias-component-text-color-default
-    );
-    --spectrum-alias-component-text-color-selected-default: var(
-        --spectrum-alias-component-text-color-default
-    );
-    --spectrum-alias-component-text-color-selected-hover: var(
-        --spectrum-alias-component-text-color-hover
-    );
-    --spectrum-alias-component-text-color-selected-down: var(
-        --spectrum-alias-component-text-color-down
-    );
-    --spectrum-alias-component-text-color-selected-key-focus: var(
-        --spectrum-alias-component-text-color-key-focus
-    );
-    --spectrum-alias-component-text-color-selected-mouse-focus: var(
-        --spectrum-alias-component-text-color-mouse-focus
-    );
-    --spectrum-alias-component-text-color-selected: var(
-        --spectrum-alias-component-text-color-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-default: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-hover: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-down: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-key-focus: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-mouse-focus: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-error-default: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-component-text-color-error-hover: var(
-        --spectrum-semantic-negative-text-color-small-hover
-    );
-    --spectrum-alias-component-text-color-error-down: var(
-        --spectrum-semantic-negative-text-color-small-down
-    );
-    --spectrum-alias-component-text-color-error-key-focus: var(
-        --spectrum-semantic-negative-text-color-small-key-focus
-    );
-    --spectrum-alias-component-text-color-error-mouse-focus: var(
-        --spectrum-semantic-negative-text-color-small-key-focus
-    );
-    --spectrum-alias-component-text-color-error: var(
-        --spectrum-alias-component-text-color-error-default
-    );
-    --spectrum-alias-component-icon-color-disabled: var(
-        --spectrum-alias-icon-color-disabled
-    );
-    --spectrum-alias-component-icon-color-default: var(
-        --spectrum-alias-icon-color
-    );
-    --spectrum-alias-component-icon-color-hover: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-component-icon-color-down: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-component-icon-color-key-focus: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-component-icon-color-mouse-focus: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-component-icon-color: var(
-        --spectrum-alias-component-icon-color-default
-    );
-    --spectrum-alias-component-icon-color-selected: var(
-        --spectrum-alias-icon-color-selected-neutral-subdued
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-default: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-hover: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-down: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-key-focus: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-background-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-quiet-disabled: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet-selected-disabled: var(
-        --spectrum-alias-component-background-color-disabled
-    );
-    --spectrum-alias-component-background-color-default: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-component-background-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-component-background-color-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-component-background-color: var(
-        --spectrum-alias-component-background-color-default
-    );
-    --spectrum-alias-component-background-color-selected-default: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-selected-hover: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-selected-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-selected-key-focus: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-selected: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-background-color-quiet-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet-hover: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet-down: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-component-background-color-quiet-key-focus: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet: var(
-        --spectrum-alias-component-background-color-quiet-default
-    );
-    --spectrum-alias-component-background-color-quiet-selected-default: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-background-color-quiet-selected-hover: var(
-        --spectrum-alias-component-background-color-selected-hover
-    );
-    --spectrum-alias-component-background-color-quiet-selected-down: var(
-        --spectrum-alias-component-background-color-selected-down
-    );
-    --spectrum-alias-component-background-color-quiet-selected-key-focus: var(
-        --spectrum-alias-component-background-color-selected-key-focus
-    );
-    --spectrum-alias-component-background-color-quiet-selected: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-default: var(
-        --spectrum-semantic-cta-background-color-default
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-hover: var(
-        --spectrum-semantic-cta-background-color-hover
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-down: var(
-        --spectrum-semantic-cta-background-color-down
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-key-focus: var(
-        --spectrum-semantic-cta-background-color-key-focus
-    );
-    --spectrum-alias-component-background-color-emphasized-selected: var(
-        --spectrum-alias-component-background-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-border-color-disabled: var(
-        --spectrum-alias-border-color-disabled
-    );
-    --spectrum-alias-component-border-color-quiet-disabled: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-default: var(
-        --spectrum-alias-border-color
-    );
-    --spectrum-alias-component-border-color-hover: var(
-        --spectrum-alias-border-color-hover
-    );
-    --spectrum-alias-component-border-color-down: var(
-        --spectrum-alias-border-color-down
-    );
-    --spectrum-alias-component-border-color-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-component-border-color: var(
-        --spectrum-alias-component-border-color-default
-    );
-    --spectrum-alias-component-border-color-selected-default: var(
-        --spectrum-alias-border-color
-    );
-    --spectrum-alias-component-border-color-selected-hover: var(
-        --spectrum-alias-border-color-hover
-    );
-    --spectrum-alias-component-border-color-selected-down: var(
-        --spectrum-alias-border-color-down
-    );
-    --spectrum-alias-component-border-color-selected-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-component-border-color-selected: var(
-        --spectrum-alias-component-border-color-selected-default
-    );
-    --spectrum-alias-component-border-color-quiet-default: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-quiet-hover: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-quiet-down: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-quiet-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-component-border-color-quiet: var(
-        --spectrum-alias-component-border-color-quiet-default
-    );
-    --spectrum-alias-component-border-color-quiet-selected-default: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-border-color-quiet-selected-hover: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-border-color-quiet-selected-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-border-color-quiet-selected-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-component-border-color-quiet-selected: var(
-        --spectrum-alias-component-border-color-quiet-selected-default
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-default: var(
-        --spectrum-semantic-cta-background-color-default
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-hover: var(
-        --spectrum-semantic-cta-background-color-hover
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-down: var(
-        --spectrum-semantic-cta-background-color-down
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-key-focus: var(
-        --spectrum-semantic-cta-background-color-key-focus
-    );
-    --spectrum-alias-component-border-color-emphasized-selected: var(
-        --spectrum-alias-component-border-color-emphasized-selected-default
-    );
-    --spectrum-alias-tag-border-color-default: var(
-        --spectrum-alias-border-color-darker-default
-    );
-    --spectrum-alias-tag-border-color-hover: var(
-        --spectrum-alias-border-color-darker-hover
-    );
-    --spectrum-alias-tag-border-color-down: var(
-        --spectrum-alias-border-color-darker-hover
-    );
-    --spectrum-alias-tag-border-color-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-tag-border-color-error-default: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-border-color-error-hover: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-border-color-error-down: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-border-color-error-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-tag-border-color-error-selected: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-border-color-selected: var(
-        --spectrum-alias-tag-background-color-selected-default
-    );
-    --spectrum-alias-tag-border-color: var(
-        --spectrum-alias-tag-border-color-default
-    );
-    --spectrum-alias-tag-border-color-disabled: var(
-        --spectrum-alias-border-color-disabled
-    );
-    --spectrum-alias-tag-border-color-error: var(
-        --spectrum-alias-tag-border-color-error-default
-    );
-    --spectrum-alias-tag-text-color-default: var(
-        --spectrum-alias-label-text-color
-    );
-    --spectrum-alias-tag-text-color-hover: var(
-        --spectrum-alias-text-color-hover
-    );
+    --spectrum-alias-transparent-red-background-color-key-focus: var(--spectrum-alias-transparent-red-background-color-hover);
+    --spectrum-alias-transparent-red-background-color-mouse-focus: var(--spectrum-alias-transparent-red-background-color-hover);
+    --spectrum-alias-transparent-red-background-color: var(--spectrum-alias-component-text-color-default);
+    --spectrum-alias-component-text-color-disabled: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-component-text-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-component-text-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-component-text-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-component-text-color-key-focus: var(--spectrum-alias-component-text-color-hover);
+    --spectrum-alias-component-text-color-mouse-focus: var(--spectrum-alias-component-text-color-hover);
+    --spectrum-alias-component-text-color: var(--spectrum-alias-component-text-color-default);
+    --spectrum-alias-component-text-color-selected-default: var(--spectrum-alias-component-text-color-default);
+    --spectrum-alias-component-text-color-selected-hover: var(--spectrum-alias-component-text-color-hover);
+    --spectrum-alias-component-text-color-selected-down: var(--spectrum-alias-component-text-color-down);
+    --spectrum-alias-component-text-color-selected-key-focus: var(--spectrum-alias-component-text-color-key-focus);
+    --spectrum-alias-component-text-color-selected-mouse-focus: var(--spectrum-alias-component-text-color-mouse-focus);
+    --spectrum-alias-component-text-color-selected: var(--spectrum-alias-component-text-color-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-default: var(--spectrum-global-color-static-white);
+    --spectrum-alias-component-text-color-emphasized-selected-hover: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-down: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-key-focus: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-mouse-focus: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-error-default: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-component-text-color-error-hover: var(--spectrum-semantic-negative-text-color-small-hover);
+    --spectrum-alias-component-text-color-error-down: var(--spectrum-semantic-negative-text-color-small-down);
+    --spectrum-alias-component-text-color-error-key-focus: var(--spectrum-semantic-negative-text-color-small-key-focus);
+    --spectrum-alias-component-text-color-error-mouse-focus: var(--spectrum-semantic-negative-text-color-small-key-focus);
+    --spectrum-alias-component-text-color-error: var(--spectrum-alias-component-text-color-error-default);
+    --spectrum-alias-component-icon-color-disabled: var(--spectrum-alias-icon-color-disabled);
+    --spectrum-alias-component-icon-color-default: var(--spectrum-alias-icon-color);
+    --spectrum-alias-component-icon-color-hover: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-component-icon-color-down: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-component-icon-color-key-focus: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-component-icon-color-mouse-focus: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-component-icon-color: var(--spectrum-alias-component-icon-color-default);
+    --spectrum-alias-component-icon-color-selected: var(--spectrum-alias-icon-color-selected-neutral-subdued);
+    --spectrum-alias-component-icon-color-emphasized-selected-default: var(--spectrum-global-color-static-white);
+    --spectrum-alias-component-icon-color-emphasized-selected-hover: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-icon-color-emphasized-selected-down: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-icon-color-emphasized-selected-key-focus: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-icon-color-emphasized-selected: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-background-color-disabled: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-quiet-disabled: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet-selected-disabled: var(--spectrum-alias-component-background-color-disabled);
+    --spectrum-alias-component-background-color-default: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-component-background-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-component-background-color-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-component-background-color: var(--spectrum-alias-component-background-color-default);
+    --spectrum-alias-component-background-color-selected-default: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-selected-hover: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-selected-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-selected-key-focus: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-selected: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-background-color-quiet-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet-hover: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet-down: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-component-background-color-quiet-key-focus: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet: var(--spectrum-alias-component-background-color-quiet-default);
+    --spectrum-alias-component-background-color-quiet-selected-default: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-background-color-quiet-selected-hover: var(--spectrum-alias-component-background-color-selected-hover);
+    --spectrum-alias-component-background-color-quiet-selected-down: var(--spectrum-alias-component-background-color-selected-down);
+    --spectrum-alias-component-background-color-quiet-selected-key-focus: var(--spectrum-alias-component-background-color-selected-key-focus);
+    --spectrum-alias-component-background-color-quiet-selected: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-background-color-emphasized-selected-default: var(--spectrum-semantic-cta-background-color-default);
+    --spectrum-alias-component-background-color-emphasized-selected-hover: var(--spectrum-semantic-cta-background-color-hover);
+    --spectrum-alias-component-background-color-emphasized-selected-down: var(--spectrum-semantic-cta-background-color-down);
+    --spectrum-alias-component-background-color-emphasized-selected-key-focus: var(--spectrum-semantic-cta-background-color-key-focus);
+    --spectrum-alias-component-background-color-emphasized-selected: var(--spectrum-alias-component-background-color-emphasized-selected-default);
+    --spectrum-alias-component-border-color-disabled: var(--spectrum-alias-border-color-disabled);
+    --spectrum-alias-component-border-color-quiet-disabled: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-default: var(--spectrum-alias-border-color);
+    --spectrum-alias-component-border-color-hover: var(--spectrum-alias-border-color-hover);
+    --spectrum-alias-component-border-color-down: var(--spectrum-alias-border-color-down);
+    --spectrum-alias-component-border-color-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-component-border-color: var(--spectrum-alias-component-border-color-default);
+    --spectrum-alias-component-border-color-selected-default: var(--spectrum-alias-border-color);
+    --spectrum-alias-component-border-color-selected-hover: var(--spectrum-alias-border-color-hover);
+    --spectrum-alias-component-border-color-selected-down: var(--spectrum-alias-border-color-down);
+    --spectrum-alias-component-border-color-selected-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-component-border-color-selected: var(--spectrum-alias-component-border-color-selected-default);
+    --spectrum-alias-component-border-color-quiet-default: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-quiet-hover: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-quiet-down: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-quiet-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-component-border-color-quiet: var(--spectrum-alias-component-border-color-quiet-default);
+    --spectrum-alias-component-border-color-quiet-selected-default: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-border-color-quiet-selected-hover: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-border-color-quiet-selected-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-border-color-quiet-selected-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-component-border-color-quiet-selected: var(--spectrum-alias-component-border-color-quiet-selected-default);
+    --spectrum-alias-component-border-color-emphasized-selected-default: var(--spectrum-semantic-cta-background-color-default);
+    --spectrum-alias-component-border-color-emphasized-selected-hover: var(--spectrum-semantic-cta-background-color-hover);
+    --spectrum-alias-component-border-color-emphasized-selected-down: var(--spectrum-semantic-cta-background-color-down);
+    --spectrum-alias-component-border-color-emphasized-selected-key-focus: var(--spectrum-semantic-cta-background-color-key-focus);
+    --spectrum-alias-component-border-color-emphasized-selected: var(--spectrum-alias-component-border-color-emphasized-selected-default);
+    --spectrum-alias-tag-border-color-default: var(--spectrum-alias-border-color-darker-default);
+    --spectrum-alias-tag-border-color-hover: var(--spectrum-alias-border-color-darker-hover);
+    --spectrum-alias-tag-border-color-down: var(--spectrum-alias-border-color-darker-hover);
+    --spectrum-alias-tag-border-color-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-tag-border-color-error-default: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-border-color-error-hover: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-border-color-error-down: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-border-color-error-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-tag-border-color-error-selected: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-border-color-selected: var(--spectrum-alias-tag-background-color-selected-default);
+    --spectrum-alias-tag-border-color: var(--spectrum-alias-tag-border-color-default);
+    --spectrum-alias-tag-border-color-disabled: var(--spectrum-alias-border-color-disabled);
+    --spectrum-alias-tag-border-color-error: var(--spectrum-alias-tag-border-color-error-default);
+    --spectrum-alias-tag-text-color-default: var(--spectrum-alias-label-text-color);
+    --spectrum-alias-tag-text-color-hover: var(--spectrum-alias-text-color-hover);
     --spectrum-alias-tag-text-color-down: var(--spectrum-alias-text-color-down);
-    --spectrum-alias-tag-text-color-key-focus: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tag-text-color-disabled: var(
-        --spectrum-global-color-gray-500
-    );
-    --spectrum-alias-tag-text-color: var(
-        --spectrum-alias-tag-text-color-default
-    );
-    --spectrum-alias-tag-text-color-error-default: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-alias-tag-text-color-error-hover: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-tag-text-color-error-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-tag-text-color-error-key-focus: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-tag-text-color-error: var(
-        --spectrum-alias-tag-text-color-error-default
-    );
-    --spectrum-alias-tag-text-color-selected: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-alias-tag-text-color-key-focus: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tag-text-color-disabled: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-tag-text-color: var(--spectrum-alias-tag-text-color-default);
+    --spectrum-alias-tag-text-color-error-default: var(--spectrum-global-color-red-600);
+    --spectrum-alias-tag-text-color-error-hover: var(--spectrum-global-color-red-700);
+    --spectrum-alias-tag-text-color-error-down: var(--spectrum-global-color-red-700);
+    --spectrum-alias-tag-text-color-error-key-focus: var(--spectrum-global-color-red-700);
+    --spectrum-alias-tag-text-color-error: var(--spectrum-alias-tag-text-color-error-default);
+    --spectrum-alias-tag-text-color-selected: var(--spectrum-global-color-gray-50);
     --spectrum-alias-tag-icon-color-default: var(--spectrum-alias-icon-color);
-    --spectrum-alias-tag-icon-color-hover: var(
-        --spectrum-alias-icon-color-hover
-    );
+    --spectrum-alias-tag-icon-color-hover: var(--spectrum-alias-icon-color-hover);
     --spectrum-alias-tag-icon-color-down: var(--spectrum-alias-icon-color-down);
-    --spectrum-alias-tag-icon-color-key-focus: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-tag-icon-color-disabled: var(
-        --spectrum-alias-icon-color-disabled
-    );
-    --spectrum-alias-tag-icon-color: var(
-        --spectrum-alias-tag-icon-color-default
-    );
+    --spectrum-alias-tag-icon-color-key-focus: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-tag-icon-color-disabled: var(--spectrum-alias-icon-color-disabled);
+    --spectrum-alias-tag-icon-color: var(--spectrum-alias-tag-icon-color-default);
     --spectrum-alias-tag-icon-color-error: var(--spectrum-global-color-red-600);
-    --spectrum-alias-tag-icon-color-selected: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-tag-background-color-default: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-tag-background-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color: var(
-        --spectrum-alias-tag-background-color-default
-    );
-    --spectrum-alias-tag-background-color-error-default: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-error-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-error-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-tag-background-color-error-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-error: var(
-        --spectrum-alias-tag-background-color-error-default
-    );
-    --spectrum-alias-tag-background-color-error-selected-default: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-background-color-error-selected-hover: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-background-color-error-selected-down: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-background-color-error-selected-key-focus: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-alias-tag-background-color-error-selected: var(
-        --spectrum-alias-tag-background-color-error-selected-default
-    );
-    --spectrum-alias-tag-background-color-selected-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-tag-background-color-selected-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-tag-background-color-selected-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tag-background-color-selected-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tag-background-color-selected: var(
-        --spectrum-alias-tag-background-color-selected-default
-    );
+    --spectrum-alias-tag-icon-color-selected: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-disabled: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-tag-background-color-default: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-tag-background-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color: var(--spectrum-alias-tag-background-color-default);
+    --spectrum-alias-tag-background-color-error-default: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-error-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-error-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-tag-background-color-error-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-error: var(--spectrum-alias-tag-background-color-error-default);
+    --spectrum-alias-tag-background-color-error-selected-default: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-background-color-error-selected-hover: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-background-color-error-selected-down: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-background-color-error-selected-key-focus: var(--spectrum-global-color-red-600);
+    --spectrum-alias-tag-background-color-error-selected: var(--spectrum-alias-tag-background-color-error-selected-default);
+    --spectrum-alias-tag-background-color-selected-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-tag-background-color-selected-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-tag-background-color-selected-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tag-background-color-selected-key-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tag-background-color-selected: var(--spectrum-alias-tag-background-color-selected-default);
     --spectrum-alias-tag-focusring-border-color-default: transparent;
     --spectrum-alias-tag-focusring-border-color-key-focus: transparent;
     --spectrum-alias-tag-focusring-border-color-disabled: transparent;
-    --spectrum-alias-tag-focusring-border-color-selected-key-focus: var(
-        --spectrum-alias-focus-ring-color
-    );
-    --spectrum-alias-tag-focusring-border-color: var(
-        --spectrum-alias-tag-focusring-border-color-default
-    );
-    --spectrum-alias-avatar-border-color-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-hover: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-down: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-key-focus: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color: var(
-        --spectrum-alias-avatar-border-color-default
-    );
-    --spectrum-alias-avatar-border-color-disabled: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected-hover: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected-down: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected-key-focus: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected: var(
-        --spectrum-alias-avatar-border-color-selected-default
-    );
-    --spectrum-alias-avatar-border-color-selected-disabled: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-toggle-background-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-toggle-background-color-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-background-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-toggle-background-color-key-focus: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-background-color: var(
-        --spectrum-alias-toggle-background-color-default
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-default: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-hover: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-key-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected: var(
-        --spectrum-alias-toggle-background-color-emphasized-selected-default
-    );
-    --spectrum-alias-toggle-border-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-toggle-border-color-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-border-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-toggle-border-color-key-focus: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-border-color: var(
-        --spectrum-alias-toggle-border-color-default
-    );
-    --spectrum-alias-toggle-icon-color-selected: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-toggle-icon-color-emphasized-selected: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-button-primary-background-color-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-button-primary-background-color-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-background-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-button-primary-background-color-key-focus: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-background-color: var(
-        --spectrum-alias-button-primary-background-color-default
-    );
-    --spectrum-alias-button-primary-border-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-border-color-hover: var(
-        --spectrum-alias-button-primary-background-color-hover
-    );
-    --spectrum-alias-button-primary-border-color-down: var(
-        --spectrum-alias-button-primary-background-color-down
-    );
-    --spectrum-alias-button-primary-border-color-key-focus: var(
-        --spectrum-alias-button-primary-background-color-key-focus
-    );
-    --spectrum-alias-button-primary-border-color: var(
-        --spectrum-alias-button-primary-border-color-default
-    );
-    --spectrum-alias-button-primary-text-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-text-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-primary-text-color-down: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-primary-text-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-primary-text-color: var(
-        --spectrum-alias-button-primary-text-color-default
-    );
-    --spectrum-alias-button-primary-icon-color-default: var(
-        --spectrum-alias-button-primary-text-color-default
-    );
-    --spectrum-alias-button-primary-icon-color-hover: var(
-        --spectrum-alias-button-primary-text-color-hover
-    );
-    --spectrum-alias-button-primary-icon-color-down: var(
-        --spectrum-alias-button-primary-text-color-down
-    );
-    --spectrum-alias-button-primary-icon-color-key-focus: var(
-        --spectrum-alias-button-primary-text-color-key-focus
-    );
-    --spectrum-alias-button-primary-icon-color: var(
-        --spectrum-alias-button-primary-icon-color-default
-    );
-    --spectrum-alias-button-secondary-background-color-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-button-secondary-background-color-hover: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-background-color-down: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-secondary-background-color-key-focus: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-background-color: var(
-        --spectrum-alias-button-secondary-background-color-default
-    );
-    --spectrum-alias-button-secondary-border-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-border-color-hover: var(
-        --spectrum-alias-button-secondary-background-color-hover
-    );
-    --spectrum-alias-button-secondary-border-color-down: var(
-        --spectrum-alias-button-secondary-background-color-down
-    );
-    --spectrum-alias-button-secondary-border-color-key-focus: var(
-        --spectrum-alias-button-secondary-background-color-key-focus
-    );
-    --spectrum-alias-button-secondary-border-color: var(
-        --spectrum-alias-button-secondary-border-color-default
-    );
-    --spectrum-alias-button-secondary-text-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-text-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-secondary-text-color-down: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-secondary-text-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-secondary-text-color: var(
-        --spectrum-alias-button-secondary-text-color-default
-    );
-    --spectrum-alias-button-secondary-icon-color-default: var(
-        --spectrum-alias-button-secondary-text-color-default
-    );
-    --spectrum-alias-button-secondary-icon-color-hover: var(
-        --spectrum-alias-button-secondary-text-color-hover
-    );
-    --spectrum-alias-button-secondary-icon-color-down: var(
-        --spectrum-alias-button-secondary-text-color-down
-    );
-    --spectrum-alias-button-secondary-icon-color-key-focus: var(
-        --spectrum-alias-button-secondary-text-color-key-focus
-    );
-    --spectrum-alias-button-secondary-icon-color: var(
-        --spectrum-alias-button-secondary-icon-color-default
-    );
-    --spectrum-alias-button-negative-background-color-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-button-negative-background-color-hover: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-background-color-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-button-negative-background-color-key-focus: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-background-color: var(
-        --spectrum-alias-button-negative-background-color-default
-    );
-    --spectrum-alias-button-negative-border-color-default: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-border-color-hover: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-border-color-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-button-negative-border-color-key-focus: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-border-color: var(
-        --spectrum-alias-button-negative-border-color-default
-    );
-    --spectrum-alias-button-negative-text-color-default: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-text-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-negative-text-color-down: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-negative-text-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-negative-text-color: var(
-        --spectrum-alias-button-negative-text-color-default
-    );
-    --spectrum-alias-button-negative-icon-color-default: var(
-        --spectrum-alias-button-negative-text-color-default
-    );
-    --spectrum-alias-button-negative-icon-color-hover: var(
-        --spectrum-alias-button-negative-text-color-hover
-    );
-    --spectrum-alias-button-negative-icon-color-down: var(
-        --spectrum-alias-button-negative-text-color-down
-    );
-    --spectrum-alias-button-negative-icon-color-key-focus: var(
-        --spectrum-alias-button-negative-text-color-key-focus
-    );
-    --spectrum-alias-button-negative-icon-color: var(
-        --spectrum-alias-button-negative-icon-color-default
-    );
-    --spectrum-alias-input-border-color-disabled: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-input-border-color-quiet-disabled: var(
-        --spectrum-alias-border-color-mid
-    );
-    --spectrum-alias-input-border-color-default: var(
-        --spectrum-alias-border-color
-    );
-    --spectrum-alias-input-border-color-hover: var(
-        --spectrum-alias-border-color-hover
-    );
-    --spectrum-alias-input-border-color-down: var(
-        --spectrum-alias-border-color-mouse-focus
-    );
-    --spectrum-alias-input-border-color-mouse-focus: var(
-        --spectrum-alias-border-color-mouse-focus
-    );
-    --spectrum-alias-input-border-color-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-input-border-color: var(
-        --spectrum-alias-input-border-color-default
-    );
-    --spectrum-alias-input-border-color-invalid-default: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-input-border-color-invalid-hover: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-input-border-color-invalid-down: var(
-        --spectrum-semantic-negative-color-down
-    );
-    --spectrum-alias-input-border-color-invalid-mouse-focus: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-input-border-color-invalid-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-input-border-color-invalid: var(
-        --spectrum-alias-input-border-color-invalid-default
-    );
-    --spectrum-alias-background-color-yellow-default: var(
-        --spectrum-global-color-static-yellow-300
-    );
-    --spectrum-alias-background-color-yellow-hover: var(
-        --spectrum-global-color-static-yellow-400
-    );
-    --spectrum-alias-background-color-yellow-key-focus: var(
-        --spectrum-global-color-static-yellow-400
-    );
-    --spectrum-alias-background-color-yellow-down: var(
-        --spectrum-global-color-static-yellow-500
-    );
-    --spectrum-alias-background-color-yellow: var(
-        --spectrum-alias-background-color-yellow-default
-    );
-    --spectrum-alias-infieldbutton-background-color: var(
-        --spectrum-global-color-gray-200
-    );
+    --spectrum-alias-tag-focusring-border-color-selected-key-focus: var(--spectrum-alias-focus-ring-color);
+    --spectrum-alias-tag-focusring-border-color: var(--spectrum-alias-tag-focusring-border-color-default);
+    --spectrum-alias-avatar-border-color-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-hover: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-down: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-key-focus: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color: var(--spectrum-alias-avatar-border-color-default);
+    --spectrum-alias-avatar-border-color-disabled: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected-hover: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected-down: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected-key-focus: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected: var(--spectrum-alias-avatar-border-color-selected-default);
+    --spectrum-alias-avatar-border-color-selected-disabled: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-toggle-background-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-toggle-background-color-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-background-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-background-color-key-focus: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-background-color: var(--spectrum-alias-toggle-background-color-default);
+    --spectrum-alias-toggle-background-color-emphasized-selected-default: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-toggle-background-color-emphasized-selected-hover: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-toggle-background-color-emphasized-selected-down: var(--spectrum-global-color-blue-700);
+    --spectrum-alias-toggle-background-color-emphasized-selected-key-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-toggle-background-color-emphasized-selected: var(--spectrum-alias-toggle-background-color-emphasized-selected-default);
+    --spectrum-alias-toggle-border-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-toggle-border-color-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-border-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-border-color-key-focus: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-border-color: var(--spectrum-alias-toggle-border-color-default);
+    --spectrum-alias-toggle-icon-color-selected: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-toggle-icon-color-emphasized-selected: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-button-primary-background-color-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-button-primary-background-color-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-background-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-button-primary-background-color-key-focus: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-background-color: var(--spectrum-alias-button-primary-background-color-default);
+    --spectrum-alias-button-primary-border-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-border-color-hover: var(--spectrum-alias-button-primary-background-color-hover);
+    --spectrum-alias-button-primary-border-color-down: var(--spectrum-alias-button-primary-background-color-down);
+    --spectrum-alias-button-primary-border-color-key-focus: var(--spectrum-alias-button-primary-background-color-key-focus);
+    --spectrum-alias-button-primary-border-color: var(--spectrum-alias-button-primary-border-color-default);
+    --spectrum-alias-button-primary-text-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-text-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-primary-text-color-down: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-primary-text-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-primary-text-color: var(--spectrum-alias-button-primary-text-color-default);
+    --spectrum-alias-button-primary-icon-color-default: var(--spectrum-alias-button-primary-text-color-default);
+    --spectrum-alias-button-primary-icon-color-hover: var(--spectrum-alias-button-primary-text-color-hover);
+    --spectrum-alias-button-primary-icon-color-down: var(--spectrum-alias-button-primary-text-color-down);
+    --spectrum-alias-button-primary-icon-color-key-focus: var(--spectrum-alias-button-primary-text-color-key-focus);
+    --spectrum-alias-button-primary-icon-color: var(--spectrum-alias-button-primary-icon-color-default);
+    --spectrum-alias-button-secondary-background-color-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-button-secondary-background-color-hover: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-background-color-down: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-secondary-background-color-key-focus: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-background-color: var(--spectrum-alias-button-secondary-background-color-default);
+    --spectrum-alias-button-secondary-border-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-border-color-hover: var(--spectrum-alias-button-secondary-background-color-hover);
+    --spectrum-alias-button-secondary-border-color-down: var(--spectrum-alias-button-secondary-background-color-down);
+    --spectrum-alias-button-secondary-border-color-key-focus: var(--spectrum-alias-button-secondary-background-color-key-focus);
+    --spectrum-alias-button-secondary-border-color: var(--spectrum-alias-button-secondary-border-color-default);
+    --spectrum-alias-button-secondary-text-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-text-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-secondary-text-color-down: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-secondary-text-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-secondary-text-color: var(--spectrum-alias-button-secondary-text-color-default);
+    --spectrum-alias-button-secondary-icon-color-default: var(--spectrum-alias-button-secondary-text-color-default);
+    --spectrum-alias-button-secondary-icon-color-hover: var(--spectrum-alias-button-secondary-text-color-hover);
+    --spectrum-alias-button-secondary-icon-color-down: var(--spectrum-alias-button-secondary-text-color-down);
+    --spectrum-alias-button-secondary-icon-color-key-focus: var(--spectrum-alias-button-secondary-text-color-key-focus);
+    --spectrum-alias-button-secondary-icon-color: var(--spectrum-alias-button-secondary-icon-color-default);
+    --spectrum-alias-button-negative-background-color-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-button-negative-background-color-hover: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-background-color-down: var(--spectrum-global-color-red-700);
+    --spectrum-alias-button-negative-background-color-key-focus: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-background-color: var(--spectrum-alias-button-negative-background-color-default);
+    --spectrum-alias-button-negative-border-color-default: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-border-color-hover: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-border-color-down: var(--spectrum-global-color-red-700);
+    --spectrum-alias-button-negative-border-color-key-focus: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-border-color: var(--spectrum-alias-button-negative-border-color-default);
+    --spectrum-alias-button-negative-text-color-default: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-text-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-negative-text-color-down: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-negative-text-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-negative-text-color: var(--spectrum-alias-button-negative-text-color-default);
+    --spectrum-alias-button-negative-icon-color-default: var(--spectrum-alias-button-negative-text-color-default);
+    --spectrum-alias-button-negative-icon-color-hover: var(--spectrum-alias-button-negative-text-color-hover);
+    --spectrum-alias-button-negative-icon-color-down: var(--spectrum-alias-button-negative-text-color-down);
+    --spectrum-alias-button-negative-icon-color-key-focus: var(--spectrum-alias-button-negative-text-color-key-focus);
+    --spectrum-alias-button-negative-icon-color: var(--spectrum-alias-button-negative-icon-color-default);
+    --spectrum-alias-input-border-color-disabled: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-input-border-color-quiet-disabled: var(--spectrum-alias-border-color-mid);
+    --spectrum-alias-input-border-color-default: var(--spectrum-alias-border-color);
+    --spectrum-alias-input-border-color-hover: var(--spectrum-alias-border-color-hover);
+    --spectrum-alias-input-border-color-down: var(--spectrum-alias-border-color-mouse-focus);
+    --spectrum-alias-input-border-color-mouse-focus: var(--spectrum-alias-border-color-mouse-focus);
+    --spectrum-alias-input-border-color-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-input-border-color: var(--spectrum-alias-input-border-color-default);
+    --spectrum-alias-input-border-color-invalid-default: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-input-border-color-invalid-hover: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-input-border-color-invalid-down: var(--spectrum-semantic-negative-color-down);
+    --spectrum-alias-input-border-color-invalid-mouse-focus: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-input-border-color-invalid-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-input-border-color-invalid: var(--spectrum-alias-input-border-color-invalid-default);
+    --spectrum-alias-background-color-yellow-default: var(--spectrum-global-color-static-yellow-300);
+    --spectrum-alias-background-color-yellow-hover: var(--spectrum-global-color-static-yellow-400);
+    --spectrum-alias-background-color-yellow-key-focus: var(--spectrum-global-color-static-yellow-400);
+    --spectrum-alias-background-color-yellow-down: var(--spectrum-global-color-static-yellow-500);
+    --spectrum-alias-background-color-yellow: var(--spectrum-alias-background-color-yellow-default);
+    --spectrum-alias-infieldbutton-background-color: var(--spectrum-global-color-gray-200);
     --spectrum-alias-infieldbutton-fill-loudnessLow-border-color-disabled: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessMedium-border-color-disabled: transparent;
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-border-color-disabled: var(
-        --spectrum-alias-component-background-color-disabled
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-default: var(
-        --spectrum-alias-input-border-color-default
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-hover: var(
-        --spectrum-alias-input-border-color-hover
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-down: var(
-        --spectrum-alias-input-border-color-down
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-mouse-focus: var(
-        --spectrum-alias-input-border-color-mouse-focus
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-key-focus: var(
-        --spectrum-alias-input-border-color-key-focus
-    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-border-color-disabled: var(--spectrum-alias-component-background-color-disabled);
+    --spectrum-alias-infieldbutton-fill-border-color-default: var(--spectrum-alias-input-border-color-default);
+    --spectrum-alias-infieldbutton-fill-border-color-hover: var(--spectrum-alias-input-border-color-hover);
+    --spectrum-alias-infieldbutton-fill-border-color-down: var(--spectrum-alias-input-border-color-down);
+    --spectrum-alias-infieldbutton-fill-border-color-mouse-focus: var(--spectrum-alias-input-border-color-mouse-focus);
+    --spectrum-alias-infieldbutton-fill-border-color-key-focus: var(--spectrum-alias-input-border-color-key-focus);
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-default: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-disabled: transparent;
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-default: var(
-        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-default
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-hover: var(
-        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-down: var(
-        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-key-focus: var(
-        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus
-    );
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-default: var(--spectrum-alias-infieldbutton-fill-loudnessLow-background-color-default);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-hover: var(--spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-down: var(--spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-key-focus: var(--spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus);
     --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-disabled: transparent;
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-default: var(
-        --spectrum-alias-component-background-color-default
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover: var(
-        --spectrum-alias-component-background-color-hover
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down: var(
-        --spectrum-alias-component-background-color-down
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus: var(
-        --spectrum-alias-component-background-color-key-focus
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-disabled: var(
-        --spectrum-alias-component-background-color-disabled
-    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-default: var(--spectrum-alias-component-background-color-default);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover: var(--spectrum-alias-component-background-color-hover);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down: var(--spectrum-alias-component-background-color-down);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus: var(--spectrum-alias-component-background-color-key-focus);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-disabled: var(--spectrum-alias-component-background-color-disabled);
     --spectrum-alias-actionbutton-staticBlack-border-color-default: #0006;
     --spectrum-alias-actionbutton-staticBlack-background-color-default: transparent;
     --spectrum-alias-actionbutton-staticBlack-border-color-hover: #0000008c;
@@ -2886,356 +1176,146 @@
     --spectrum-alias-actionbutton-staticWhite-background-color-disabled: transparent;
     --spectrum-alias-actionbutton-staticWhite-border-color-disabled-selected: transparent;
     --spectrum-alias-actionbutton-staticWhite-background-color-disabled-selected: #ffffff1a;
-    --spectrum-alias-tabs-divider-background-color-default: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-tabs-divider-background-color-quiet: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-tabitem-text-color-default: var(
-        --spectrum-alias-label-text-color
-    );
-    --spectrum-alias-tabitem-text-color-hover: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tabitem-text-color-down: var(
-        --spectrum-alias-text-color-down
-    );
-    --spectrum-alias-tabitem-text-color-key-focus: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tabitem-text-color-mouse-focus: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tabitem-text-color: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-default: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tabitem-text-color-selected-hover: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-down: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-key-focus: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-mouse-focus: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-default: var(
-        --spectrum-global-color-static-blue-500
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-hover: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-down: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-key-focus: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-mouse-focus: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-selection-indicator-color-default: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-selection-indicator-color-emphasized: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-icon-color-disabled: var(
-        --spectrum-alias-text-color-disabled
-    );
-    --spectrum-alias-tabitem-icon-color-default: var(
-        --spectrum-alias-icon-color
-    );
-    --spectrum-alias-tabitem-icon-color-hover: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-tabitem-icon-color-down: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-tabitem-icon-color-key-focus: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-tabitem-icon-color-mouse-focus: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-tabitem-icon-color: var(
-        --spectrum-alias-tabitem-icon-color-default
-    );
-    --spectrum-alias-tabitem-icon-color-selected: var(
-        --spectrum-alias-icon-color-selected-neutral
-    );
-    --spectrum-alias-tabitem-icon-color-emphasized: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-icon-color-emphasized-selected: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-global-color-blue-500
-    );
+    --spectrum-alias-tabs-divider-background-color-default: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-tabs-divider-background-color-quiet: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-tabitem-text-color-default: var(--spectrum-alias-label-text-color);
+    --spectrum-alias-tabitem-text-color-hover: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tabitem-text-color-down: var(--spectrum-alias-text-color-down);
+    --spectrum-alias-tabitem-text-color-key-focus: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tabitem-text-color-mouse-focus: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tabitem-text-color: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-text-color-selected-default: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tabitem-text-color-selected-hover: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected-down: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected-key-focus: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected-mouse-focus: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-default: var(--spectrum-global-color-static-blue-500);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-hover: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-down: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-key-focus: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-mouse-focus: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-selection-indicator-color-default: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-selection-indicator-color-emphasized: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-icon-color-disabled: var(--spectrum-alias-text-color-disabled);
+    --spectrum-alias-tabitem-icon-color-default: var(--spectrum-alias-icon-color);
+    --spectrum-alias-tabitem-icon-color-hover: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-tabitem-icon-color-down: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-tabitem-icon-color-key-focus: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-tabitem-icon-color-mouse-focus: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-tabitem-icon-color: var(--spectrum-alias-tabitem-icon-color-default);
+    --spectrum-alias-tabitem-icon-color-selected: var(--spectrum-alias-icon-color-selected-neutral);
+    --spectrum-alias-tabitem-icon-color-emphasized: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-icon-color-emphasized-selected: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-assetcard-selectionindicator-background-color-ordered: var(--spectrum-global-color-blue-500);
     --spectrum-alias-assetcard-overlay-background-color: #1b7ff51a;
-    --spectrum-alias-assetcard-border-color-selected: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-alias-assetcard-border-color-selected-hover: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-alias-assetcard-border-color-selected-down: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-background-color-default: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
+    --spectrum-alias-assetcard-border-color-selected: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-assetcard-border-color-selected-hover: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-assetcard-border-color-selected-down: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-background-color-default: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-disabled: var(--spectrum-global-color-gray-200);
     --spectrum-alias-background-color-transparent: transparent;
     --spectrum-alias-background-color-overbackground-down: #fff3;
     --spectrum-alias-background-color-quiet-overbackground-hover: #ffffff1a;
     --spectrum-alias-background-color-quiet-overbackground-down: #fff3;
     --spectrum-alias-background-color-overbackground-disabled: #ffffff1a;
     --spectrum-alias-background-color-quickactions-overlay: #0003;
-    --spectrum-alias-placeholder-text-color: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-placeholder-text-color-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-placeholder-text-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-placeholder-text-color-selected: var(
-        --spectrum-global-color-gray-800
-    );
+    --spectrum-alias-placeholder-text-color: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-placeholder-text-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-placeholder-text-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-placeholder-text-color-selected: var(--spectrum-global-color-gray-800);
     --spectrum-alias-label-text-color: var(--spectrum-global-color-gray-700);
     --spectrum-alias-text-color: var(--spectrum-global-color-gray-800);
     --spectrum-alias-text-color-hover: var(--spectrum-global-color-gray-900);
     --spectrum-alias-text-color-down: var(--spectrum-global-color-gray-900);
-    --spectrum-alias-text-color-key-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-text-color-mouse-focus: var(
-        --spectrum-global-color-blue-600
-    );
+    --spectrum-alias-text-color-key-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-text-color-mouse-focus: var(--spectrum-global-color-blue-600);
     --spectrum-alias-text-color-disabled: var(--spectrum-global-color-gray-500);
     --spectrum-alias-text-color-invalid: var(--spectrum-global-color-red-500);
     --spectrum-alias-text-color-selected: var(--spectrum-global-color-blue-600);
-    --spectrum-alias-text-color-selected-neutral: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-text-color-overbackground: var(
-        --spectrum-global-color-static-white
-    );
+    --spectrum-alias-text-color-selected-neutral: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-text-color-overbackground: var(--spectrum-global-color-static-white);
     --spectrum-alias-text-color-overbackground-disabled: #fff3;
     --spectrum-alias-text-color-quiet-overbackground-disabled: #fff3;
     --spectrum-alias-heading-text-color: var(--spectrum-global-color-gray-900);
-    --spectrum-alias-link-primary-text-color-default: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-link-primary-text-color-hover: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-link-primary-text-color-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-alias-link-primary-text-color-key-focus: var(
-        --spectrum-alias-text-color-key-focus
-    );
-    --spectrum-alias-link-primary-text-color: var(
-        --spectrum-alias-link-primary-text-color-default
-    );
-    --spectrum-alias-link-secondary-text-color-default: var(
-        --spectrum-alias-link-primary-text-color-default
-    );
-    --spectrum-alias-link-secondary-text-color-hover: var(
-        --spectrum-alias-link-primary-text-color-hover
-    );
-    --spectrum-alias-link-secondary-text-color-down: var(
-        --spectrum-alias-link-primary-text-color-down
-    );
-    --spectrum-alias-link-secondary-text-color-key-focus: var(
-        --spectrum-alias-link-primary-text-color-key-focus
-    );
-    --spectrum-alias-link-secondary-text-color: var(
-        --spectrum-alias-link-secondary-text-color-default
-    );
+    --spectrum-alias-link-primary-text-color-default: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-link-primary-text-color-hover: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-link-primary-text-color-down: var(--spectrum-global-color-blue-700);
+    --spectrum-alias-link-primary-text-color-key-focus: var(--spectrum-alias-text-color-key-focus);
+    --spectrum-alias-link-primary-text-color: var(--spectrum-alias-link-primary-text-color-default);
+    --spectrum-alias-link-secondary-text-color-default: var(--spectrum-alias-link-primary-text-color-default);
+    --spectrum-alias-link-secondary-text-color-hover: var(--spectrum-alias-link-primary-text-color-hover);
+    --spectrum-alias-link-secondary-text-color-down: var(--spectrum-alias-link-primary-text-color-down);
+    --spectrum-alias-link-secondary-text-color-key-focus: var(--spectrum-alias-link-primary-text-color-key-focus);
+    --spectrum-alias-link-secondary-text-color: var(--spectrum-alias-link-secondary-text-color-default);
     --spectrum-alias-border-color: var(--spectrum-global-color-gray-400);
     --spectrum-alias-border-color-hover: var(--spectrum-global-color-gray-500);
     --spectrum-alias-border-color-down: var(--spectrum-global-color-gray-500);
-    --spectrum-alias-border-color-key-focus: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-alias-border-color-mouse-focus: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-alias-border-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-border-color-extralight: var(
-        --spectrum-global-color-gray-100
-    );
+    --spectrum-alias-border-color-key-focus: var(--spectrum-global-color-blue-400);
+    --spectrum-alias-border-color-mouse-focus: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-border-color-disabled: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-border-color-extralight: var(--spectrum-global-color-gray-100);
     --spectrum-alias-border-color-light: var(--spectrum-global-color-gray-200);
     --spectrum-alias-border-color-mid: var(--spectrum-global-color-gray-300);
     --spectrum-alias-border-color-dark: var(--spectrum-global-color-gray-400);
-    --spectrum-alias-border-color-darker-default: var(
-        --spectrum-global-color-gray-600
-    );
-    --spectrum-alias-border-color-darker-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-border-color-darker-down: var(
-        --spectrum-global-color-gray-900
-    );
+    --spectrum-alias-border-color-darker-default: var(--spectrum-global-color-gray-600);
+    --spectrum-alias-border-color-darker-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-border-color-darker-down: var(--spectrum-global-color-gray-900);
     --spectrum-alias-border-color-transparent: transparent;
     --spectrum-alias-border-color-translucent-dark: #0000000d;
     --spectrum-alias-border-color-translucent-darker: #0000001a;
     --spectrum-alias-focus-color: var(--spectrum-global-color-blue-400);
     --spectrum-alias-focus-ring-color: var(--spectrum-alias-focus-color);
     --spectrum-alias-track-color-default: var(--spectrum-global-color-gray-300);
-    --spectrum-alias-track-fill-color-overbackground: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-track-color-disabled: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-thumbnail-darksquare-background-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-thumbnail-lightsquare-background-color: var(
-        --spectrum-global-color-static-white
-    );
+    --spectrum-alias-track-fill-color-overbackground: var(--spectrum-global-color-static-white);
+    --spectrum-alias-track-color-disabled: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-thumbnail-darksquare-background-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-thumbnail-lightsquare-background-color: var(--spectrum-global-color-static-white);
     --spectrum-alias-track-color-overbackground: #fff3;
     --spectrum-alias-icon-color: var(--spectrum-global-color-gray-700);
-    --spectrum-alias-icon-color-overbackground: var(
-        --spectrum-global-color-static-white
-    );
+    --spectrum-alias-icon-color-overbackground: var(--spectrum-global-color-static-white);
     --spectrum-alias-icon-color-hover: var(--spectrum-global-color-gray-900);
     --spectrum-alias-icon-color-down: var(--spectrum-global-color-gray-900);
-    --spectrum-alias-icon-color-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
+    --spectrum-alias-icon-color-key-focus: var(--spectrum-global-color-gray-900);
     --spectrum-alias-icon-color-disabled: var(--spectrum-global-color-gray-400);
     --spectrum-alias-icon-color-overbackground-disabled: #fff3;
     --spectrum-alias-icon-color-quiet-overbackground-disabled: #ffffff26;
-    --spectrum-alias-icon-color-selected-neutral: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-icon-color-selected-neutral-subdued: var(
-        --spectrum-global-color-gray-800
-    );
+    --spectrum-alias-icon-color-selected-neutral: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-icon-color-selected-neutral-subdued: var(--spectrum-global-color-gray-800);
     --spectrum-alias-icon-color-selected: var(--spectrum-global-color-blue-500);
-    --spectrum-alias-icon-color-selected-hover: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-icon-color-selected-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-alias-icon-color-selected-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-image-opacity-disabled: var(
-        --spectrum-global-color-opacity-30
-    );
-    --spectrum-alias-toolbar-background-color: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-code-highlight-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-code-highlight-background-color: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-code-highlight-color-keyword: var(
-        --spectrum-global-color-fuchsia-600
-    );
-    --spectrum-alias-code-highlight-color-section: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-alias-code-highlight-color-literal: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-code-highlight-color-attribute: var(
-        --spectrum-global-color-seafoam-600
-    );
-    --spectrum-alias-code-highlight-color-class: var(
-        --spectrum-global-color-magenta-600
-    );
-    --spectrum-alias-code-highlight-color-variable: var(
-        --spectrum-global-color-purple-600
-    );
-    --spectrum-alias-code-highlight-color-title: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-alias-code-highlight-color-string: var(
-        --spectrum-global-color-fuchsia-600
-    );
-    --spectrum-alias-code-highlight-color-function: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-code-highlight-color-comment: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-categorical-color-1: var(
-        --spectrum-global-color-static-seafoam-200
-    );
-    --spectrum-alias-categorical-color-2: var(
-        --spectrum-global-color-static-indigo-700
-    );
-    --spectrum-alias-categorical-color-3: var(
-        --spectrum-global-color-static-orange-500
-    );
-    --spectrum-alias-categorical-color-4: var(
-        --spectrum-global-color-static-magenta-500
-    );
-    --spectrum-alias-categorical-color-5: var(
-        --spectrum-global-color-static-indigo-200
-    );
-    --spectrum-alias-categorical-color-6: var(
-        --spectrum-global-color-static-celery-200
-    );
-    --spectrum-alias-categorical-color-7: var(
-        --spectrum-global-color-static-blue-500
-    );
-    --spectrum-alias-categorical-color-8: var(
-        --spectrum-global-color-static-purple-800
-    );
-    --spectrum-alias-categorical-color-9: var(
-        --spectrum-global-color-static-yellow-500
-    );
-    --spectrum-alias-categorical-color-10: var(
-        --spectrum-global-color-static-orange-700
-    );
-    --spectrum-alias-categorical-color-11: var(
-        --spectrum-global-color-static-green-600
-    );
-    --spectrum-alias-categorical-color-12: var(
-        --spectrum-global-color-static-chartreuse-300
-    );
-    --spectrum-alias-categorical-color-13: var(
-        --spectrum-global-color-static-blue-200
-    );
-    --spectrum-alias-categorical-color-14: var(
-        --spectrum-global-color-static-fuchsia-500
-    );
-    --spectrum-alias-categorical-color-15: var(
-        --spectrum-global-color-static-magenta-200
-    );
-    --spectrum-alias-categorical-color-16: var(
-        --spectrum-global-color-static-yellow-200
-    );
+    --spectrum-alias-icon-color-selected-hover: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-icon-color-selected-down: var(--spectrum-global-color-blue-700);
+    --spectrum-alias-icon-color-selected-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-image-opacity-disabled: var(--spectrum-global-color-opacity-30);
+    --spectrum-alias-toolbar-background-color: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-code-highlight-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-code-highlight-background-color: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-code-highlight-color-keyword: var(--spectrum-global-color-fuchsia-600);
+    --spectrum-alias-code-highlight-color-section: var(--spectrum-global-color-red-600);
+    --spectrum-alias-code-highlight-color-literal: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-code-highlight-color-attribute: var(--spectrum-global-color-seafoam-600);
+    --spectrum-alias-code-highlight-color-class: var(--spectrum-global-color-magenta-600);
+    --spectrum-alias-code-highlight-color-variable: var(--spectrum-global-color-purple-600);
+    --spectrum-alias-code-highlight-color-title: var(--spectrum-global-color-indigo-600);
+    --spectrum-alias-code-highlight-color-string: var(--spectrum-global-color-fuchsia-600);
+    --spectrum-alias-code-highlight-color-function: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-code-highlight-color-comment: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-categorical-color-1: var(--spectrum-global-color-static-seafoam-200);
+    --spectrum-alias-categorical-color-2: var(--spectrum-global-color-static-indigo-700);
+    --spectrum-alias-categorical-color-3: var(--spectrum-global-color-static-orange-500);
+    --spectrum-alias-categorical-color-4: var(--spectrum-global-color-static-magenta-500);
+    --spectrum-alias-categorical-color-5: var(--spectrum-global-color-static-indigo-200);
+    --spectrum-alias-categorical-color-6: var(--spectrum-global-color-static-celery-200);
+    --spectrum-alias-categorical-color-7: var(--spectrum-global-color-static-blue-500);
+    --spectrum-alias-categorical-color-8: var(--spectrum-global-color-static-purple-800);
+    --spectrum-alias-categorical-color-9: var(--spectrum-global-color-static-yellow-500);
+    --spectrum-alias-categorical-color-10: var(--spectrum-global-color-static-orange-700);
+    --spectrum-alias-categorical-color-11: var(--spectrum-global-color-static-green-600);
+    --spectrum-alias-categorical-color-12: var(--spectrum-global-color-static-chartreuse-300);
+    --spectrum-alias-categorical-color-13: var(--spectrum-global-color-static-blue-200);
+    --spectrum-alias-categorical-color-14: var(--spectrum-global-color-static-fuchsia-500);
+    --spectrum-alias-categorical-color-15: var(--spectrum-global-color-static-magenta-200);
+    --spectrum-alias-categorical-color-16: var(--spectrum-global-color-static-yellow-200);
 }

--- a/tools/styles/spectrum-scale-large.css
+++ b/tools/styles/spectrum-scale-large.css
@@ -69,220 +69,82 @@
     --spectrum-global-dimension-font-size-1100: 55px;
     --spectrum-global-dimension-font-size-1200: 62px;
     --spectrum-global-dimension-font-size-1300: 70px;
-    --spectrum-alias-item-text-padding-top-l: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-text-padding-bottom-s: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-item-workflow-padding-left-m: var(
-        --spectrum-global-dimension-static-size-150
-    );
+    --spectrum-alias-item-text-padding-top-l: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-text-padding-bottom-s: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-item-workflow-padding-left-m: var(--spectrum-global-dimension-static-size-150);
     --spectrum-alias-item-rounded-workflow-padding-left-m: 17px;
     --spectrum-alias-item-rounded-workflow-padding-left-xl: 27px;
-    --spectrum-alias-item-mark-padding-top-m: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-item-mark-padding-bottom-m: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-item-mark-padding-left-m: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-control-1-size-l: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-control-1-size-xl: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-control-2-size-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-control-3-height-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-control-3-width-s: var(
-        --spectrum-global-dimension-size-325
-    );
-    --spectrum-alias-item-control-3-width-m: var(
-        --spectrum-global-dimension-static-size-450
-    );
+    --spectrum-alias-item-mark-padding-top-m: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-item-mark-padding-bottom-m: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-item-mark-padding-left-m: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-control-1-size-l: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-control-1-size-xl: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-control-2-size-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-control-3-height-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-control-3-width-s: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-item-control-3-width-m: var(--spectrum-global-dimension-static-size-450);
     --spectrum-alias-item-control-3-width-l: 41px;
     --spectrum-alias-item-control-3-width-xl: 46px;
-    --spectrum-alias-item-mark-size-m: var(
-        --spectrum-global-dimension-static-size-325
-    );
-    --spectrum-alias-component-focusring-border-radius: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-control-two-size-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-control-three-height-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-control-three-width-s: var(
-        --spectrum-global-dimension-size-325
-    );
-    --spectrum-alias-control-three-width-m: var(
-        --spectrum-global-dimension-static-size-450
-    );
+    --spectrum-alias-item-mark-size-m: var(--spectrum-global-dimension-static-size-325);
+    --spectrum-alias-component-focusring-border-radius: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-control-two-size-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-control-three-height-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-control-three-width-s: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-control-three-width-m: var(--spectrum-global-dimension-static-size-450);
     --spectrum-alias-control-three-width-l: 41px;
     --spectrum-alias-control-three-width-xl: 46px;
-    --spectrum-alias-search-padding-left-m: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-focus-ring-border-radius-regular: var(
-        --spectrum-global-dimension-static-size-115
-    );
-    --spectrum-alias-focus-ring-radius-default: var(
-        --spectrum-global-dimension-static-size-115
-    );
-    --spectrum-alias-workflow-icon-size-l: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-ui-icon-chevron-size-75: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-chevron-size-100: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-chevron-size-200: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-chevron-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-chevron-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-chevron-size-500: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-checkmark-size-50: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-checkmark-size-75: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-checkmark-size-100: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-checkmark-size-200: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-checkmark-size-500: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-checkmark-size-600: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-ui-icon-dash-size-50: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-dash-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-dash-size-100: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-dash-size-200: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-dash-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-dash-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-dash-size-500: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-dash-size-600: var(
-        --spectrum-global-dimension-static-size-275
-    );
-    --spectrum-alias-ui-icon-cross-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-cross-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-cross-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-cross-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-cross-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-cross-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-cross-size-600: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-arrow-size-75: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-arrow-size-100: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-arrow-size-200: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-arrow-size-500: var(
-        --spectrum-global-dimension-static-size-275
-    );
-    --spectrum-alias-ui-icon-arrow-size-600: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-asterisk-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-asterisk-size-300: var(
-        --spectrum-global-dimension-static-size-150
-    );
+    --spectrum-alias-search-padding-left-m: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-focus-ring-border-radius-regular: var(--spectrum-global-dimension-static-size-115);
+    --spectrum-alias-focus-ring-radius-default: var(--spectrum-global-dimension-static-size-115);
+    --spectrum-alias-workflow-icon-size-l: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-ui-icon-chevron-size-75: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-chevron-size-100: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-chevron-size-200: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-chevron-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-chevron-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-chevron-size-500: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-checkmark-size-50: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-checkmark-size-75: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-checkmark-size-100: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-checkmark-size-200: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-checkmark-size-500: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-checkmark-size-600: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-ui-icon-dash-size-50: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-dash-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-dash-size-100: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-dash-size-200: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-dash-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-dash-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-dash-size-500: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-dash-size-600: var(--spectrum-global-dimension-static-size-275);
+    --spectrum-alias-ui-icon-cross-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-cross-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-cross-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-cross-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-cross-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-cross-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-cross-size-600: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-arrow-size-75: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-arrow-size-100: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-arrow-size-200: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-arrow-size-500: var(--spectrum-global-dimension-static-size-275);
+    --spectrum-alias-ui-icon-arrow-size-600: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-asterisk-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-asterisk-size-300: var(--spectrum-global-dimension-static-size-150);
     --spectrum-alias-avatar-size-100: 26px;
     --spectrum-alias-avatar-size-400: 36px;
     --spectrum-alias-avatar-size-600: 46px;
-    --spectrum-alias-tag-icon-size-l: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-tag-focusring-border-radius: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-dialog-confirm-title-text-size: var(
-        --spectrum-alias-heading-xs-text-size
-    );
-    --spectrum-dialog-confirm-description-text-size: var(
-        --spectrum-global-dimension-font-size-75
-    );
+    --spectrum-alias-tag-icon-size-l: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-tag-focusring-border-radius: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-dialog-confirm-title-text-size: var(--spectrum-alias-heading-xs-text-size);
+    --spectrum-dialog-confirm-description-text-size: var(--spectrum-global-dimension-font-size-75);
 }

--- a/tools/styles/spectrum-scale-medium.css
+++ b/tools/styles/spectrum-scale-medium.css
@@ -69,218 +69,82 @@
     --spectrum-global-dimension-font-size-1100: 45px;
     --spectrum-global-dimension-font-size-1200: 50px;
     --spectrum-global-dimension-font-size-1300: 60px;
-    --spectrum-alias-item-text-padding-top-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-text-padding-bottom-s: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-item-workflow-padding-left-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-rounded-workflow-padding-left-m: var(
-        --spectrum-global-dimension-size-175
-    );
+    --spectrum-alias-item-text-padding-top-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-text-padding-bottom-s: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-item-workflow-padding-left-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-rounded-workflow-padding-left-m: var(--spectrum-global-dimension-size-175);
     --spectrum-alias-item-rounded-workflow-padding-left-xl: 21px;
-    --spectrum-alias-item-mark-padding-top-m: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-item-mark-padding-bottom-m: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-item-mark-padding-left-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-1-size-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-1-size-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-2-size-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-control-3-height-s: var(
-        --spectrum-global-dimension-size-150
-    );
+    --spectrum-alias-item-mark-padding-top-m: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-item-mark-padding-bottom-m: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-item-mark-padding-left-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-1-size-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-1-size-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-2-size-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-control-3-height-s: var(--spectrum-global-dimension-size-150);
     --spectrum-alias-item-control-3-width-s: 23px;
-    --spectrum-alias-item-control-3-width-m: var(
-        --spectrum-global-dimension-static-size-325
-    );
+    --spectrum-alias-item-control-3-width-m: var(--spectrum-global-dimension-static-size-325);
     --spectrum-alias-item-control-3-width-l: 29px;
     --spectrum-alias-item-control-3-width-xl: 33px;
-    --spectrum-alias-item-mark-size-m: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-component-focusring-border-radius: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-control-two-size-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-control-three-height-s: var(
-        --spectrum-global-dimension-size-150
-    );
+    --spectrum-alias-item-mark-size-m: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-component-focusring-border-radius: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-control-two-size-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-control-three-height-s: var(--spectrum-global-dimension-size-150);
     --spectrum-alias-control-three-width-s: 23px;
-    --spectrum-alias-control-three-width-m: var(
-        --spectrum-global-dimension-static-size-325
-    );
+    --spectrum-alias-control-three-width-m: var(--spectrum-global-dimension-static-size-325);
     --spectrum-alias-control-three-width-l: 29px;
     --spectrum-alias-control-three-width-xl: 33px;
-    --spectrum-alias-search-padding-left-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-focus-ring-border-radius-regular: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-focus-ring-radius-default: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-workflow-icon-size-l: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-chevron-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-chevron-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-chevron-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-chevron-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-chevron-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-chevron-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-50: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-checkmark-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-checkmark-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-checkmark-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-checkmark-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-checkmark-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-600: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-dash-size-50: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-dash-size-75: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-dash-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-dash-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-dash-size-300: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-dash-size-400: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-dash-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-dash-size-600: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-cross-size-75: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-cross-size-100: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-cross-size-200: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-cross-size-300: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-cross-size-400: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-cross-size-500: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-cross-size-600: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-arrow-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-arrow-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-arrow-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-arrow-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-500: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-arrow-size-600: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-ui-icon-asterisk-size-200: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-asterisk-size-300: var(
-        --spectrum-global-dimension-static-size-125
-    );
+    --spectrum-alias-search-padding-left-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-focus-ring-border-radius-regular: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-focus-ring-radius-default: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-workflow-icon-size-l: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-chevron-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-chevron-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-chevron-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-chevron-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-chevron-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-chevron-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-50: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-checkmark-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-checkmark-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-checkmark-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-checkmark-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-checkmark-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-600: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-dash-size-50: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-dash-size-75: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-dash-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-dash-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-dash-size-300: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-dash-size-400: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-dash-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-dash-size-600: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-cross-size-75: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-cross-size-100: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-cross-size-200: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-cross-size-300: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-cross-size-400: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-cross-size-500: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-cross-size-600: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-arrow-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-arrow-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-arrow-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-arrow-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-500: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-arrow-size-600: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-ui-icon-asterisk-size-200: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-asterisk-size-300: var(--spectrum-global-dimension-static-size-125);
     --spectrum-alias-avatar-size-100: var(--spectrum-global-dimension-size-250);
     --spectrum-alias-avatar-size-400: var(--spectrum-global-dimension-size-350);
     --spectrum-alias-avatar-size-600: var(--spectrum-global-dimension-size-450);
-    --spectrum-alias-tag-icon-size-l: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-tag-focusring-border-radius: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-dialog-confirm-title-text-size: var(
-        --spectrum-alias-heading-s-text-size
-    );
-    --spectrum-dialog-confirm-description-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
+    --spectrum-alias-tag-icon-size-l: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-tag-focusring-border-radius: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-dialog-confirm-title-text-size: var(--spectrum-alias-heading-s-text-size);
+    --spectrum-dialog-confirm-description-text-size: var(--spectrum-global-dimension-font-size-100);
 }

--- a/tools/styles/spectrum-theme-dark.css
+++ b/tools/styles/spectrum-theme-dark.css
@@ -23,250 +23,126 @@
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 34, 184, 51;
-    --spectrum-global-color-celery-400: rgb(
-        var(--spectrum-global-color-celery-400-rgb)
-    );
+    --spectrum-global-color-celery-400: rgb(var(--spectrum-global-color-celery-400-rgb));
     --spectrum-global-color-celery-500-rgb: 68, 202, 73;
-    --spectrum-global-color-celery-500: rgb(
-        var(--spectrum-global-color-celery-500-rgb)
-    );
+    --spectrum-global-color-celery-500: rgb(var(--spectrum-global-color-celery-500-rgb));
     --spectrum-global-color-celery-600-rgb: 105, 220, 99;
-    --spectrum-global-color-celery-600: rgb(
-        var(--spectrum-global-color-celery-600-rgb)
-    );
+    --spectrum-global-color-celery-600: rgb(var(--spectrum-global-color-celery-600-rgb));
     --spectrum-global-color-celery-700-rgb: 142, 235, 127;
-    --spectrum-global-color-celery-700: rgb(
-        var(--spectrum-global-color-celery-700-rgb)
-    );
+    --spectrum-global-color-celery-700: rgb(var(--spectrum-global-color-celery-700-rgb));
     --spectrum-global-color-chartreuse-400-rgb: 148, 192, 8;
-    --spectrum-global-color-chartreuse-400: rgb(
-        var(--spectrum-global-color-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-chartreuse-400: rgb(var(--spectrum-global-color-chartreuse-400-rgb));
     --spectrum-global-color-chartreuse-500-rgb: 166, 211, 18;
-    --spectrum-global-color-chartreuse-500: rgb(
-        var(--spectrum-global-color-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-chartreuse-500: rgb(var(--spectrum-global-color-chartreuse-500-rgb));
     --spectrum-global-color-chartreuse-600-rgb: 184, 229, 37;
-    --spectrum-global-color-chartreuse-600: rgb(
-        var(--spectrum-global-color-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-chartreuse-600: rgb(var(--spectrum-global-color-chartreuse-600-rgb));
     --spectrum-global-color-chartreuse-700-rgb: 205, 245, 71;
-    --spectrum-global-color-chartreuse-700: rgb(
-        var(--spectrum-global-color-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-chartreuse-700: rgb(var(--spectrum-global-color-chartreuse-700-rgb));
     --spectrum-global-color-yellow-400-rgb: 228, 194, 0;
-    --spectrum-global-color-yellow-400: rgb(
-        var(--spectrum-global-color-yellow-400-rgb)
-    );
+    --spectrum-global-color-yellow-400: rgb(var(--spectrum-global-color-yellow-400-rgb));
     --spectrum-global-color-yellow-500-rgb: 244, 213, 0;
-    --spectrum-global-color-yellow-500: rgb(
-        var(--spectrum-global-color-yellow-500-rgb)
-    );
+    --spectrum-global-color-yellow-500: rgb(var(--spectrum-global-color-yellow-500-rgb));
     --spectrum-global-color-yellow-600-rgb: 249, 232, 92;
-    --spectrum-global-color-yellow-600: rgb(
-        var(--spectrum-global-color-yellow-600-rgb)
-    );
+    --spectrum-global-color-yellow-600: rgb(var(--spectrum-global-color-yellow-600-rgb));
     --spectrum-global-color-yellow-700-rgb: 252, 246, 187;
-    --spectrum-global-color-yellow-700: rgb(
-        var(--spectrum-global-color-yellow-700-rgb)
-    );
+    --spectrum-global-color-yellow-700: rgb(var(--spectrum-global-color-yellow-700-rgb));
     --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
-    --spectrum-global-color-magenta-400: rgb(
-        var(--spectrum-global-color-magenta-400-rgb)
-    );
+    --spectrum-global-color-magenta-400: rgb(var(--spectrum-global-color-magenta-400-rgb));
     --spectrum-global-color-magenta-500-rgb: 237, 87, 149;
-    --spectrum-global-color-magenta-500: rgb(
-        var(--spectrum-global-color-magenta-500-rgb)
-    );
+    --spectrum-global-color-magenta-500: rgb(var(--spectrum-global-color-magenta-500-rgb));
     --spectrum-global-color-magenta-600-rgb: 249, 114, 167;
-    --spectrum-global-color-magenta-600: rgb(
-        var(--spectrum-global-color-magenta-600-rgb)
-    );
+    --spectrum-global-color-magenta-600: rgb(var(--spectrum-global-color-magenta-600-rgb));
     --spectrum-global-color-magenta-700-rgb: 255, 143, 185;
-    --spectrum-global-color-magenta-700: rgb(
-        var(--spectrum-global-color-magenta-700-rgb)
-    );
+    --spectrum-global-color-magenta-700: rgb(var(--spectrum-global-color-magenta-700-rgb));
     --spectrum-global-color-fuchsia-400-rgb: 205, 57, 206;
-    --spectrum-global-color-fuchsia-400: rgb(
-        var(--spectrum-global-color-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-fuchsia-400: rgb(var(--spectrum-global-color-fuchsia-400-rgb));
     --spectrum-global-color-fuchsia-500-rgb: 223, 81, 224;
-    --spectrum-global-color-fuchsia-500: rgb(
-        var(--spectrum-global-color-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-fuchsia-500: rgb(var(--spectrum-global-color-fuchsia-500-rgb));
     --spectrum-global-color-fuchsia-600-rgb: 235, 110, 236;
-    --spectrum-global-color-fuchsia-600: rgb(
-        var(--spectrum-global-color-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-fuchsia-600: rgb(var(--spectrum-global-color-fuchsia-600-rgb));
     --spectrum-global-color-fuchsia-700-rgb: 244, 140, 242;
-    --spectrum-global-color-fuchsia-700: rgb(
-        var(--spectrum-global-color-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-fuchsia-700: rgb(var(--spectrum-global-color-fuchsia-700-rgb));
     --spectrum-global-color-purple-400-rgb: 157, 87, 243;
-    --spectrum-global-color-purple-400: rgb(
-        var(--spectrum-global-color-purple-400-rgb)
-    );
+    --spectrum-global-color-purple-400: rgb(var(--spectrum-global-color-purple-400-rgb));
     --spectrum-global-color-purple-500-rgb: 172, 111, 249;
-    --spectrum-global-color-purple-500: rgb(
-        var(--spectrum-global-color-purple-500-rgb)
-    );
+    --spectrum-global-color-purple-500: rgb(var(--spectrum-global-color-purple-500-rgb));
     --spectrum-global-color-purple-600-rgb: 187, 135, 251;
-    --spectrum-global-color-purple-600: rgb(
-        var(--spectrum-global-color-purple-600-rgb)
-    );
+    --spectrum-global-color-purple-600: rgb(var(--spectrum-global-color-purple-600-rgb));
     --spectrum-global-color-purple-700-rgb: 202, 159, 252;
-    --spectrum-global-color-purple-700: rgb(
-        var(--spectrum-global-color-purple-700-rgb)
-    );
+    --spectrum-global-color-purple-700: rgb(var(--spectrum-global-color-purple-700-rgb));
     --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
-    --spectrum-global-color-indigo-400: rgb(
-        var(--spectrum-global-color-indigo-400-rgb)
-    );
+    --spectrum-global-color-indigo-400: rgb(var(--spectrum-global-color-indigo-400-rgb));
     --spectrum-global-color-indigo-500-rgb: 124, 129, 251;
-    --spectrum-global-color-indigo-500: rgb(
-        var(--spectrum-global-color-indigo-500-rgb)
-    );
+    --spectrum-global-color-indigo-500: rgb(var(--spectrum-global-color-indigo-500-rgb));
     --spectrum-global-color-indigo-600-rgb: 145, 149, 255;
-    --spectrum-global-color-indigo-600: rgb(
-        var(--spectrum-global-color-indigo-600-rgb)
-    );
+    --spectrum-global-color-indigo-600: rgb(var(--spectrum-global-color-indigo-600-rgb));
     --spectrum-global-color-indigo-700-rgb: 167, 170, 255;
-    --spectrum-global-color-indigo-700: rgb(
-        var(--spectrum-global-color-indigo-700-rgb)
-    );
+    --spectrum-global-color-indigo-700: rgb(var(--spectrum-global-color-indigo-700-rgb));
     --spectrum-global-color-seafoam-400-rgb: 0, 158, 152;
-    --spectrum-global-color-seafoam-400: rgb(
-        var(--spectrum-global-color-seafoam-400-rgb)
-    );
+    --spectrum-global-color-seafoam-400: rgb(var(--spectrum-global-color-seafoam-400-rgb));
     --spectrum-global-color-seafoam-500-rgb: 3, 178, 171;
-    --spectrum-global-color-seafoam-500: rgb(
-        var(--spectrum-global-color-seafoam-500-rgb)
-    );
+    --spectrum-global-color-seafoam-500: rgb(var(--spectrum-global-color-seafoam-500-rgb));
     --spectrum-global-color-seafoam-600-rgb: 54, 197, 189;
-    --spectrum-global-color-seafoam-600: rgb(
-        var(--spectrum-global-color-seafoam-600-rgb)
-    );
+    --spectrum-global-color-seafoam-600: rgb(var(--spectrum-global-color-seafoam-600-rgb));
     --spectrum-global-color-seafoam-700-rgb: 93, 214, 207;
-    --spectrum-global-color-seafoam-700: rgb(
-        var(--spectrum-global-color-seafoam-700-rgb)
-    );
+    --spectrum-global-color-seafoam-700: rgb(var(--spectrum-global-color-seafoam-700-rgb));
     --spectrum-global-color-red-400-rgb: 234, 56, 41;
-    --spectrum-global-color-red-400: rgb(
-        var(--spectrum-global-color-red-400-rgb)
-    );
+    --spectrum-global-color-red-400: rgb(var(--spectrum-global-color-red-400-rgb));
     --spectrum-global-color-red-500-rgb: 246, 88, 67;
-    --spectrum-global-color-red-500: rgb(
-        var(--spectrum-global-color-red-500-rgb)
-    );
+    --spectrum-global-color-red-500: rgb(var(--spectrum-global-color-red-500-rgb));
     --spectrum-global-color-red-600-rgb: 255, 117, 94;
-    --spectrum-global-color-red-600: rgb(
-        var(--spectrum-global-color-red-600-rgb)
-    );
+    --spectrum-global-color-red-600: rgb(var(--spectrum-global-color-red-600-rgb));
     --spectrum-global-color-red-700-rgb: 255, 149, 129;
-    --spectrum-global-color-red-700: rgb(
-        var(--spectrum-global-color-red-700-rgb)
-    );
+    --spectrum-global-color-red-700: rgb(var(--spectrum-global-color-red-700-rgb));
     --spectrum-global-color-orange-400-rgb: 244, 129, 12;
-    --spectrum-global-color-orange-400: rgb(
-        var(--spectrum-global-color-orange-400-rgb)
-    );
+    --spectrum-global-color-orange-400: rgb(var(--spectrum-global-color-orange-400-rgb));
     --spectrum-global-color-orange-500-rgb: 254, 154, 46;
-    --spectrum-global-color-orange-500: rgb(
-        var(--spectrum-global-color-orange-500-rgb)
-    );
+    --spectrum-global-color-orange-500: rgb(var(--spectrum-global-color-orange-500-rgb));
     --spectrum-global-color-orange-600-rgb: 255, 181, 88;
-    --spectrum-global-color-orange-600: rgb(
-        var(--spectrum-global-color-orange-600-rgb)
-    );
+    --spectrum-global-color-orange-600: rgb(var(--spectrum-global-color-orange-600-rgb));
     --spectrum-global-color-orange-700-rgb: 253, 206, 136;
-    --spectrum-global-color-orange-700: rgb(
-        var(--spectrum-global-color-orange-700-rgb)
-    );
+    --spectrum-global-color-orange-700: rgb(var(--spectrum-global-color-orange-700-rgb));
     --spectrum-global-color-green-400-rgb: 18, 162, 108;
-    --spectrum-global-color-green-400: rgb(
-        var(--spectrum-global-color-green-400-rgb)
-    );
+    --spectrum-global-color-green-400: rgb(var(--spectrum-global-color-green-400-rgb));
     --spectrum-global-color-green-500-rgb: 43, 180, 125;
-    --spectrum-global-color-green-500: rgb(
-        var(--spectrum-global-color-green-500-rgb)
-    );
+    --spectrum-global-color-green-500: rgb(var(--spectrum-global-color-green-500-rgb));
     --spectrum-global-color-green-600-rgb: 67, 199, 143;
-    --spectrum-global-color-green-600: rgb(
-        var(--spectrum-global-color-green-600-rgb)
-    );
+    --spectrum-global-color-green-600: rgb(var(--spectrum-global-color-green-600-rgb));
     --spectrum-global-color-green-700-rgb: 94, 217, 162;
-    --spectrum-global-color-green-700: rgb(
-        var(--spectrum-global-color-green-700-rgb)
-    );
+    --spectrum-global-color-green-700: rgb(var(--spectrum-global-color-green-700-rgb));
     --spectrum-global-color-blue-400-rgb: 52, 143, 244;
-    --spectrum-global-color-blue-400: rgb(
-        var(--spectrum-global-color-blue-400-rgb)
-    );
+    --spectrum-global-color-blue-400: rgb(var(--spectrum-global-color-blue-400-rgb));
     --spectrum-global-color-blue-500-rgb: 84, 163, 246;
-    --spectrum-global-color-blue-500: rgb(
-        var(--spectrum-global-color-blue-500-rgb)
-    );
+    --spectrum-global-color-blue-500: rgb(var(--spectrum-global-color-blue-500-rgb));
     --spectrum-global-color-blue-600-rgb: 114, 183, 249;
-    --spectrum-global-color-blue-600: rgb(
-        var(--spectrum-global-color-blue-600-rgb)
-    );
+    --spectrum-global-color-blue-600: rgb(var(--spectrum-global-color-blue-600-rgb));
     --spectrum-global-color-blue-700-rgb: 143, 202, 252;
-    --spectrum-global-color-blue-700: rgb(
-        var(--spectrum-global-color-blue-700-rgb)
-    );
+    --spectrum-global-color-blue-700: rgb(var(--spectrum-global-color-blue-700-rgb));
     --spectrum-global-color-gray-50-rgb: 29, 29, 29;
-    --spectrum-global-color-gray-50: rgb(
-        var(--spectrum-global-color-gray-50-rgb)
-    );
+    --spectrum-global-color-gray-50: rgb(var(--spectrum-global-color-gray-50-rgb));
     --spectrum-global-color-gray-75-rgb: 38, 38, 38;
-    --spectrum-global-color-gray-75: rgb(
-        var(--spectrum-global-color-gray-75-rgb)
-    );
+    --spectrum-global-color-gray-75: rgb(var(--spectrum-global-color-gray-75-rgb));
     --spectrum-global-color-gray-100-rgb: 50, 50, 50;
-    --spectrum-global-color-gray-100: rgb(
-        var(--spectrum-global-color-gray-100-rgb)
-    );
+    --spectrum-global-color-gray-100: rgb(var(--spectrum-global-color-gray-100-rgb));
     --spectrum-global-color-gray-200-rgb: 63, 63, 63;
-    --spectrum-global-color-gray-200: rgb(
-        var(--spectrum-global-color-gray-200-rgb)
-    );
+    --spectrum-global-color-gray-200: rgb(var(--spectrum-global-color-gray-200-rgb));
     --spectrum-global-color-gray-300-rgb: 84, 84, 84;
-    --spectrum-global-color-gray-300: rgb(
-        var(--spectrum-global-color-gray-300-rgb)
-    );
+    --spectrum-global-color-gray-300: rgb(var(--spectrum-global-color-gray-300-rgb));
     --spectrum-global-color-gray-400-rgb: 112, 112, 112;
-    --spectrum-global-color-gray-400: rgb(
-        var(--spectrum-global-color-gray-400-rgb)
-    );
+    --spectrum-global-color-gray-400: rgb(var(--spectrum-global-color-gray-400-rgb));
     --spectrum-global-color-gray-500-rgb: 144, 144, 144;
-    --spectrum-global-color-gray-500: rgb(
-        var(--spectrum-global-color-gray-500-rgb)
-    );
+    --spectrum-global-color-gray-500: rgb(var(--spectrum-global-color-gray-500-rgb));
     --spectrum-global-color-gray-600-rgb: 178, 178, 178;
-    --spectrum-global-color-gray-600: rgb(
-        var(--spectrum-global-color-gray-600-rgb)
-    );
+    --spectrum-global-color-gray-600: rgb(var(--spectrum-global-color-gray-600-rgb));
     --spectrum-global-color-gray-700-rgb: 209, 209, 209;
-    --spectrum-global-color-gray-700: rgb(
-        var(--spectrum-global-color-gray-700-rgb)
-    );
+    --spectrum-global-color-gray-700: rgb(var(--spectrum-global-color-gray-700-rgb));
     --spectrum-global-color-gray-800-rgb: 235, 235, 235;
-    --spectrum-global-color-gray-800: rgb(
-        var(--spectrum-global-color-gray-800-rgb)
-    );
+    --spectrum-global-color-gray-800: rgb(var(--spectrum-global-color-gray-800-rgb));
     --spectrum-global-color-gray-900-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-900: rgb(
-        var(--spectrum-global-color-gray-900-rgb)
-    );
-    --spectrum-alias-background-color-primary: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-secondary: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-background-color-tertiary: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-global-color-gray-900: rgb(var(--spectrum-global-color-gray-900-rgb));
+    --spectrum-alias-background-color-primary: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-secondary: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-background-color-tertiary: var(--spectrum-global-color-gray-50);
     --spectrum-alias-background-color-modal-overlay: #00000080;
     --spectrum-alias-dropshadow-color: #00000080;
     --spectrum-alias-background-color-hover-overlay: #ffffff0f;
@@ -276,18 +152,10 @@
     --spectrum-alias-highlight-selected-hover: #54a3f640;
     --spectrum-alias-text-highlight-color: #54a3f640;
     --spectrum-alias-background-color-quickactions: #323232e6;
-    --spectrum-alias-border-color-selected: var(
-        --spectrum-global-color-blue-600
-    );
+    --spectrum-alias-border-color-selected: var(--spectrum-global-color-blue-600);
     --spectrum-alias-border-color-translucent: #ffffff1a;
     --spectrum-alias-radial-reaction-color-default: #ebebeb99;
-    --spectrum-alias-pasteboard-background-color: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-appframe-border-color: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-appframe-separator-color: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-alias-pasteboard-background-color: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-appframe-border-color: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-appframe-separator-color: var(--spectrum-global-color-gray-50);
 }

--- a/tools/styles/spectrum-theme-darkest.css
+++ b/tools/styles/spectrum-theme-darkest.css
@@ -23,250 +23,126 @@
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 13, 171, 37;
-    --spectrum-global-color-celery-400: rgb(
-        var(--spectrum-global-color-celery-400-rgb)
-    );
+    --spectrum-global-color-celery-400: rgb(var(--spectrum-global-color-celery-400-rgb));
     --spectrum-global-color-celery-500-rgb: 45, 191, 58;
-    --spectrum-global-color-celery-500: rgb(
-        var(--spectrum-global-color-celery-500-rgb)
-    );
+    --spectrum-global-color-celery-500: rgb(var(--spectrum-global-color-celery-500-rgb));
     --spectrum-global-color-celery-600-rgb: 80, 208, 82;
-    --spectrum-global-color-celery-600: rgb(
-        var(--spectrum-global-color-celery-600-rgb)
-    );
+    --spectrum-global-color-celery-600: rgb(var(--spectrum-global-color-celery-600-rgb));
     --spectrum-global-color-celery-700-rgb: 115, 224, 107;
-    --spectrum-global-color-celery-700: rgb(
-        var(--spectrum-global-color-celery-700-rgb)
-    );
+    --spectrum-global-color-celery-700: rgb(var(--spectrum-global-color-celery-700-rgb));
     --spectrum-global-color-chartreuse-400-rgb: 138, 180, 3;
-    --spectrum-global-color-chartreuse-400: rgb(
-        var(--spectrum-global-color-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-chartreuse-400: rgb(var(--spectrum-global-color-chartreuse-400-rgb));
     --spectrum-global-color-chartreuse-500-rgb: 154, 198, 11;
-    --spectrum-global-color-chartreuse-500: rgb(
-        var(--spectrum-global-color-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-chartreuse-500: rgb(var(--spectrum-global-color-chartreuse-500-rgb));
     --spectrum-global-color-chartreuse-600-rgb: 170, 216, 22;
-    --spectrum-global-color-chartreuse-600: rgb(
-        var(--spectrum-global-color-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-chartreuse-600: rgb(var(--spectrum-global-color-chartreuse-600-rgb));
     --spectrum-global-color-chartreuse-700-rgb: 187, 232, 41;
-    --spectrum-global-color-chartreuse-700: rgb(
-        var(--spectrum-global-color-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-chartreuse-700: rgb(var(--spectrum-global-color-chartreuse-700-rgb));
     --spectrum-global-color-yellow-400-rgb: 216, 181, 0;
-    --spectrum-global-color-yellow-400: rgb(
-        var(--spectrum-global-color-yellow-400-rgb)
-    );
+    --spectrum-global-color-yellow-400: rgb(var(--spectrum-global-color-yellow-400-rgb));
     --spectrum-global-color-yellow-500-rgb: 233, 199, 0;
-    --spectrum-global-color-yellow-500: rgb(
-        var(--spectrum-global-color-yellow-500-rgb)
-    );
+    --spectrum-global-color-yellow-500: rgb(var(--spectrum-global-color-yellow-500-rgb));
     --spectrum-global-color-yellow-600-rgb: 247, 216, 4;
-    --spectrum-global-color-yellow-600: rgb(
-        var(--spectrum-global-color-yellow-600-rgb)
-    );
+    --spectrum-global-color-yellow-600: rgb(var(--spectrum-global-color-yellow-600-rgb));
     --spectrum-global-color-yellow-700-rgb: 249, 233, 97;
-    --spectrum-global-color-yellow-700: rgb(
-        var(--spectrum-global-color-yellow-700-rgb)
-    );
+    --spectrum-global-color-yellow-700: rgb(var(--spectrum-global-color-yellow-700-rgb));
     --spectrum-global-color-magenta-400-rgb: 209, 43, 114;
-    --spectrum-global-color-magenta-400: rgb(
-        var(--spectrum-global-color-magenta-400-rgb)
-    );
+    --spectrum-global-color-magenta-400: rgb(var(--spectrum-global-color-magenta-400-rgb));
     --spectrum-global-color-magenta-500-rgb: 227, 69, 137;
-    --spectrum-global-color-magenta-500: rgb(
-        var(--spectrum-global-color-magenta-500-rgb)
-    );
+    --spectrum-global-color-magenta-500: rgb(var(--spectrum-global-color-magenta-500-rgb));
     --spectrum-global-color-magenta-600-rgb: 241, 97, 156;
-    --spectrum-global-color-magenta-600: rgb(
-        var(--spectrum-global-color-magenta-600-rgb)
-    );
+    --spectrum-global-color-magenta-600: rgb(var(--spectrum-global-color-magenta-600-rgb));
     --spectrum-global-color-magenta-700-rgb: 252, 124, 173;
-    --spectrum-global-color-magenta-700: rgb(
-        var(--spectrum-global-color-magenta-700-rgb)
-    );
+    --spectrum-global-color-magenta-700: rgb(var(--spectrum-global-color-magenta-700-rgb));
     --spectrum-global-color-fuchsia-400-rgb: 191, 43, 191;
-    --spectrum-global-color-fuchsia-400: rgb(
-        var(--spectrum-global-color-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-fuchsia-400: rgb(var(--spectrum-global-color-fuchsia-400-rgb));
     --spectrum-global-color-fuchsia-500-rgb: 211, 65, 213;
-    --spectrum-global-color-fuchsia-500: rgb(
-        var(--spectrum-global-color-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-fuchsia-500: rgb(var(--spectrum-global-color-fuchsia-500-rgb));
     --spectrum-global-color-fuchsia-600-rgb: 228, 91, 229;
-    --spectrum-global-color-fuchsia-600: rgb(
-        var(--spectrum-global-color-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-fuchsia-600: rgb(var(--spectrum-global-color-fuchsia-600-rgb));
     --spectrum-global-color-fuchsia-700-rgb: 239, 120, 238;
-    --spectrum-global-color-fuchsia-700: rgb(
-        var(--spectrum-global-color-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-fuchsia-700: rgb(var(--spectrum-global-color-fuchsia-700-rgb));
     --spectrum-global-color-purple-400-rgb: 145, 70, 236;
-    --spectrum-global-color-purple-400: rgb(
-        var(--spectrum-global-color-purple-400-rgb)
-    );
+    --spectrum-global-color-purple-400: rgb(var(--spectrum-global-color-purple-400-rgb));
     --spectrum-global-color-purple-500-rgb: 162, 94, 246;
-    --spectrum-global-color-purple-500: rgb(
-        var(--spectrum-global-color-purple-500-rgb)
-    );
+    --spectrum-global-color-purple-500: rgb(var(--spectrum-global-color-purple-500-rgb));
     --spectrum-global-color-purple-600-rgb: 178, 119, 250;
-    --spectrum-global-color-purple-600: rgb(
-        var(--spectrum-global-color-purple-600-rgb)
-    );
+    --spectrum-global-color-purple-600: rgb(var(--spectrum-global-color-purple-600-rgb));
     --spectrum-global-color-purple-700-rgb: 192, 143, 252;
-    --spectrum-global-color-purple-700: rgb(
-        var(--spectrum-global-color-purple-700-rgb)
-    );
+    --spectrum-global-color-purple-700: rgb(var(--spectrum-global-color-purple-700-rgb));
     --spectrum-global-color-indigo-400-rgb: 90, 96, 235;
-    --spectrum-global-color-indigo-400: rgb(
-        var(--spectrum-global-color-indigo-400-rgb)
-    );
+    --spectrum-global-color-indigo-400: rgb(var(--spectrum-global-color-indigo-400-rgb));
     --spectrum-global-color-indigo-500-rgb: 110, 115, 246;
-    --spectrum-global-color-indigo-500: rgb(
-        var(--spectrum-global-color-indigo-500-rgb)
-    );
+    --spectrum-global-color-indigo-500: rgb(var(--spectrum-global-color-indigo-500-rgb));
     --spectrum-global-color-indigo-600-rgb: 132, 136, 253;
-    --spectrum-global-color-indigo-600: rgb(
-        var(--spectrum-global-color-indigo-600-rgb)
-    );
+    --spectrum-global-color-indigo-600: rgb(var(--spectrum-global-color-indigo-600-rgb));
     --spectrum-global-color-indigo-700-rgb: 153, 157, 255;
-    --spectrum-global-color-indigo-700: rgb(
-        var(--spectrum-global-color-indigo-700-rgb)
-    );
+    --spectrum-global-color-indigo-700: rgb(var(--spectrum-global-color-indigo-700-rgb));
     --spectrum-global-color-seafoam-400-rgb: 0, 146, 140;
-    --spectrum-global-color-seafoam-400: rgb(
-        var(--spectrum-global-color-seafoam-400-rgb)
-    );
+    --spectrum-global-color-seafoam-400: rgb(var(--spectrum-global-color-seafoam-400-rgb));
     --spectrum-global-color-seafoam-500-rgb: 0, 165, 159;
-    --spectrum-global-color-seafoam-500: rgb(
-        var(--spectrum-global-color-seafoam-500-rgb)
-    );
+    --spectrum-global-color-seafoam-500: rgb(var(--spectrum-global-color-seafoam-500-rgb));
     --spectrum-global-color-seafoam-600-rgb: 26, 185, 178;
-    --spectrum-global-color-seafoam-600: rgb(
-        var(--spectrum-global-color-seafoam-600-rgb)
-    );
+    --spectrum-global-color-seafoam-600: rgb(var(--spectrum-global-color-seafoam-600-rgb));
     --spectrum-global-color-seafoam-700-rgb: 66, 202, 195;
-    --spectrum-global-color-seafoam-700: rgb(
-        var(--spectrum-global-color-seafoam-700-rgb)
-    );
+    --spectrum-global-color-seafoam-700: rgb(var(--spectrum-global-color-seafoam-700-rgb));
     --spectrum-global-color-red-400-rgb: 221, 33, 24;
-    --spectrum-global-color-red-400: rgb(
-        var(--spectrum-global-color-red-400-rgb)
-    );
+    --spectrum-global-color-red-400: rgb(var(--spectrum-global-color-red-400-rgb));
     --spectrum-global-color-red-500-rgb: 238, 67, 49;
-    --spectrum-global-color-red-500: rgb(
-        var(--spectrum-global-color-red-500-rgb)
-    );
+    --spectrum-global-color-red-500: rgb(var(--spectrum-global-color-red-500-rgb));
     --spectrum-global-color-red-600-rgb: 249, 99, 76;
-    --spectrum-global-color-red-600: rgb(
-        var(--spectrum-global-color-red-600-rgb)
-    );
+    --spectrum-global-color-red-600: rgb(var(--spectrum-global-color-red-600-rgb));
     --spectrum-global-color-red-700-rgb: 255, 129, 107;
-    --spectrum-global-color-red-700: rgb(
-        var(--spectrum-global-color-red-700-rgb)
-    );
+    --spectrum-global-color-red-700: rgb(var(--spectrum-global-color-red-700-rgb));
     --spectrum-global-color-orange-400-rgb: 232, 116, 0;
-    --spectrum-global-color-orange-400: rgb(
-        var(--spectrum-global-color-orange-400-rgb)
-    );
+    --spectrum-global-color-orange-400: rgb(var(--spectrum-global-color-orange-400-rgb));
     --spectrum-global-color-orange-500-rgb: 249, 137, 23;
-    --spectrum-global-color-orange-500: rgb(
-        var(--spectrum-global-color-orange-500-rgb)
-    );
+    --spectrum-global-color-orange-500: rgb(var(--spectrum-global-color-orange-500-rgb));
     --spectrum-global-color-orange-600-rgb: 255, 162, 59;
-    --spectrum-global-color-orange-600: rgb(
-        var(--spectrum-global-color-orange-600-rgb)
-    );
+    --spectrum-global-color-orange-600: rgb(var(--spectrum-global-color-orange-600-rgb));
     --spectrum-global-color-orange-700-rgb: 255, 188, 102;
-    --spectrum-global-color-orange-700: rgb(
-        var(--spectrum-global-color-orange-700-rgb)
-    );
+    --spectrum-global-color-orange-700: rgb(var(--spectrum-global-color-orange-700-rgb));
     --spectrum-global-color-green-400-rgb: 0, 149, 98;
-    --spectrum-global-color-green-400: rgb(
-        var(--spectrum-global-color-green-400-rgb)
-    );
+    --spectrum-global-color-green-400: rgb(var(--spectrum-global-color-green-400-rgb));
     --spectrum-global-color-green-500-rgb: 28, 168, 114;
-    --spectrum-global-color-green-500: rgb(
-        var(--spectrum-global-color-green-500-rgb)
-    );
+    --spectrum-global-color-green-500: rgb(var(--spectrum-global-color-green-500-rgb));
     --spectrum-global-color-green-600-rgb: 52, 187, 132;
-    --spectrum-global-color-green-600: rgb(
-        var(--spectrum-global-color-green-600-rgb)
-    );
+    --spectrum-global-color-green-600: rgb(var(--spectrum-global-color-green-600-rgb));
     --spectrum-global-color-green-700-rgb: 75, 205, 149;
-    --spectrum-global-color-green-700: rgb(
-        var(--spectrum-global-color-green-700-rgb)
-    );
+    --spectrum-global-color-green-700: rgb(var(--spectrum-global-color-green-700-rgb));
     --spectrum-global-color-blue-400-rgb: 29, 128, 245;
-    --spectrum-global-color-blue-400: rgb(
-        var(--spectrum-global-color-blue-400-rgb)
-    );
+    --spectrum-global-color-blue-400: rgb(var(--spectrum-global-color-blue-400-rgb));
     --spectrum-global-color-blue-500-rgb: 64, 150, 243;
-    --spectrum-global-color-blue-500: rgb(
-        var(--spectrum-global-color-blue-500-rgb)
-    );
+    --spectrum-global-color-blue-500: rgb(var(--spectrum-global-color-blue-500-rgb));
     --spectrum-global-color-blue-600-rgb: 94, 170, 247;
-    --spectrum-global-color-blue-600: rgb(
-        var(--spectrum-global-color-blue-600-rgb)
-    );
+    --spectrum-global-color-blue-600: rgb(var(--spectrum-global-color-blue-600-rgb));
     --spectrum-global-color-blue-700-rgb: 124, 189, 250;
-    --spectrum-global-color-blue-700: rgb(
-        var(--spectrum-global-color-blue-700-rgb)
-    );
+    --spectrum-global-color-blue-700: rgb(var(--spectrum-global-color-blue-700-rgb));
     --spectrum-global-color-gray-50-rgb: 0, 0, 0;
-    --spectrum-global-color-gray-50: rgb(
-        var(--spectrum-global-color-gray-50-rgb)
-    );
+    --spectrum-global-color-gray-50: rgb(var(--spectrum-global-color-gray-50-rgb));
     --spectrum-global-color-gray-75-rgb: 14, 14, 14;
-    --spectrum-global-color-gray-75: rgb(
-        var(--spectrum-global-color-gray-75-rgb)
-    );
+    --spectrum-global-color-gray-75: rgb(var(--spectrum-global-color-gray-75-rgb));
     --spectrum-global-color-gray-100-rgb: 29, 29, 29;
-    --spectrum-global-color-gray-100: rgb(
-        var(--spectrum-global-color-gray-100-rgb)
-    );
+    --spectrum-global-color-gray-100: rgb(var(--spectrum-global-color-gray-100-rgb));
     --spectrum-global-color-gray-200-rgb: 48, 48, 48;
-    --spectrum-global-color-gray-200: rgb(
-        var(--spectrum-global-color-gray-200-rgb)
-    );
+    --spectrum-global-color-gray-200: rgb(var(--spectrum-global-color-gray-200-rgb));
     --spectrum-global-color-gray-300-rgb: 75, 75, 75;
-    --spectrum-global-color-gray-300: rgb(
-        var(--spectrum-global-color-gray-300-rgb)
-    );
+    --spectrum-global-color-gray-300: rgb(var(--spectrum-global-color-gray-300-rgb));
     --spectrum-global-color-gray-400-rgb: 106, 106, 106;
-    --spectrum-global-color-gray-400: rgb(
-        var(--spectrum-global-color-gray-400-rgb)
-    );
+    --spectrum-global-color-gray-400: rgb(var(--spectrum-global-color-gray-400-rgb));
     --spectrum-global-color-gray-500-rgb: 141, 141, 141;
-    --spectrum-global-color-gray-500: rgb(
-        var(--spectrum-global-color-gray-500-rgb)
-    );
+    --spectrum-global-color-gray-500: rgb(var(--spectrum-global-color-gray-500-rgb));
     --spectrum-global-color-gray-600-rgb: 176, 176, 176;
-    --spectrum-global-color-gray-600: rgb(
-        var(--spectrum-global-color-gray-600-rgb)
-    );
+    --spectrum-global-color-gray-600: rgb(var(--spectrum-global-color-gray-600-rgb));
     --spectrum-global-color-gray-700-rgb: 208, 208, 208;
-    --spectrum-global-color-gray-700: rgb(
-        var(--spectrum-global-color-gray-700-rgb)
-    );
+    --spectrum-global-color-gray-700: rgb(var(--spectrum-global-color-gray-700-rgb));
     --spectrum-global-color-gray-800-rgb: 235, 235, 235;
-    --spectrum-global-color-gray-800: rgb(
-        var(--spectrum-global-color-gray-800-rgb)
-    );
+    --spectrum-global-color-gray-800: rgb(var(--spectrum-global-color-gray-800-rgb));
     --spectrum-global-color-gray-900-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-900: rgb(
-        var(--spectrum-global-color-gray-900-rgb)
-    );
-    --spectrum-alias-background-color-primary: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-secondary: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-background-color-tertiary: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-global-color-gray-900: rgb(var(--spectrum-global-color-gray-900-rgb));
+    --spectrum-alias-background-color-primary: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-secondary: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-background-color-tertiary: var(--spectrum-global-color-gray-50);
     --spectrum-alias-background-color-modal-overlay: #0009;
     --spectrum-alias-dropshadow-color: #000c;
     --spectrum-alias-background-color-hover-overlay: #ffffff14;
@@ -276,18 +152,10 @@
     --spectrum-alias-highlight-selected-hover: #4096f34d;
     --spectrum-alias-text-highlight-color: #4096f34d;
     --spectrum-alias-background-color-quickactions: #1d1d1de6;
-    --spectrum-alias-border-color-selected: var(
-        --spectrum-global-color-blue-600
-    );
+    --spectrum-alias-border-color-selected: var(--spectrum-global-color-blue-600);
     --spectrum-alias-border-color-translucent: #ffffff1a;
     --spectrum-alias-radial-reaction-color-default: #ebebeb99;
-    --spectrum-alias-pasteboard-background-color: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-appframe-border-color: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-appframe-separator-color: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-alias-pasteboard-background-color: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-appframe-border-color: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-appframe-separator-color: var(--spectrum-global-color-gray-50);
 }

--- a/tools/styles/spectrum-theme-light.css
+++ b/tools/styles/spectrum-theme-light.css
@@ -23,250 +23,126 @@
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 39, 187, 54;
-    --spectrum-global-color-celery-400: rgb(
-        var(--spectrum-global-color-celery-400-rgb)
-    );
+    --spectrum-global-color-celery-400: rgb(var(--spectrum-global-color-celery-400-rgb));
     --spectrum-global-color-celery-500-rgb: 7, 167, 33;
-    --spectrum-global-color-celery-500: rgb(
-        var(--spectrum-global-color-celery-500-rgb)
-    );
+    --spectrum-global-color-celery-500: rgb(var(--spectrum-global-color-celery-500-rgb));
     --spectrum-global-color-celery-600-rgb: 0, 145, 18;
-    --spectrum-global-color-celery-600: rgb(
-        var(--spectrum-global-color-celery-600-rgb)
-    );
+    --spectrum-global-color-celery-600: rgb(var(--spectrum-global-color-celery-600-rgb));
     --spectrum-global-color-celery-700-rgb: 0, 124, 15;
-    --spectrum-global-color-celery-700: rgb(
-        var(--spectrum-global-color-celery-700-rgb)
-    );
+    --spectrum-global-color-celery-700: rgb(var(--spectrum-global-color-celery-700-rgb));
     --spectrum-global-color-chartreuse-400-rgb: 152, 197, 10;
-    --spectrum-global-color-chartreuse-400: rgb(
-        var(--spectrum-global-color-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-chartreuse-400: rgb(var(--spectrum-global-color-chartreuse-400-rgb));
     --spectrum-global-color-chartreuse-500-rgb: 135, 177, 3;
-    --spectrum-global-color-chartreuse-500: rgb(
-        var(--spectrum-global-color-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-chartreuse-500: rgb(var(--spectrum-global-color-chartreuse-500-rgb));
     --spectrum-global-color-chartreuse-600-rgb: 118, 156, 0;
-    --spectrum-global-color-chartreuse-600: rgb(
-        var(--spectrum-global-color-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-chartreuse-600: rgb(var(--spectrum-global-color-chartreuse-600-rgb));
     --spectrum-global-color-chartreuse-700-rgb: 103, 136, 0;
-    --spectrum-global-color-chartreuse-700: rgb(
-        var(--spectrum-global-color-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-chartreuse-700: rgb(var(--spectrum-global-color-chartreuse-700-rgb));
     --spectrum-global-color-yellow-400-rgb: 232, 198, 0;
-    --spectrum-global-color-yellow-400: rgb(
-        var(--spectrum-global-color-yellow-400-rgb)
-    );
+    --spectrum-global-color-yellow-400: rgb(var(--spectrum-global-color-yellow-400-rgb));
     --spectrum-global-color-yellow-500-rgb: 215, 179, 0;
-    --spectrum-global-color-yellow-500: rgb(
-        var(--spectrum-global-color-yellow-500-rgb)
-    );
+    --spectrum-global-color-yellow-500: rgb(var(--spectrum-global-color-yellow-500-rgb));
     --spectrum-global-color-yellow-600-rgb: 196, 159, 0;
-    --spectrum-global-color-yellow-600: rgb(
-        var(--spectrum-global-color-yellow-600-rgb)
-    );
+    --spectrum-global-color-yellow-600: rgb(var(--spectrum-global-color-yellow-600-rgb));
     --spectrum-global-color-yellow-700-rgb: 176, 140, 0;
-    --spectrum-global-color-yellow-700: rgb(
-        var(--spectrum-global-color-yellow-700-rgb)
-    );
+    --spectrum-global-color-yellow-700: rgb(var(--spectrum-global-color-yellow-700-rgb));
     --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
-    --spectrum-global-color-magenta-400: rgb(
-        var(--spectrum-global-color-magenta-400-rgb)
-    );
+    --spectrum-global-color-magenta-400: rgb(var(--spectrum-global-color-magenta-400-rgb));
     --spectrum-global-color-magenta-500-rgb: 200, 34, 105;
-    --spectrum-global-color-magenta-500: rgb(
-        var(--spectrum-global-color-magenta-500-rgb)
-    );
+    --spectrum-global-color-magenta-500: rgb(var(--spectrum-global-color-magenta-500-rgb));
     --spectrum-global-color-magenta-600-rgb: 173, 9, 85;
-    --spectrum-global-color-magenta-600: rgb(
-        var(--spectrum-global-color-magenta-600-rgb)
-    );
+    --spectrum-global-color-magenta-600: rgb(var(--spectrum-global-color-magenta-600-rgb));
     --spectrum-global-color-magenta-700-rgb: 142, 0, 69;
-    --spectrum-global-color-magenta-700: rgb(
-        var(--spectrum-global-color-magenta-700-rgb)
-    );
+    --spectrum-global-color-magenta-700: rgb(var(--spectrum-global-color-magenta-700-rgb));
     --spectrum-global-color-fuchsia-400-rgb: 205, 58, 206;
-    --spectrum-global-color-fuchsia-400: rgb(
-        var(--spectrum-global-color-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-fuchsia-400: rgb(var(--spectrum-global-color-fuchsia-400-rgb));
     --spectrum-global-color-fuchsia-500-rgb: 182, 34, 183;
-    --spectrum-global-color-fuchsia-500: rgb(
-        var(--spectrum-global-color-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-fuchsia-500: rgb(var(--spectrum-global-color-fuchsia-500-rgb));
     --spectrum-global-color-fuchsia-600-rgb: 157, 3, 158;
-    --spectrum-global-color-fuchsia-600: rgb(
-        var(--spectrum-global-color-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-fuchsia-600: rgb(var(--spectrum-global-color-fuchsia-600-rgb));
     --spectrum-global-color-fuchsia-700-rgb: 128, 0, 129;
-    --spectrum-global-color-fuchsia-700: rgb(
-        var(--spectrum-global-color-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-fuchsia-700: rgb(var(--spectrum-global-color-fuchsia-700-rgb));
     --spectrum-global-color-purple-400-rgb: 157, 87, 244;
-    --spectrum-global-color-purple-400: rgb(
-        var(--spectrum-global-color-purple-400-rgb)
-    );
+    --spectrum-global-color-purple-400: rgb(var(--spectrum-global-color-purple-400-rgb));
     --spectrum-global-color-purple-500-rgb: 137, 61, 231;
-    --spectrum-global-color-purple-500: rgb(
-        var(--spectrum-global-color-purple-500-rgb)
-    );
+    --spectrum-global-color-purple-500: rgb(var(--spectrum-global-color-purple-500-rgb));
     --spectrum-global-color-purple-600-rgb: 115, 38, 211;
-    --spectrum-global-color-purple-600: rgb(
-        var(--spectrum-global-color-purple-600-rgb)
-    );
+    --spectrum-global-color-purple-600: rgb(var(--spectrum-global-color-purple-600-rgb));
     --spectrum-global-color-purple-700-rgb: 93, 19, 183;
-    --spectrum-global-color-purple-700: rgb(
-        var(--spectrum-global-color-purple-700-rgb)
-    );
+    --spectrum-global-color-purple-700: rgb(var(--spectrum-global-color-purple-700-rgb));
     --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
-    --spectrum-global-color-indigo-400: rgb(
-        var(--spectrum-global-color-indigo-400-rgb)
-    );
+    --spectrum-global-color-indigo-400: rgb(var(--spectrum-global-color-indigo-400-rgb));
     --spectrum-global-color-indigo-500-rgb: 82, 88, 228;
-    --spectrum-global-color-indigo-500: rgb(
-        var(--spectrum-global-color-indigo-500-rgb)
-    );
+    --spectrum-global-color-indigo-500: rgb(var(--spectrum-global-color-indigo-500-rgb));
     --spectrum-global-color-indigo-600-rgb: 64, 70, 202;
-    --spectrum-global-color-indigo-600: rgb(
-        var(--spectrum-global-color-indigo-600-rgb)
-    );
+    --spectrum-global-color-indigo-600: rgb(var(--spectrum-global-color-indigo-600-rgb));
     --spectrum-global-color-indigo-700-rgb: 50, 54, 168;
-    --spectrum-global-color-indigo-700: rgb(
-        var(--spectrum-global-color-indigo-700-rgb)
-    );
+    --spectrum-global-color-indigo-700: rgb(var(--spectrum-global-color-indigo-700-rgb));
     --spectrum-global-color-seafoam-400-rgb: 0, 161, 154;
-    --spectrum-global-color-seafoam-400: rgb(
-        var(--spectrum-global-color-seafoam-400-rgb)
-    );
+    --spectrum-global-color-seafoam-400: rgb(var(--spectrum-global-color-seafoam-400-rgb));
     --spectrum-global-color-seafoam-500-rgb: 0, 140, 135;
-    --spectrum-global-color-seafoam-500: rgb(
-        var(--spectrum-global-color-seafoam-500-rgb)
-    );
+    --spectrum-global-color-seafoam-500: rgb(var(--spectrum-global-color-seafoam-500-rgb));
     --spectrum-global-color-seafoam-600-rgb: 0, 119, 114;
-    --spectrum-global-color-seafoam-600: rgb(
-        var(--spectrum-global-color-seafoam-600-rgb)
-    );
+    --spectrum-global-color-seafoam-600: rgb(var(--spectrum-global-color-seafoam-600-rgb));
     --spectrum-global-color-seafoam-700-rgb: 0, 99, 95;
-    --spectrum-global-color-seafoam-700: rgb(
-        var(--spectrum-global-color-seafoam-700-rgb)
-    );
+    --spectrum-global-color-seafoam-700: rgb(var(--spectrum-global-color-seafoam-700-rgb));
     --spectrum-global-color-red-400-rgb: 234, 56, 41;
-    --spectrum-global-color-red-400: rgb(
-        var(--spectrum-global-color-red-400-rgb)
-    );
+    --spectrum-global-color-red-400: rgb(var(--spectrum-global-color-red-400-rgb));
     --spectrum-global-color-red-500-rgb: 211, 21, 16;
-    --spectrum-global-color-red-500: rgb(
-        var(--spectrum-global-color-red-500-rgb)
-    );
+    --spectrum-global-color-red-500: rgb(var(--spectrum-global-color-red-500-rgb));
     --spectrum-global-color-red-600-rgb: 180, 0, 0;
-    --spectrum-global-color-red-600: rgb(
-        var(--spectrum-global-color-red-600-rgb)
-    );
+    --spectrum-global-color-red-600: rgb(var(--spectrum-global-color-red-600-rgb));
     --spectrum-global-color-red-700-rgb: 147, 0, 0;
-    --spectrum-global-color-red-700: rgb(
-        var(--spectrum-global-color-red-700-rgb)
-    );
+    --spectrum-global-color-red-700: rgb(var(--spectrum-global-color-red-700-rgb));
     --spectrum-global-color-orange-400-rgb: 246, 133, 17;
-    --spectrum-global-color-orange-400: rgb(
-        var(--spectrum-global-color-orange-400-rgb)
-    );
+    --spectrum-global-color-orange-400: rgb(var(--spectrum-global-color-orange-400-rgb));
     --spectrum-global-color-orange-500-rgb: 228, 111, 0;
-    --spectrum-global-color-orange-500: rgb(
-        var(--spectrum-global-color-orange-500-rgb)
-    );
+    --spectrum-global-color-orange-500: rgb(var(--spectrum-global-color-orange-500-rgb));
     --spectrum-global-color-orange-600-rgb: 203, 93, 0;
-    --spectrum-global-color-orange-600: rgb(
-        var(--spectrum-global-color-orange-600-rgb)
-    );
+    --spectrum-global-color-orange-600: rgb(var(--spectrum-global-color-orange-600-rgb));
     --spectrum-global-color-orange-700-rgb: 177, 76, 0;
-    --spectrum-global-color-orange-700: rgb(
-        var(--spectrum-global-color-orange-700-rgb)
-    );
+    --spectrum-global-color-orange-700: rgb(var(--spectrum-global-color-orange-700-rgb));
     --spectrum-global-color-green-400-rgb: 0, 143, 93;
-    --spectrum-global-color-green-400: rgb(
-        var(--spectrum-global-color-green-400-rgb)
-    );
+    --spectrum-global-color-green-400: rgb(var(--spectrum-global-color-green-400-rgb));
     --spectrum-global-color-green-500-rgb: 0, 122, 77;
-    --spectrum-global-color-green-500: rgb(
-        var(--spectrum-global-color-green-500-rgb)
-    );
+    --spectrum-global-color-green-500: rgb(var(--spectrum-global-color-green-500-rgb));
     --spectrum-global-color-green-600-rgb: 0, 101, 62;
-    --spectrum-global-color-green-600: rgb(
-        var(--spectrum-global-color-green-600-rgb)
-    );
+    --spectrum-global-color-green-600: rgb(var(--spectrum-global-color-green-600-rgb));
     --spectrum-global-color-green-700-rgb: 0, 81, 50;
-    --spectrum-global-color-green-700: rgb(
-        var(--spectrum-global-color-green-700-rgb)
-    );
+    --spectrum-global-color-green-700: rgb(var(--spectrum-global-color-green-700-rgb));
     --spectrum-global-color-blue-400-rgb: 20, 122, 243;
-    --spectrum-global-color-blue-400: rgb(
-        var(--spectrum-global-color-blue-400-rgb)
-    );
+    --spectrum-global-color-blue-400: rgb(var(--spectrum-global-color-blue-400-rgb));
     --spectrum-global-color-blue-500-rgb: 2, 101, 220;
-    --spectrum-global-color-blue-500: rgb(
-        var(--spectrum-global-color-blue-500-rgb)
-    );
+    --spectrum-global-color-blue-500: rgb(var(--spectrum-global-color-blue-500-rgb));
     --spectrum-global-color-blue-600-rgb: 0, 84, 182;
-    --spectrum-global-color-blue-600: rgb(
-        var(--spectrum-global-color-blue-600-rgb)
-    );
+    --spectrum-global-color-blue-600: rgb(var(--spectrum-global-color-blue-600-rgb));
     --spectrum-global-color-blue-700-rgb: 0, 68, 145;
-    --spectrum-global-color-blue-700: rgb(
-        var(--spectrum-global-color-blue-700-rgb)
-    );
+    --spectrum-global-color-blue-700: rgb(var(--spectrum-global-color-blue-700-rgb));
     --spectrum-global-color-gray-50-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-50: rgb(
-        var(--spectrum-global-color-gray-50-rgb)
-    );
+    --spectrum-global-color-gray-50: rgb(var(--spectrum-global-color-gray-50-rgb));
     --spectrum-global-color-gray-75-rgb: 253, 253, 253;
-    --spectrum-global-color-gray-75: rgb(
-        var(--spectrum-global-color-gray-75-rgb)
-    );
+    --spectrum-global-color-gray-75: rgb(var(--spectrum-global-color-gray-75-rgb));
     --spectrum-global-color-gray-100-rgb: 248, 248, 248;
-    --spectrum-global-color-gray-100: rgb(
-        var(--spectrum-global-color-gray-100-rgb)
-    );
+    --spectrum-global-color-gray-100: rgb(var(--spectrum-global-color-gray-100-rgb));
     --spectrum-global-color-gray-200-rgb: 230, 230, 230;
-    --spectrum-global-color-gray-200: rgb(
-        var(--spectrum-global-color-gray-200-rgb)
-    );
+    --spectrum-global-color-gray-200: rgb(var(--spectrum-global-color-gray-200-rgb));
     --spectrum-global-color-gray-300-rgb: 213, 213, 213;
-    --spectrum-global-color-gray-300: rgb(
-        var(--spectrum-global-color-gray-300-rgb)
-    );
+    --spectrum-global-color-gray-300: rgb(var(--spectrum-global-color-gray-300-rgb));
     --spectrum-global-color-gray-400-rgb: 177, 177, 177;
-    --spectrum-global-color-gray-400: rgb(
-        var(--spectrum-global-color-gray-400-rgb)
-    );
+    --spectrum-global-color-gray-400: rgb(var(--spectrum-global-color-gray-400-rgb));
     --spectrum-global-color-gray-500-rgb: 144, 144, 144;
-    --spectrum-global-color-gray-500: rgb(
-        var(--spectrum-global-color-gray-500-rgb)
-    );
+    --spectrum-global-color-gray-500: rgb(var(--spectrum-global-color-gray-500-rgb));
     --spectrum-global-color-gray-600-rgb: 109, 109, 109;
-    --spectrum-global-color-gray-600: rgb(
-        var(--spectrum-global-color-gray-600-rgb)
-    );
+    --spectrum-global-color-gray-600: rgb(var(--spectrum-global-color-gray-600-rgb));
     --spectrum-global-color-gray-700-rgb: 70, 70, 70;
-    --spectrum-global-color-gray-700: rgb(
-        var(--spectrum-global-color-gray-700-rgb)
-    );
+    --spectrum-global-color-gray-700: rgb(var(--spectrum-global-color-gray-700-rgb));
     --spectrum-global-color-gray-800-rgb: 34, 34, 34;
-    --spectrum-global-color-gray-800: rgb(
-        var(--spectrum-global-color-gray-800-rgb)
-    );
+    --spectrum-global-color-gray-800: rgb(var(--spectrum-global-color-gray-800-rgb));
     --spectrum-global-color-gray-900-rgb: 0, 0, 0;
-    --spectrum-global-color-gray-900: rgb(
-        var(--spectrum-global-color-gray-900-rgb)
-    );
-    --spectrum-alias-background-color-primary: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-background-color-secondary: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-tertiary: var(
-        --spectrum-global-color-gray-300
-    );
+    --spectrum-global-color-gray-900: rgb(var(--spectrum-global-color-gray-900-rgb));
+    --spectrum-alias-background-color-primary: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-background-color-secondary: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-tertiary: var(--spectrum-global-color-gray-300);
     --spectrum-alias-background-color-modal-overlay: #0006;
     --spectrum-alias-dropshadow-color: #00000026;
     --spectrum-alias-background-color-hover-overlay: #0000000a;
@@ -276,18 +152,10 @@
     --spectrum-alias-highlight-selected-hover: #0265dc33;
     --spectrum-alias-text-highlight-color: #0265dc33;
     --spectrum-alias-background-color-quickactions: #f8f8f8e6;
-    --spectrum-alias-border-color-selected: var(
-        --spectrum-global-color-blue-500
-    );
+    --spectrum-alias-border-color-selected: var(--spectrum-global-color-blue-500);
     --spectrum-alias-border-color-translucent: #0000001a;
     --spectrum-alias-radial-reaction-color-default: #2229;
-    --spectrum-alias-pasteboard-background-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-appframe-border-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-appframe-separator-color: var(
-        --spectrum-global-color-gray-300
-    );
+    --spectrum-alias-pasteboard-background-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-appframe-border-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-appframe-separator-color: var(--spectrum-global-color-gray-300);
 }

--- a/tools/styles/spectrum-theme-lightest.css
+++ b/tools/styles/spectrum-theme-lightest.css
@@ -23,250 +23,126 @@
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 48, 193, 61;
-    --spectrum-global-color-celery-400: rgb(
-        var(--spectrum-global-color-celery-400-rgb)
-    );
+    --spectrum-global-color-celery-400: rgb(var(--spectrum-global-color-celery-400-rgb));
     --spectrum-global-color-celery-500-rgb: 15, 172, 38;
-    --spectrum-global-color-celery-500: rgb(
-        var(--spectrum-global-color-celery-500-rgb)
-    );
+    --spectrum-global-color-celery-500: rgb(var(--spectrum-global-color-celery-500-rgb));
     --spectrum-global-color-celery-600-rgb: 0, 150, 20;
-    --spectrum-global-color-celery-600: rgb(
-        var(--spectrum-global-color-celery-600-rgb)
-    );
+    --spectrum-global-color-celery-600: rgb(var(--spectrum-global-color-celery-600-rgb));
     --spectrum-global-color-celery-700-rgb: 0, 128, 15;
-    --spectrum-global-color-celery-700: rgb(
-        var(--spectrum-global-color-celery-700-rgb)
-    );
+    --spectrum-global-color-celery-700: rgb(var(--spectrum-global-color-celery-700-rgb));
     --spectrum-global-color-chartreuse-400-rgb: 157, 203, 13;
-    --spectrum-global-color-chartreuse-400: rgb(
-        var(--spectrum-global-color-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-chartreuse-400: rgb(var(--spectrum-global-color-chartreuse-400-rgb));
     --spectrum-global-color-chartreuse-500-rgb: 139, 182, 4;
-    --spectrum-global-color-chartreuse-500: rgb(
-        var(--spectrum-global-color-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-chartreuse-500: rgb(var(--spectrum-global-color-chartreuse-500-rgb));
     --spectrum-global-color-chartreuse-600-rgb: 122, 162, 0;
-    --spectrum-global-color-chartreuse-600: rgb(
-        var(--spectrum-global-color-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-chartreuse-600: rgb(var(--spectrum-global-color-chartreuse-600-rgb));
     --spectrum-global-color-chartreuse-700-rgb: 106, 141, 0;
-    --spectrum-global-color-chartreuse-700: rgb(
-        var(--spectrum-global-color-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-chartreuse-700: rgb(var(--spectrum-global-color-chartreuse-700-rgb));
     --spectrum-global-color-yellow-400-rgb: 238, 205, 0;
-    --spectrum-global-color-yellow-400: rgb(
-        var(--spectrum-global-color-yellow-400-rgb)
-    );
+    --spectrum-global-color-yellow-400: rgb(var(--spectrum-global-color-yellow-400-rgb));
     --spectrum-global-color-yellow-500-rgb: 221, 185, 0;
-    --spectrum-global-color-yellow-500: rgb(
-        var(--spectrum-global-color-yellow-500-rgb)
-    );
+    --spectrum-global-color-yellow-500: rgb(var(--spectrum-global-color-yellow-500-rgb));
     --spectrum-global-color-yellow-600-rgb: 201, 164, 0;
-    --spectrum-global-color-yellow-600: rgb(
-        var(--spectrum-global-color-yellow-600-rgb)
-    );
+    --spectrum-global-color-yellow-600: rgb(var(--spectrum-global-color-yellow-600-rgb));
     --spectrum-global-color-yellow-700-rgb: 181, 144, 0;
-    --spectrum-global-color-yellow-700: rgb(
-        var(--spectrum-global-color-yellow-700-rgb)
-    );
+    --spectrum-global-color-yellow-700: rgb(var(--spectrum-global-color-yellow-700-rgb));
     --spectrum-global-color-magenta-400-rgb: 226, 68, 135;
-    --spectrum-global-color-magenta-400: rgb(
-        var(--spectrum-global-color-magenta-400-rgb)
-    );
+    --spectrum-global-color-magenta-400: rgb(var(--spectrum-global-color-magenta-400-rgb));
     --spectrum-global-color-magenta-500-rgb: 205, 40, 111;
-    --spectrum-global-color-magenta-500: rgb(
-        var(--spectrum-global-color-magenta-500-rgb)
-    );
+    --spectrum-global-color-magenta-500: rgb(var(--spectrum-global-color-magenta-500-rgb));
     --spectrum-global-color-magenta-600-rgb: 179, 15, 89;
-    --spectrum-global-color-magenta-600: rgb(
-        var(--spectrum-global-color-magenta-600-rgb)
-    );
+    --spectrum-global-color-magenta-600: rgb(var(--spectrum-global-color-magenta-600-rgb));
     --spectrum-global-color-magenta-700-rgb: 149, 0, 72;
-    --spectrum-global-color-magenta-700: rgb(
-        var(--spectrum-global-color-magenta-700-rgb)
-    );
+    --spectrum-global-color-magenta-700: rgb(var(--spectrum-global-color-magenta-700-rgb));
     --spectrum-global-color-fuchsia-400-rgb: 211, 63, 212;
-    --spectrum-global-color-fuchsia-400: rgb(
-        var(--spectrum-global-color-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-fuchsia-400: rgb(var(--spectrum-global-color-fuchsia-400-rgb));
     --spectrum-global-color-fuchsia-500-rgb: 188, 39, 187;
-    --spectrum-global-color-fuchsia-500: rgb(
-        var(--spectrum-global-color-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-fuchsia-500: rgb(var(--spectrum-global-color-fuchsia-500-rgb));
     --spectrum-global-color-fuchsia-600-rgb: 163, 10, 163;
-    --spectrum-global-color-fuchsia-600: rgb(
-        var(--spectrum-global-color-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-fuchsia-600: rgb(var(--spectrum-global-color-fuchsia-600-rgb));
     --spectrum-global-color-fuchsia-700-rgb: 135, 0, 136;
-    --spectrum-global-color-fuchsia-700: rgb(
-        var(--spectrum-global-color-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-fuchsia-700: rgb(var(--spectrum-global-color-fuchsia-700-rgb));
     --spectrum-global-color-purple-400-rgb: 161, 93, 246;
-    --spectrum-global-color-purple-400: rgb(
-        var(--spectrum-global-color-purple-400-rgb)
-    );
+    --spectrum-global-color-purple-400: rgb(var(--spectrum-global-color-purple-400-rgb));
     --spectrum-global-color-purple-500-rgb: 142, 67, 234;
-    --spectrum-global-color-purple-500: rgb(
-        var(--spectrum-global-color-purple-500-rgb)
-    );
+    --spectrum-global-color-purple-500: rgb(var(--spectrum-global-color-purple-500-rgb));
     --spectrum-global-color-purple-600-rgb: 120, 43, 216;
-    --spectrum-global-color-purple-600: rgb(
-        var(--spectrum-global-color-purple-600-rgb)
-    );
+    --spectrum-global-color-purple-600: rgb(var(--spectrum-global-color-purple-600-rgb));
     --spectrum-global-color-purple-700-rgb: 98, 23, 190;
-    --spectrum-global-color-purple-700: rgb(
-        var(--spectrum-global-color-purple-700-rgb)
-    );
+    --spectrum-global-color-purple-700: rgb(var(--spectrum-global-color-purple-700-rgb));
     --spectrum-global-color-indigo-400-rgb: 109, 115, 246;
-    --spectrum-global-color-indigo-400: rgb(
-        var(--spectrum-global-color-indigo-400-rgb)
-    );
+    --spectrum-global-color-indigo-400: rgb(var(--spectrum-global-color-indigo-400-rgb));
     --spectrum-global-color-indigo-500-rgb: 87, 93, 232;
-    --spectrum-global-color-indigo-500: rgb(
-        var(--spectrum-global-color-indigo-500-rgb)
-    );
+    --spectrum-global-color-indigo-500: rgb(var(--spectrum-global-color-indigo-500-rgb));
     --spectrum-global-color-indigo-600-rgb: 68, 74, 208;
-    --spectrum-global-color-indigo-600: rgb(
-        var(--spectrum-global-color-indigo-600-rgb)
-    );
+    --spectrum-global-color-indigo-600: rgb(var(--spectrum-global-color-indigo-600-rgb));
     --spectrum-global-color-indigo-700-rgb: 53, 58, 176;
-    --spectrum-global-color-indigo-700: rgb(
-        var(--spectrum-global-color-indigo-700-rgb)
-    );
+    --spectrum-global-color-indigo-700: rgb(var(--spectrum-global-color-indigo-700-rgb));
     --spectrum-global-color-seafoam-400-rgb: 0, 166, 160;
-    --spectrum-global-color-seafoam-400: rgb(
-        var(--spectrum-global-color-seafoam-400-rgb)
-    );
+    --spectrum-global-color-seafoam-400: rgb(var(--spectrum-global-color-seafoam-400-rgb));
     --spectrum-global-color-seafoam-500-rgb: 0, 145, 139;
-    --spectrum-global-color-seafoam-500: rgb(
-        var(--spectrum-global-color-seafoam-500-rgb)
-    );
+    --spectrum-global-color-seafoam-500: rgb(var(--spectrum-global-color-seafoam-500-rgb));
     --spectrum-global-color-seafoam-600-rgb: 0, 124, 118;
-    --spectrum-global-color-seafoam-600: rgb(
-        var(--spectrum-global-color-seafoam-600-rgb)
-    );
+    --spectrum-global-color-seafoam-600: rgb(var(--spectrum-global-color-seafoam-600-rgb));
     --spectrum-global-color-seafoam-700-rgb: 0, 103, 99;
-    --spectrum-global-color-seafoam-700: rgb(
-        var(--spectrum-global-color-seafoam-700-rgb)
-    );
+    --spectrum-global-color-seafoam-700: rgb(var(--spectrum-global-color-seafoam-700-rgb));
     --spectrum-global-color-red-400-rgb: 237, 64, 48;
-    --spectrum-global-color-red-400: rgb(
-        var(--spectrum-global-color-red-400-rgb)
-    );
+    --spectrum-global-color-red-400: rgb(var(--spectrum-global-color-red-400-rgb));
     --spectrum-global-color-red-500-rgb: 217, 28, 21;
-    --spectrum-global-color-red-500: rgb(
-        var(--spectrum-global-color-red-500-rgb)
-    );
+    --spectrum-global-color-red-500: rgb(var(--spectrum-global-color-red-500-rgb));
     --spectrum-global-color-red-600-rgb: 187, 2, 2;
-    --spectrum-global-color-red-600: rgb(
-        var(--spectrum-global-color-red-600-rgb)
-    );
+    --spectrum-global-color-red-600: rgb(var(--spectrum-global-color-red-600-rgb));
     --spectrum-global-color-red-700-rgb: 154, 0, 0;
-    --spectrum-global-color-red-700: rgb(
-        var(--spectrum-global-color-red-700-rgb)
-    );
+    --spectrum-global-color-red-700: rgb(var(--spectrum-global-color-red-700-rgb));
     --spectrum-global-color-orange-400-rgb: 250, 139, 26;
-    --spectrum-global-color-orange-400: rgb(
-        var(--spectrum-global-color-orange-400-rgb)
-    );
+    --spectrum-global-color-orange-400: rgb(var(--spectrum-global-color-orange-400-rgb));
     --spectrum-global-color-orange-500-rgb: 233, 117, 0;
-    --spectrum-global-color-orange-500: rgb(
-        var(--spectrum-global-color-orange-500-rgb)
-    );
+    --spectrum-global-color-orange-500: rgb(var(--spectrum-global-color-orange-500-rgb));
     --spectrum-global-color-orange-600-rgb: 209, 97, 0;
-    --spectrum-global-color-orange-600: rgb(
-        var(--spectrum-global-color-orange-600-rgb)
-    );
+    --spectrum-global-color-orange-600: rgb(var(--spectrum-global-color-orange-600-rgb));
     --spectrum-global-color-orange-700-rgb: 182, 80, 0;
-    --spectrum-global-color-orange-700: rgb(
-        var(--spectrum-global-color-orange-700-rgb)
-    );
+    --spectrum-global-color-orange-700: rgb(var(--spectrum-global-color-orange-700-rgb));
     --spectrum-global-color-green-400-rgb: 0, 148, 97;
-    --spectrum-global-color-green-400: rgb(
-        var(--spectrum-global-color-green-400-rgb)
-    );
+    --spectrum-global-color-green-400: rgb(var(--spectrum-global-color-green-400-rgb));
     --spectrum-global-color-green-500-rgb: 0, 126, 80;
-    --spectrum-global-color-green-500: rgb(
-        var(--spectrum-global-color-green-500-rgb)
-    );
+    --spectrum-global-color-green-500: rgb(var(--spectrum-global-color-green-500-rgb));
     --spectrum-global-color-green-600-rgb: 0, 105, 65;
-    --spectrum-global-color-green-600: rgb(
-        var(--spectrum-global-color-green-600-rgb)
-    );
+    --spectrum-global-color-green-600: rgb(var(--spectrum-global-color-green-600-rgb));
     --spectrum-global-color-green-700-rgb: 0, 86, 53;
-    --spectrum-global-color-green-700: rgb(
-        var(--spectrum-global-color-green-700-rgb)
-    );
+    --spectrum-global-color-green-700: rgb(var(--spectrum-global-color-green-700-rgb));
     --spectrum-global-color-blue-400-rgb: 27, 127, 245;
-    --spectrum-global-color-blue-400: rgb(
-        var(--spectrum-global-color-blue-400-rgb)
-    );
+    --spectrum-global-color-blue-400: rgb(var(--spectrum-global-color-blue-400-rgb));
     --spectrum-global-color-blue-500-rgb: 4, 105, 227;
-    --spectrum-global-color-blue-500: rgb(
-        var(--spectrum-global-color-blue-500-rgb)
-    );
+    --spectrum-global-color-blue-500: rgb(var(--spectrum-global-color-blue-500-rgb));
     --spectrum-global-color-blue-600-rgb: 0, 87, 190;
-    --spectrum-global-color-blue-600: rgb(
-        var(--spectrum-global-color-blue-600-rgb)
-    );
+    --spectrum-global-color-blue-600: rgb(var(--spectrum-global-color-blue-600-rgb));
     --spectrum-global-color-blue-700-rgb: 0, 72, 153;
-    --spectrum-global-color-blue-700: rgb(
-        var(--spectrum-global-color-blue-700-rgb)
-    );
+    --spectrum-global-color-blue-700: rgb(var(--spectrum-global-color-blue-700-rgb));
     --spectrum-global-color-gray-50-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-50: rgb(
-        var(--spectrum-global-color-gray-50-rgb)
-    );
+    --spectrum-global-color-gray-50: rgb(var(--spectrum-global-color-gray-50-rgb));
     --spectrum-global-color-gray-75-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-75: rgb(
-        var(--spectrum-global-color-gray-75-rgb)
-    );
+    --spectrum-global-color-gray-75: rgb(var(--spectrum-global-color-gray-75-rgb));
     --spectrum-global-color-gray-100-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-100: rgb(
-        var(--spectrum-global-color-gray-100-rgb)
-    );
+    --spectrum-global-color-gray-100: rgb(var(--spectrum-global-color-gray-100-rgb));
     --spectrum-global-color-gray-200-rgb: 235, 235, 235;
-    --spectrum-global-color-gray-200: rgb(
-        var(--spectrum-global-color-gray-200-rgb)
-    );
+    --spectrum-global-color-gray-200: rgb(var(--spectrum-global-color-gray-200-rgb));
     --spectrum-global-color-gray-300-rgb: 217, 217, 217;
-    --spectrum-global-color-gray-300: rgb(
-        var(--spectrum-global-color-gray-300-rgb)
-    );
+    --spectrum-global-color-gray-300: rgb(var(--spectrum-global-color-gray-300-rgb));
     --spectrum-global-color-gray-400-rgb: 179, 179, 179;
-    --spectrum-global-color-gray-400: rgb(
-        var(--spectrum-global-color-gray-400-rgb)
-    );
+    --spectrum-global-color-gray-400: rgb(var(--spectrum-global-color-gray-400-rgb));
     --spectrum-global-color-gray-500-rgb: 146, 146, 146;
-    --spectrum-global-color-gray-500: rgb(
-        var(--spectrum-global-color-gray-500-rgb)
-    );
+    --spectrum-global-color-gray-500: rgb(var(--spectrum-global-color-gray-500-rgb));
     --spectrum-global-color-gray-600-rgb: 110, 110, 110;
-    --spectrum-global-color-gray-600: rgb(
-        var(--spectrum-global-color-gray-600-rgb)
-    );
+    --spectrum-global-color-gray-600: rgb(var(--spectrum-global-color-gray-600-rgb));
     --spectrum-global-color-gray-700-rgb: 71, 71, 71;
-    --spectrum-global-color-gray-700: rgb(
-        var(--spectrum-global-color-gray-700-rgb)
-    );
+    --spectrum-global-color-gray-700: rgb(var(--spectrum-global-color-gray-700-rgb));
     --spectrum-global-color-gray-800-rgb: 34, 34, 34;
-    --spectrum-global-color-gray-800: rgb(
-        var(--spectrum-global-color-gray-800-rgb)
-    );
+    --spectrum-global-color-gray-800: rgb(var(--spectrum-global-color-gray-800-rgb));
     --spectrum-global-color-gray-900-rgb: 0, 0, 0;
-    --spectrum-global-color-gray-900: rgb(
-        var(--spectrum-global-color-gray-900-rgb)
-    );
-    --spectrum-alias-background-color-primary: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-background-color-secondary: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-tertiary: var(
-        --spectrum-global-color-gray-300
-    );
+    --spectrum-global-color-gray-900: rgb(var(--spectrum-global-color-gray-900-rgb));
+    --spectrum-alias-background-color-primary: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-background-color-secondary: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-tertiary: var(--spectrum-global-color-gray-300);
     --spectrum-alias-background-color-modal-overlay: #0006;
     --spectrum-alias-dropshadow-color: #00000026;
     --spectrum-alias-background-color-hover-overlay: #0000000a;
@@ -276,18 +152,10 @@
     --spectrum-alias-highlight-selected-hover: #0469e333;
     --spectrum-alias-text-highlight-color: #0469e333;
     --spectrum-alias-background-color-quickactions: #ffffffe6;
-    --spectrum-alias-border-color-selected: var(
-        --spectrum-global-color-blue-500
-    );
+    --spectrum-alias-border-color-selected: var(--spectrum-global-color-blue-500);
     --spectrum-alias-border-color-translucent: #0000001a;
     --spectrum-alias-radial-reaction-color-default: #2229;
-    --spectrum-alias-pasteboard-background-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-appframe-border-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-appframe-separator-color: var(
-        --spectrum-global-color-gray-300
-    );
+    --spectrum-alias-pasteboard-background-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-appframe-border-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-appframe-separator-color: var(--spectrum-global-color-gray-300);
 }

--- a/tools/styles/spectrum-two/spectrum-core-global.css
+++ b/tools/styles/spectrum-two/spectrum-core-global.css
@@ -21,353 +21,179 @@
     --spectrum-global-color-status: Verified;
     --spectrum-global-color-version: 5.1;
     --spectrum-global-color-static-black-rgb: 0, 0, 0;
-    --spectrum-global-color-static-black: rgb(
-        var(--spectrum-global-color-static-black-rgb)
-    );
+    --spectrum-global-color-static-black: rgb(var(--spectrum-global-color-static-black-rgb));
     --spectrum-global-color-static-white-rgb: 255, 255, 255;
-    --spectrum-global-color-static-white: rgb(
-        var(--spectrum-global-color-static-white-rgb)
-    );
+    --spectrum-global-color-static-white: rgb(var(--spectrum-global-color-static-white-rgb));
     --spectrum-global-color-static-blue-rgb: 0, 87, 191;
-    --spectrum-global-color-static-blue: rgb(
-        var(--spectrum-global-color-static-blue-rgb)
-    );
+    --spectrum-global-color-static-blue: rgb(var(--spectrum-global-color-static-blue-rgb));
     --spectrum-global-color-static-gray-50-rgb: 255, 255, 255;
-    --spectrum-global-color-static-gray-50: rgb(
-        var(--spectrum-global-color-static-gray-50-rgb)
-    );
+    --spectrum-global-color-static-gray-50: rgb(var(--spectrum-global-color-static-gray-50-rgb));
     --spectrum-global-color-static-gray-75-rgb: 255, 255, 255;
-    --spectrum-global-color-static-gray-75: rgb(
-        var(--spectrum-global-color-static-gray-75-rgb)
-    );
+    --spectrum-global-color-static-gray-75: rgb(var(--spectrum-global-color-static-gray-75-rgb));
     --spectrum-global-color-static-gray-100-rgb: 255, 255, 255;
-    --spectrum-global-color-static-gray-100: rgb(
-        var(--spectrum-global-color-static-gray-100-rgb)
-    );
+    --spectrum-global-color-static-gray-100: rgb(var(--spectrum-global-color-static-gray-100-rgb));
     --spectrum-global-color-static-gray-200-rgb: 235, 235, 235;
-    --spectrum-global-color-static-gray-200: rgb(
-        var(--spectrum-global-color-static-gray-200-rgb)
-    );
+    --spectrum-global-color-static-gray-200: rgb(var(--spectrum-global-color-static-gray-200-rgb));
     --spectrum-global-color-static-gray-300-rgb: 217, 217, 217;
-    --spectrum-global-color-static-gray-300: rgb(
-        var(--spectrum-global-color-static-gray-300-rgb)
-    );
+    --spectrum-global-color-static-gray-300: rgb(var(--spectrum-global-color-static-gray-300-rgb));
     --spectrum-global-color-static-gray-400-rgb: 179, 179, 179;
-    --spectrum-global-color-static-gray-400: rgb(
-        var(--spectrum-global-color-static-gray-400-rgb)
-    );
+    --spectrum-global-color-static-gray-400: rgb(var(--spectrum-global-color-static-gray-400-rgb));
     --spectrum-global-color-static-gray-500-rgb: 146, 146, 146;
-    --spectrum-global-color-static-gray-500: rgb(
-        var(--spectrum-global-color-static-gray-500-rgb)
-    );
+    --spectrum-global-color-static-gray-500: rgb(var(--spectrum-global-color-static-gray-500-rgb));
     --spectrum-global-color-static-gray-600-rgb: 110, 110, 110;
-    --spectrum-global-color-static-gray-600: rgb(
-        var(--spectrum-global-color-static-gray-600-rgb)
-    );
+    --spectrum-global-color-static-gray-600: rgb(var(--spectrum-global-color-static-gray-600-rgb));
     --spectrum-global-color-static-gray-700-rgb: 71, 71, 71;
-    --spectrum-global-color-static-gray-700: rgb(
-        var(--spectrum-global-color-static-gray-700-rgb)
-    );
+    --spectrum-global-color-static-gray-700: rgb(var(--spectrum-global-color-static-gray-700-rgb));
     --spectrum-global-color-static-gray-800-rgb: 34, 34, 34;
-    --spectrum-global-color-static-gray-800: rgb(
-        var(--spectrum-global-color-static-gray-800-rgb)
-    );
+    --spectrum-global-color-static-gray-800: rgb(var(--spectrum-global-color-static-gray-800-rgb));
     --spectrum-global-color-static-gray-900-rgb: 0, 0, 0;
-    --spectrum-global-color-static-gray-900: rgb(
-        var(--spectrum-global-color-static-gray-900-rgb)
-    );
+    --spectrum-global-color-static-gray-900: rgb(var(--spectrum-global-color-static-gray-900-rgb));
     --spectrum-global-color-static-red-400-rgb: 237, 64, 48;
-    --spectrum-global-color-static-red-400: rgb(
-        var(--spectrum-global-color-static-red-400-rgb)
-    );
+    --spectrum-global-color-static-red-400: rgb(var(--spectrum-global-color-static-red-400-rgb));
     --spectrum-global-color-static-red-500-rgb: 217, 28, 21;
-    --spectrum-global-color-static-red-500: rgb(
-        var(--spectrum-global-color-static-red-500-rgb)
-    );
+    --spectrum-global-color-static-red-500: rgb(var(--spectrum-global-color-static-red-500-rgb));
     --spectrum-global-color-static-red-600-rgb: 187, 2, 2;
-    --spectrum-global-color-static-red-600: rgb(
-        var(--spectrum-global-color-static-red-600-rgb)
-    );
+    --spectrum-global-color-static-red-600: rgb(var(--spectrum-global-color-static-red-600-rgb));
     --spectrum-global-color-static-red-700-rgb: 154, 0, 0;
-    --spectrum-global-color-static-red-700: rgb(
-        var(--spectrum-global-color-static-red-700-rgb)
-    );
+    --spectrum-global-color-static-red-700: rgb(var(--spectrum-global-color-static-red-700-rgb));
     --spectrum-global-color-static-red-800-rgb: 124, 0, 0;
-    --spectrum-global-color-static-red-800: rgb(
-        var(--spectrum-global-color-static-red-800-rgb)
-    );
+    --spectrum-global-color-static-red-800: rgb(var(--spectrum-global-color-static-red-800-rgb));
     --spectrum-global-color-static-orange-400-rgb: 250, 139, 26;
-    --spectrum-global-color-static-orange-400: rgb(
-        var(--spectrum-global-color-static-orange-400-rgb)
-    );
+    --spectrum-global-color-static-orange-400: rgb(var(--spectrum-global-color-static-orange-400-rgb));
     --spectrum-global-color-static-orange-500-rgb: 233, 117, 0;
-    --spectrum-global-color-static-orange-500: rgb(
-        var(--spectrum-global-color-static-orange-500-rgb)
-    );
+    --spectrum-global-color-static-orange-500: rgb(var(--spectrum-global-color-static-orange-500-rgb));
     --spectrum-global-color-static-orange-600-rgb: 209, 97, 0;
-    --spectrum-global-color-static-orange-600: rgb(
-        var(--spectrum-global-color-static-orange-600-rgb)
-    );
+    --spectrum-global-color-static-orange-600: rgb(var(--spectrum-global-color-static-orange-600-rgb));
     --spectrum-global-color-static-orange-700-rgb: 182, 80, 0;
-    --spectrum-global-color-static-orange-700: rgb(
-        var(--spectrum-global-color-static-orange-700-rgb)
-    );
+    --spectrum-global-color-static-orange-700: rgb(var(--spectrum-global-color-static-orange-700-rgb));
     --spectrum-global-color-static-orange-800-rgb: 155, 64, 0;
-    --spectrum-global-color-static-orange-800: rgb(
-        var(--spectrum-global-color-static-orange-800-rgb)
-    );
+    --spectrum-global-color-static-orange-800: rgb(var(--spectrum-global-color-static-orange-800-rgb));
     --spectrum-global-color-static-yellow-200-rgb: 250, 237, 123;
-    --spectrum-global-color-static-yellow-200: rgb(
-        var(--spectrum-global-color-static-yellow-200-rgb)
-    );
+    --spectrum-global-color-static-yellow-200: rgb(var(--spectrum-global-color-static-yellow-200-rgb));
     --spectrum-global-color-static-yellow-300-rgb: 250, 224, 23;
-    --spectrum-global-color-static-yellow-300: rgb(
-        var(--spectrum-global-color-static-yellow-300-rgb)
-    );
+    --spectrum-global-color-static-yellow-300: rgb(var(--spectrum-global-color-static-yellow-300-rgb));
     --spectrum-global-color-static-yellow-400-rgb: 238, 205, 0;
-    --spectrum-global-color-static-yellow-400: rgb(
-        var(--spectrum-global-color-static-yellow-400-rgb)
-    );
+    --spectrum-global-color-static-yellow-400: rgb(var(--spectrum-global-color-static-yellow-400-rgb));
     --spectrum-global-color-static-yellow-500-rgb: 221, 185, 0;
-    --spectrum-global-color-static-yellow-500: rgb(
-        var(--spectrum-global-color-static-yellow-500-rgb)
-    );
+    --spectrum-global-color-static-yellow-500: rgb(var(--spectrum-global-color-static-yellow-500-rgb));
     --spectrum-global-color-static-yellow-600-rgb: 201, 164, 0;
-    --spectrum-global-color-static-yellow-600: rgb(
-        var(--spectrum-global-color-static-yellow-600-rgb)
-    );
+    --spectrum-global-color-static-yellow-600: rgb(var(--spectrum-global-color-static-yellow-600-rgb));
     --spectrum-global-color-static-yellow-700-rgb: 181, 144, 0;
-    --spectrum-global-color-static-yellow-700: rgb(
-        var(--spectrum-global-color-static-yellow-700-rgb)
-    );
+    --spectrum-global-color-static-yellow-700: rgb(var(--spectrum-global-color-static-yellow-700-rgb));
     --spectrum-global-color-static-yellow-800-rgb: 160, 125, 0;
-    --spectrum-global-color-static-yellow-800: rgb(
-        var(--spectrum-global-color-static-yellow-800-rgb)
-    );
+    --spectrum-global-color-static-yellow-800: rgb(var(--spectrum-global-color-static-yellow-800-rgb));
     --spectrum-global-color-static-chartreuse-300-rgb: 176, 222, 27;
-    --spectrum-global-color-static-chartreuse-300: rgb(
-        var(--spectrum-global-color-static-chartreuse-300-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-300: rgb(var(--spectrum-global-color-static-chartreuse-300-rgb));
     --spectrum-global-color-static-chartreuse-400-rgb: 157, 203, 13;
-    --spectrum-global-color-static-chartreuse-400: rgb(
-        var(--spectrum-global-color-static-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-400: rgb(var(--spectrum-global-color-static-chartreuse-400-rgb));
     --spectrum-global-color-static-chartreuse-500-rgb: 139, 182, 4;
-    --spectrum-global-color-static-chartreuse-500: rgb(
-        var(--spectrum-global-color-static-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-500: rgb(var(--spectrum-global-color-static-chartreuse-500-rgb));
     --spectrum-global-color-static-chartreuse-600-rgb: 122, 162, 0;
-    --spectrum-global-color-static-chartreuse-600: rgb(
-        var(--spectrum-global-color-static-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-600: rgb(var(--spectrum-global-color-static-chartreuse-600-rgb));
     --spectrum-global-color-static-chartreuse-700-rgb: 106, 141, 0;
-    --spectrum-global-color-static-chartreuse-700: rgb(
-        var(--spectrum-global-color-static-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-700: rgb(var(--spectrum-global-color-static-chartreuse-700-rgb));
     --spectrum-global-color-static-chartreuse-800-rgb: 90, 120, 0;
-    --spectrum-global-color-static-chartreuse-800: rgb(
-        var(--spectrum-global-color-static-chartreuse-800-rgb)
-    );
+    --spectrum-global-color-static-chartreuse-800: rgb(var(--spectrum-global-color-static-chartreuse-800-rgb));
     --spectrum-global-color-static-celery-200-rgb: 126, 229, 114;
-    --spectrum-global-color-static-celery-200: rgb(
-        var(--spectrum-global-color-static-celery-200-rgb)
-    );
+    --spectrum-global-color-static-celery-200: rgb(var(--spectrum-global-color-static-celery-200-rgb));
     --spectrum-global-color-static-celery-300-rgb: 87, 212, 86;
-    --spectrum-global-color-static-celery-300: rgb(
-        var(--spectrum-global-color-static-celery-300-rgb)
-    );
+    --spectrum-global-color-static-celery-300: rgb(var(--spectrum-global-color-static-celery-300-rgb));
     --spectrum-global-color-static-celery-400-rgb: 48, 193, 61;
-    --spectrum-global-color-static-celery-400: rgb(
-        var(--spectrum-global-color-static-celery-400-rgb)
-    );
+    --spectrum-global-color-static-celery-400: rgb(var(--spectrum-global-color-static-celery-400-rgb));
     --spectrum-global-color-static-celery-500-rgb: 15, 172, 38;
-    --spectrum-global-color-static-celery-500: rgb(
-        var(--spectrum-global-color-static-celery-500-rgb)
-    );
+    --spectrum-global-color-static-celery-500: rgb(var(--spectrum-global-color-static-celery-500-rgb));
     --spectrum-global-color-static-celery-600-rgb: 0, 150, 20;
-    --spectrum-global-color-static-celery-600: rgb(
-        var(--spectrum-global-color-static-celery-600-rgb)
-    );
+    --spectrum-global-color-static-celery-600: rgb(var(--spectrum-global-color-static-celery-600-rgb));
     --spectrum-global-color-static-celery-700-rgb: 0, 128, 15;
-    --spectrum-global-color-static-celery-700: rgb(
-        var(--spectrum-global-color-static-celery-700-rgb)
-    );
+    --spectrum-global-color-static-celery-700: rgb(var(--spectrum-global-color-static-celery-700-rgb));
     --spectrum-global-color-static-celery-800-rgb: 0, 107, 15;
-    --spectrum-global-color-static-celery-800: rgb(
-        var(--spectrum-global-color-static-celery-800-rgb)
-    );
+    --spectrum-global-color-static-celery-800: rgb(var(--spectrum-global-color-static-celery-800-rgb));
     --spectrum-global-color-static-green-400-rgb: 29, 169, 115;
-    --spectrum-global-color-static-green-400: rgb(
-        var(--spectrum-global-color-static-green-400-rgb)
-    );
+    --spectrum-global-color-static-green-400: rgb(var(--spectrum-global-color-static-green-400-rgb));
     --spectrum-global-color-static-green-500-rgb: 0, 148, 97;
-    --spectrum-global-color-static-green-500: rgb(
-        var(--spectrum-global-color-static-green-500-rgb)
-    );
+    --spectrum-global-color-static-green-500: rgb(var(--spectrum-global-color-static-green-500-rgb));
     --spectrum-global-color-static-green-600-rgb: 0, 126, 80;
-    --spectrum-global-color-static-green-600: rgb(
-        var(--spectrum-global-color-static-green-600-rgb)
-    );
+    --spectrum-global-color-static-green-600: rgb(var(--spectrum-global-color-static-green-600-rgb));
     --spectrum-global-color-static-green-700-rgb: 0, 105, 65;
-    --spectrum-global-color-static-green-700: rgb(
-        var(--spectrum-global-color-static-green-700-rgb)
-    );
+    --spectrum-global-color-static-green-700: rgb(var(--spectrum-global-color-static-green-700-rgb));
     --spectrum-global-color-static-green-800-rgb: 0, 86, 53;
-    --spectrum-global-color-static-green-800: rgb(
-        var(--spectrum-global-color-static-green-800-rgb)
-    );
+    --spectrum-global-color-static-green-800: rgb(var(--spectrum-global-color-static-green-800-rgb));
     --spectrum-global-color-static-seafoam-200-rgb: 75, 206, 199;
-    --spectrum-global-color-static-seafoam-200: rgb(
-        var(--spectrum-global-color-static-seafoam-200-rgb)
-    );
+    --spectrum-global-color-static-seafoam-200: rgb(var(--spectrum-global-color-static-seafoam-200-rgb));
     --spectrum-global-color-static-seafoam-300-rgb: 32, 187, 180;
-    --spectrum-global-color-static-seafoam-300: rgb(
-        var(--spectrum-global-color-static-seafoam-300-rgb)
-    );
+    --spectrum-global-color-static-seafoam-300: rgb(var(--spectrum-global-color-static-seafoam-300-rgb));
     --spectrum-global-color-static-seafoam-400-rgb: 0, 166, 160;
-    --spectrum-global-color-static-seafoam-400: rgb(
-        var(--spectrum-global-color-static-seafoam-400-rgb)
-    );
+    --spectrum-global-color-static-seafoam-400: rgb(var(--spectrum-global-color-static-seafoam-400-rgb));
     --spectrum-global-color-static-seafoam-500-rgb: 0, 145, 139;
-    --spectrum-global-color-static-seafoam-500: rgb(
-        var(--spectrum-global-color-static-seafoam-500-rgb)
-    );
+    --spectrum-global-color-static-seafoam-500: rgb(var(--spectrum-global-color-static-seafoam-500-rgb));
     --spectrum-global-color-static-seafoam-600-rgb: 0, 124, 118;
-    --spectrum-global-color-static-seafoam-600: rgb(
-        var(--spectrum-global-color-static-seafoam-600-rgb)
-    );
+    --spectrum-global-color-static-seafoam-600: rgb(var(--spectrum-global-color-static-seafoam-600-rgb));
     --spectrum-global-color-static-seafoam-700-rgb: 0, 103, 99;
-    --spectrum-global-color-static-seafoam-700: rgb(
-        var(--spectrum-global-color-static-seafoam-700-rgb)
-    );
+    --spectrum-global-color-static-seafoam-700: rgb(var(--spectrum-global-color-static-seafoam-700-rgb));
     --spectrum-global-color-static-seafoam-800-rgb: 10, 83, 80;
-    --spectrum-global-color-static-seafoam-800: rgb(
-        var(--spectrum-global-color-static-seafoam-800-rgb)
-    );
+    --spectrum-global-color-static-seafoam-800: rgb(var(--spectrum-global-color-static-seafoam-800-rgb));
     --spectrum-global-color-static-blue-200-rgb: 130, 193, 251;
-    --spectrum-global-color-static-blue-200: rgb(
-        var(--spectrum-global-color-static-blue-200-rgb)
-    );
+    --spectrum-global-color-static-blue-200: rgb(var(--spectrum-global-color-static-blue-200-rgb));
     --spectrum-global-color-static-blue-300-rgb: 98, 173, 247;
-    --spectrum-global-color-static-blue-300: rgb(
-        var(--spectrum-global-color-static-blue-300-rgb)
-    );
+    --spectrum-global-color-static-blue-300: rgb(var(--spectrum-global-color-static-blue-300-rgb));
     --spectrum-global-color-static-blue-400-rgb: 66, 151, 244;
-    --spectrum-global-color-static-blue-400: rgb(
-        var(--spectrum-global-color-static-blue-400-rgb)
-    );
+    --spectrum-global-color-static-blue-400: rgb(var(--spectrum-global-color-static-blue-400-rgb));
     --spectrum-global-color-static-blue-500-rgb: 27, 127, 245;
-    --spectrum-global-color-static-blue-500: rgb(
-        var(--spectrum-global-color-static-blue-500-rgb)
-    );
+    --spectrum-global-color-static-blue-500: rgb(var(--spectrum-global-color-static-blue-500-rgb));
     --spectrum-global-color-static-blue-600-rgb: 4, 105, 227;
-    --spectrum-global-color-static-blue-600: rgb(
-        var(--spectrum-global-color-static-blue-600-rgb)
-    );
+    --spectrum-global-color-static-blue-600: rgb(var(--spectrum-global-color-static-blue-600-rgb));
     --spectrum-global-color-static-blue-700-rgb: 0, 87, 190;
-    --spectrum-global-color-static-blue-700: rgb(
-        var(--spectrum-global-color-static-blue-700-rgb)
-    );
+    --spectrum-global-color-static-blue-700: rgb(var(--spectrum-global-color-static-blue-700-rgb));
     --spectrum-global-color-static-blue-800-rgb: 0, 72, 153;
-    --spectrum-global-color-static-blue-800: rgb(
-        var(--spectrum-global-color-static-blue-800-rgb)
-    );
+    --spectrum-global-color-static-blue-800: rgb(var(--spectrum-global-color-static-blue-800-rgb));
     --spectrum-global-color-static-indigo-200-rgb: 178, 181, 255;
-    --spectrum-global-color-static-indigo-200: rgb(
-        var(--spectrum-global-color-static-indigo-200-rgb)
-    );
+    --spectrum-global-color-static-indigo-200: rgb(var(--spectrum-global-color-static-indigo-200-rgb));
     --spectrum-global-color-static-indigo-300-rgb: 155, 159, 255;
-    --spectrum-global-color-static-indigo-300: rgb(
-        var(--spectrum-global-color-static-indigo-300-rgb)
-    );
+    --spectrum-global-color-static-indigo-300: rgb(var(--spectrum-global-color-static-indigo-300-rgb));
     --spectrum-global-color-static-indigo-400-rgb: 132, 137, 253;
-    --spectrum-global-color-static-indigo-400: rgb(
-        var(--spectrum-global-color-static-indigo-400-rgb)
-    );
+    --spectrum-global-color-static-indigo-400: rgb(var(--spectrum-global-color-static-indigo-400-rgb));
     --spectrum-global-color-static-indigo-500-rgb: 109, 115, 246;
-    --spectrum-global-color-static-indigo-500: rgb(
-        var(--spectrum-global-color-static-indigo-500-rgb)
-    );
+    --spectrum-global-color-static-indigo-500: rgb(var(--spectrum-global-color-static-indigo-500-rgb));
     --spectrum-global-color-static-indigo-600-rgb: 87, 93, 232;
-    --spectrum-global-color-static-indigo-600: rgb(
-        var(--spectrum-global-color-static-indigo-600-rgb)
-    );
+    --spectrum-global-color-static-indigo-600: rgb(var(--spectrum-global-color-static-indigo-600-rgb));
     --spectrum-global-color-static-indigo-700-rgb: 68, 74, 208;
-    --spectrum-global-color-static-indigo-700: rgb(
-        var(--spectrum-global-color-static-indigo-700-rgb)
-    );
+    --spectrum-global-color-static-indigo-700: rgb(var(--spectrum-global-color-static-indigo-700-rgb));
     --spectrum-global-color-static-indigo-800-rgb: 68, 74, 208;
-    --spectrum-global-color-static-indigo-800: rgb(
-        var(--spectrum-global-color-static-indigo-800-rgb)
-    );
+    --spectrum-global-color-static-indigo-800: rgb(var(--spectrum-global-color-static-indigo-800-rgb));
     --spectrum-global-color-static-purple-400-rgb: 178, 121, 250;
-    --spectrum-global-color-static-purple-400: rgb(
-        var(--spectrum-global-color-static-purple-400-rgb)
-    );
+    --spectrum-global-color-static-purple-400: rgb(var(--spectrum-global-color-static-purple-400-rgb));
     --spectrum-global-color-static-purple-500-rgb: 161, 93, 246;
-    --spectrum-global-color-static-purple-500: rgb(
-        var(--spectrum-global-color-static-purple-500-rgb)
-    );
+    --spectrum-global-color-static-purple-500: rgb(var(--spectrum-global-color-static-purple-500-rgb));
     --spectrum-global-color-static-purple-600-rgb: 142, 67, 234;
-    --spectrum-global-color-static-purple-600: rgb(
-        var(--spectrum-global-color-static-purple-600-rgb)
-    );
+    --spectrum-global-color-static-purple-600: rgb(var(--spectrum-global-color-static-purple-600-rgb));
     --spectrum-global-color-static-purple-700-rgb: 120, 43, 216;
-    --spectrum-global-color-static-purple-700: rgb(
-        var(--spectrum-global-color-static-purple-700-rgb)
-    );
+    --spectrum-global-color-static-purple-700: rgb(var(--spectrum-global-color-static-purple-700-rgb));
     --spectrum-global-color-static-purple-800-rgb: 98, 23, 190;
-    --spectrum-global-color-static-purple-800: rgb(
-        var(--spectrum-global-color-static-purple-800-rgb)
-    );
+    --spectrum-global-color-static-purple-800: rgb(var(--spectrum-global-color-static-purple-800-rgb));
     --spectrum-global-color-static-fuchsia-400-rgb: 228, 93, 230;
-    --spectrum-global-color-static-fuchsia-400: rgb(
-        var(--spectrum-global-color-static-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-400: rgb(var(--spectrum-global-color-static-fuchsia-400-rgb));
     --spectrum-global-color-static-fuchsia-500-rgb: 211, 63, 212;
-    --spectrum-global-color-static-fuchsia-500: rgb(
-        var(--spectrum-global-color-static-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-500: rgb(var(--spectrum-global-color-static-fuchsia-500-rgb));
     --spectrum-global-color-static-fuchsia-600-rgb: 188, 39, 187;
-    --spectrum-global-color-static-fuchsia-600: rgb(
-        var(--spectrum-global-color-static-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-600: rgb(var(--spectrum-global-color-static-fuchsia-600-rgb));
     --spectrum-global-color-static-fuchsia-700-rgb: 163, 10, 163;
-    --spectrum-global-color-static-fuchsia-700: rgb(
-        var(--spectrum-global-color-static-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-700: rgb(var(--spectrum-global-color-static-fuchsia-700-rgb));
     --spectrum-global-color-static-fuchsia-800-rgb: 135, 0, 136;
-    --spectrum-global-color-static-fuchsia-800: rgb(
-        var(--spectrum-global-color-static-fuchsia-800-rgb)
-    );
+    --spectrum-global-color-static-fuchsia-800: rgb(var(--spectrum-global-color-static-fuchsia-800-rgb));
     --spectrum-global-color-static-magenta-200-rgb: 253, 127, 175;
-    --spectrum-global-color-static-magenta-200: rgb(
-        var(--spectrum-global-color-static-magenta-200-rgb)
-    );
+    --spectrum-global-color-static-magenta-200: rgb(var(--spectrum-global-color-static-magenta-200-rgb));
     --spectrum-global-color-static-magenta-300-rgb: 242, 98, 157;
-    --spectrum-global-color-static-magenta-300: rgb(
-        var(--spectrum-global-color-static-magenta-300-rgb)
-    );
+    --spectrum-global-color-static-magenta-300: rgb(var(--spectrum-global-color-static-magenta-300-rgb));
     --spectrum-global-color-static-magenta-400-rgb: 226, 68, 135;
-    --spectrum-global-color-static-magenta-400: rgb(
-        var(--spectrum-global-color-static-magenta-400-rgb)
-    );
+    --spectrum-global-color-static-magenta-400: rgb(var(--spectrum-global-color-static-magenta-400-rgb));
     --spectrum-global-color-static-magenta-500-rgb: 205, 40, 111;
-    --spectrum-global-color-static-magenta-500: rgb(
-        var(--spectrum-global-color-static-magenta-500-rgb)
-    );
+    --spectrum-global-color-static-magenta-500: rgb(var(--spectrum-global-color-static-magenta-500-rgb));
     --spectrum-global-color-static-magenta-600-rgb: 179, 15, 89;
-    --spectrum-global-color-static-magenta-600: rgb(
-        var(--spectrum-global-color-static-magenta-600-rgb)
-    );
+    --spectrum-global-color-static-magenta-600: rgb(var(--spectrum-global-color-static-magenta-600-rgb));
     --spectrum-global-color-static-magenta-700-rgb: 149, 0, 72;
-    --spectrum-global-color-static-magenta-700: rgb(
-        var(--spectrum-global-color-static-magenta-700-rgb)
-    );
+    --spectrum-global-color-static-magenta-700: rgb(var(--spectrum-global-color-static-magenta-700-rgb));
     --spectrum-global-color-static-magenta-800-rgb: 119, 0, 58;
-    --spectrum-global-color-static-magenta-800: rgb(
-        var(--spectrum-global-color-static-magenta-800-rgb)
-    );
+    --spectrum-global-color-static-magenta-800: rgb(var(--spectrum-global-color-static-magenta-800-rgb));
     --spectrum-global-color-static-transparent-white-200: #ffffff1a;
     --spectrum-global-color-static-transparent-white-300: #ffffff40;
     --spectrum-global-color-static-transparent-white-400: #fff6;
@@ -376,9 +202,7 @@
     --spectrum-global-color-static-transparent-white-700: #fffc;
     --spectrum-global-color-static-transparent-white-800: #ffffffe6;
     --spectrum-global-color-static-transparent-white-900-rgb: 255, 255, 255;
-    --spectrum-global-color-static-transparent-white-900: rgb(
-        var(--spectrum-global-color-static-transparent-white-900-rgb)
-    );
+    --spectrum-global-color-static-transparent-white-900: rgb(var(--spectrum-global-color-static-transparent-white-900-rgb));
     --spectrum-global-color-static-transparent-black-200: #0000001a;
     --spectrum-global-color-static-transparent-black-300: #00000040;
     --spectrum-global-color-static-transparent-black-400: #0006;
@@ -387,271 +211,97 @@
     --spectrum-global-color-static-transparent-black-700: #000c;
     --spectrum-global-color-static-transparent-black-800: #000000e6;
     --spectrum-global-color-static-transparent-black-900-rgb: 0, 0, 0;
-    --spectrum-global-color-static-transparent-black-900: rgb(
-        var(--spectrum-global-color-static-transparent-black-900-rgb)
-    );
-    --spectrum-global-color-sequential-cerulean: #e9fff1, #c8f1e4, #a5e3d7,
-        #82d5ca, #68c5c1, #54b4ba, #3fa2b2, #2991ac, #2280a2, #1f6d98, #1d5c8d,
-        #1a4b83, #1a3979, #1a266f, #191264, #180057;
-    --spectrum-global-color-sequential-forest: #ffffdf, #e2f6ba, #c4eb95,
-        #a4e16d, #8dd366, #77c460, #5fb65a, #48a754, #36984f, #2c894d, #237a4a,
-        #196b47, #105c45, #094d41, #033f3e, #00313a;
-    --spectrum-global-color-sequential-rose: #fff4dd, #ffddd7, #ffc5d2, #feaecb,
-        #fa96c4, #f57ebd, #ef64b5, #e846ad, #d238a1, #bb2e96, #a3248c, #8a1b83,
-        #71167c, #560f74, #370b6e, #000968;
-    --spectrum-global-color-diverging-orange-yellow-seafoam: #580000, #79260b,
-        #9c4511, #bd651a, #dd8629, #f5ad52, #fed693, #ffffe0, #bbe4d1, #76c7be,
-        #3ea8a6, #208288, #076769, #00494b, #002c2d;
-    --spectrum-global-color-diverging-red-yellow-blue: #4a001e, #751232, #a52747,
-        #c65154, #e47961, #f0a882, #fad4ac, #ffffe0, #bce2cf, #89c0c4, #579eb9,
-        #397aa8, #1c5796, #163771, #10194d;
-    --spectrum-global-color-diverging-red-blue: #4a001e, #731331, #9f2945,
-        #cc415a, #e06e85, #ed9ab0, #f8c3d9, #faf0ff, #c6d0f2, #92b2de, #5d94cb,
-        #2f74b3, #265191, #163670, #0b194c;
-    --spectrum-semantic-negative-background-color: var(
-        --spectrum-global-color-static-red-600
-    );
-    --spectrum-semantic-negative-color-default: var(
-        --spectrum-global-color-red-500
-    );
-    --spectrum-semantic-negative-color-hover: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-color-dark: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-border-color: var(
-        --spectrum-global-color-red-400
-    );
-    --spectrum-semantic-negative-icon-color: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-status-color: var(
-        --spectrum-global-color-red-400
-    );
-    --spectrum-semantic-negative-text-color-large: var(
-        --spectrum-global-color-red-500
-    );
-    --spectrum-semantic-negative-text-color-small: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-text-color-small-hover: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-semantic-negative-text-color-small-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-semantic-negative-text-color-small-key-focus: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-semantic-negative-color-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-semantic-negative-color-key-focus: var(
-        --spectrum-global-color-red-400
-    );
-    --spectrum-semantic-negative-background-color-default: var(
-        --spectrum-global-color-static-red-600
-    );
-    --spectrum-semantic-negative-background-color-hover: var(
-        --spectrum-global-color-static-red-700
-    );
-    --spectrum-semantic-negative-background-color-down: var(
-        --spectrum-global-color-static-red-800
-    );
-    --spectrum-semantic-negative-background-color-key-focus: var(
-        --spectrum-global-color-static-red-700
-    );
-    --spectrum-semantic-notice-background-color: var(
-        --spectrum-global-color-static-orange-600
-    );
-    --spectrum-semantic-notice-color-default: var(
-        --spectrum-global-color-orange-500
-    );
-    --spectrum-semantic-notice-color-dark: var(
-        --spectrum-global-color-orange-600
-    );
-    --spectrum-semantic-notice-border-color: var(
-        --spectrum-global-color-orange-400
-    );
-    --spectrum-semantic-notice-icon-color: var(
-        --spectrum-global-color-orange-600
-    );
-    --spectrum-semantic-notice-status-color: var(
-        --spectrum-global-color-orange-400
-    );
-    --spectrum-semantic-notice-text-color-large: var(
-        --spectrum-global-color-orange-500
-    );
-    --spectrum-semantic-notice-text-color-small: var(
-        --spectrum-global-color-orange-600
-    );
-    --spectrum-semantic-notice-color-down: var(
-        --spectrum-global-color-orange-700
-    );
-    --spectrum-semantic-notice-color-key-focus: var(
-        --spectrum-global-color-orange-400
-    );
-    --spectrum-semantic-notice-background-color-default: var(
-        --spectrum-global-color-static-orange-600
-    );
-    --spectrum-semantic-notice-background-color-hover: var(
-        --spectrum-global-color-static-orange-700
-    );
-    --spectrum-semantic-notice-background-color-down: var(
-        --spectrum-global-color-static-orange-800
-    );
-    --spectrum-semantic-notice-background-color-key-focus: var(
-        --spectrum-global-color-static-orange-700
-    );
-    --spectrum-semantic-positive-background-color: var(
-        --spectrum-global-color-static-green-600
-    );
-    --spectrum-semantic-positive-color-default: var(
-        --spectrum-global-color-green-500
-    );
-    --spectrum-semantic-positive-color-dark: var(
-        --spectrum-global-color-green-600
-    );
-    --spectrum-semantic-positive-border-color: var(
-        --spectrum-global-color-green-400
-    );
-    --spectrum-semantic-positive-icon-color: var(
-        --spectrum-global-color-green-600
-    );
-    --spectrum-semantic-positive-status-color: var(
-        --spectrum-global-color-green-400
-    );
-    --spectrum-semantic-positive-text-color-large: var(
-        --spectrum-global-color-green-500
-    );
-    --spectrum-semantic-positive-text-color-small: var(
-        --spectrum-global-color-green-600
-    );
-    --spectrum-semantic-positive-color-down: var(
-        --spectrum-global-color-green-700
-    );
-    --spectrum-semantic-positive-color-key-focus: var(
-        --spectrum-global-color-green-400
-    );
-    --spectrum-semantic-positive-background-color-default: var(
-        --spectrum-global-color-static-green-600
-    );
-    --spectrum-semantic-positive-background-color-hover: var(
-        --spectrum-global-color-static-green-700
-    );
-    --spectrum-semantic-positive-background-color-down: var(
-        --spectrum-global-color-static-green-800
-    );
-    --spectrum-semantic-positive-background-color-key-focus: var(
-        --spectrum-global-color-static-green-700
-    );
-    --spectrum-semantic-informative-background-color: var(
-        --spectrum-global-color-static-blue-600
-    );
-    --spectrum-semantic-informative-color-default: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-semantic-informative-color-dark: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-informative-border-color: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-semantic-informative-icon-color: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-informative-status-color: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-semantic-informative-text-color-large: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-semantic-informative-text-color-small: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-informative-color-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-semantic-informative-color-key-focus: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-semantic-informative-background-color-default: var(
-        --spectrum-global-color-static-blue-600
-    );
-    --spectrum-semantic-informative-background-color-hover: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-informative-background-color-down: var(
-        --spectrum-global-color-static-blue-800
-    );
-    --spectrum-semantic-informative-background-color-key-focus: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-cta-background-color-default: var(
-        --spectrum-global-color-static-blue-600
-    );
-    --spectrum-semantic-cta-background-color-hover: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-cta-background-color-down: var(
-        --spectrum-global-color-static-blue-800
-    );
-    --spectrum-semantic-cta-background-color-key-focus: var(
-        --spectrum-global-color-static-blue-700
-    );
-    --spectrum-semantic-emphasized-border-color-default: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-semantic-emphasized-border-color-hover: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-emphasized-border-color-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-semantic-emphasized-border-color-key-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-semantic-neutral-background-color-default: var(
-        --spectrum-global-color-static-gray-700
-    );
-    --spectrum-semantic-neutral-background-color-hover: var(
-        --spectrum-global-color-static-gray-800
-    );
-    --spectrum-semantic-neutral-background-color-down: var(
-        --spectrum-global-color-static-gray-900
-    );
-    --spectrum-semantic-neutral-background-color-key-focus: var(
-        --spectrum-global-color-static-gray-800
-    );
-    --spectrum-semantic-presence-color-1: var(
-        --spectrum-global-color-static-red-500
-    );
-    --spectrum-semantic-presence-color-2: var(
-        --spectrum-global-color-static-orange-400
-    );
-    --spectrum-semantic-presence-color-3: var(
-        --spectrum-global-color-static-yellow-400
-    );
+    --spectrum-global-color-static-transparent-black-900: rgb(var(--spectrum-global-color-static-transparent-black-900-rgb));
+    --spectrum-global-color-sequential-cerulean: #e9fff1, #c8f1e4, #a5e3d7, #82d5ca, #68c5c1, #54b4ba, #3fa2b2, #2991ac, #2280a2, #1f6d98, #1d5c8d, #1a4b83, #1a3979, #1a266f, #191264, #180057;
+    --spectrum-global-color-sequential-forest: #ffffdf, #e2f6ba, #c4eb95, #a4e16d, #8dd366, #77c460, #5fb65a, #48a754, #36984f, #2c894d, #237a4a, #196b47, #105c45, #094d41, #033f3e, #00313a;
+    --spectrum-global-color-sequential-rose: #fff4dd, #ffddd7, #ffc5d2, #feaecb, #fa96c4, #f57ebd, #ef64b5, #e846ad, #d238a1, #bb2e96, #a3248c, #8a1b83, #71167c, #560f74, #370b6e, #000968;
+    --spectrum-global-color-diverging-orange-yellow-seafoam: #580000, #79260b, #9c4511, #bd651a, #dd8629, #f5ad52, #fed693, #ffffe0, #bbe4d1, #76c7be, #3ea8a6, #208288, #076769, #00494b, #002c2d;
+    --spectrum-global-color-diverging-red-yellow-blue: #4a001e, #751232, #a52747, #c65154, #e47961, #f0a882, #fad4ac, #ffffe0, #bce2cf, #89c0c4, #579eb9, #397aa8, #1c5796, #163771, #10194d;
+    --spectrum-global-color-diverging-red-blue: #4a001e, #731331, #9f2945, #cc415a, #e06e85, #ed9ab0, #f8c3d9, #faf0ff, #c6d0f2, #92b2de, #5d94cb, #2f74b3, #265191, #163670, #0b194c;
+    --spectrum-semantic-negative-background-color: var(--spectrum-global-color-static-red-600);
+    --spectrum-semantic-negative-color-default: var(--spectrum-global-color-red-500);
+    --spectrum-semantic-negative-color-hover: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-color-dark: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-border-color: var(--spectrum-global-color-red-400);
+    --spectrum-semantic-negative-icon-color: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-status-color: var(--spectrum-global-color-red-400);
+    --spectrum-semantic-negative-text-color-large: var(--spectrum-global-color-red-500);
+    --spectrum-semantic-negative-text-color-small: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-text-color-small-hover: var(--spectrum-global-color-red-700);
+    --spectrum-semantic-negative-text-color-small-down: var(--spectrum-global-color-red-700);
+    --spectrum-semantic-negative-text-color-small-key-focus: var(--spectrum-global-color-red-600);
+    --spectrum-semantic-negative-color-down: var(--spectrum-global-color-red-700);
+    --spectrum-semantic-negative-color-key-focus: var(--spectrum-global-color-red-400);
+    --spectrum-semantic-negative-background-color-default: var(--spectrum-global-color-static-red-600);
+    --spectrum-semantic-negative-background-color-hover: var(--spectrum-global-color-static-red-700);
+    --spectrum-semantic-negative-background-color-down: var(--spectrum-global-color-static-red-800);
+    --spectrum-semantic-negative-background-color-key-focus: var(--spectrum-global-color-static-red-700);
+    --spectrum-semantic-notice-background-color: var(--spectrum-global-color-static-orange-600);
+    --spectrum-semantic-notice-color-default: var(--spectrum-global-color-orange-500);
+    --spectrum-semantic-notice-color-dark: var(--spectrum-global-color-orange-600);
+    --spectrum-semantic-notice-border-color: var(--spectrum-global-color-orange-400);
+    --spectrum-semantic-notice-icon-color: var(--spectrum-global-color-orange-600);
+    --spectrum-semantic-notice-status-color: var(--spectrum-global-color-orange-400);
+    --spectrum-semantic-notice-text-color-large: var(--spectrum-global-color-orange-500);
+    --spectrum-semantic-notice-text-color-small: var(--spectrum-global-color-orange-600);
+    --spectrum-semantic-notice-color-down: var(--spectrum-global-color-orange-700);
+    --spectrum-semantic-notice-color-key-focus: var(--spectrum-global-color-orange-400);
+    --spectrum-semantic-notice-background-color-default: var(--spectrum-global-color-static-orange-600);
+    --spectrum-semantic-notice-background-color-hover: var(--spectrum-global-color-static-orange-700);
+    --spectrum-semantic-notice-background-color-down: var(--spectrum-global-color-static-orange-800);
+    --spectrum-semantic-notice-background-color-key-focus: var(--spectrum-global-color-static-orange-700);
+    --spectrum-semantic-positive-background-color: var(--spectrum-global-color-static-green-600);
+    --spectrum-semantic-positive-color-default: var(--spectrum-global-color-green-500);
+    --spectrum-semantic-positive-color-dark: var(--spectrum-global-color-green-600);
+    --spectrum-semantic-positive-border-color: var(--spectrum-global-color-green-400);
+    --spectrum-semantic-positive-icon-color: var(--spectrum-global-color-green-600);
+    --spectrum-semantic-positive-status-color: var(--spectrum-global-color-green-400);
+    --spectrum-semantic-positive-text-color-large: var(--spectrum-global-color-green-500);
+    --spectrum-semantic-positive-text-color-small: var(--spectrum-global-color-green-600);
+    --spectrum-semantic-positive-color-down: var(--spectrum-global-color-green-700);
+    --spectrum-semantic-positive-color-key-focus: var(--spectrum-global-color-green-400);
+    --spectrum-semantic-positive-background-color-default: var(--spectrum-global-color-static-green-600);
+    --spectrum-semantic-positive-background-color-hover: var(--spectrum-global-color-static-green-700);
+    --spectrum-semantic-positive-background-color-down: var(--spectrum-global-color-static-green-800);
+    --spectrum-semantic-positive-background-color-key-focus: var(--spectrum-global-color-static-green-700);
+    --spectrum-semantic-informative-background-color: var(--spectrum-global-color-static-blue-600);
+    --spectrum-semantic-informative-color-default: var(--spectrum-global-color-blue-500);
+    --spectrum-semantic-informative-color-dark: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-informative-border-color: var(--spectrum-global-color-blue-400);
+    --spectrum-semantic-informative-icon-color: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-informative-status-color: var(--spectrum-global-color-blue-400);
+    --spectrum-semantic-informative-text-color-large: var(--spectrum-global-color-blue-500);
+    --spectrum-semantic-informative-text-color-small: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-informative-color-down: var(--spectrum-global-color-blue-700);
+    --spectrum-semantic-informative-color-key-focus: var(--spectrum-global-color-blue-400);
+    --spectrum-semantic-informative-background-color-default: var(--spectrum-global-color-static-blue-600);
+    --spectrum-semantic-informative-background-color-hover: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-informative-background-color-down: var(--spectrum-global-color-static-blue-800);
+    --spectrum-semantic-informative-background-color-key-focus: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-cta-background-color-default: var(--spectrum-global-color-static-blue-600);
+    --spectrum-semantic-cta-background-color-hover: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-cta-background-color-down: var(--spectrum-global-color-static-blue-800);
+    --spectrum-semantic-cta-background-color-key-focus: var(--spectrum-global-color-static-blue-700);
+    --spectrum-semantic-emphasized-border-color-default: var(--spectrum-global-color-blue-500);
+    --spectrum-semantic-emphasized-border-color-hover: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-emphasized-border-color-down: var(--spectrum-global-color-blue-700);
+    --spectrum-semantic-emphasized-border-color-key-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-semantic-neutral-background-color-default: var(--spectrum-global-color-static-gray-700);
+    --spectrum-semantic-neutral-background-color-hover: var(--spectrum-global-color-static-gray-800);
+    --spectrum-semantic-neutral-background-color-down: var(--spectrum-global-color-static-gray-900);
+    --spectrum-semantic-neutral-background-color-key-focus: var(--spectrum-global-color-static-gray-800);
+    --spectrum-semantic-presence-color-1: var(--spectrum-global-color-static-red-500);
+    --spectrum-semantic-presence-color-2: var(--spectrum-global-color-static-orange-400);
+    --spectrum-semantic-presence-color-3: var(--spectrum-global-color-static-yellow-400);
     --spectrum-semantic-presence-color-4-rgb: 75, 204, 162;
-    --spectrum-semantic-presence-color-4: rgb(
-        var(--spectrum-semantic-presence-color-4-rgb)
-    );
+    --spectrum-semantic-presence-color-4: rgb(var(--spectrum-semantic-presence-color-4-rgb));
     --spectrum-semantic-presence-color-5-rgb: 0, 199, 255;
-    --spectrum-semantic-presence-color-5: rgb(
-        var(--spectrum-semantic-presence-color-5-rgb)
-    );
+    --spectrum-semantic-presence-color-5: rgb(var(--spectrum-semantic-presence-color-5-rgb));
     --spectrum-semantic-presence-color-6-rgb: 0, 140, 184;
-    --spectrum-semantic-presence-color-6: rgb(
-        var(--spectrum-semantic-presence-color-6-rgb)
-    );
+    --spectrum-semantic-presence-color-6: rgb(var(--spectrum-semantic-presence-color-6-rgb));
     --spectrum-semantic-presence-color-7-rgb: 126, 75, 243;
-    --spectrum-semantic-presence-color-7: rgb(
-        var(--spectrum-semantic-presence-color-7-rgb)
-    );
-    --spectrum-semantic-presence-color-8: var(
-        --spectrum-global-color-static-fuchsia-600
-    );
+    --spectrum-semantic-presence-color-7: rgb(var(--spectrum-semantic-presence-color-7-rgb));
+    --spectrum-semantic-presence-color-8: var(--spectrum-global-color-static-fuchsia-600);
     --spectrum-global-dimension-static-percent-50: 50%;
     --spectrum-global-dimension-static-percent-70: 70%;
     --spectrum-global-dimension-static-percent-100: 100%;
@@ -723,12 +373,9 @@
     --spectrum-global-dimension-static-font-size-800: 32px;
     --spectrum-global-dimension-static-font-size-900: 36px;
     --spectrum-global-dimension-static-font-size-1000: 40px;
-    --spectrum-global-font-family-base: adobe-clean, 'Source Sans Pro',
-        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu,
-        'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-global-font-family-serif: adobe-clean-serif, 'Source Serif Pro',
-        Georgia, serif;
-    --spectrum-global-font-family-code: 'Source Code Pro', Monaco, monospace;
+    --spectrum-global-font-family-base: adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-global-font-family-serif: adobe-clean-serif, "Source Serif Pro", Georgia, serif;
+    --spectrum-global-font-family-code: "Source Code Pro", Monaco, monospace;
     --spectrum-global-font-weight-thin: 100;
     --spectrum-global-font-weight-ultra-light: 200;
     --spectrum-global-font-weight-light: 300;
@@ -750,313 +397,112 @@
     --spectrum-global-font-multiplier-0: 0em;
     --spectrum-global-font-multiplier-25: 0.25em;
     --spectrum-global-font-multiplier-75: 0.75em;
-    --spectrum-global-font-font-family-ar: myriad-arabic, adobe-clean,
-        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-global-font-font-family-he: myriad-hebrew, adobe-clean,
-        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-global-font-font-family-zh: adobe-clean-han-traditional,
-        source-han-traditional, 'MingLiu', 'Heiti TC Light', 'sans-serif';
-    --spectrum-global-font-font-family-zhhans: adobe-clean-han-simplified-c,
-        source-han-simplified-c, 'SimSun', 'Heiti SC Light', 'sans-serif';
-    --spectrum-global-font-font-family-ko: adobe-clean-han-korean,
-        source-han-korean, 'Malgun Gothic', 'Apple Gothic', 'sans-serif';
-    --spectrum-global-font-font-family-ja: adobe-clean-han-japanese,
-        'Hiragino Kaku Gothic ProN', 'ヒラギノ角ゴ ProN W3', 'Osaka', YuGothic,
-        'Yu Gothic', 'メイリオ', Meiryo, 'ＭＳ Ｐゴシック', 'MS PGothic',
-        'sans-serif';
-    --spectrum-global-font-font-family-condensed: adobe-clean-han-traditional,
-        source-han-traditional, 'MingLiu', 'Heiti TC Light', adobe-clean,
-        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
-    --spectrum-alias-border-size-thin: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-border-size-thick: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-size-thicker: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-size-thickest: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thin: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-offset-thick: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-offset-thicker: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thickest: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-baseline: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-grid-gutter-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-gutter-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-gutter-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-gutter-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-gutter-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-margin-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-margin-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-margin-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-margin-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-margin-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-radial-reaction-size-default: var(
-        --spectrum-global-dimension-static-size-550
-    );
-    --spectrum-alias-focus-ring-gap: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-focus-ring-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-loupe-entry-animation-duration: var(
-        --spectrum-global-animation-duration-300
-    );
-    --spectrum-alias-loupe-exit-animation-duration: var(
-        --spectrum-global-animation-duration-300
-    );
-    --spectrum-alias-heading-text-line-height: var(
-        --spectrum-global-font-line-height-small
-    );
-    --spectrum-alias-heading-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-heading-text-font-weight-regular-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-light: var(
-        --spectrum-global-font-weight-light
-    );
-    --spectrum-alias-heading-text-font-weight-light-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-heading-text-font-weight-heavy: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-heavy-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-quiet: var(
-        --spectrum-global-font-weight-light
-    );
-    --spectrum-alias-heading-text-font-weight-quiet-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-heading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-text-font-weight-strong-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-heading-margin-bottom: var(
-        --spectrum-global-font-multiplier-25
-    );
-    --spectrum-alias-subheading-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-subheading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-body-text-font-family: var(
-        --spectrum-global-font-family-base
-    );
-    --spectrum-alias-body-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-body-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-body-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-body-margin-bottom: var(
-        --spectrum-global-font-multiplier-75
-    );
-    --spectrum-alias-detail-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-detail-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-detail-text-font-weight-light: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-heading-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-article-heading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-heading-text-font-weight-quiet: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-article-heading-text-font-weight-quiet-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-article-body-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-article-body-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-subheading-text-font-weight: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-article-subheading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-article-detail-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-article-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-code-text-font-family: var(
-        --spectrum-global-font-family-code
-    );
-    --spectrum-alias-code-text-font-weight-regular: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-code-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-code-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-code-margin-bottom: var(
-        --spectrum-global-font-multiplier-0
-    );
+    --spectrum-global-font-font-family-ar: myriad-arabic, adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-global-font-font-family-he: myriad-hebrew, adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-global-font-font-family-zh: adobe-clean-han-traditional, source-han-traditional, "MingLiu", "Heiti TC Light", "sans-serif";
+    --spectrum-global-font-font-family-zhhans: adobe-clean-han-simplified-c, source-han-simplified-c, "SimSun", "Heiti SC Light", "sans-serif";
+    --spectrum-global-font-font-family-ko: adobe-clean-han-korean, source-han-korean, "Malgun Gothic", "Apple Gothic", "sans-serif";
+    --spectrum-global-font-font-family-ja: adobe-clean-han-japanese, "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ ProN W3", "Osaka", YuGothic, "Yu Gothic", "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", "sans-serif";
+    --spectrum-global-font-font-family-condensed: adobe-clean-han-traditional, source-han-traditional, "MingLiu", "Heiti TC Light", adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
+    --spectrum-alias-border-size-thin: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-border-size-thick: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-size-thicker: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-size-thickest: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thin: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-offset-thick: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-offset-thicker: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thickest: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-baseline: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-grid-gutter-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-gutter-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-gutter-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-gutter-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-gutter-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-margin-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-margin-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-margin-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-margin-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-margin-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-layout-region-margin-bottom-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-layout-region-margin-bottom-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-radial-reaction-size-default: var(--spectrum-global-dimension-static-size-550);
+    --spectrum-alias-focus-ring-gap: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-focus-ring-size: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-loupe-entry-animation-duration: var(--spectrum-global-animation-duration-300);
+    --spectrum-alias-loupe-exit-animation-duration: var(--spectrum-global-animation-duration-300);
+    --spectrum-alias-heading-text-line-height: var(--spectrum-global-font-line-height-small);
+    --spectrum-alias-heading-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-heading-text-font-weight-regular-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-light: var(--spectrum-global-font-weight-light);
+    --spectrum-alias-heading-text-font-weight-light-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-heading-text-font-weight-heavy: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-heavy-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-quiet: var(--spectrum-global-font-weight-light);
+    --spectrum-alias-heading-text-font-weight-quiet-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-heading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-text-font-weight-strong-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-heading-margin-bottom: var(--spectrum-global-font-multiplier-25);
+    --spectrum-alias-subheading-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-subheading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-body-text-font-family: var(--spectrum-global-font-family-base);
+    --spectrum-alias-body-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-body-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-body-text-font-weight-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-body-margin-bottom: var(--spectrum-global-font-multiplier-75);
+    --spectrum-alias-detail-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-detail-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-detail-text-font-weight-light: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-detail-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-heading-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-article-heading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-heading-text-font-weight-quiet: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-article-heading-text-font-weight-quiet-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-article-body-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-article-body-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-subheading-text-font-weight: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-article-subheading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-article-detail-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-article-detail-text-font-weight-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-code-text-font-family: var(--spectrum-global-font-family-code);
+    --spectrum-alias-code-text-font-weight-regular: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-code-text-font-weight-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-code-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-code-margin-bottom: var(--spectrum-global-font-multiplier-0);
     --spectrum-alias-font-family-ar: var(--spectrum-global-font-font-family-ar);
     --spectrum-alias-font-family-he: var(--spectrum-global-font-font-family-he);
     --spectrum-alias-font-family-zh: var(--spectrum-global-font-font-family-zh);
-    --spectrum-alias-font-family-zhhans: var(
-        --spectrum-global-font-font-family-zhhans
-    );
+    --spectrum-alias-font-family-zhhans: var(--spectrum-global-font-font-family-zhhans);
     --spectrum-alias-font-family-ko: var(--spectrum-global-font-font-family-ko);
     --spectrum-alias-font-family-ja: var(--spectrum-global-font-font-family-ja);
-    --spectrum-alias-font-family-condensed: var(
-        --spectrum-global-font-font-family-condensed
-    );
-    --spectrum-alias-button-text-line-height: var(
-        --spectrum-global-font-line-height-small
-    );
-    --spectrum-alias-component-text-line-height: var(
-        --spectrum-global-font-line-height-small
-    );
-    --spectrum-alias-han-component-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-serif-text-font-family: var(
-        --spectrum-global-font-family-serif
-    );
-    --spectrum-alias-han-heading-text-line-height: var(
-        --spectrum-global-font-line-height-medium
-    );
-    --spectrum-alias-han-heading-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-regular-emphasis: var(
-        --spectrum-global-font-weight-extra-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-regular-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-heading-text-font-weight-quiet-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-light: var(
-        --spectrum-global-font-weight-light
-    );
-    --spectrum-alias-han-heading-text-font-weight-light-emphasis: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-han-heading-text-font-weight-light-strong: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-heading-text-font-weight-heavy: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-heading-text-font-weight-heavy-emphasis: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-heading-text-font-weight-heavy-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-body-text-line-height: var(
-        --spectrum-global-font-line-height-large
-    );
-    --spectrum-alias-han-body-text-font-weight-regular: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-han-body-text-font-weight-emphasis: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-body-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-subheading-text-font-weight-regular: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-subheading-text-font-weight-emphasis: var(
-        --spectrum-global-font-weight-extra-bold
-    );
-    --spectrum-alias-han-subheading-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
-    --spectrum-alias-han-detail-text-font-weight: var(
-        --spectrum-global-font-weight-regular
-    );
-    --spectrum-alias-han-detail-text-font-weight-emphasis: var(
-        --spectrum-global-font-weight-bold
-    );
-    --spectrum-alias-han-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-black
-    );
+    --spectrum-alias-font-family-condensed: var(--spectrum-global-font-font-family-condensed);
+    --spectrum-alias-button-text-line-height: var(--spectrum-global-font-line-height-small);
+    --spectrum-alias-component-text-line-height: var(--spectrum-global-font-line-height-small);
+    --spectrum-alias-han-component-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-serif-text-font-family: var(--spectrum-global-font-family-serif);
+    --spectrum-alias-han-heading-text-line-height: var(--spectrum-global-font-line-height-medium);
+    --spectrum-alias-han-heading-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-heading-text-font-weight-regular-emphasis: var(--spectrum-global-font-weight-extra-bold);
+    --spectrum-alias-han-heading-text-font-weight-regular-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-heading-text-font-weight-quiet-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-heading-text-font-weight-light: var(--spectrum-global-font-weight-light);
+    --spectrum-alias-han-heading-text-font-weight-light-emphasis: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-han-heading-text-font-weight-light-strong: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-heading-text-font-weight-heavy: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-heading-text-font-weight-heavy-emphasis: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-heading-text-font-weight-heavy-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-body-text-line-height: var(--spectrum-global-font-line-height-large);
+    --spectrum-alias-han-body-text-font-weight-regular: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-han-body-text-font-weight-emphasis: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-body-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-subheading-text-font-weight-regular: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-subheading-text-font-weight-emphasis: var(--spectrum-global-font-weight-extra-bold);
+    --spectrum-alias-han-subheading-text-font-weight-strong: var(--spectrum-global-font-weight-black);
+    --spectrum-alias-han-detail-text-font-weight: var(--spectrum-global-font-weight-regular);
+    --spectrum-alias-han-detail-text-font-weight-emphasis: var(--spectrum-global-font-weight-bold);
+    --spectrum-alias-han-detail-text-font-weight-strong: var(--spectrum-global-font-weight-black);
 }
 
 :root,
@@ -1065,652 +511,232 @@
     --spectrum-alias-item-height-m: var(--spectrum-global-dimension-size-400);
     --spectrum-alias-item-height-l: var(--spectrum-global-dimension-size-500);
     --spectrum-alias-item-height-xl: var(--spectrum-global-dimension-size-600);
-    --spectrum-alias-item-rounded-border-radius-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-rounded-border-radius-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-rounded-border-radius-l: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-item-rounded-border-radius-xl: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-item-text-size-s: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-item-text-size-m: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-item-text-size-l: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-item-text-size-xl: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-item-text-padding-top-s: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-item-text-padding-top-m: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-text-padding-top-xl: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-text-padding-bottom-m: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-text-padding-bottom-l: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-text-padding-bottom-xl: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-item-icon-padding-top-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-icon-padding-top-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-icon-padding-top-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-icon-padding-top-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-icon-padding-bottom-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-icon-padding-bottom-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-icon-padding-bottom-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-icon-padding-bottom-xl: var(
-        --spectrum-global-dimension-size-160
-    );
+    --spectrum-alias-item-rounded-border-radius-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-rounded-border-radius-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-rounded-border-radius-l: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-item-rounded-border-radius-xl: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-item-text-size-s: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-item-text-size-m: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-item-text-size-l: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-item-text-size-xl: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-item-text-padding-top-s: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-item-text-padding-top-m: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-text-padding-top-xl: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-text-padding-bottom-m: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-text-padding-bottom-l: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-text-padding-bottom-xl: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-item-icon-padding-top-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-icon-padding-top-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-icon-padding-top-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-icon-padding-top-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-icon-padding-bottom-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-icon-padding-bottom-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-icon-padding-bottom-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-icon-padding-bottom-xl: var(--spectrum-global-dimension-size-160);
     --spectrum-alias-item-padding-s: var(--spectrum-global-dimension-size-115);
     --spectrum-alias-item-padding-m: var(--spectrum-global-dimension-size-150);
     --spectrum-alias-item-padding-l: var(--spectrum-global-dimension-size-185);
     --spectrum-alias-item-padding-xl: var(--spectrum-global-dimension-size-225);
-    --spectrum-alias-item-rounded-padding-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-rounded-padding-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-rounded-padding-l: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-item-rounded-padding-xl: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-item-icononly-padding-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-icononly-padding-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-icononly-padding-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-icononly-padding-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-control-gap-s: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-gap-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-gap-l: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-control-gap-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-workflow-icon-gap-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-workflow-icon-gap-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-workflow-icon-gap-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-workflow-icon-gap-xl: var(
-        --spectrum-global-dimension-size-125
-    );
+    --spectrum-alias-item-rounded-padding-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-rounded-padding-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-rounded-padding-l: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-item-rounded-padding-xl: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-item-icononly-padding-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-icononly-padding-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-icononly-padding-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-icononly-padding-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-control-gap-s: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-gap-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-gap-l: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-control-gap-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-workflow-icon-gap-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-workflow-icon-gap-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-workflow-icon-gap-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-workflow-icon-gap-xl: var(--spectrum-global-dimension-size-125);
     --spectrum-alias-item-mark-gap-s: var(--spectrum-global-dimension-size-85);
     --spectrum-alias-item-mark-gap-m: var(--spectrum-global-dimension-size-100);
     --spectrum-alias-item-mark-gap-l: var(--spectrum-global-dimension-size-115);
-    --spectrum-alias-item-mark-gap-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-ui-icon-gap-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-ui-icon-gap-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-ui-icon-gap-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-ui-icon-gap-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-clearbutton-gap-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-item-clearbutton-gap-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-clearbutton-gap-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-clearbutton-gap-xl: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-workflow-padding-left-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-workflow-padding-left-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-workflow-padding-left-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-rounded-workflow-padding-left-s: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-rounded-workflow-padding-left-l: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-mark-padding-top-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-item-mark-padding-top-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-mark-padding-top-xl: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-mark-padding-bottom-s: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-item-mark-padding-bottom-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-mark-padding-bottom-xl: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-item-mark-padding-left-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-mark-padding-left-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-mark-padding-left-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-control-1-size-s: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-item-control-1-size-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-control-2-size-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-item-control-2-size-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-control-2-size-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-control-2-size-xxl: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-item-control-2-border-radius-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-2-border-radius-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-control-2-border-radius-l: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-control-2-border-radius-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-2-border-radius-xxl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-2-padding-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-2-padding-m: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-2-padding-l: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-control-2-padding-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-control-3-height-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-item-control-3-height-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-item-control-3-height-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-control-3-border-radius-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-3-border-radius-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-item-control-3-border-radius-l: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-item-control-3-border-radius-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-3-padding-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-item-control-3-padding-m: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-control-3-padding-l: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-control-3-padding-xl: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-item-mark-size-s: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-item-mark-size-l: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-item-mark-size-xl: var(
-        --spectrum-global-dimension-size-325
-    );
-    --spectrum-alias-heading-xxxl-text-size: var(
-        --spectrum-global-dimension-font-size-1300
-    );
-    --spectrum-alias-heading-xxl-text-size: var(
-        --spectrum-global-dimension-font-size-1100
-    );
-    --spectrum-alias-heading-xl-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-l-text-size: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading-m-text-size: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading-s-text-size: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-xs-text-size: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-xxs-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-xxxl-margin-top: var(
-        --spectrum-global-dimension-font-size-1200
-    );
-    --spectrum-alias-heading-xxl-margin-top: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-xl-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-l-margin-top: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading-m-margin-top: var(
-        --spectrum-global-dimension-font-size-400
-    );
-    --spectrum-alias-heading-s-margin-top: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-xs-margin-top: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-xxs-margin-top: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-heading-han-xxxl-text-size: var(
-        --spectrum-global-dimension-font-size-1300
-    );
-    --spectrum-alias-heading-han-xxl-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-han-xl-text-size: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-han-l-text-size: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading-han-m-text-size: var(
-        --spectrum-global-dimension-font-size-400
-    );
-    --spectrum-alias-heading-han-s-text-size: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-han-xs-text-size: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-han-xxs-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-han-xxxl-margin-top: var(
-        --spectrum-global-dimension-font-size-1200
-    );
-    --spectrum-alias-heading-han-xxl-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-han-xl-margin-top: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading-han-l-margin-top: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading-han-m-margin-top: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-han-s-margin-top: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-heading-han-xs-margin-top: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-heading-han-xxs-margin-top: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-component-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-component-border-radius-quiet: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-component-focusring-gap: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-component-focusring-gap-emphasized: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-component-focusring-size: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-component-focusring-size-emphasized: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-input-border-size: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-input-focusring-gap: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-input-quiet-focusline-gap: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-control-two-size-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-control-two-size-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-control-two-size-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-control-two-size-xxl: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-control-two-border-radius-s: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-control-two-border-radius-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-control-two-border-radius-l: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-control-two-border-radius-xl: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-control-two-border-radius-xxl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-s: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-m: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-l: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-control-two-focus-ring-border-radius-xxl: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-control-three-height-m: var(
-        --spectrum-global-dimension-size-175
-    );
-    --spectrum-alias-control-three-height-l: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-control-three-height-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-infieldbutton-icon-margin-y-xl: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-infieldbutton-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
+    --spectrum-alias-item-mark-gap-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-ui-icon-gap-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-ui-icon-gap-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-ui-icon-gap-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-ui-icon-gap-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-clearbutton-gap-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-item-clearbutton-gap-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-clearbutton-gap-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-clearbutton-gap-xl: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-workflow-padding-left-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-workflow-padding-left-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-workflow-padding-left-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-rounded-workflow-padding-left-s: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-rounded-workflow-padding-left-l: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-mark-padding-top-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-item-mark-padding-top-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-mark-padding-top-xl: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-mark-padding-bottom-s: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-item-mark-padding-bottom-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-mark-padding-bottom-xl: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-item-mark-padding-left-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-mark-padding-left-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-mark-padding-left-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-control-1-size-s: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-item-control-1-size-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-control-2-size-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-item-control-2-size-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-control-2-size-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-control-2-size-xxl: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-item-control-2-border-radius-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-2-border-radius-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-control-2-border-radius-l: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-control-2-border-radius-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-2-border-radius-xxl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-2-padding-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-2-padding-m: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-2-padding-l: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-control-2-padding-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-control-3-height-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-item-control-3-height-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-item-control-3-height-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-control-3-border-radius-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-3-border-radius-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-control-3-border-radius-l: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-control-3-border-radius-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-3-padding-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-item-control-3-padding-m: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-control-3-padding-l: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-control-3-padding-xl: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-mark-size-s: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-mark-size-l: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-item-mark-size-xl: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-heading-xxxl-text-size: var(--spectrum-global-dimension-font-size-1300);
+    --spectrum-alias-heading-xxl-text-size: var(--spectrum-global-dimension-font-size-1100);
+    --spectrum-alias-heading-xl-text-size: var(--spectrum-global-dimension-font-size-900);
+    --spectrum-alias-heading-l-text-size: var(--spectrum-global-dimension-font-size-700);
+    --spectrum-alias-heading-m-text-size: var(--spectrum-global-dimension-font-size-500);
+    --spectrum-alias-heading-s-text-size: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-heading-xs-text-size: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-xxs-text-size: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-xxxl-margin-top: var(--spectrum-global-dimension-font-size-1200);
+    --spectrum-alias-heading-xxl-margin-top: var(--spectrum-global-dimension-font-size-900);
+    --spectrum-alias-heading-xl-margin-top: var(--spectrum-global-dimension-font-size-800);
+    --spectrum-alias-heading-l-margin-top: var(--spectrum-global-dimension-font-size-600);
+    --spectrum-alias-heading-m-margin-top: var(--spectrum-global-dimension-font-size-400);
+    --spectrum-alias-heading-s-margin-top: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-xs-margin-top: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-xxs-margin-top: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-heading-han-xxxl-text-size: var(--spectrum-global-dimension-font-size-1300);
+    --spectrum-alias-heading-han-xxl-text-size: var(--spectrum-global-dimension-font-size-900);
+    --spectrum-alias-heading-han-xl-text-size: var(--spectrum-global-dimension-font-size-800);
+    --spectrum-alias-heading-han-l-text-size: var(--spectrum-global-dimension-font-size-600);
+    --spectrum-alias-heading-han-m-text-size: var(--spectrum-global-dimension-font-size-400);
+    --spectrum-alias-heading-han-s-text-size: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-heading-han-xs-text-size: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-han-xxs-text-size: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-han-xxxl-margin-top: var(--spectrum-global-dimension-font-size-1200);
+    --spectrum-alias-heading-han-xxl-margin-top: var(--spectrum-global-dimension-font-size-800);
+    --spectrum-alias-heading-han-xl-margin-top: var(--spectrum-global-dimension-font-size-700);
+    --spectrum-alias-heading-han-l-margin-top: var(--spectrum-global-dimension-font-size-500);
+    --spectrum-alias-heading-han-m-margin-top: var(--spectrum-global-dimension-font-size-300);
+    --spectrum-alias-heading-han-s-margin-top: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-heading-han-xs-margin-top: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-heading-han-xxs-margin-top: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-component-border-radius: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-component-border-radius-quiet: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-component-focusring-gap: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-component-focusring-gap-emphasized: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-component-focusring-size: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-component-focusring-size-emphasized: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-input-border-size: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-input-focusring-gap: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-input-quiet-focusline-gap: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-control-two-size-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-control-two-size-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-control-two-size-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-control-two-size-xxl: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-control-two-border-radius-s: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-control-two-border-radius-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-control-two-border-radius-l: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-control-two-border-radius-xl: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-control-two-border-radius-xxl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-control-two-focus-ring-border-radius-s: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-control-two-focus-ring-border-radius-m: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-control-two-focus-ring-border-radius-l: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-control-two-focus-ring-border-radius-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-control-two-focus-ring-border-radius-xxl: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-control-three-height-m: var(--spectrum-global-dimension-size-175);
+    --spectrum-alias-control-three-height-l: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-control-three-height-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-infieldbutton-icon-margin-y-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-infieldbutton-icon-margin-y-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-infieldbutton-icon-margin-y-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-infieldbutton-icon-margin-y-xl: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-infieldbutton-border-radius: var(--spectrum-global-dimension-size-50);
     --spectrum-alias-infieldbutton-border-radius-sided: 0;
-    --spectrum-alias-infieldbutton-border-size: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-infieldbutton-fill-padding-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-infieldbutton-fill-padding-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-infieldbutton-fill-padding-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-infieldbutton-fill-padding-xl: var(
-        --spectrum-global-dimension-size-160
-    );
+    --spectrum-alias-infieldbutton-border-size: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-infieldbutton-fill-padding-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-infieldbutton-fill-padding-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-infieldbutton-fill-padding-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-infieldbutton-fill-padding-xl: var(--spectrum-global-dimension-size-160);
     --spectrum-alias-infieldbutton-padding-s: 0;
     --spectrum-alias-infieldbutton-padding-m: 0;
     --spectrum-alias-infieldbutton-padding-l: 0;
     --spectrum-alias-infieldbutton-padding-xl: 0;
-    --spectrum-alias-infieldbutton-full-height-s: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-infieldbutton-full-height-m: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-infieldbutton-full-height-l: var(
-        --spectrum-global-dimension-size-500
-    );
-    --spectrum-alias-infieldbutton-full-height-xl: var(
-        --spectrum-global-dimension-size-600
-    );
-    --spectrum-alias-infieldbutton-half-height-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-infieldbutton-half-height-m: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-infieldbutton-half-height-l: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-infieldbutton-half-height-xl: var(
-        --spectrum-global-dimension-size-300
-    );
+    --spectrum-alias-infieldbutton-full-height-s: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-infieldbutton-full-height-m: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-infieldbutton-full-height-l: var(--spectrum-global-dimension-size-500);
+    --spectrum-alias-infieldbutton-full-height-xl: var(--spectrum-global-dimension-size-600);
+    --spectrum-alias-infieldbutton-half-height-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-infieldbutton-half-height-m: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-infieldbutton-half-height-l: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-infieldbutton-half-height-xl: var(--spectrum-global-dimension-size-300);
     --spectrum-alias-stepperbutton-gap: 0;
-    --spectrum-alias-stepperbutton-width-s: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-stepperbutton-width-m: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-stepperbutton-width-l: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-stepperbutton-width-xl: var(
-        --spectrum-global-dimension-size-450
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-stepperbutton-icon-x-offset-xl: var(
-        --spectrum-global-dimension-size-130
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-s: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-m: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-l: var(
-        --spectrum-global-dimension-size-65
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-top-xl: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-bottom-s: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-bottom-m: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-bottom-l: var(
-        --spectrum-global-dimension-size-40
-    );
-    --spectrum-alias-stepperbutton-icon-y-offset-bottom-xl: var(
-        --spectrum-global-dimension-size-50
-    );
+    --spectrum-alias-stepperbutton-width-s: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-stepperbutton-width-m: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-stepperbutton-width-l: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-stepperbutton-width-xl: var(--spectrum-global-dimension-size-450);
+    --spectrum-alias-stepperbutton-icon-x-offset-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-stepperbutton-icon-x-offset-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-stepperbutton-icon-x-offset-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-stepperbutton-icon-x-offset-xl: var(--spectrum-global-dimension-size-130);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-s: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-m: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-l: var(--spectrum-global-dimension-size-65);
+    --spectrum-alias-stepperbutton-icon-y-offset-top-xl: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-s: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-m: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-l: var(--spectrum-global-dimension-size-40);
+    --spectrum-alias-stepperbutton-icon-y-offset-bottom-xl: var(--spectrum-global-dimension-size-50);
     --spectrum-alias-stepperbutton-radius-touching: 0;
-    --spectrum-alias-clearbutton-icon-margin-s: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-clearbutton-icon-margin-m: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-clearbutton-icon-margin-l: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-clearbutton-icon-margin-xl: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-clearbutton-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-pickerbutton-icononly-padding-x-xl: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-pickerbutton-icon-margin-y-xl: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-m: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-pickerbutton-label-padding-y-xl: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-pickerbutton-border-radius-rounded: var(
-        --spectrum-global-dimension-size-50
-    );
+    --spectrum-alias-clearbutton-icon-margin-s: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-clearbutton-icon-margin-m: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-clearbutton-icon-margin-l: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-clearbutton-icon-margin-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-clearbutton-border-radius: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-pickerbutton-icononly-padding-x-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-pickerbutton-icononly-padding-x-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-pickerbutton-icononly-padding-x-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-pickerbutton-icononly-padding-x-xl: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-pickerbutton-icon-margin-y-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-pickerbutton-icon-margin-y-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-pickerbutton-icon-margin-y-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-pickerbutton-icon-margin-y-xl: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-pickerbutton-label-padding-y-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-pickerbutton-label-padding-y-m: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-pickerbutton-label-padding-y-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-pickerbutton-label-padding-y-xl: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-pickerbutton-border-radius-rounded: var(--spectrum-global-dimension-size-50);
     --spectrum-alias-pickerbutton-border-radius-rounded-sided: 0;
-    --spectrum-alias-search-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
+    --spectrum-alias-search-border-radius: var(--spectrum-global-dimension-size-50);
     --spectrum-alias-search-border-radius-quiet: 0;
-    --spectrum-alias-combobox-quiet-button-offset-x: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-thumbnail-border-radius-small: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-actiongroup-button-gap: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-actiongroup-button-gap-compact: var(
-        --spectrum-global-dimension-size-0
-    );
-    --spectrum-alias-actiongroup-button-gap-quiet: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-actiongroup-button-gap-quiet-compact: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-search-padding-left-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-search-padding-left-l: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-search-padding-left-xl: var(
-        --spectrum-global-dimension-size-185
-    );
+    --spectrum-alias-combobox-quiet-button-offset-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-thumbnail-border-radius-small: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-actiongroup-button-gap: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-actiongroup-button-gap-compact: var(--spectrum-global-dimension-size-0);
+    --spectrum-alias-actiongroup-button-gap-quiet: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-actiongroup-button-gap-quiet-compact: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-search-padding-left-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-search-padding-left-l: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-search-padding-left-xl: var(--spectrum-global-dimension-size-185);
     --spectrum-alias-percent-50: 50%;
     --spectrum-alias-percent-70: 70%;
     --spectrum-alias-percent-100: 100%;
@@ -1722,297 +748,111 @@
     --spectrum-alias-grid-columns: 12;
     --spectrum-alias-grid-fluid-width: 100%;
     --spectrum-alias-grid-fixed-max-width: 1280px;
-    --spectrum-alias-border-size-thin: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-border-size-thick: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-size-thicker: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-size-thickest: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thin: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-border-offset-thick: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-border-offset-thicker: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-border-offset-thickest: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-baseline: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-grid-gutter-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-gutter-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-gutter-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-gutter-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-gutter-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-margin-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-margin-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-margin-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-margin-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-margin-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-small: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(
-        --spectrum-global-dimension-static-size-400
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-large: var(
-        --spectrum-global-dimension-static-size-500
-    );
-    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-radial-reaction-size-default: var(
-        --spectrum-global-dimension-static-size-550
-    );
-    --spectrum-alias-focus-ring-gap: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-focus-ring-size: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-focus-ring-gap-small: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-focus-ring-size-small: var(
-        --spectrum-global-dimension-static-size-10
-    );
+    --spectrum-alias-border-size-thin: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-border-size-thick: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-size-thicker: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-size-thickest: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thin: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-border-offset-thick: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-border-offset-thicker: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-border-offset-thickest: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-baseline: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-grid-gutter-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-gutter-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-gutter-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-gutter-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-gutter-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-margin-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-margin-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-margin-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-margin-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-margin-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-grid-layout-region-margin-bottom-small: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(--spectrum-global-dimension-static-size-400);
+    --spectrum-alias-grid-layout-region-margin-bottom-large: var(--spectrum-global-dimension-static-size-500);
+    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-radial-reaction-size-default: var(--spectrum-global-dimension-static-size-550);
+    --spectrum-alias-focus-ring-gap: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-focus-ring-size: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-focus-ring-gap-small: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-focus-ring-size-small: var(--spectrum-global-dimension-static-size-10);
     --spectrum-alias-dropshadow-blur: var(--spectrum-global-dimension-size-50);
-    --spectrum-alias-dropshadow-offset-y: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-font-size-default: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-layout-label-gap-size: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-pill-button-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-pill-button-text-baseline: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-border-radius-xsmall: var(
-        --spectrum-global-dimension-size-10
-    );
-    --spectrum-alias-border-radius-small: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-border-radius-regular: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-border-radius-medium: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-border-radius-large: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-border-radius-xlarge: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-focus-ring-border-radius-xsmall: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-focus-ring-border-radius-small: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-focus-ring-border-radius-medium: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-focus-ring-border-radius-large: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-focus-ring-border-radius-xlarge: var(
-        --spectrum-global-dimension-size-350
-    );
-    --spectrum-alias-single-line-height: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-single-line-width: var(
-        --spectrum-global-dimension-size-2400
-    );
-    --spectrum-alias-workflow-icon-size-s: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-workflow-icon-size-m: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-workflow-icon-size-xl: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-ui-icon-alert-size-75: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-ui-icon-alert-size-100: var(
-        --spectrum-global-dimension-size-225
-    );
-    --spectrum-alias-ui-icon-alert-size-200: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-ui-icon-alert-size-300: var(
-        --spectrum-global-dimension-size-275
-    );
-    --spectrum-alias-ui-icon-triplegripper-size-100-height: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-ui-icon-doublegripper-size-100-width: var(
-        --spectrum-global-dimension-size-200
-    );
-    --spectrum-alias-ui-icon-singlegripper-size-100-width: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-75: var(
-        --spectrum-global-dimension-size-65
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-200: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-ui-icon-asterisk-size-75: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-asterisk-size-100: var(
-        --spectrum-global-dimension-size-100
-    );
+    --spectrum-alias-dropshadow-offset-y: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-font-size-default: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-layout-label-gap-size: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-pill-button-text-size: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-pill-button-text-baseline: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-border-radius-xsmall: var(--spectrum-global-dimension-size-10);
+    --spectrum-alias-border-radius-small: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-border-radius-regular: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-border-radius-medium: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-border-radius-large: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-border-radius-xlarge: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-focus-ring-border-radius-xsmall: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-focus-ring-border-radius-small: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-focus-ring-border-radius-medium: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-focus-ring-border-radius-large: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-focus-ring-border-radius-xlarge: var(--spectrum-global-dimension-size-350);
+    --spectrum-alias-single-line-height: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-single-line-width: var(--spectrum-global-dimension-size-2400);
+    --spectrum-alias-workflow-icon-size-s: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-workflow-icon-size-m: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-workflow-icon-size-xl: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-ui-icon-alert-size-75: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-ui-icon-alert-size-100: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-ui-icon-alert-size-200: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-ui-icon-alert-size-300: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-ui-icon-triplegripper-size-100-height: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-ui-icon-doublegripper-size-100-width: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-ui-icon-singlegripper-size-100-width: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-ui-icon-cornertriangle-size-75: var(--spectrum-global-dimension-size-65);
+    --spectrum-alias-ui-icon-cornertriangle-size-200: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-ui-icon-asterisk-size-75: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-asterisk-size-100: var(--spectrum-global-dimension-size-100);
     --spectrum-alias-avatar-size-50: var(--spectrum-global-dimension-size-200);
     --spectrum-alias-avatar-size-75: var(--spectrum-global-dimension-size-225);
     --spectrum-alias-avatar-size-200: var(--spectrum-global-dimension-size-275);
     --spectrum-alias-avatar-size-300: var(--spectrum-global-dimension-size-325);
     --spectrum-alias-avatar-size-500: var(--spectrum-global-dimension-size-400);
     --spectrum-alias-avatar-size-700: var(--spectrum-global-dimension-size-500);
-    --spectrum-alias-avatar-border-size: var(
-        --spectrum-global-dimension-size-0
-    );
-    --spectrum-alias-tag-border-radius: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-tag-border-size-default: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-tag-border-size-key-focus: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-tag-border-size-disabled: var(
-        --spectrum-global-dimension-size-0
-    );
-    --spectrum-alias-tag-border-size: var(
-        --spectrum-global-dimension-static-size-10
-    );
-    --spectrum-alias-tag-padding-right-s: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-tag-padding-right-m: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-tag-padding-right-l: var(
-        --spectrum-global-dimension-size-185
-    );
+    --spectrum-alias-avatar-border-size: var(--spectrum-global-dimension-size-0);
+    --spectrum-alias-tag-border-radius: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-tag-border-size-default: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-tag-border-size-key-focus: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-tag-border-size-disabled: var(--spectrum-global-dimension-size-0);
+    --spectrum-alias-tag-border-size: var(--spectrum-global-dimension-static-size-10);
+    --spectrum-alias-tag-padding-right-s: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-tag-padding-right-m: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-tag-padding-right-l: var(--spectrum-global-dimension-size-185);
     --spectrum-alias-tag-height-s: var(--spectrum-global-dimension-size-300);
     --spectrum-alias-tag-height-m: var(--spectrum-global-dimension-size-400);
     --spectrum-alias-tag-height-l: var(--spectrum-global-dimension-size-500);
-    --spectrum-alias-tag-font-size-s: var(
-        --spectrum-global-dimension-font-size-75
-    );
-    --spectrum-alias-tag-font-size-m: var(
-        --spectrum-global-dimension-font-size-100
-    );
-    --spectrum-alias-tag-font-size-l: var(
-        --spectrum-global-dimension-font-size-200
-    );
-    --spectrum-alias-tag-text-padding-top-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-tag-text-padding-top-m: var(
-        --spectrum-global-dimension-size-75
-    );
-    --spectrum-alias-tag-text-padding-top-l: var(
-        --spectrum-global-dimension-size-115
-    );
+    --spectrum-alias-tag-font-size-s: var(--spectrum-global-dimension-font-size-75);
+    --spectrum-alias-tag-font-size-m: var(--spectrum-global-dimension-font-size-100);
+    --spectrum-alias-tag-font-size-l: var(--spectrum-global-dimension-font-size-200);
+    --spectrum-alias-tag-text-padding-top-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-tag-text-padding-top-m: var(--spectrum-global-dimension-size-75);
+    --spectrum-alias-tag-text-padding-top-l: var(--spectrum-global-dimension-size-115);
     --spectrum-alias-tag-icon-size-s: var(--spectrum-global-dimension-size-200);
     --spectrum-alias-tag-icon-size-m: var(--spectrum-global-dimension-size-225);
-    --spectrum-alias-tag-icon-margin-top-s: var(
-        --spectrum-global-dimension-size-50
-    );
-    --spectrum-alias-tag-icon-margin-top-m: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-tag-icon-margin-top-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-tag-icon-margin-right-s: var(
-        --spectrum-global-dimension-size-85
-    );
-    --spectrum-alias-tag-icon-margin-right-m: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-tag-icon-margin-right-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-tag-clearbutton-width-s: var(
-        --spectrum-global-dimension-size-300
-    );
-    --spectrum-alias-tag-clearbutton-width-m: var(
-        --spectrum-global-dimension-size-400
-    );
-    --spectrum-alias-tag-clearbutton-width-l: var(
-        --spectrum-global-dimension-size-500
-    );
-    --spectrum-alias-tag-clearbutton-icon-margin-s: var(
-        --spectrum-global-dimension-size-100
-    );
-    --spectrum-alias-tag-clearbutton-icon-margin-m: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-tag-clearbutton-icon-margin-l: var(
-        --spectrum-global-dimension-size-185
-    );
-    --spectrum-alias-tag-focusring-size: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-tag-focusring-gap: var(
-        --spectrum-global-dimension-static-size-0
-    );
-    --spectrum-alias-tag-focusring-gap-selected: var(
-        --spectrum-global-dimension-size-25
-    );
-    --spectrum-alias-colorloupe-width: var(
-        --spectrum-global-dimension-static-size-600
-    );
-    --spectrum-alias-colorloupe-height: var(
-        --spectrum-global-dimension-static-size-800
-    );
+    --spectrum-alias-tag-icon-margin-top-s: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-tag-icon-margin-top-m: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-tag-icon-margin-top-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-tag-icon-margin-right-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-tag-icon-margin-right-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-tag-icon-margin-right-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-tag-clearbutton-width-s: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-tag-clearbutton-width-m: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-tag-clearbutton-width-l: var(--spectrum-global-dimension-size-500);
+    --spectrum-alias-tag-clearbutton-icon-margin-s: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-tag-clearbutton-icon-margin-m: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-tag-clearbutton-icon-margin-l: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-tag-focusring-size: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-tag-focusring-gap: var(--spectrum-global-dimension-static-size-0);
+    --spectrum-alias-tag-focusring-gap-selected: var(--spectrum-global-dimension-size-25);
+    --spectrum-alias-colorloupe-width: var(--spectrum-global-dimension-static-size-600);
+    --spectrum-alias-colorloupe-height: var(--spectrum-global-dimension-static-size-800);
 }
 
 :root,
@@ -2020,848 +860,298 @@
     --spectrum-alias-colorhandle-outer-border-color: #0000006b;
     --spectrum-alias-transparent-blue-background-color-hover: #0057be26;
     --spectrum-alias-transparent-blue-background-color-down: #0048994d;
-    --spectrum-alias-transparent-blue-background-color-key-focus: var(
-        --spectrum-alias-transparent-blue-background-color-hover
-    );
-    --spectrum-alias-transparent-blue-background-color-mouse-focus: var(
-        --spectrum-alias-transparent-blue-background-color-hover
-    );
-    --spectrum-alias-transparent-blue-background-color: var(
-        --spectrum-alias-component-text-color-default
-    );
+    --spectrum-alias-transparent-blue-background-color-key-focus: var(--spectrum-alias-transparent-blue-background-color-hover);
+    --spectrum-alias-transparent-blue-background-color-mouse-focus: var(--spectrum-alias-transparent-blue-background-color-hover);
+    --spectrum-alias-transparent-blue-background-color: var(--spectrum-alias-component-text-color-default);
     --spectrum-alias-transparent-red-background-color-hover: #9a000026;
     --spectrum-alias-transparent-red-background-color-down: #7c00004d;
-    --spectrum-alias-transparent-red-background-color-key-focus: var(
-        --spectrum-alias-transparent-red-background-color-hover
-    );
-    --spectrum-alias-transparent-red-background-color-mouse-focus: var(
-        --spectrum-alias-transparent-red-background-color-hover
-    );
-    --spectrum-alias-transparent-red-background-color: var(
-        --spectrum-alias-component-text-color-default
-    );
-    --spectrum-alias-component-text-color-disabled: var(
-        --spectrum-global-color-gray-500
-    );
-    --spectrum-alias-component-text-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-component-text-color-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-component-text-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-component-text-color-key-focus: var(
-        --spectrum-alias-component-text-color-hover
-    );
-    --spectrum-alias-component-text-color-mouse-focus: var(
-        --spectrum-alias-component-text-color-hover
-    );
-    --spectrum-alias-component-text-color: var(
-        --spectrum-alias-component-text-color-default
-    );
-    --spectrum-alias-component-text-color-selected-default: var(
-        --spectrum-alias-component-text-color-default
-    );
-    --spectrum-alias-component-text-color-selected-hover: var(
-        --spectrum-alias-component-text-color-hover
-    );
-    --spectrum-alias-component-text-color-selected-down: var(
-        --spectrum-alias-component-text-color-down
-    );
-    --spectrum-alias-component-text-color-selected-key-focus: var(
-        --spectrum-alias-component-text-color-key-focus
-    );
-    --spectrum-alias-component-text-color-selected-mouse-focus: var(
-        --spectrum-alias-component-text-color-mouse-focus
-    );
-    --spectrum-alias-component-text-color-selected: var(
-        --spectrum-alias-component-text-color-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-default: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-hover: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-down: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-key-focus: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected-mouse-focus: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-emphasized-selected: var(
-        --spectrum-alias-component-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-text-color-error-default: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-component-text-color-error-hover: var(
-        --spectrum-semantic-negative-text-color-small-hover
-    );
-    --spectrum-alias-component-text-color-error-down: var(
-        --spectrum-semantic-negative-text-color-small-down
-    );
-    --spectrum-alias-component-text-color-error-key-focus: var(
-        --spectrum-semantic-negative-text-color-small-key-focus
-    );
-    --spectrum-alias-component-text-color-error-mouse-focus: var(
-        --spectrum-semantic-negative-text-color-small-key-focus
-    );
-    --spectrum-alias-component-text-color-error: var(
-        --spectrum-alias-component-text-color-error-default
-    );
-    --spectrum-alias-component-icon-color-disabled: var(
-        --spectrum-alias-icon-color-disabled
-    );
-    --spectrum-alias-component-icon-color-default: var(
-        --spectrum-alias-icon-color
-    );
-    --spectrum-alias-component-icon-color-hover: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-component-icon-color-down: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-component-icon-color-key-focus: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-component-icon-color-mouse-focus: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-component-icon-color: var(
-        --spectrum-alias-component-icon-color-default
-    );
-    --spectrum-alias-component-icon-color-selected: var(
-        --spectrum-alias-icon-color-selected-neutral-subdued
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-default: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-hover: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-down: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected-key-focus: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-icon-color-emphasized-selected: var(
-        --spectrum-alias-component-icon-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-background-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-quiet-disabled: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet-selected-disabled: var(
-        --spectrum-alias-component-background-color-disabled
-    );
-    --spectrum-alias-component-background-color-default: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-component-background-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-component-background-color-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-component-background-color: var(
-        --spectrum-alias-component-background-color-default
-    );
-    --spectrum-alias-component-background-color-selected-default: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-selected-hover: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-selected-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-selected-key-focus: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-background-color-selected: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-background-color-quiet-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet-hover: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet-down: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-component-background-color-quiet-key-focus: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-component-background-color-quiet: var(
-        --spectrum-alias-component-background-color-quiet-default
-    );
-    --spectrum-alias-component-background-color-quiet-selected-default: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-background-color-quiet-selected-hover: var(
-        --spectrum-alias-component-background-color-selected-hover
-    );
-    --spectrum-alias-component-background-color-quiet-selected-down: var(
-        --spectrum-alias-component-background-color-selected-down
-    );
-    --spectrum-alias-component-background-color-quiet-selected-key-focus: var(
-        --spectrum-alias-component-background-color-selected-key-focus
-    );
-    --spectrum-alias-component-background-color-quiet-selected: var(
-        --spectrum-alias-component-background-color-selected-default
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-default: var(
-        --spectrum-semantic-cta-background-color-default
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-hover: var(
-        --spectrum-semantic-cta-background-color-hover
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-down: var(
-        --spectrum-semantic-cta-background-color-down
-    );
-    --spectrum-alias-component-background-color-emphasized-selected-key-focus: var(
-        --spectrum-semantic-cta-background-color-key-focus
-    );
-    --spectrum-alias-component-background-color-emphasized-selected: var(
-        --spectrum-alias-component-background-color-emphasized-selected-default
-    );
-    --spectrum-alias-component-border-color-disabled: var(
-        --spectrum-alias-border-color-disabled
-    );
-    --spectrum-alias-component-border-color-quiet-disabled: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-default: var(
-        --spectrum-alias-border-color
-    );
-    --spectrum-alias-component-border-color-hover: var(
-        --spectrum-alias-border-color-hover
-    );
-    --spectrum-alias-component-border-color-down: var(
-        --spectrum-alias-border-color-down
-    );
-    --spectrum-alias-component-border-color-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-component-border-color: var(
-        --spectrum-alias-component-border-color-default
-    );
-    --spectrum-alias-component-border-color-selected-default: var(
-        --spectrum-alias-border-color
-    );
-    --spectrum-alias-component-border-color-selected-hover: var(
-        --spectrum-alias-border-color-hover
-    );
-    --spectrum-alias-component-border-color-selected-down: var(
-        --spectrum-alias-border-color-down
-    );
-    --spectrum-alias-component-border-color-selected-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-component-border-color-selected: var(
-        --spectrum-alias-component-border-color-selected-default
-    );
-    --spectrum-alias-component-border-color-quiet-default: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-quiet-hover: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-quiet-down: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-component-border-color-quiet-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-component-border-color-quiet: var(
-        --spectrum-alias-component-border-color-quiet-default
-    );
-    --spectrum-alias-component-border-color-quiet-selected-default: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-border-color-quiet-selected-hover: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-border-color-quiet-selected-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-component-border-color-quiet-selected-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-component-border-color-quiet-selected: var(
-        --spectrum-alias-component-border-color-quiet-selected-default
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-default: var(
-        --spectrum-semantic-cta-background-color-default
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-hover: var(
-        --spectrum-semantic-cta-background-color-hover
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-down: var(
-        --spectrum-semantic-cta-background-color-down
-    );
-    --spectrum-alias-component-border-color-emphasized-selected-key-focus: var(
-        --spectrum-semantic-cta-background-color-key-focus
-    );
-    --spectrum-alias-component-border-color-emphasized-selected: var(
-        --spectrum-alias-component-border-color-emphasized-selected-default
-    );
-    --spectrum-alias-tag-border-color-default: var(
-        --spectrum-alias-border-color-darker-default
-    );
-    --spectrum-alias-tag-border-color-hover: var(
-        --spectrum-alias-border-color-darker-hover
-    );
-    --spectrum-alias-tag-border-color-down: var(
-        --spectrum-alias-border-color-darker-hover
-    );
-    --spectrum-alias-tag-border-color-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-tag-border-color-error-default: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-border-color-error-hover: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-border-color-error-down: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-border-color-error-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-tag-border-color-error-selected: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-border-color-selected: var(
-        --spectrum-alias-tag-background-color-selected-default
-    );
-    --spectrum-alias-tag-border-color: var(
-        --spectrum-alias-tag-border-color-default
-    );
-    --spectrum-alias-tag-border-color-disabled: var(
-        --spectrum-alias-border-color-disabled
-    );
-    --spectrum-alias-tag-border-color-error: var(
-        --spectrum-alias-tag-border-color-error-default
-    );
-    --spectrum-alias-tag-text-color-default: var(
-        --spectrum-alias-label-text-color
-    );
-    --spectrum-alias-tag-text-color-hover: var(
-        --spectrum-alias-text-color-hover
-    );
+    --spectrum-alias-transparent-red-background-color-key-focus: var(--spectrum-alias-transparent-red-background-color-hover);
+    --spectrum-alias-transparent-red-background-color-mouse-focus: var(--spectrum-alias-transparent-red-background-color-hover);
+    --spectrum-alias-transparent-red-background-color: var(--spectrum-alias-component-text-color-default);
+    --spectrum-alias-component-text-color-disabled: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-component-text-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-component-text-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-component-text-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-component-text-color-key-focus: var(--spectrum-alias-component-text-color-hover);
+    --spectrum-alias-component-text-color-mouse-focus: var(--spectrum-alias-component-text-color-hover);
+    --spectrum-alias-component-text-color: var(--spectrum-alias-component-text-color-default);
+    --spectrum-alias-component-text-color-selected-default: var(--spectrum-alias-component-text-color-default);
+    --spectrum-alias-component-text-color-selected-hover: var(--spectrum-alias-component-text-color-hover);
+    --spectrum-alias-component-text-color-selected-down: var(--spectrum-alias-component-text-color-down);
+    --spectrum-alias-component-text-color-selected-key-focus: var(--spectrum-alias-component-text-color-key-focus);
+    --spectrum-alias-component-text-color-selected-mouse-focus: var(--spectrum-alias-component-text-color-mouse-focus);
+    --spectrum-alias-component-text-color-selected: var(--spectrum-alias-component-text-color-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-default: var(--spectrum-global-color-static-white);
+    --spectrum-alias-component-text-color-emphasized-selected-hover: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-down: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-key-focus: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected-mouse-focus: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-emphasized-selected: var(--spectrum-alias-component-text-color-emphasized-selected-default);
+    --spectrum-alias-component-text-color-error-default: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-component-text-color-error-hover: var(--spectrum-semantic-negative-text-color-small-hover);
+    --spectrum-alias-component-text-color-error-down: var(--spectrum-semantic-negative-text-color-small-down);
+    --spectrum-alias-component-text-color-error-key-focus: var(--spectrum-semantic-negative-text-color-small-key-focus);
+    --spectrum-alias-component-text-color-error-mouse-focus: var(--spectrum-semantic-negative-text-color-small-key-focus);
+    --spectrum-alias-component-text-color-error: var(--spectrum-alias-component-text-color-error-default);
+    --spectrum-alias-component-icon-color-disabled: var(--spectrum-alias-icon-color-disabled);
+    --spectrum-alias-component-icon-color-default: var(--spectrum-alias-icon-color);
+    --spectrum-alias-component-icon-color-hover: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-component-icon-color-down: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-component-icon-color-key-focus: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-component-icon-color-mouse-focus: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-component-icon-color: var(--spectrum-alias-component-icon-color-default);
+    --spectrum-alias-component-icon-color-selected: var(--spectrum-alias-icon-color-selected-neutral-subdued);
+    --spectrum-alias-component-icon-color-emphasized-selected-default: var(--spectrum-global-color-static-white);
+    --spectrum-alias-component-icon-color-emphasized-selected-hover: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-icon-color-emphasized-selected-down: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-icon-color-emphasized-selected-key-focus: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-icon-color-emphasized-selected: var(--spectrum-alias-component-icon-color-emphasized-selected-default);
+    --spectrum-alias-component-background-color-disabled: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-quiet-disabled: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet-selected-disabled: var(--spectrum-alias-component-background-color-disabled);
+    --spectrum-alias-component-background-color-default: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-component-background-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-component-background-color-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-component-background-color: var(--spectrum-alias-component-background-color-default);
+    --spectrum-alias-component-background-color-selected-default: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-selected-hover: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-selected-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-selected-key-focus: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-background-color-selected: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-background-color-quiet-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet-hover: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet-down: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-component-background-color-quiet-key-focus: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-component-background-color-quiet: var(--spectrum-alias-component-background-color-quiet-default);
+    --spectrum-alias-component-background-color-quiet-selected-default: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-background-color-quiet-selected-hover: var(--spectrum-alias-component-background-color-selected-hover);
+    --spectrum-alias-component-background-color-quiet-selected-down: var(--spectrum-alias-component-background-color-selected-down);
+    --spectrum-alias-component-background-color-quiet-selected-key-focus: var(--spectrum-alias-component-background-color-selected-key-focus);
+    --spectrum-alias-component-background-color-quiet-selected: var(--spectrum-alias-component-background-color-selected-default);
+    --spectrum-alias-component-background-color-emphasized-selected-default: var(--spectrum-semantic-cta-background-color-default);
+    --spectrum-alias-component-background-color-emphasized-selected-hover: var(--spectrum-semantic-cta-background-color-hover);
+    --spectrum-alias-component-background-color-emphasized-selected-down: var(--spectrum-semantic-cta-background-color-down);
+    --spectrum-alias-component-background-color-emphasized-selected-key-focus: var(--spectrum-semantic-cta-background-color-key-focus);
+    --spectrum-alias-component-background-color-emphasized-selected: var(--spectrum-alias-component-background-color-emphasized-selected-default);
+    --spectrum-alias-component-border-color-disabled: var(--spectrum-alias-border-color-disabled);
+    --spectrum-alias-component-border-color-quiet-disabled: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-default: var(--spectrum-alias-border-color);
+    --spectrum-alias-component-border-color-hover: var(--spectrum-alias-border-color-hover);
+    --spectrum-alias-component-border-color-down: var(--spectrum-alias-border-color-down);
+    --spectrum-alias-component-border-color-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-component-border-color: var(--spectrum-alias-component-border-color-default);
+    --spectrum-alias-component-border-color-selected-default: var(--spectrum-alias-border-color);
+    --spectrum-alias-component-border-color-selected-hover: var(--spectrum-alias-border-color-hover);
+    --spectrum-alias-component-border-color-selected-down: var(--spectrum-alias-border-color-down);
+    --spectrum-alias-component-border-color-selected-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-component-border-color-selected: var(--spectrum-alias-component-border-color-selected-default);
+    --spectrum-alias-component-border-color-quiet-default: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-quiet-hover: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-quiet-down: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-component-border-color-quiet-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-component-border-color-quiet: var(--spectrum-alias-component-border-color-quiet-default);
+    --spectrum-alias-component-border-color-quiet-selected-default: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-border-color-quiet-selected-hover: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-border-color-quiet-selected-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-component-border-color-quiet-selected-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-component-border-color-quiet-selected: var(--spectrum-alias-component-border-color-quiet-selected-default);
+    --spectrum-alias-component-border-color-emphasized-selected-default: var(--spectrum-semantic-cta-background-color-default);
+    --spectrum-alias-component-border-color-emphasized-selected-hover: var(--spectrum-semantic-cta-background-color-hover);
+    --spectrum-alias-component-border-color-emphasized-selected-down: var(--spectrum-semantic-cta-background-color-down);
+    --spectrum-alias-component-border-color-emphasized-selected-key-focus: var(--spectrum-semantic-cta-background-color-key-focus);
+    --spectrum-alias-component-border-color-emphasized-selected: var(--spectrum-alias-component-border-color-emphasized-selected-default);
+    --spectrum-alias-tag-border-color-default: var(--spectrum-alias-border-color-darker-default);
+    --spectrum-alias-tag-border-color-hover: var(--spectrum-alias-border-color-darker-hover);
+    --spectrum-alias-tag-border-color-down: var(--spectrum-alias-border-color-darker-hover);
+    --spectrum-alias-tag-border-color-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-tag-border-color-error-default: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-border-color-error-hover: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-border-color-error-down: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-border-color-error-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-tag-border-color-error-selected: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-border-color-selected: var(--spectrum-alias-tag-background-color-selected-default);
+    --spectrum-alias-tag-border-color: var(--spectrum-alias-tag-border-color-default);
+    --spectrum-alias-tag-border-color-disabled: var(--spectrum-alias-border-color-disabled);
+    --spectrum-alias-tag-border-color-error: var(--spectrum-alias-tag-border-color-error-default);
+    --spectrum-alias-tag-text-color-default: var(--spectrum-alias-label-text-color);
+    --spectrum-alias-tag-text-color-hover: var(--spectrum-alias-text-color-hover);
     --spectrum-alias-tag-text-color-down: var(--spectrum-alias-text-color-down);
-    --spectrum-alias-tag-text-color-key-focus: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tag-text-color-disabled: var(
-        --spectrum-global-color-gray-500
-    );
-    --spectrum-alias-tag-text-color: var(
-        --spectrum-alias-tag-text-color-default
-    );
-    --spectrum-alias-tag-text-color-error-default: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-alias-tag-text-color-error-hover: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-tag-text-color-error-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-tag-text-color-error-key-focus: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-tag-text-color-error: var(
-        --spectrum-alias-tag-text-color-error-default
-    );
-    --spectrum-alias-tag-text-color-selected: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-alias-tag-text-color-key-focus: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tag-text-color-disabled: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-tag-text-color: var(--spectrum-alias-tag-text-color-default);
+    --spectrum-alias-tag-text-color-error-default: var(--spectrum-global-color-red-600);
+    --spectrum-alias-tag-text-color-error-hover: var(--spectrum-global-color-red-700);
+    --spectrum-alias-tag-text-color-error-down: var(--spectrum-global-color-red-700);
+    --spectrum-alias-tag-text-color-error-key-focus: var(--spectrum-global-color-red-700);
+    --spectrum-alias-tag-text-color-error: var(--spectrum-alias-tag-text-color-error-default);
+    --spectrum-alias-tag-text-color-selected: var(--spectrum-global-color-gray-50);
     --spectrum-alias-tag-icon-color-default: var(--spectrum-alias-icon-color);
-    --spectrum-alias-tag-icon-color-hover: var(
-        --spectrum-alias-icon-color-hover
-    );
+    --spectrum-alias-tag-icon-color-hover: var(--spectrum-alias-icon-color-hover);
     --spectrum-alias-tag-icon-color-down: var(--spectrum-alias-icon-color-down);
-    --spectrum-alias-tag-icon-color-key-focus: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-tag-icon-color-disabled: var(
-        --spectrum-alias-icon-color-disabled
-    );
-    --spectrum-alias-tag-icon-color: var(
-        --spectrum-alias-tag-icon-color-default
-    );
+    --spectrum-alias-tag-icon-color-key-focus: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-tag-icon-color-disabled: var(--spectrum-alias-icon-color-disabled);
+    --spectrum-alias-tag-icon-color: var(--spectrum-alias-tag-icon-color-default);
     --spectrum-alias-tag-icon-color-error: var(--spectrum-global-color-red-600);
-    --spectrum-alias-tag-icon-color-selected: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-tag-background-color-default: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-tag-background-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color: var(
-        --spectrum-alias-tag-background-color-default
-    );
-    --spectrum-alias-tag-background-color-error-default: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-error-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-error-down: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-tag-background-color-error-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-tag-background-color-error: var(
-        --spectrum-alias-tag-background-color-error-default
-    );
-    --spectrum-alias-tag-background-color-error-selected-default: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-tag-background-color-error-selected-hover: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-background-color-error-selected-down: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-tag-background-color-error-selected-key-focus: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-alias-tag-background-color-error-selected: var(
-        --spectrum-alias-tag-background-color-error-selected-default
-    );
-    --spectrum-alias-tag-background-color-selected-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-tag-background-color-selected-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-tag-background-color-selected-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tag-background-color-selected-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tag-background-color-selected: var(
-        --spectrum-alias-tag-background-color-selected-default
-    );
+    --spectrum-alias-tag-icon-color-selected: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-disabled: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-tag-background-color-default: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-tag-background-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color: var(--spectrum-alias-tag-background-color-default);
+    --spectrum-alias-tag-background-color-error-default: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-error-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-error-down: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-tag-background-color-error-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-tag-background-color-error: var(--spectrum-alias-tag-background-color-error-default);
+    --spectrum-alias-tag-background-color-error-selected-default: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-tag-background-color-error-selected-hover: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-background-color-error-selected-down: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-tag-background-color-error-selected-key-focus: var(--spectrum-global-color-red-600);
+    --spectrum-alias-tag-background-color-error-selected: var(--spectrum-alias-tag-background-color-error-selected-default);
+    --spectrum-alias-tag-background-color-selected-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-tag-background-color-selected-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-tag-background-color-selected-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tag-background-color-selected-key-focus: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tag-background-color-selected: var(--spectrum-alias-tag-background-color-selected-default);
     --spectrum-alias-tag-focusring-border-color-default: transparent;
     --spectrum-alias-tag-focusring-border-color-key-focus: transparent;
     --spectrum-alias-tag-focusring-border-color-disabled: transparent;
-    --spectrum-alias-tag-focusring-border-color-selected-key-focus: var(
-        --spectrum-alias-focus-ring-color
-    );
-    --spectrum-alias-tag-focusring-border-color: var(
-        --spectrum-alias-tag-focusring-border-color-default
-    );
-    --spectrum-alias-avatar-border-color-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-hover: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-down: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-key-focus: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color: var(
-        --spectrum-alias-avatar-border-color-default
-    );
-    --spectrum-alias-avatar-border-color-disabled: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected-hover: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected-down: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected-key-focus: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-avatar-border-color-selected: var(
-        --spectrum-alias-avatar-border-color-selected-default
-    );
-    --spectrum-alias-avatar-border-color-selected-disabled: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-toggle-background-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-toggle-background-color-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-background-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-toggle-background-color-key-focus: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-background-color: var(
-        --spectrum-alias-toggle-background-color-default
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-default: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-hover: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected-key-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-toggle-background-color-emphasized-selected: var(
-        --spectrum-alias-toggle-background-color-emphasized-selected-default
-    );
-    --spectrum-alias-toggle-border-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-toggle-border-color-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-border-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-toggle-border-color-key-focus: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-toggle-border-color: var(
-        --spectrum-alias-toggle-border-color-default
-    );
-    --spectrum-alias-toggle-icon-color-selected: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-toggle-icon-color-emphasized-selected: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-button-primary-background-color-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-button-primary-background-color-hover: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-background-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-button-primary-background-color-key-focus: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-background-color: var(
-        --spectrum-alias-button-primary-background-color-default
-    );
-    --spectrum-alias-button-primary-border-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-border-color-hover: var(
-        --spectrum-alias-button-primary-background-color-hover
-    );
-    --spectrum-alias-button-primary-border-color-down: var(
-        --spectrum-alias-button-primary-background-color-down
-    );
-    --spectrum-alias-button-primary-border-color-key-focus: var(
-        --spectrum-alias-button-primary-background-color-key-focus
-    );
-    --spectrum-alias-button-primary-border-color: var(
-        --spectrum-alias-button-primary-border-color-default
-    );
-    --spectrum-alias-button-primary-text-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-primary-text-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-primary-text-color-down: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-primary-text-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-primary-text-color: var(
-        --spectrum-alias-button-primary-text-color-default
-    );
-    --spectrum-alias-button-primary-icon-color-default: var(
-        --spectrum-alias-button-primary-text-color-default
-    );
-    --spectrum-alias-button-primary-icon-color-hover: var(
-        --spectrum-alias-button-primary-text-color-hover
-    );
-    --spectrum-alias-button-primary-icon-color-down: var(
-        --spectrum-alias-button-primary-text-color-down
-    );
-    --spectrum-alias-button-primary-icon-color-key-focus: var(
-        --spectrum-alias-button-primary-text-color-key-focus
-    );
-    --spectrum-alias-button-primary-icon-color: var(
-        --spectrum-alias-button-primary-icon-color-default
-    );
-    --spectrum-alias-button-secondary-background-color-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-button-secondary-background-color-hover: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-background-color-down: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-button-secondary-background-color-key-focus: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-background-color: var(
-        --spectrum-alias-button-secondary-background-color-default
-    );
-    --spectrum-alias-button-secondary-border-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-border-color-hover: var(
-        --spectrum-alias-button-secondary-background-color-hover
-    );
-    --spectrum-alias-button-secondary-border-color-down: var(
-        --spectrum-alias-button-secondary-background-color-down
-    );
-    --spectrum-alias-button-secondary-border-color-key-focus: var(
-        --spectrum-alias-button-secondary-background-color-key-focus
-    );
-    --spectrum-alias-button-secondary-border-color: var(
-        --spectrum-alias-button-secondary-border-color-default
-    );
-    --spectrum-alias-button-secondary-text-color-default: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-button-secondary-text-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-secondary-text-color-down: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-secondary-text-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-secondary-text-color: var(
-        --spectrum-alias-button-secondary-text-color-default
-    );
-    --spectrum-alias-button-secondary-icon-color-default: var(
-        --spectrum-alias-button-secondary-text-color-default
-    );
-    --spectrum-alias-button-secondary-icon-color-hover: var(
-        --spectrum-alias-button-secondary-text-color-hover
-    );
-    --spectrum-alias-button-secondary-icon-color-down: var(
-        --spectrum-alias-button-secondary-text-color-down
-    );
-    --spectrum-alias-button-secondary-icon-color-key-focus: var(
-        --spectrum-alias-button-secondary-text-color-key-focus
-    );
-    --spectrum-alias-button-secondary-icon-color: var(
-        --spectrum-alias-button-secondary-icon-color-default
-    );
-    --spectrum-alias-button-negative-background-color-default: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-button-negative-background-color-hover: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-background-color-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-button-negative-background-color-key-focus: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-background-color: var(
-        --spectrum-alias-button-negative-background-color-default
-    );
-    --spectrum-alias-button-negative-border-color-default: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-border-color-hover: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-border-color-down: var(
-        --spectrum-global-color-red-700
-    );
-    --spectrum-alias-button-negative-border-color-key-focus: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-border-color: var(
-        --spectrum-alias-button-negative-border-color-default
-    );
-    --spectrum-alias-button-negative-text-color-default: var(
-        --spectrum-semantic-negative-text-color-small
-    );
-    --spectrum-alias-button-negative-text-color-hover: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-negative-text-color-down: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-negative-text-color-key-focus: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-button-negative-text-color: var(
-        --spectrum-alias-button-negative-text-color-default
-    );
-    --spectrum-alias-button-negative-icon-color-default: var(
-        --spectrum-alias-button-negative-text-color-default
-    );
-    --spectrum-alias-button-negative-icon-color-hover: var(
-        --spectrum-alias-button-negative-text-color-hover
-    );
-    --spectrum-alias-button-negative-icon-color-down: var(
-        --spectrum-alias-button-negative-text-color-down
-    );
-    --spectrum-alias-button-negative-icon-color-key-focus: var(
-        --spectrum-alias-button-negative-text-color-key-focus
-    );
-    --spectrum-alias-button-negative-icon-color: var(
-        --spectrum-alias-button-negative-icon-color-default
-    );
-    --spectrum-alias-input-border-color-disabled: var(
-        --spectrum-alias-border-color-transparent
-    );
-    --spectrum-alias-input-border-color-quiet-disabled: var(
-        --spectrum-alias-border-color-mid
-    );
-    --spectrum-alias-input-border-color-default: var(
-        --spectrum-alias-border-color
-    );
-    --spectrum-alias-input-border-color-hover: var(
-        --spectrum-alias-border-color-hover
-    );
-    --spectrum-alias-input-border-color-down: var(
-        --spectrum-alias-border-color-mouse-focus
-    );
-    --spectrum-alias-input-border-color-mouse-focus: var(
-        --spectrum-alias-border-color-mouse-focus
-    );
-    --spectrum-alias-input-border-color-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-input-border-color: var(
-        --spectrum-alias-input-border-color-default
-    );
-    --spectrum-alias-input-border-color-invalid-default: var(
-        --spectrum-semantic-negative-color-default
-    );
-    --spectrum-alias-input-border-color-invalid-hover: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-input-border-color-invalid-down: var(
-        --spectrum-semantic-negative-color-down
-    );
-    --spectrum-alias-input-border-color-invalid-mouse-focus: var(
-        --spectrum-semantic-negative-color-hover
-    );
-    --spectrum-alias-input-border-color-invalid-key-focus: var(
-        --spectrum-alias-border-color-key-focus
-    );
-    --spectrum-alias-input-border-color-invalid: var(
-        --spectrum-alias-input-border-color-invalid-default
-    );
-    --spectrum-alias-background-color-yellow-default: var(
-        --spectrum-global-color-static-yellow-300
-    );
-    --spectrum-alias-background-color-yellow-hover: var(
-        --spectrum-global-color-static-yellow-400
-    );
-    --spectrum-alias-background-color-yellow-key-focus: var(
-        --spectrum-global-color-static-yellow-400
-    );
-    --spectrum-alias-background-color-yellow-down: var(
-        --spectrum-global-color-static-yellow-500
-    );
-    --spectrum-alias-background-color-yellow: var(
-        --spectrum-alias-background-color-yellow-default
-    );
-    --spectrum-alias-infieldbutton-background-color: var(
-        --spectrum-global-color-gray-200
-    );
+    --spectrum-alias-tag-focusring-border-color-selected-key-focus: var(--spectrum-alias-focus-ring-color);
+    --spectrum-alias-tag-focusring-border-color: var(--spectrum-alias-tag-focusring-border-color-default);
+    --spectrum-alias-avatar-border-color-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-hover: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-down: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-key-focus: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color: var(--spectrum-alias-avatar-border-color-default);
+    --spectrum-alias-avatar-border-color-disabled: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected-hover: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected-down: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected-key-focus: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-avatar-border-color-selected: var(--spectrum-alias-avatar-border-color-selected-default);
+    --spectrum-alias-avatar-border-color-selected-disabled: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-toggle-background-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-toggle-background-color-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-background-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-background-color-key-focus: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-background-color: var(--spectrum-alias-toggle-background-color-default);
+    --spectrum-alias-toggle-background-color-emphasized-selected-default: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-toggle-background-color-emphasized-selected-hover: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-toggle-background-color-emphasized-selected-down: var(--spectrum-global-color-blue-700);
+    --spectrum-alias-toggle-background-color-emphasized-selected-key-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-toggle-background-color-emphasized-selected: var(--spectrum-alias-toggle-background-color-emphasized-selected-default);
+    --spectrum-alias-toggle-border-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-toggle-border-color-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-border-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-border-color-key-focus: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-toggle-border-color: var(--spectrum-alias-toggle-border-color-default);
+    --spectrum-alias-toggle-icon-color-selected: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-toggle-icon-color-emphasized-selected: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-button-primary-background-color-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-button-primary-background-color-hover: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-background-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-button-primary-background-color-key-focus: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-background-color: var(--spectrum-alias-button-primary-background-color-default);
+    --spectrum-alias-button-primary-border-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-border-color-hover: var(--spectrum-alias-button-primary-background-color-hover);
+    --spectrum-alias-button-primary-border-color-down: var(--spectrum-alias-button-primary-background-color-down);
+    --spectrum-alias-button-primary-border-color-key-focus: var(--spectrum-alias-button-primary-background-color-key-focus);
+    --spectrum-alias-button-primary-border-color: var(--spectrum-alias-button-primary-border-color-default);
+    --spectrum-alias-button-primary-text-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-primary-text-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-primary-text-color-down: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-primary-text-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-primary-text-color: var(--spectrum-alias-button-primary-text-color-default);
+    --spectrum-alias-button-primary-icon-color-default: var(--spectrum-alias-button-primary-text-color-default);
+    --spectrum-alias-button-primary-icon-color-hover: var(--spectrum-alias-button-primary-text-color-hover);
+    --spectrum-alias-button-primary-icon-color-down: var(--spectrum-alias-button-primary-text-color-down);
+    --spectrum-alias-button-primary-icon-color-key-focus: var(--spectrum-alias-button-primary-text-color-key-focus);
+    --spectrum-alias-button-primary-icon-color: var(--spectrum-alias-button-primary-icon-color-default);
+    --spectrum-alias-button-secondary-background-color-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-button-secondary-background-color-hover: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-background-color-down: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-button-secondary-background-color-key-focus: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-background-color: var(--spectrum-alias-button-secondary-background-color-default);
+    --spectrum-alias-button-secondary-border-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-border-color-hover: var(--spectrum-alias-button-secondary-background-color-hover);
+    --spectrum-alias-button-secondary-border-color-down: var(--spectrum-alias-button-secondary-background-color-down);
+    --spectrum-alias-button-secondary-border-color-key-focus: var(--spectrum-alias-button-secondary-background-color-key-focus);
+    --spectrum-alias-button-secondary-border-color: var(--spectrum-alias-button-secondary-border-color-default);
+    --spectrum-alias-button-secondary-text-color-default: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-button-secondary-text-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-secondary-text-color-down: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-secondary-text-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-secondary-text-color: var(--spectrum-alias-button-secondary-text-color-default);
+    --spectrum-alias-button-secondary-icon-color-default: var(--spectrum-alias-button-secondary-text-color-default);
+    --spectrum-alias-button-secondary-icon-color-hover: var(--spectrum-alias-button-secondary-text-color-hover);
+    --spectrum-alias-button-secondary-icon-color-down: var(--spectrum-alias-button-secondary-text-color-down);
+    --spectrum-alias-button-secondary-icon-color-key-focus: var(--spectrum-alias-button-secondary-text-color-key-focus);
+    --spectrum-alias-button-secondary-icon-color: var(--spectrum-alias-button-secondary-icon-color-default);
+    --spectrum-alias-button-negative-background-color-default: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-button-negative-background-color-hover: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-background-color-down: var(--spectrum-global-color-red-700);
+    --spectrum-alias-button-negative-background-color-key-focus: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-background-color: var(--spectrum-alias-button-negative-background-color-default);
+    --spectrum-alias-button-negative-border-color-default: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-border-color-hover: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-border-color-down: var(--spectrum-global-color-red-700);
+    --spectrum-alias-button-negative-border-color-key-focus: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-border-color: var(--spectrum-alias-button-negative-border-color-default);
+    --spectrum-alias-button-negative-text-color-default: var(--spectrum-semantic-negative-text-color-small);
+    --spectrum-alias-button-negative-text-color-hover: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-negative-text-color-down: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-negative-text-color-key-focus: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-button-negative-text-color: var(--spectrum-alias-button-negative-text-color-default);
+    --spectrum-alias-button-negative-icon-color-default: var(--spectrum-alias-button-negative-text-color-default);
+    --spectrum-alias-button-negative-icon-color-hover: var(--spectrum-alias-button-negative-text-color-hover);
+    --spectrum-alias-button-negative-icon-color-down: var(--spectrum-alias-button-negative-text-color-down);
+    --spectrum-alias-button-negative-icon-color-key-focus: var(--spectrum-alias-button-negative-text-color-key-focus);
+    --spectrum-alias-button-negative-icon-color: var(--spectrum-alias-button-negative-icon-color-default);
+    --spectrum-alias-input-border-color-disabled: var(--spectrum-alias-border-color-transparent);
+    --spectrum-alias-input-border-color-quiet-disabled: var(--spectrum-alias-border-color-mid);
+    --spectrum-alias-input-border-color-default: var(--spectrum-alias-border-color);
+    --spectrum-alias-input-border-color-hover: var(--spectrum-alias-border-color-hover);
+    --spectrum-alias-input-border-color-down: var(--spectrum-alias-border-color-mouse-focus);
+    --spectrum-alias-input-border-color-mouse-focus: var(--spectrum-alias-border-color-mouse-focus);
+    --spectrum-alias-input-border-color-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-input-border-color: var(--spectrum-alias-input-border-color-default);
+    --spectrum-alias-input-border-color-invalid-default: var(--spectrum-semantic-negative-color-default);
+    --spectrum-alias-input-border-color-invalid-hover: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-input-border-color-invalid-down: var(--spectrum-semantic-negative-color-down);
+    --spectrum-alias-input-border-color-invalid-mouse-focus: var(--spectrum-semantic-negative-color-hover);
+    --spectrum-alias-input-border-color-invalid-key-focus: var(--spectrum-alias-border-color-key-focus);
+    --spectrum-alias-input-border-color-invalid: var(--spectrum-alias-input-border-color-invalid-default);
+    --spectrum-alias-background-color-yellow-default: var(--spectrum-global-color-static-yellow-300);
+    --spectrum-alias-background-color-yellow-hover: var(--spectrum-global-color-static-yellow-400);
+    --spectrum-alias-background-color-yellow-key-focus: var(--spectrum-global-color-static-yellow-400);
+    --spectrum-alias-background-color-yellow-down: var(--spectrum-global-color-static-yellow-500);
+    --spectrum-alias-background-color-yellow: var(--spectrum-alias-background-color-yellow-default);
+    --spectrum-alias-infieldbutton-background-color: var(--spectrum-global-color-gray-200);
     --spectrum-alias-infieldbutton-fill-loudnessLow-border-color-disabled: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessMedium-border-color-disabled: transparent;
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-border-color-disabled: var(
-        --spectrum-alias-component-background-color-disabled
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-default: var(
-        --spectrum-alias-input-border-color-default
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-hover: var(
-        --spectrum-alias-input-border-color-hover
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-down: var(
-        --spectrum-alias-input-border-color-down
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-mouse-focus: var(
-        --spectrum-alias-input-border-color-mouse-focus
-    );
-    --spectrum-alias-infieldbutton-fill-border-color-key-focus: var(
-        --spectrum-alias-input-border-color-key-focus
-    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-border-color-disabled: var(--spectrum-alias-component-background-color-disabled);
+    --spectrum-alias-infieldbutton-fill-border-color-default: var(--spectrum-alias-input-border-color-default);
+    --spectrum-alias-infieldbutton-fill-border-color-hover: var(--spectrum-alias-input-border-color-hover);
+    --spectrum-alias-infieldbutton-fill-border-color-down: var(--spectrum-alias-input-border-color-down);
+    --spectrum-alias-infieldbutton-fill-border-color-mouse-focus: var(--spectrum-alias-input-border-color-mouse-focus);
+    --spectrum-alias-infieldbutton-fill-border-color-key-focus: var(--spectrum-alias-input-border-color-key-focus);
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-default: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus: transparent;
     --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-disabled: transparent;
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-default: var(
-        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-default
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-hover: var(
-        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-down: var(
-        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-key-focus: var(
-        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus
-    );
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-default: var(--spectrum-alias-infieldbutton-fill-loudnessLow-background-color-default);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-hover: var(--spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-down: var(--spectrum-alias-infieldbutton-fill-loudnessLow-background-color-down);
+    --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-key-focus: var(--spectrum-alias-infieldbutton-fill-loudnessLow-background-color-key-focus);
     --spectrum-alias-infieldbutton-fill-loudnessMedium-background-color-disabled: transparent;
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-default: var(
-        --spectrum-alias-component-background-color-default
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover: var(
-        --spectrum-alias-component-background-color-hover
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down: var(
-        --spectrum-alias-component-background-color-down
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus: var(
-        --spectrum-alias-component-background-color-key-focus
-    );
-    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-disabled: var(
-        --spectrum-alias-component-background-color-disabled
-    );
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-default: var(--spectrum-alias-component-background-color-default);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover: var(--spectrum-alias-component-background-color-hover);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-down: var(--spectrum-alias-component-background-color-down);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-key-focus: var(--spectrum-alias-component-background-color-key-focus);
+    --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-disabled: var(--spectrum-alias-component-background-color-disabled);
     --spectrum-alias-actionbutton-staticBlack-border-color-default: #0006;
     --spectrum-alias-actionbutton-staticBlack-background-color-default: transparent;
     --spectrum-alias-actionbutton-staticBlack-border-color-hover: #0000008c;
@@ -2886,356 +1176,146 @@
     --spectrum-alias-actionbutton-staticWhite-background-color-disabled: transparent;
     --spectrum-alias-actionbutton-staticWhite-border-color-disabled-selected: transparent;
     --spectrum-alias-actionbutton-staticWhite-background-color-disabled-selected: #ffffff1a;
-    --spectrum-alias-tabs-divider-background-color-default: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-tabs-divider-background-color-quiet: var(
-        --spectrum-alias-background-color-transparent
-    );
-    --spectrum-alias-tabitem-text-color-default: var(
-        --spectrum-alias-label-text-color
-    );
-    --spectrum-alias-tabitem-text-color-hover: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tabitem-text-color-down: var(
-        --spectrum-alias-text-color-down
-    );
-    --spectrum-alias-tabitem-text-color-key-focus: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tabitem-text-color-mouse-focus: var(
-        --spectrum-alias-text-color-hover
-    );
-    --spectrum-alias-tabitem-text-color: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-default: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-tabitem-text-color-selected-hover: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-down: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-key-focus: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected-mouse-focus: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-selected: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-default: var(
-        --spectrum-global-color-static-blue-500
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-hover: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-down: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-key-focus: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected-mouse-focus: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-text-color-emphasized-selected: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-selection-indicator-color-default: var(
-        --spectrum-alias-tabitem-text-color-selected-default
-    );
-    --spectrum-alias-tabitem-selection-indicator-color-emphasized: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-tabitem-icon-color-disabled: var(
-        --spectrum-alias-text-color-disabled
-    );
-    --spectrum-alias-tabitem-icon-color-default: var(
-        --spectrum-alias-icon-color
-    );
-    --spectrum-alias-tabitem-icon-color-hover: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-tabitem-icon-color-down: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-tabitem-icon-color-key-focus: var(
-        --spectrum-alias-icon-color-hover
-    );
-    --spectrum-alias-tabitem-icon-color-mouse-focus: var(
-        --spectrum-alias-icon-color-down
-    );
-    --spectrum-alias-tabitem-icon-color: var(
-        --spectrum-alias-tabitem-icon-color-default
-    );
-    --spectrum-alias-tabitem-icon-color-selected: var(
-        --spectrum-alias-icon-color-selected-neutral
-    );
-    --spectrum-alias-tabitem-icon-color-emphasized: var(
-        --spectrum-alias-tabitem-text-color-default
-    );
-    --spectrum-alias-tabitem-icon-color-emphasized-selected: var(
-        --spectrum-alias-tabitem-text-color-emphasized-selected-default
-    );
-    --spectrum-alias-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-global-color-blue-500
-    );
+    --spectrum-alias-tabs-divider-background-color-default: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-tabs-divider-background-color-quiet: var(--spectrum-alias-background-color-transparent);
+    --spectrum-alias-tabitem-text-color-default: var(--spectrum-alias-label-text-color);
+    --spectrum-alias-tabitem-text-color-hover: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tabitem-text-color-down: var(--spectrum-alias-text-color-down);
+    --spectrum-alias-tabitem-text-color-key-focus: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tabitem-text-color-mouse-focus: var(--spectrum-alias-text-color-hover);
+    --spectrum-alias-tabitem-text-color: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-text-color-selected-default: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-tabitem-text-color-selected-hover: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected-down: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected-key-focus: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected-mouse-focus: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-selected: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-default: var(--spectrum-global-color-static-blue-500);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-hover: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-down: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-key-focus: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected-mouse-focus: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-text-color-emphasized-selected: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-selection-indicator-color-default: var(--spectrum-alias-tabitem-text-color-selected-default);
+    --spectrum-alias-tabitem-selection-indicator-color-emphasized: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-tabitem-icon-color-disabled: var(--spectrum-alias-text-color-disabled);
+    --spectrum-alias-tabitem-icon-color-default: var(--spectrum-alias-icon-color);
+    --spectrum-alias-tabitem-icon-color-hover: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-tabitem-icon-color-down: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-tabitem-icon-color-key-focus: var(--spectrum-alias-icon-color-hover);
+    --spectrum-alias-tabitem-icon-color-mouse-focus: var(--spectrum-alias-icon-color-down);
+    --spectrum-alias-tabitem-icon-color: var(--spectrum-alias-tabitem-icon-color-default);
+    --spectrum-alias-tabitem-icon-color-selected: var(--spectrum-alias-icon-color-selected-neutral);
+    --spectrum-alias-tabitem-icon-color-emphasized: var(--spectrum-alias-tabitem-text-color-default);
+    --spectrum-alias-tabitem-icon-color-emphasized-selected: var(--spectrum-alias-tabitem-text-color-emphasized-selected-default);
+    --spectrum-alias-assetcard-selectionindicator-background-color-ordered: var(--spectrum-global-color-blue-500);
     --spectrum-alias-assetcard-overlay-background-color: #1b7ff51a;
-    --spectrum-alias-assetcard-border-color-selected: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-alias-assetcard-border-color-selected-hover: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-alias-assetcard-border-color-selected-down: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-background-color-default: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
+    --spectrum-alias-assetcard-border-color-selected: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-assetcard-border-color-selected-hover: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-assetcard-border-color-selected-down: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-background-color-default: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-disabled: var(--spectrum-global-color-gray-200);
     --spectrum-alias-background-color-transparent: transparent;
     --spectrum-alias-background-color-overbackground-down: #fff3;
     --spectrum-alias-background-color-quiet-overbackground-hover: #ffffff1a;
     --spectrum-alias-background-color-quiet-overbackground-down: #fff3;
     --spectrum-alias-background-color-overbackground-disabled: #ffffff1a;
     --spectrum-alias-background-color-quickactions-overlay: #0003;
-    --spectrum-alias-placeholder-text-color: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-placeholder-text-color-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-placeholder-text-color-down: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-placeholder-text-color-selected: var(
-        --spectrum-global-color-gray-800
-    );
+    --spectrum-alias-placeholder-text-color: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-placeholder-text-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-placeholder-text-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-placeholder-text-color-selected: var(--spectrum-global-color-gray-800);
     --spectrum-alias-label-text-color: var(--spectrum-global-color-gray-700);
     --spectrum-alias-text-color: var(--spectrum-global-color-gray-800);
     --spectrum-alias-text-color-hover: var(--spectrum-global-color-gray-900);
     --spectrum-alias-text-color-down: var(--spectrum-global-color-gray-900);
-    --spectrum-alias-text-color-key-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-text-color-mouse-focus: var(
-        --spectrum-global-color-blue-600
-    );
+    --spectrum-alias-text-color-key-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-text-color-mouse-focus: var(--spectrum-global-color-blue-600);
     --spectrum-alias-text-color-disabled: var(--spectrum-global-color-gray-500);
     --spectrum-alias-text-color-invalid: var(--spectrum-global-color-red-500);
     --spectrum-alias-text-color-selected: var(--spectrum-global-color-blue-600);
-    --spectrum-alias-text-color-selected-neutral: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-text-color-overbackground: var(
-        --spectrum-global-color-static-white
-    );
+    --spectrum-alias-text-color-selected-neutral: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-text-color-overbackground: var(--spectrum-global-color-static-white);
     --spectrum-alias-text-color-overbackground-disabled: #fff3;
     --spectrum-alias-text-color-quiet-overbackground-disabled: #fff3;
     --spectrum-alias-heading-text-color: var(--spectrum-global-color-gray-900);
-    --spectrum-alias-link-primary-text-color-default: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-link-primary-text-color-hover: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-link-primary-text-color-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-alias-link-primary-text-color-key-focus: var(
-        --spectrum-alias-text-color-key-focus
-    );
-    --spectrum-alias-link-primary-text-color: var(
-        --spectrum-alias-link-primary-text-color-default
-    );
-    --spectrum-alias-link-secondary-text-color-default: var(
-        --spectrum-alias-link-primary-text-color-default
-    );
-    --spectrum-alias-link-secondary-text-color-hover: var(
-        --spectrum-alias-link-primary-text-color-hover
-    );
-    --spectrum-alias-link-secondary-text-color-down: var(
-        --spectrum-alias-link-primary-text-color-down
-    );
-    --spectrum-alias-link-secondary-text-color-key-focus: var(
-        --spectrum-alias-link-primary-text-color-key-focus
-    );
-    --spectrum-alias-link-secondary-text-color: var(
-        --spectrum-alias-link-secondary-text-color-default
-    );
+    --spectrum-alias-link-primary-text-color-default: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-link-primary-text-color-hover: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-link-primary-text-color-down: var(--spectrum-global-color-blue-700);
+    --spectrum-alias-link-primary-text-color-key-focus: var(--spectrum-alias-text-color-key-focus);
+    --spectrum-alias-link-primary-text-color: var(--spectrum-alias-link-primary-text-color-default);
+    --spectrum-alias-link-secondary-text-color-default: var(--spectrum-alias-link-primary-text-color-default);
+    --spectrum-alias-link-secondary-text-color-hover: var(--spectrum-alias-link-primary-text-color-hover);
+    --spectrum-alias-link-secondary-text-color-down: var(--spectrum-alias-link-primary-text-color-down);
+    --spectrum-alias-link-secondary-text-color-key-focus: var(--spectrum-alias-link-primary-text-color-key-focus);
+    --spectrum-alias-link-secondary-text-color: var(--spectrum-alias-link-secondary-text-color-default);
     --spectrum-alias-border-color: var(--spectrum-global-color-gray-400);
     --spectrum-alias-border-color-hover: var(--spectrum-global-color-gray-500);
     --spectrum-alias-border-color-down: var(--spectrum-global-color-gray-500);
-    --spectrum-alias-border-color-key-focus: var(
-        --spectrum-global-color-blue-400
-    );
-    --spectrum-alias-border-color-mouse-focus: var(
-        --spectrum-global-color-blue-500
-    );
-    --spectrum-alias-border-color-disabled: var(
-        --spectrum-global-color-gray-200
-    );
-    --spectrum-alias-border-color-extralight: var(
-        --spectrum-global-color-gray-100
-    );
+    --spectrum-alias-border-color-key-focus: var(--spectrum-global-color-blue-400);
+    --spectrum-alias-border-color-mouse-focus: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-border-color-disabled: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-border-color-extralight: var(--spectrum-global-color-gray-100);
     --spectrum-alias-border-color-light: var(--spectrum-global-color-gray-200);
     --spectrum-alias-border-color-mid: var(--spectrum-global-color-gray-300);
     --spectrum-alias-border-color-dark: var(--spectrum-global-color-gray-400);
-    --spectrum-alias-border-color-darker-default: var(
-        --spectrum-global-color-gray-600
-    );
-    --spectrum-alias-border-color-darker-hover: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-border-color-darker-down: var(
-        --spectrum-global-color-gray-900
-    );
+    --spectrum-alias-border-color-darker-default: var(--spectrum-global-color-gray-600);
+    --spectrum-alias-border-color-darker-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-border-color-darker-down: var(--spectrum-global-color-gray-900);
     --spectrum-alias-border-color-transparent: transparent;
     --spectrum-alias-border-color-translucent-dark: #0000000d;
     --spectrum-alias-border-color-translucent-darker: #0000001a;
     --spectrum-alias-focus-color: var(--spectrum-global-color-blue-400);
     --spectrum-alias-focus-ring-color: var(--spectrum-alias-focus-color);
     --spectrum-alias-track-color-default: var(--spectrum-global-color-gray-300);
-    --spectrum-alias-track-fill-color-overbackground: var(
-        --spectrum-global-color-static-white
-    );
-    --spectrum-alias-track-color-disabled: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-thumbnail-darksquare-background-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-thumbnail-lightsquare-background-color: var(
-        --spectrum-global-color-static-white
-    );
+    --spectrum-alias-track-fill-color-overbackground: var(--spectrum-global-color-static-white);
+    --spectrum-alias-track-color-disabled: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-thumbnail-darksquare-background-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-thumbnail-lightsquare-background-color: var(--spectrum-global-color-static-white);
     --spectrum-alias-track-color-overbackground: #fff3;
     --spectrum-alias-icon-color: var(--spectrum-global-color-gray-700);
-    --spectrum-alias-icon-color-overbackground: var(
-        --spectrum-global-color-static-white
-    );
+    --spectrum-alias-icon-color-overbackground: var(--spectrum-global-color-static-white);
     --spectrum-alias-icon-color-hover: var(--spectrum-global-color-gray-900);
     --spectrum-alias-icon-color-down: var(--spectrum-global-color-gray-900);
-    --spectrum-alias-icon-color-key-focus: var(
-        --spectrum-global-color-gray-900
-    );
+    --spectrum-alias-icon-color-key-focus: var(--spectrum-global-color-gray-900);
     --spectrum-alias-icon-color-disabled: var(--spectrum-global-color-gray-400);
     --spectrum-alias-icon-color-overbackground-disabled: #fff3;
     --spectrum-alias-icon-color-quiet-overbackground-disabled: #ffffff26;
-    --spectrum-alias-icon-color-selected-neutral: var(
-        --spectrum-global-color-gray-900
-    );
-    --spectrum-alias-icon-color-selected-neutral-subdued: var(
-        --spectrum-global-color-gray-800
-    );
+    --spectrum-alias-icon-color-selected-neutral: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-icon-color-selected-neutral-subdued: var(--spectrum-global-color-gray-800);
     --spectrum-alias-icon-color-selected: var(--spectrum-global-color-blue-500);
-    --spectrum-alias-icon-color-selected-hover: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-icon-color-selected-down: var(
-        --spectrum-global-color-blue-700
-    );
-    --spectrum-alias-icon-color-selected-focus: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-image-opacity-disabled: var(
-        --spectrum-global-color-opacity-30
-    );
-    --spectrum-alias-toolbar-background-color: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-code-highlight-color-default: var(
-        --spectrum-global-color-gray-800
-    );
-    --spectrum-alias-code-highlight-background-color: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-code-highlight-color-keyword: var(
-        --spectrum-global-color-fuchsia-600
-    );
-    --spectrum-alias-code-highlight-color-section: var(
-        --spectrum-global-color-red-600
-    );
-    --spectrum-alias-code-highlight-color-literal: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-code-highlight-color-attribute: var(
-        --spectrum-global-color-seafoam-600
-    );
-    --spectrum-alias-code-highlight-color-class: var(
-        --spectrum-global-color-magenta-600
-    );
-    --spectrum-alias-code-highlight-color-variable: var(
-        --spectrum-global-color-purple-600
-    );
-    --spectrum-alias-code-highlight-color-title: var(
-        --spectrum-global-color-indigo-600
-    );
-    --spectrum-alias-code-highlight-color-string: var(
-        --spectrum-global-color-fuchsia-600
-    );
-    --spectrum-alias-code-highlight-color-function: var(
-        --spectrum-global-color-blue-600
-    );
-    --spectrum-alias-code-highlight-color-comment: var(
-        --spectrum-global-color-gray-700
-    );
-    --spectrum-alias-categorical-color-1: var(
-        --spectrum-global-color-static-seafoam-200
-    );
-    --spectrum-alias-categorical-color-2: var(
-        --spectrum-global-color-static-indigo-700
-    );
-    --spectrum-alias-categorical-color-3: var(
-        --spectrum-global-color-static-orange-500
-    );
-    --spectrum-alias-categorical-color-4: var(
-        --spectrum-global-color-static-magenta-500
-    );
-    --spectrum-alias-categorical-color-5: var(
-        --spectrum-global-color-static-indigo-200
-    );
-    --spectrum-alias-categorical-color-6: var(
-        --spectrum-global-color-static-celery-200
-    );
-    --spectrum-alias-categorical-color-7: var(
-        --spectrum-global-color-static-blue-500
-    );
-    --spectrum-alias-categorical-color-8: var(
-        --spectrum-global-color-static-purple-800
-    );
-    --spectrum-alias-categorical-color-9: var(
-        --spectrum-global-color-static-yellow-500
-    );
-    --spectrum-alias-categorical-color-10: var(
-        --spectrum-global-color-static-orange-700
-    );
-    --spectrum-alias-categorical-color-11: var(
-        --spectrum-global-color-static-green-600
-    );
-    --spectrum-alias-categorical-color-12: var(
-        --spectrum-global-color-static-chartreuse-300
-    );
-    --spectrum-alias-categorical-color-13: var(
-        --spectrum-global-color-static-blue-200
-    );
-    --spectrum-alias-categorical-color-14: var(
-        --spectrum-global-color-static-fuchsia-500
-    );
-    --spectrum-alias-categorical-color-15: var(
-        --spectrum-global-color-static-magenta-200
-    );
-    --spectrum-alias-categorical-color-16: var(
-        --spectrum-global-color-static-yellow-200
-    );
+    --spectrum-alias-icon-color-selected-hover: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-icon-color-selected-down: var(--spectrum-global-color-blue-700);
+    --spectrum-alias-icon-color-selected-focus: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-image-opacity-disabled: var(--spectrum-global-color-opacity-30);
+    --spectrum-alias-toolbar-background-color: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-code-highlight-color-default: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-code-highlight-background-color: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-code-highlight-color-keyword: var(--spectrum-global-color-fuchsia-600);
+    --spectrum-alias-code-highlight-color-section: var(--spectrum-global-color-red-600);
+    --spectrum-alias-code-highlight-color-literal: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-code-highlight-color-attribute: var(--spectrum-global-color-seafoam-600);
+    --spectrum-alias-code-highlight-color-class: var(--spectrum-global-color-magenta-600);
+    --spectrum-alias-code-highlight-color-variable: var(--spectrum-global-color-purple-600);
+    --spectrum-alias-code-highlight-color-title: var(--spectrum-global-color-indigo-600);
+    --spectrum-alias-code-highlight-color-string: var(--spectrum-global-color-fuchsia-600);
+    --spectrum-alias-code-highlight-color-function: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-code-highlight-color-comment: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-categorical-color-1: var(--spectrum-global-color-static-seafoam-200);
+    --spectrum-alias-categorical-color-2: var(--spectrum-global-color-static-indigo-700);
+    --spectrum-alias-categorical-color-3: var(--spectrum-global-color-static-orange-500);
+    --spectrum-alias-categorical-color-4: var(--spectrum-global-color-static-magenta-500);
+    --spectrum-alias-categorical-color-5: var(--spectrum-global-color-static-indigo-200);
+    --spectrum-alias-categorical-color-6: var(--spectrum-global-color-static-celery-200);
+    --spectrum-alias-categorical-color-7: var(--spectrum-global-color-static-blue-500);
+    --spectrum-alias-categorical-color-8: var(--spectrum-global-color-static-purple-800);
+    --spectrum-alias-categorical-color-9: var(--spectrum-global-color-static-yellow-500);
+    --spectrum-alias-categorical-color-10: var(--spectrum-global-color-static-orange-700);
+    --spectrum-alias-categorical-color-11: var(--spectrum-global-color-static-green-600);
+    --spectrum-alias-categorical-color-12: var(--spectrum-global-color-static-chartreuse-300);
+    --spectrum-alias-categorical-color-13: var(--spectrum-global-color-static-blue-200);
+    --spectrum-alias-categorical-color-14: var(--spectrum-global-color-static-fuchsia-500);
+    --spectrum-alias-categorical-color-15: var(--spectrum-global-color-static-magenta-200);
+    --spectrum-alias-categorical-color-16: var(--spectrum-global-color-static-yellow-200);
 }

--- a/tools/styles/spectrum-two/spectrum-scale-large.css
+++ b/tools/styles/spectrum-two/spectrum-scale-large.css
@@ -69,220 +69,82 @@
     --spectrum-global-dimension-font-size-1100: 55px;
     --spectrum-global-dimension-font-size-1200: 62px;
     --spectrum-global-dimension-font-size-1300: 70px;
-    --spectrum-alias-item-text-padding-top-l: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-text-padding-bottom-s: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-item-workflow-padding-left-m: var(
-        --spectrum-global-dimension-static-size-150
-    );
+    --spectrum-alias-item-text-padding-top-l: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-text-padding-bottom-s: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-item-workflow-padding-left-m: var(--spectrum-global-dimension-static-size-150);
     --spectrum-alias-item-rounded-workflow-padding-left-m: 17px;
     --spectrum-alias-item-rounded-workflow-padding-left-xl: 27px;
-    --spectrum-alias-item-mark-padding-top-m: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-item-mark-padding-bottom-m: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-item-mark-padding-left-m: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-control-1-size-l: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-control-1-size-xl: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-item-control-2-size-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-control-3-height-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-item-control-3-width-s: var(
-        --spectrum-global-dimension-size-325
-    );
-    --spectrum-alias-item-control-3-width-m: var(
-        --spectrum-global-dimension-static-size-450
-    );
+    --spectrum-alias-item-mark-padding-top-m: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-item-mark-padding-bottom-m: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-item-mark-padding-left-m: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-control-1-size-l: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-control-1-size-xl: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-item-control-2-size-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-control-3-height-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-item-control-3-width-s: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-item-control-3-width-m: var(--spectrum-global-dimension-static-size-450);
     --spectrum-alias-item-control-3-width-l: 41px;
     --spectrum-alias-item-control-3-width-xl: 46px;
-    --spectrum-alias-item-mark-size-m: var(
-        --spectrum-global-dimension-static-size-325
-    );
-    --spectrum-alias-component-focusring-border-radius: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-control-two-size-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-control-three-height-s: var(
-        --spectrum-global-dimension-size-160
-    );
-    --spectrum-alias-control-three-width-s: var(
-        --spectrum-global-dimension-size-325
-    );
-    --spectrum-alias-control-three-width-m: var(
-        --spectrum-global-dimension-static-size-450
-    );
+    --spectrum-alias-item-mark-size-m: var(--spectrum-global-dimension-static-size-325);
+    --spectrum-alias-component-focusring-border-radius: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-control-two-size-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-control-three-height-s: var(--spectrum-global-dimension-size-160);
+    --spectrum-alias-control-three-width-s: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-control-three-width-m: var(--spectrum-global-dimension-static-size-450);
     --spectrum-alias-control-three-width-l: 41px;
     --spectrum-alias-control-three-width-xl: 46px;
-    --spectrum-alias-search-padding-left-m: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-focus-ring-border-radius-regular: var(
-        --spectrum-global-dimension-static-size-115
-    );
-    --spectrum-alias-focus-ring-radius-default: var(
-        --spectrum-global-dimension-static-size-115
-    );
-    --spectrum-alias-workflow-icon-size-l: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-ui-icon-chevron-size-75: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-chevron-size-100: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-chevron-size-200: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-chevron-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-chevron-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-chevron-size-500: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-checkmark-size-50: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-checkmark-size-75: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-checkmark-size-100: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-checkmark-size-200: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-checkmark-size-500: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-checkmark-size-600: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-ui-icon-dash-size-50: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-dash-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-dash-size-100: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-dash-size-200: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-dash-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-dash-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-dash-size-500: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-dash-size-600: var(
-        --spectrum-global-dimension-static-size-275
-    );
-    --spectrum-alias-ui-icon-cross-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-cross-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-cross-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-cross-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-cross-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-cross-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-cross-size-600: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-arrow-size-75: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-arrow-size-100: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-arrow-size-200: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-300: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-400: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-arrow-size-500: var(
-        --spectrum-global-dimension-static-size-275
-    );
-    --spectrum-alias-ui-icon-arrow-size-600: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-asterisk-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-asterisk-size-300: var(
-        --spectrum-global-dimension-static-size-150
-    );
+    --spectrum-alias-search-padding-left-m: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-focus-ring-border-radius-regular: var(--spectrum-global-dimension-static-size-115);
+    --spectrum-alias-focus-ring-radius-default: var(--spectrum-global-dimension-static-size-115);
+    --spectrum-alias-workflow-icon-size-l: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-ui-icon-chevron-size-75: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-chevron-size-100: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-chevron-size-200: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-chevron-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-chevron-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-chevron-size-500: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-checkmark-size-50: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-checkmark-size-75: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-checkmark-size-100: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-checkmark-size-200: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-checkmark-size-500: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-checkmark-size-600: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-ui-icon-dash-size-50: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-dash-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-dash-size-100: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-dash-size-200: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-dash-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-dash-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-dash-size-500: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-dash-size-600: var(--spectrum-global-dimension-static-size-275);
+    --spectrum-alias-ui-icon-cross-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-cross-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-cross-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-cross-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-cross-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-cross-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-cross-size-600: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-arrow-size-75: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-arrow-size-100: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-arrow-size-200: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-300: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-400: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-arrow-size-500: var(--spectrum-global-dimension-static-size-275);
+    --spectrum-alias-ui-icon-arrow-size-600: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-asterisk-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-asterisk-size-300: var(--spectrum-global-dimension-static-size-150);
     --spectrum-alias-avatar-size-100: 26px;
     --spectrum-alias-avatar-size-400: 36px;
     --spectrum-alias-avatar-size-600: 46px;
-    --spectrum-alias-tag-icon-size-l: var(
-        --spectrum-global-dimension-static-size-300
-    );
-    --spectrum-alias-tag-focusring-border-radius: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-dialog-confirm-title-text-size: var(
-        --spectrum-alias-heading-xs-text-size
-    );
-    --spectrum-dialog-confirm-description-text-size: var(
-        --spectrum-global-dimension-font-size-75
-    );
+    --spectrum-alias-tag-icon-size-l: var(--spectrum-global-dimension-static-size-300);
+    --spectrum-alias-tag-focusring-border-radius: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-dialog-confirm-title-text-size: var(--spectrum-alias-heading-xs-text-size);
+    --spectrum-dialog-confirm-description-text-size: var(--spectrum-global-dimension-font-size-75);
 }

--- a/tools/styles/spectrum-two/spectrum-scale-medium.css
+++ b/tools/styles/spectrum-two/spectrum-scale-medium.css
@@ -69,218 +69,82 @@
     --spectrum-global-dimension-font-size-1100: 45px;
     --spectrum-global-dimension-font-size-1200: 50px;
     --spectrum-global-dimension-font-size-1300: 60px;
-    --spectrum-alias-item-text-padding-top-l: var(
-        --spectrum-global-dimension-size-115
-    );
-    --spectrum-alias-item-text-padding-bottom-s: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-item-workflow-padding-left-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-rounded-workflow-padding-left-m: var(
-        --spectrum-global-dimension-size-175
-    );
+    --spectrum-alias-item-text-padding-top-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-text-padding-bottom-s: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-item-workflow-padding-left-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-rounded-workflow-padding-left-m: var(--spectrum-global-dimension-size-175);
     --spectrum-alias-item-rounded-workflow-padding-left-xl: 21px;
-    --spectrum-alias-item-mark-padding-top-m: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-item-mark-padding-bottom-m: var(
-        --spectrum-global-dimension-static-size-75
-    );
-    --spectrum-alias-item-mark-padding-left-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-1-size-l: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-1-size-xl: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-item-control-2-size-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-item-control-3-height-s: var(
-        --spectrum-global-dimension-size-150
-    );
+    --spectrum-alias-item-mark-padding-top-m: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-item-mark-padding-bottom-m: var(--spectrum-global-dimension-static-size-75);
+    --spectrum-alias-item-mark-padding-left-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-1-size-l: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-1-size-xl: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-item-control-2-size-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-control-3-height-s: var(--spectrum-global-dimension-size-150);
     --spectrum-alias-item-control-3-width-s: 23px;
-    --spectrum-alias-item-control-3-width-m: var(
-        --spectrum-global-dimension-static-size-325
-    );
+    --spectrum-alias-item-control-3-width-m: var(--spectrum-global-dimension-static-size-325);
     --spectrum-alias-item-control-3-width-l: 29px;
     --spectrum-alias-item-control-3-width-xl: 33px;
-    --spectrum-alias-item-mark-size-m: var(
-        --spectrum-global-dimension-size-250
-    );
-    --spectrum-alias-component-focusring-border-radius: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-control-two-size-s: var(
-        --spectrum-global-dimension-size-150
-    );
-    --spectrum-alias-control-three-height-s: var(
-        --spectrum-global-dimension-size-150
-    );
+    --spectrum-alias-item-mark-size-m: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-component-focusring-border-radius: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-control-two-size-s: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-control-three-height-s: var(--spectrum-global-dimension-size-150);
     --spectrum-alias-control-three-width-s: 23px;
-    --spectrum-alias-control-three-width-m: var(
-        --spectrum-global-dimension-static-size-325
-    );
+    --spectrum-alias-control-three-width-m: var(--spectrum-global-dimension-static-size-325);
     --spectrum-alias-control-three-width-l: 29px;
     --spectrum-alias-control-three-width-xl: 33px;
-    --spectrum-alias-search-padding-left-m: var(
-        --spectrum-global-dimension-size-125
-    );
-    --spectrum-alias-focus-ring-border-radius-regular: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-focus-ring-radius-default: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-workflow-icon-size-l: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-chevron-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-chevron-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-chevron-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-chevron-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-chevron-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-chevron-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-50: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-checkmark-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-checkmark-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-checkmark-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-checkmark-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-checkmark-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-checkmark-size-600: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-dash-size-50: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-dash-size-75: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-dash-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-dash-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-dash-size-300: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-dash-size-400: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-dash-size-500: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-dash-size-600: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-cross-size-75: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-cross-size-100: var(
-        --spectrum-global-dimension-static-size-100
-    );
-    --spectrum-alias-ui-icon-cross-size-200: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-cross-size-300: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-cross-size-400: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-cross-size-500: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-cross-size-600: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-75: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-arrow-size-100: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-arrow-size-200: var(
-        --spectrum-global-dimension-static-size-150
-    );
-    --spectrum-alias-ui-icon-arrow-size-300: var(
-        --spectrum-global-dimension-static-size-175
-    );
-    --spectrum-alias-ui-icon-arrow-size-400: var(
-        --spectrum-global-dimension-static-size-200
-    );
-    --spectrum-alias-ui-icon-arrow-size-500: var(
-        --spectrum-global-dimension-static-size-225
-    );
-    --spectrum-alias-ui-icon-arrow-size-600: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-50
-    );
-    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
-        --spectrum-global-dimension-static-size-25
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-alias-ui-icon-asterisk-size-200: var(
-        --spectrum-global-dimension-static-size-125
-    );
-    --spectrum-alias-ui-icon-asterisk-size-300: var(
-        --spectrum-global-dimension-static-size-125
-    );
+    --spectrum-alias-search-padding-left-m: var(--spectrum-global-dimension-size-125);
+    --spectrum-alias-focus-ring-border-radius-regular: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-focus-ring-radius-default: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-workflow-icon-size-l: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-chevron-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-chevron-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-chevron-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-chevron-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-chevron-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-chevron-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-50: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-checkmark-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-checkmark-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-checkmark-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-checkmark-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-checkmark-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-checkmark-size-600: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-dash-size-50: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-dash-size-75: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-dash-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-dash-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-dash-size-300: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-dash-size-400: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-dash-size-500: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-dash-size-600: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-cross-size-75: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-cross-size-100: var(--spectrum-global-dimension-static-size-100);
+    --spectrum-alias-ui-icon-cross-size-200: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-cross-size-300: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-cross-size-400: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-cross-size-500: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-cross-size-600: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-75: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-arrow-size-100: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-arrow-size-200: var(--spectrum-global-dimension-static-size-150);
+    --spectrum-alias-ui-icon-arrow-size-300: var(--spectrum-global-dimension-static-size-175);
+    --spectrum-alias-ui-icon-arrow-size-400: var(--spectrum-global-dimension-static-size-200);
+    --spectrum-alias-ui-icon-arrow-size-500: var(--spectrum-global-dimension-static-size-225);
+    --spectrum-alias-ui-icon-arrow-size-600: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(--spectrum-global-dimension-static-size-50);
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(--spectrum-global-dimension-static-size-25);
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(--spectrum-global-dimension-static-size-85);
+    --spectrum-alias-ui-icon-asterisk-size-200: var(--spectrum-global-dimension-static-size-125);
+    --spectrum-alias-ui-icon-asterisk-size-300: var(--spectrum-global-dimension-static-size-125);
     --spectrum-alias-avatar-size-100: var(--spectrum-global-dimension-size-250);
     --spectrum-alias-avatar-size-400: var(--spectrum-global-dimension-size-350);
     --spectrum-alias-avatar-size-600: var(--spectrum-global-dimension-size-450);
-    --spectrum-alias-tag-icon-size-l: var(
-        --spectrum-global-dimension-static-size-250
-    );
-    --spectrum-alias-tag-focusring-border-radius: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-dialog-confirm-title-text-size: var(
-        --spectrum-alias-heading-s-text-size
-    );
-    --spectrum-dialog-confirm-description-text-size: var(
-        --spectrum-global-dimension-font-size-100
-    );
+    --spectrum-alias-tag-icon-size-l: var(--spectrum-global-dimension-static-size-250);
+    --spectrum-alias-tag-focusring-border-radius: var(--spectrum-global-dimension-static-size-65);
+    --spectrum-dialog-confirm-title-text-size: var(--spectrum-alias-heading-s-text-size);
+    --spectrum-dialog-confirm-description-text-size: var(--spectrum-global-dimension-font-size-100);
 }

--- a/tools/styles/spectrum-two/spectrum-theme-dark.css
+++ b/tools/styles/spectrum-two/spectrum-theme-dark.css
@@ -23,250 +23,126 @@
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 34, 184, 51;
-    --spectrum-global-color-celery-400: rgb(
-        var(--spectrum-global-color-celery-400-rgb)
-    );
+    --spectrum-global-color-celery-400: rgb(var(--spectrum-global-color-celery-400-rgb));
     --spectrum-global-color-celery-500-rgb: 68, 202, 73;
-    --spectrum-global-color-celery-500: rgb(
-        var(--spectrum-global-color-celery-500-rgb)
-    );
+    --spectrum-global-color-celery-500: rgb(var(--spectrum-global-color-celery-500-rgb));
     --spectrum-global-color-celery-600-rgb: 105, 220, 99;
-    --spectrum-global-color-celery-600: rgb(
-        var(--spectrum-global-color-celery-600-rgb)
-    );
+    --spectrum-global-color-celery-600: rgb(var(--spectrum-global-color-celery-600-rgb));
     --spectrum-global-color-celery-700-rgb: 142, 235, 127;
-    --spectrum-global-color-celery-700: rgb(
-        var(--spectrum-global-color-celery-700-rgb)
-    );
+    --spectrum-global-color-celery-700: rgb(var(--spectrum-global-color-celery-700-rgb));
     --spectrum-global-color-chartreuse-400-rgb: 148, 192, 8;
-    --spectrum-global-color-chartreuse-400: rgb(
-        var(--spectrum-global-color-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-chartreuse-400: rgb(var(--spectrum-global-color-chartreuse-400-rgb));
     --spectrum-global-color-chartreuse-500-rgb: 166, 211, 18;
-    --spectrum-global-color-chartreuse-500: rgb(
-        var(--spectrum-global-color-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-chartreuse-500: rgb(var(--spectrum-global-color-chartreuse-500-rgb));
     --spectrum-global-color-chartreuse-600-rgb: 184, 229, 37;
-    --spectrum-global-color-chartreuse-600: rgb(
-        var(--spectrum-global-color-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-chartreuse-600: rgb(var(--spectrum-global-color-chartreuse-600-rgb));
     --spectrum-global-color-chartreuse-700-rgb: 205, 245, 71;
-    --spectrum-global-color-chartreuse-700: rgb(
-        var(--spectrum-global-color-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-chartreuse-700: rgb(var(--spectrum-global-color-chartreuse-700-rgb));
     --spectrum-global-color-yellow-400-rgb: 228, 194, 0;
-    --spectrum-global-color-yellow-400: rgb(
-        var(--spectrum-global-color-yellow-400-rgb)
-    );
+    --spectrum-global-color-yellow-400: rgb(var(--spectrum-global-color-yellow-400-rgb));
     --spectrum-global-color-yellow-500-rgb: 244, 213, 0;
-    --spectrum-global-color-yellow-500: rgb(
-        var(--spectrum-global-color-yellow-500-rgb)
-    );
+    --spectrum-global-color-yellow-500: rgb(var(--spectrum-global-color-yellow-500-rgb));
     --spectrum-global-color-yellow-600-rgb: 249, 232, 92;
-    --spectrum-global-color-yellow-600: rgb(
-        var(--spectrum-global-color-yellow-600-rgb)
-    );
+    --spectrum-global-color-yellow-600: rgb(var(--spectrum-global-color-yellow-600-rgb));
     --spectrum-global-color-yellow-700-rgb: 252, 246, 187;
-    --spectrum-global-color-yellow-700: rgb(
-        var(--spectrum-global-color-yellow-700-rgb)
-    );
+    --spectrum-global-color-yellow-700: rgb(var(--spectrum-global-color-yellow-700-rgb));
     --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
-    --spectrum-global-color-magenta-400: rgb(
-        var(--spectrum-global-color-magenta-400-rgb)
-    );
+    --spectrum-global-color-magenta-400: rgb(var(--spectrum-global-color-magenta-400-rgb));
     --spectrum-global-color-magenta-500-rgb: 237, 87, 149;
-    --spectrum-global-color-magenta-500: rgb(
-        var(--spectrum-global-color-magenta-500-rgb)
-    );
+    --spectrum-global-color-magenta-500: rgb(var(--spectrum-global-color-magenta-500-rgb));
     --spectrum-global-color-magenta-600-rgb: 249, 114, 167;
-    --spectrum-global-color-magenta-600: rgb(
-        var(--spectrum-global-color-magenta-600-rgb)
-    );
+    --spectrum-global-color-magenta-600: rgb(var(--spectrum-global-color-magenta-600-rgb));
     --spectrum-global-color-magenta-700-rgb: 255, 143, 185;
-    --spectrum-global-color-magenta-700: rgb(
-        var(--spectrum-global-color-magenta-700-rgb)
-    );
+    --spectrum-global-color-magenta-700: rgb(var(--spectrum-global-color-magenta-700-rgb));
     --spectrum-global-color-fuchsia-400-rgb: 205, 57, 206;
-    --spectrum-global-color-fuchsia-400: rgb(
-        var(--spectrum-global-color-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-fuchsia-400: rgb(var(--spectrum-global-color-fuchsia-400-rgb));
     --spectrum-global-color-fuchsia-500-rgb: 223, 81, 224;
-    --spectrum-global-color-fuchsia-500: rgb(
-        var(--spectrum-global-color-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-fuchsia-500: rgb(var(--spectrum-global-color-fuchsia-500-rgb));
     --spectrum-global-color-fuchsia-600-rgb: 235, 110, 236;
-    --spectrum-global-color-fuchsia-600: rgb(
-        var(--spectrum-global-color-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-fuchsia-600: rgb(var(--spectrum-global-color-fuchsia-600-rgb));
     --spectrum-global-color-fuchsia-700-rgb: 244, 140, 242;
-    --spectrum-global-color-fuchsia-700: rgb(
-        var(--spectrum-global-color-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-fuchsia-700: rgb(var(--spectrum-global-color-fuchsia-700-rgb));
     --spectrum-global-color-purple-400-rgb: 157, 87, 243;
-    --spectrum-global-color-purple-400: rgb(
-        var(--spectrum-global-color-purple-400-rgb)
-    );
+    --spectrum-global-color-purple-400: rgb(var(--spectrum-global-color-purple-400-rgb));
     --spectrum-global-color-purple-500-rgb: 172, 111, 249;
-    --spectrum-global-color-purple-500: rgb(
-        var(--spectrum-global-color-purple-500-rgb)
-    );
+    --spectrum-global-color-purple-500: rgb(var(--spectrum-global-color-purple-500-rgb));
     --spectrum-global-color-purple-600-rgb: 187, 135, 251;
-    --spectrum-global-color-purple-600: rgb(
-        var(--spectrum-global-color-purple-600-rgb)
-    );
+    --spectrum-global-color-purple-600: rgb(var(--spectrum-global-color-purple-600-rgb));
     --spectrum-global-color-purple-700-rgb: 202, 159, 252;
-    --spectrum-global-color-purple-700: rgb(
-        var(--spectrum-global-color-purple-700-rgb)
-    );
+    --spectrum-global-color-purple-700: rgb(var(--spectrum-global-color-purple-700-rgb));
     --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
-    --spectrum-global-color-indigo-400: rgb(
-        var(--spectrum-global-color-indigo-400-rgb)
-    );
+    --spectrum-global-color-indigo-400: rgb(var(--spectrum-global-color-indigo-400-rgb));
     --spectrum-global-color-indigo-500-rgb: 124, 129, 251;
-    --spectrum-global-color-indigo-500: rgb(
-        var(--spectrum-global-color-indigo-500-rgb)
-    );
+    --spectrum-global-color-indigo-500: rgb(var(--spectrum-global-color-indigo-500-rgb));
     --spectrum-global-color-indigo-600-rgb: 145, 149, 255;
-    --spectrum-global-color-indigo-600: rgb(
-        var(--spectrum-global-color-indigo-600-rgb)
-    );
+    --spectrum-global-color-indigo-600: rgb(var(--spectrum-global-color-indigo-600-rgb));
     --spectrum-global-color-indigo-700-rgb: 167, 170, 255;
-    --spectrum-global-color-indigo-700: rgb(
-        var(--spectrum-global-color-indigo-700-rgb)
-    );
+    --spectrum-global-color-indigo-700: rgb(var(--spectrum-global-color-indigo-700-rgb));
     --spectrum-global-color-seafoam-400-rgb: 0, 158, 152;
-    --spectrum-global-color-seafoam-400: rgb(
-        var(--spectrum-global-color-seafoam-400-rgb)
-    );
+    --spectrum-global-color-seafoam-400: rgb(var(--spectrum-global-color-seafoam-400-rgb));
     --spectrum-global-color-seafoam-500-rgb: 3, 178, 171;
-    --spectrum-global-color-seafoam-500: rgb(
-        var(--spectrum-global-color-seafoam-500-rgb)
-    );
+    --spectrum-global-color-seafoam-500: rgb(var(--spectrum-global-color-seafoam-500-rgb));
     --spectrum-global-color-seafoam-600-rgb: 54, 197, 189;
-    --spectrum-global-color-seafoam-600: rgb(
-        var(--spectrum-global-color-seafoam-600-rgb)
-    );
+    --spectrum-global-color-seafoam-600: rgb(var(--spectrum-global-color-seafoam-600-rgb));
     --spectrum-global-color-seafoam-700-rgb: 93, 214, 207;
-    --spectrum-global-color-seafoam-700: rgb(
-        var(--spectrum-global-color-seafoam-700-rgb)
-    );
+    --spectrum-global-color-seafoam-700: rgb(var(--spectrum-global-color-seafoam-700-rgb));
     --spectrum-global-color-red-400-rgb: 234, 56, 41;
-    --spectrum-global-color-red-400: rgb(
-        var(--spectrum-global-color-red-400-rgb)
-    );
+    --spectrum-global-color-red-400: rgb(var(--spectrum-global-color-red-400-rgb));
     --spectrum-global-color-red-500-rgb: 246, 88, 67;
-    --spectrum-global-color-red-500: rgb(
-        var(--spectrum-global-color-red-500-rgb)
-    );
+    --spectrum-global-color-red-500: rgb(var(--spectrum-global-color-red-500-rgb));
     --spectrum-global-color-red-600-rgb: 255, 117, 94;
-    --spectrum-global-color-red-600: rgb(
-        var(--spectrum-global-color-red-600-rgb)
-    );
+    --spectrum-global-color-red-600: rgb(var(--spectrum-global-color-red-600-rgb));
     --spectrum-global-color-red-700-rgb: 255, 149, 129;
-    --spectrum-global-color-red-700: rgb(
-        var(--spectrum-global-color-red-700-rgb)
-    );
+    --spectrum-global-color-red-700: rgb(var(--spectrum-global-color-red-700-rgb));
     --spectrum-global-color-orange-400-rgb: 244, 129, 12;
-    --spectrum-global-color-orange-400: rgb(
-        var(--spectrum-global-color-orange-400-rgb)
-    );
+    --spectrum-global-color-orange-400: rgb(var(--spectrum-global-color-orange-400-rgb));
     --spectrum-global-color-orange-500-rgb: 254, 154, 46;
-    --spectrum-global-color-orange-500: rgb(
-        var(--spectrum-global-color-orange-500-rgb)
-    );
+    --spectrum-global-color-orange-500: rgb(var(--spectrum-global-color-orange-500-rgb));
     --spectrum-global-color-orange-600-rgb: 255, 181, 88;
-    --spectrum-global-color-orange-600: rgb(
-        var(--spectrum-global-color-orange-600-rgb)
-    );
+    --spectrum-global-color-orange-600: rgb(var(--spectrum-global-color-orange-600-rgb));
     --spectrum-global-color-orange-700-rgb: 253, 206, 136;
-    --spectrum-global-color-orange-700: rgb(
-        var(--spectrum-global-color-orange-700-rgb)
-    );
+    --spectrum-global-color-orange-700: rgb(var(--spectrum-global-color-orange-700-rgb));
     --spectrum-global-color-green-400-rgb: 18, 162, 108;
-    --spectrum-global-color-green-400: rgb(
-        var(--spectrum-global-color-green-400-rgb)
-    );
+    --spectrum-global-color-green-400: rgb(var(--spectrum-global-color-green-400-rgb));
     --spectrum-global-color-green-500-rgb: 43, 180, 125;
-    --spectrum-global-color-green-500: rgb(
-        var(--spectrum-global-color-green-500-rgb)
-    );
+    --spectrum-global-color-green-500: rgb(var(--spectrum-global-color-green-500-rgb));
     --spectrum-global-color-green-600-rgb: 67, 199, 143;
-    --spectrum-global-color-green-600: rgb(
-        var(--spectrum-global-color-green-600-rgb)
-    );
+    --spectrum-global-color-green-600: rgb(var(--spectrum-global-color-green-600-rgb));
     --spectrum-global-color-green-700-rgb: 94, 217, 162;
-    --spectrum-global-color-green-700: rgb(
-        var(--spectrum-global-color-green-700-rgb)
-    );
+    --spectrum-global-color-green-700: rgb(var(--spectrum-global-color-green-700-rgb));
     --spectrum-global-color-blue-400-rgb: 52, 143, 244;
-    --spectrum-global-color-blue-400: rgb(
-        var(--spectrum-global-color-blue-400-rgb)
-    );
+    --spectrum-global-color-blue-400: rgb(var(--spectrum-global-color-blue-400-rgb));
     --spectrum-global-color-blue-500-rgb: 84, 163, 246;
-    --spectrum-global-color-blue-500: rgb(
-        var(--spectrum-global-color-blue-500-rgb)
-    );
+    --spectrum-global-color-blue-500: rgb(var(--spectrum-global-color-blue-500-rgb));
     --spectrum-global-color-blue-600-rgb: 114, 183, 249;
-    --spectrum-global-color-blue-600: rgb(
-        var(--spectrum-global-color-blue-600-rgb)
-    );
+    --spectrum-global-color-blue-600: rgb(var(--spectrum-global-color-blue-600-rgb));
     --spectrum-global-color-blue-700-rgb: 143, 202, 252;
-    --spectrum-global-color-blue-700: rgb(
-        var(--spectrum-global-color-blue-700-rgb)
-    );
+    --spectrum-global-color-blue-700: rgb(var(--spectrum-global-color-blue-700-rgb));
     --spectrum-global-color-gray-50-rgb: 29, 29, 29;
-    --spectrum-global-color-gray-50: rgb(
-        var(--spectrum-global-color-gray-50-rgb)
-    );
+    --spectrum-global-color-gray-50: rgb(var(--spectrum-global-color-gray-50-rgb));
     --spectrum-global-color-gray-75-rgb: 38, 38, 38;
-    --spectrum-global-color-gray-75: rgb(
-        var(--spectrum-global-color-gray-75-rgb)
-    );
+    --spectrum-global-color-gray-75: rgb(var(--spectrum-global-color-gray-75-rgb));
     --spectrum-global-color-gray-100-rgb: 50, 50, 50;
-    --spectrum-global-color-gray-100: rgb(
-        var(--spectrum-global-color-gray-100-rgb)
-    );
+    --spectrum-global-color-gray-100: rgb(var(--spectrum-global-color-gray-100-rgb));
     --spectrum-global-color-gray-200-rgb: 63, 63, 63;
-    --spectrum-global-color-gray-200: rgb(
-        var(--spectrum-global-color-gray-200-rgb)
-    );
+    --spectrum-global-color-gray-200: rgb(var(--spectrum-global-color-gray-200-rgb));
     --spectrum-global-color-gray-300-rgb: 84, 84, 84;
-    --spectrum-global-color-gray-300: rgb(
-        var(--spectrum-global-color-gray-300-rgb)
-    );
+    --spectrum-global-color-gray-300: rgb(var(--spectrum-global-color-gray-300-rgb));
     --spectrum-global-color-gray-400-rgb: 112, 112, 112;
-    --spectrum-global-color-gray-400: rgb(
-        var(--spectrum-global-color-gray-400-rgb)
-    );
+    --spectrum-global-color-gray-400: rgb(var(--spectrum-global-color-gray-400-rgb));
     --spectrum-global-color-gray-500-rgb: 144, 144, 144;
-    --spectrum-global-color-gray-500: rgb(
-        var(--spectrum-global-color-gray-500-rgb)
-    );
+    --spectrum-global-color-gray-500: rgb(var(--spectrum-global-color-gray-500-rgb));
     --spectrum-global-color-gray-600-rgb: 178, 178, 178;
-    --spectrum-global-color-gray-600: rgb(
-        var(--spectrum-global-color-gray-600-rgb)
-    );
+    --spectrum-global-color-gray-600: rgb(var(--spectrum-global-color-gray-600-rgb));
     --spectrum-global-color-gray-700-rgb: 209, 209, 209;
-    --spectrum-global-color-gray-700: rgb(
-        var(--spectrum-global-color-gray-700-rgb)
-    );
+    --spectrum-global-color-gray-700: rgb(var(--spectrum-global-color-gray-700-rgb));
     --spectrum-global-color-gray-800-rgb: 235, 235, 235;
-    --spectrum-global-color-gray-800: rgb(
-        var(--spectrum-global-color-gray-800-rgb)
-    );
+    --spectrum-global-color-gray-800: rgb(var(--spectrum-global-color-gray-800-rgb));
     --spectrum-global-color-gray-900-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-900: rgb(
-        var(--spectrum-global-color-gray-900-rgb)
-    );
-    --spectrum-alias-background-color-primary: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-secondary: var(
-        --spectrum-global-color-gray-75
-    );
-    --spectrum-alias-background-color-tertiary: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-global-color-gray-900: rgb(var(--spectrum-global-color-gray-900-rgb));
+    --spectrum-alias-background-color-primary: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-secondary: var(--spectrum-global-color-gray-75);
+    --spectrum-alias-background-color-tertiary: var(--spectrum-global-color-gray-50);
     --spectrum-alias-background-color-modal-overlay: #00000080;
     --spectrum-alias-dropshadow-color: #00000080;
     --spectrum-alias-background-color-hover-overlay: #ffffff0f;
@@ -276,18 +152,10 @@
     --spectrum-alias-highlight-selected-hover: #54a3f640;
     --spectrum-alias-text-highlight-color: #54a3f640;
     --spectrum-alias-background-color-quickactions: #323232e6;
-    --spectrum-alias-border-color-selected: var(
-        --spectrum-global-color-blue-600
-    );
+    --spectrum-alias-border-color-selected: var(--spectrum-global-color-blue-600);
     --spectrum-alias-border-color-translucent: #ffffff1a;
     --spectrum-alias-radial-reaction-color-default: #ebebeb99;
-    --spectrum-alias-pasteboard-background-color: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-appframe-border-color: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-appframe-separator-color: var(
-        --spectrum-global-color-gray-50
-    );
+    --spectrum-alias-pasteboard-background-color: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-appframe-border-color: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-appframe-separator-color: var(--spectrum-global-color-gray-50);
 }

--- a/tools/styles/spectrum-two/spectrum-theme-light.css
+++ b/tools/styles/spectrum-two/spectrum-theme-light.css
@@ -23,250 +23,126 @@
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 39, 187, 54;
-    --spectrum-global-color-celery-400: rgb(
-        var(--spectrum-global-color-celery-400-rgb)
-    );
+    --spectrum-global-color-celery-400: rgb(var(--spectrum-global-color-celery-400-rgb));
     --spectrum-global-color-celery-500-rgb: 7, 167, 33;
-    --spectrum-global-color-celery-500: rgb(
-        var(--spectrum-global-color-celery-500-rgb)
-    );
+    --spectrum-global-color-celery-500: rgb(var(--spectrum-global-color-celery-500-rgb));
     --spectrum-global-color-celery-600-rgb: 0, 145, 18;
-    --spectrum-global-color-celery-600: rgb(
-        var(--spectrum-global-color-celery-600-rgb)
-    );
+    --spectrum-global-color-celery-600: rgb(var(--spectrum-global-color-celery-600-rgb));
     --spectrum-global-color-celery-700-rgb: 0, 124, 15;
-    --spectrum-global-color-celery-700: rgb(
-        var(--spectrum-global-color-celery-700-rgb)
-    );
+    --spectrum-global-color-celery-700: rgb(var(--spectrum-global-color-celery-700-rgb));
     --spectrum-global-color-chartreuse-400-rgb: 152, 197, 10;
-    --spectrum-global-color-chartreuse-400: rgb(
-        var(--spectrum-global-color-chartreuse-400-rgb)
-    );
+    --spectrum-global-color-chartreuse-400: rgb(var(--spectrum-global-color-chartreuse-400-rgb));
     --spectrum-global-color-chartreuse-500-rgb: 135, 177, 3;
-    --spectrum-global-color-chartreuse-500: rgb(
-        var(--spectrum-global-color-chartreuse-500-rgb)
-    );
+    --spectrum-global-color-chartreuse-500: rgb(var(--spectrum-global-color-chartreuse-500-rgb));
     --spectrum-global-color-chartreuse-600-rgb: 118, 156, 0;
-    --spectrum-global-color-chartreuse-600: rgb(
-        var(--spectrum-global-color-chartreuse-600-rgb)
-    );
+    --spectrum-global-color-chartreuse-600: rgb(var(--spectrum-global-color-chartreuse-600-rgb));
     --spectrum-global-color-chartreuse-700-rgb: 103, 136, 0;
-    --spectrum-global-color-chartreuse-700: rgb(
-        var(--spectrum-global-color-chartreuse-700-rgb)
-    );
+    --spectrum-global-color-chartreuse-700: rgb(var(--spectrum-global-color-chartreuse-700-rgb));
     --spectrum-global-color-yellow-400-rgb: 232, 198, 0;
-    --spectrum-global-color-yellow-400: rgb(
-        var(--spectrum-global-color-yellow-400-rgb)
-    );
+    --spectrum-global-color-yellow-400: rgb(var(--spectrum-global-color-yellow-400-rgb));
     --spectrum-global-color-yellow-500-rgb: 215, 179, 0;
-    --spectrum-global-color-yellow-500: rgb(
-        var(--spectrum-global-color-yellow-500-rgb)
-    );
+    --spectrum-global-color-yellow-500: rgb(var(--spectrum-global-color-yellow-500-rgb));
     --spectrum-global-color-yellow-600-rgb: 196, 159, 0;
-    --spectrum-global-color-yellow-600: rgb(
-        var(--spectrum-global-color-yellow-600-rgb)
-    );
+    --spectrum-global-color-yellow-600: rgb(var(--spectrum-global-color-yellow-600-rgb));
     --spectrum-global-color-yellow-700-rgb: 176, 140, 0;
-    --spectrum-global-color-yellow-700: rgb(
-        var(--spectrum-global-color-yellow-700-rgb)
-    );
+    --spectrum-global-color-yellow-700: rgb(var(--spectrum-global-color-yellow-700-rgb));
     --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
-    --spectrum-global-color-magenta-400: rgb(
-        var(--spectrum-global-color-magenta-400-rgb)
-    );
+    --spectrum-global-color-magenta-400: rgb(var(--spectrum-global-color-magenta-400-rgb));
     --spectrum-global-color-magenta-500-rgb: 200, 34, 105;
-    --spectrum-global-color-magenta-500: rgb(
-        var(--spectrum-global-color-magenta-500-rgb)
-    );
+    --spectrum-global-color-magenta-500: rgb(var(--spectrum-global-color-magenta-500-rgb));
     --spectrum-global-color-magenta-600-rgb: 173, 9, 85;
-    --spectrum-global-color-magenta-600: rgb(
-        var(--spectrum-global-color-magenta-600-rgb)
-    );
+    --spectrum-global-color-magenta-600: rgb(var(--spectrum-global-color-magenta-600-rgb));
     --spectrum-global-color-magenta-700-rgb: 142, 0, 69;
-    --spectrum-global-color-magenta-700: rgb(
-        var(--spectrum-global-color-magenta-700-rgb)
-    );
+    --spectrum-global-color-magenta-700: rgb(var(--spectrum-global-color-magenta-700-rgb));
     --spectrum-global-color-fuchsia-400-rgb: 205, 58, 206;
-    --spectrum-global-color-fuchsia-400: rgb(
-        var(--spectrum-global-color-fuchsia-400-rgb)
-    );
+    --spectrum-global-color-fuchsia-400: rgb(var(--spectrum-global-color-fuchsia-400-rgb));
     --spectrum-global-color-fuchsia-500-rgb: 182, 34, 183;
-    --spectrum-global-color-fuchsia-500: rgb(
-        var(--spectrum-global-color-fuchsia-500-rgb)
-    );
+    --spectrum-global-color-fuchsia-500: rgb(var(--spectrum-global-color-fuchsia-500-rgb));
     --spectrum-global-color-fuchsia-600-rgb: 157, 3, 158;
-    --spectrum-global-color-fuchsia-600: rgb(
-        var(--spectrum-global-color-fuchsia-600-rgb)
-    );
+    --spectrum-global-color-fuchsia-600: rgb(var(--spectrum-global-color-fuchsia-600-rgb));
     --spectrum-global-color-fuchsia-700-rgb: 128, 0, 129;
-    --spectrum-global-color-fuchsia-700: rgb(
-        var(--spectrum-global-color-fuchsia-700-rgb)
-    );
+    --spectrum-global-color-fuchsia-700: rgb(var(--spectrum-global-color-fuchsia-700-rgb));
     --spectrum-global-color-purple-400-rgb: 157, 87, 244;
-    --spectrum-global-color-purple-400: rgb(
-        var(--spectrum-global-color-purple-400-rgb)
-    );
+    --spectrum-global-color-purple-400: rgb(var(--spectrum-global-color-purple-400-rgb));
     --spectrum-global-color-purple-500-rgb: 137, 61, 231;
-    --spectrum-global-color-purple-500: rgb(
-        var(--spectrum-global-color-purple-500-rgb)
-    );
+    --spectrum-global-color-purple-500: rgb(var(--spectrum-global-color-purple-500-rgb));
     --spectrum-global-color-purple-600-rgb: 115, 38, 211;
-    --spectrum-global-color-purple-600: rgb(
-        var(--spectrum-global-color-purple-600-rgb)
-    );
+    --spectrum-global-color-purple-600: rgb(var(--spectrum-global-color-purple-600-rgb));
     --spectrum-global-color-purple-700-rgb: 93, 19, 183;
-    --spectrum-global-color-purple-700: rgb(
-        var(--spectrum-global-color-purple-700-rgb)
-    );
+    --spectrum-global-color-purple-700: rgb(var(--spectrum-global-color-purple-700-rgb));
     --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
-    --spectrum-global-color-indigo-400: rgb(
-        var(--spectrum-global-color-indigo-400-rgb)
-    );
+    --spectrum-global-color-indigo-400: rgb(var(--spectrum-global-color-indigo-400-rgb));
     --spectrum-global-color-indigo-500-rgb: 82, 88, 228;
-    --spectrum-global-color-indigo-500: rgb(
-        var(--spectrum-global-color-indigo-500-rgb)
-    );
+    --spectrum-global-color-indigo-500: rgb(var(--spectrum-global-color-indigo-500-rgb));
     --spectrum-global-color-indigo-600-rgb: 64, 70, 202;
-    --spectrum-global-color-indigo-600: rgb(
-        var(--spectrum-global-color-indigo-600-rgb)
-    );
+    --spectrum-global-color-indigo-600: rgb(var(--spectrum-global-color-indigo-600-rgb));
     --spectrum-global-color-indigo-700-rgb: 50, 54, 168;
-    --spectrum-global-color-indigo-700: rgb(
-        var(--spectrum-global-color-indigo-700-rgb)
-    );
+    --spectrum-global-color-indigo-700: rgb(var(--spectrum-global-color-indigo-700-rgb));
     --spectrum-global-color-seafoam-400-rgb: 0, 161, 154;
-    --spectrum-global-color-seafoam-400: rgb(
-        var(--spectrum-global-color-seafoam-400-rgb)
-    );
+    --spectrum-global-color-seafoam-400: rgb(var(--spectrum-global-color-seafoam-400-rgb));
     --spectrum-global-color-seafoam-500-rgb: 0, 140, 135;
-    --spectrum-global-color-seafoam-500: rgb(
-        var(--spectrum-global-color-seafoam-500-rgb)
-    );
+    --spectrum-global-color-seafoam-500: rgb(var(--spectrum-global-color-seafoam-500-rgb));
     --spectrum-global-color-seafoam-600-rgb: 0, 119, 114;
-    --spectrum-global-color-seafoam-600: rgb(
-        var(--spectrum-global-color-seafoam-600-rgb)
-    );
+    --spectrum-global-color-seafoam-600: rgb(var(--spectrum-global-color-seafoam-600-rgb));
     --spectrum-global-color-seafoam-700-rgb: 0, 99, 95;
-    --spectrum-global-color-seafoam-700: rgb(
-        var(--spectrum-global-color-seafoam-700-rgb)
-    );
+    --spectrum-global-color-seafoam-700: rgb(var(--spectrum-global-color-seafoam-700-rgb));
     --spectrum-global-color-red-400-rgb: 234, 56, 41;
-    --spectrum-global-color-red-400: rgb(
-        var(--spectrum-global-color-red-400-rgb)
-    );
+    --spectrum-global-color-red-400: rgb(var(--spectrum-global-color-red-400-rgb));
     --spectrum-global-color-red-500-rgb: 211, 21, 16;
-    --spectrum-global-color-red-500: rgb(
-        var(--spectrum-global-color-red-500-rgb)
-    );
+    --spectrum-global-color-red-500: rgb(var(--spectrum-global-color-red-500-rgb));
     --spectrum-global-color-red-600-rgb: 180, 0, 0;
-    --spectrum-global-color-red-600: rgb(
-        var(--spectrum-global-color-red-600-rgb)
-    );
+    --spectrum-global-color-red-600: rgb(var(--spectrum-global-color-red-600-rgb));
     --spectrum-global-color-red-700-rgb: 147, 0, 0;
-    --spectrum-global-color-red-700: rgb(
-        var(--spectrum-global-color-red-700-rgb)
-    );
+    --spectrum-global-color-red-700: rgb(var(--spectrum-global-color-red-700-rgb));
     --spectrum-global-color-orange-400-rgb: 246, 133, 17;
-    --spectrum-global-color-orange-400: rgb(
-        var(--spectrum-global-color-orange-400-rgb)
-    );
+    --spectrum-global-color-orange-400: rgb(var(--spectrum-global-color-orange-400-rgb));
     --spectrum-global-color-orange-500-rgb: 228, 111, 0;
-    --spectrum-global-color-orange-500: rgb(
-        var(--spectrum-global-color-orange-500-rgb)
-    );
+    --spectrum-global-color-orange-500: rgb(var(--spectrum-global-color-orange-500-rgb));
     --spectrum-global-color-orange-600-rgb: 203, 93, 0;
-    --spectrum-global-color-orange-600: rgb(
-        var(--spectrum-global-color-orange-600-rgb)
-    );
+    --spectrum-global-color-orange-600: rgb(var(--spectrum-global-color-orange-600-rgb));
     --spectrum-global-color-orange-700-rgb: 177, 76, 0;
-    --spectrum-global-color-orange-700: rgb(
-        var(--spectrum-global-color-orange-700-rgb)
-    );
+    --spectrum-global-color-orange-700: rgb(var(--spectrum-global-color-orange-700-rgb));
     --spectrum-global-color-green-400-rgb: 0, 143, 93;
-    --spectrum-global-color-green-400: rgb(
-        var(--spectrum-global-color-green-400-rgb)
-    );
+    --spectrum-global-color-green-400: rgb(var(--spectrum-global-color-green-400-rgb));
     --spectrum-global-color-green-500-rgb: 0, 122, 77;
-    --spectrum-global-color-green-500: rgb(
-        var(--spectrum-global-color-green-500-rgb)
-    );
+    --spectrum-global-color-green-500: rgb(var(--spectrum-global-color-green-500-rgb));
     --spectrum-global-color-green-600-rgb: 0, 101, 62;
-    --spectrum-global-color-green-600: rgb(
-        var(--spectrum-global-color-green-600-rgb)
-    );
+    --spectrum-global-color-green-600: rgb(var(--spectrum-global-color-green-600-rgb));
     --spectrum-global-color-green-700-rgb: 0, 81, 50;
-    --spectrum-global-color-green-700: rgb(
-        var(--spectrum-global-color-green-700-rgb)
-    );
+    --spectrum-global-color-green-700: rgb(var(--spectrum-global-color-green-700-rgb));
     --spectrum-global-color-blue-400-rgb: 20, 122, 243;
-    --spectrum-global-color-blue-400: rgb(
-        var(--spectrum-global-color-blue-400-rgb)
-    );
+    --spectrum-global-color-blue-400: rgb(var(--spectrum-global-color-blue-400-rgb));
     --spectrum-global-color-blue-500-rgb: 2, 101, 220;
-    --spectrum-global-color-blue-500: rgb(
-        var(--spectrum-global-color-blue-500-rgb)
-    );
+    --spectrum-global-color-blue-500: rgb(var(--spectrum-global-color-blue-500-rgb));
     --spectrum-global-color-blue-600-rgb: 0, 84, 182;
-    --spectrum-global-color-blue-600: rgb(
-        var(--spectrum-global-color-blue-600-rgb)
-    );
+    --spectrum-global-color-blue-600: rgb(var(--spectrum-global-color-blue-600-rgb));
     --spectrum-global-color-blue-700-rgb: 0, 68, 145;
-    --spectrum-global-color-blue-700: rgb(
-        var(--spectrum-global-color-blue-700-rgb)
-    );
+    --spectrum-global-color-blue-700: rgb(var(--spectrum-global-color-blue-700-rgb));
     --spectrum-global-color-gray-50-rgb: 255, 255, 255;
-    --spectrum-global-color-gray-50: rgb(
-        var(--spectrum-global-color-gray-50-rgb)
-    );
+    --spectrum-global-color-gray-50: rgb(var(--spectrum-global-color-gray-50-rgb));
     --spectrum-global-color-gray-75-rgb: 253, 253, 253;
-    --spectrum-global-color-gray-75: rgb(
-        var(--spectrum-global-color-gray-75-rgb)
-    );
+    --spectrum-global-color-gray-75: rgb(var(--spectrum-global-color-gray-75-rgb));
     --spectrum-global-color-gray-100-rgb: 248, 248, 248;
-    --spectrum-global-color-gray-100: rgb(
-        var(--spectrum-global-color-gray-100-rgb)
-    );
+    --spectrum-global-color-gray-100: rgb(var(--spectrum-global-color-gray-100-rgb));
     --spectrum-global-color-gray-200-rgb: 230, 230, 230;
-    --spectrum-global-color-gray-200: rgb(
-        var(--spectrum-global-color-gray-200-rgb)
-    );
+    --spectrum-global-color-gray-200: rgb(var(--spectrum-global-color-gray-200-rgb));
     --spectrum-global-color-gray-300-rgb: 213, 213, 213;
-    --spectrum-global-color-gray-300: rgb(
-        var(--spectrum-global-color-gray-300-rgb)
-    );
+    --spectrum-global-color-gray-300: rgb(var(--spectrum-global-color-gray-300-rgb));
     --spectrum-global-color-gray-400-rgb: 177, 177, 177;
-    --spectrum-global-color-gray-400: rgb(
-        var(--spectrum-global-color-gray-400-rgb)
-    );
+    --spectrum-global-color-gray-400: rgb(var(--spectrum-global-color-gray-400-rgb));
     --spectrum-global-color-gray-500-rgb: 144, 144, 144;
-    --spectrum-global-color-gray-500: rgb(
-        var(--spectrum-global-color-gray-500-rgb)
-    );
+    --spectrum-global-color-gray-500: rgb(var(--spectrum-global-color-gray-500-rgb));
     --spectrum-global-color-gray-600-rgb: 109, 109, 109;
-    --spectrum-global-color-gray-600: rgb(
-        var(--spectrum-global-color-gray-600-rgb)
-    );
+    --spectrum-global-color-gray-600: rgb(var(--spectrum-global-color-gray-600-rgb));
     --spectrum-global-color-gray-700-rgb: 70, 70, 70;
-    --spectrum-global-color-gray-700: rgb(
-        var(--spectrum-global-color-gray-700-rgb)
-    );
+    --spectrum-global-color-gray-700: rgb(var(--spectrum-global-color-gray-700-rgb));
     --spectrum-global-color-gray-800-rgb: 34, 34, 34;
-    --spectrum-global-color-gray-800: rgb(
-        var(--spectrum-global-color-gray-800-rgb)
-    );
+    --spectrum-global-color-gray-800: rgb(var(--spectrum-global-color-gray-800-rgb));
     --spectrum-global-color-gray-900-rgb: 0, 0, 0;
-    --spectrum-global-color-gray-900: rgb(
-        var(--spectrum-global-color-gray-900-rgb)
-    );
-    --spectrum-alias-background-color-primary: var(
-        --spectrum-global-color-gray-50
-    );
-    --spectrum-alias-background-color-secondary: var(
-        --spectrum-global-color-gray-100
-    );
-    --spectrum-alias-background-color-tertiary: var(
-        --spectrum-global-color-gray-300
-    );
+    --spectrum-global-color-gray-900: rgb(var(--spectrum-global-color-gray-900-rgb));
+    --spectrum-alias-background-color-primary: var(--spectrum-global-color-gray-50);
+    --spectrum-alias-background-color-secondary: var(--spectrum-global-color-gray-100);
+    --spectrum-alias-background-color-tertiary: var(--spectrum-global-color-gray-300);
     --spectrum-alias-background-color-modal-overlay: #0006;
     --spectrum-alias-dropshadow-color: #00000026;
     --spectrum-alias-background-color-hover-overlay: #0000000a;
@@ -276,18 +152,10 @@
     --spectrum-alias-highlight-selected-hover: #0265dc33;
     --spectrum-alias-text-highlight-color: #0265dc33;
     --spectrum-alias-background-color-quickactions: #f8f8f8e6;
-    --spectrum-alias-border-color-selected: var(
-        --spectrum-global-color-blue-500
-    );
+    --spectrum-alias-border-color-selected: var(--spectrum-global-color-blue-500);
     --spectrum-alias-border-color-translucent: #0000001a;
     --spectrum-alias-radial-reaction-color-default: #2229;
-    --spectrum-alias-pasteboard-background-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-appframe-border-color: var(
-        --spectrum-global-color-gray-300
-    );
-    --spectrum-alias-appframe-separator-color: var(
-        --spectrum-global-color-gray-300
-    );
+    --spectrum-alias-pasteboard-background-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-appframe-border-color: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-appframe-separator-color: var(--spectrum-global-color-gray-300);
 }

--- a/tools/styles/src/body-overrides.css
+++ b/tools/styles/src/body-overrides.css
@@ -12,9 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Body {
-    --spectrum-body-sans-serif-font-family: var(
-        --system-body-sans-serif-font-family
-    );
+    --spectrum-body-sans-serif-font-family: var(--system-body-sans-serif-font-family);
     --spectrum-body-serif-font-family: var(--system-body-serif-font-family);
     --spectrum-body-cjk-font-family: var(--system-body-cjk-font-family);
     --spectrum-body-cjk-letter-spacing: var(--system-body-cjk-letter-spacing);

--- a/tools/styles/src/detail-overrides.css
+++ b/tools/styles/src/detail-overrides.css
@@ -12,9 +12,7 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Detail {
-    --spectrum-detail-sans-serif-font-family: var(
-        --system-detail-sans-serif-font-family
-    );
+    --spectrum-detail-sans-serif-font-family: var(--system-detail-sans-serif-font-family);
     --spectrum-detail-serif-font-family: var(--system-detail-serif-font-family);
     --spectrum-detail-cjk-font-family: var(--system-detail-cjk-font-family);
     --spectrum-detail-font-color: var(--system-detail-font-color);

--- a/tools/styles/src/heading-overrides.css
+++ b/tools/styles/src/heading-overrides.css
@@ -12,16 +12,10 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum-Heading {
-    --spectrum-heading-sans-serif-font-family: var(
-        --system-heading-sans-serif-font-family
-    );
-    --spectrum-heading-serif-font-family: var(
-        --system-heading-serif-font-family
-    );
+    --spectrum-heading-sans-serif-font-family: var(--system-heading-sans-serif-font-family);
+    --spectrum-heading-serif-font-family: var(--system-heading-serif-font-family);
     --spectrum-heading-cjk-font-family: var(--system-heading-cjk-font-family);
-    --spectrum-heading-cjk-letter-spacing: var(
-        --system-heading-cjk-letter-spacing
-    );
+    --spectrum-heading-cjk-letter-spacing: var(--system-heading-cjk-letter-spacing);
     --spectrum-heading-font-color: var(--system-heading-font-color);
     --spectrum-heading-font-size: var(--system-heading-font-size);
     --spectrum-heading-cjk-font-size: var(--system-heading-cjk-font-size);
@@ -29,56 +23,40 @@ governing permissions and limitations under the License.
 
 .spectrum-Heading--sizeXXS {
     --spectrum-heading-font-size: var(--system-heading-size-xxs-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xxs-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xxs-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXS {
     --spectrum-heading-font-size: var(--system-heading-size-xs-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xs-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xs-cjk-font-size);
 }
 
 .spectrum-Heading--sizeS {
     --spectrum-heading-font-size: var(--system-heading-size-s-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-s-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-s-cjk-font-size);
 }
 
 .spectrum-Heading--sizeM {
     --spectrum-heading-font-size: var(--system-heading-size-m-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-m-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-m-cjk-font-size);
 }
 
 .spectrum-Heading--sizeL {
     --spectrum-heading-font-size: var(--system-heading-size-l-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-l-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-l-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXL {
     --spectrum-heading-font-size: var(--system-heading-size-xl-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xl-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xl-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXXL {
     --spectrum-heading-font-size: var(--system-heading-size-xxl-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xxl-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xxl-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXXXL {
     --spectrum-heading-font-size: var(--system-heading-size-xxxl-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xxxl-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xxxl-cjk-font-size);
 }

--- a/tools/styles/typography.css
+++ b/tools/styles/typography.css
@@ -13,130 +13,58 @@
 }
 
 .spectrum-Typography .spectrum-Heading {
-    --spectrum-heading-margin-start: calc(
-        var(--mod-heading-font-size, var(--spectrum-heading-font-size)) *
-            var(--spectrum-heading-margin-top-multiplier)
-    );
-    --spectrum-heading-margin-end: calc(
-        var(--mod-heading-font-size, var(--spectrum-heading-font-size)) *
-            var(--spectrum-heading-margin-bottom-multiplier)
-    );
+    --spectrum-heading-margin-start: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-top-multiplier));
+    --spectrum-heading-margin-end: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-bottom-multiplier));
 }
 
 .spectrum-Typography .spectrum-Body {
-    --spectrum-body-margin-end: calc(
-        var(--mod-body-font-size, var(--spectrum-body-font-size)) *
-            var(--spectrum-body-margin-multiplier)
-    );
+    --spectrum-body-margin-end: calc(var(--mod-body-font-size, var(--spectrum-body-font-size)) * var(--spectrum-body-margin-multiplier));
 }
 
 .spectrum-Typography .spectrum-Detail {
-    --spectrum-detail-margin-start: calc(
-        var(--mod-detail-font-size, var(--spectrum-detail-font-size)) *
-            var(--spectrum-detail-margin-top-multiplier)
-    );
-    --spectrum-detail-margin-end: calc(
-        var(--mod-detail-font-size, var(--spectrum-detail-font-size)) *
-            var(--spectrum-detail-margin-bottom-multiplier)
-    );
+    --spectrum-detail-margin-start: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-top-multiplier));
+    --spectrum-detail-margin-end: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-bottom-multiplier));
 }
 
 .spectrum-Heading {
-    font-family: var(
-        --mod-heading-sans-serif-font-family,
-        var(--spectrum-heading-sans-serif-font-family)
-    );
-    font-style: var(
-        --mod-heading-sans-serif-font-style,
-        var(--spectrum-heading-sans-serif-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-font-weight,
-        var(--spectrum-heading-sans-serif-font-weight)
-    );
+    font-family: var(--mod-heading-sans-serif-font-family, var(--spectrum-heading-sans-serif-font-family));
+    font-style: var(--mod-heading-sans-serif-font-style, var(--spectrum-heading-sans-serif-font-style));
+    font-weight: var(--mod-heading-sans-serif-font-weight, var(--spectrum-heading-sans-serif-font-weight));
     font-size: var(--mod-heading-font-size, var(--spectrum-heading-font-size));
-    color: var(
-        --highcontrast-heading-font-color,
-        var(--mod-heading-font-color, var(--spectrum-heading-font-color))
-    );
-    line-height: var(
-        --mod-heading-line-height,
-        var(--spectrum-heading-line-height)
-    );
-    margin-block-start: var(
-        --mod-heading-margin-start,
-        var(--spectrum-heading-margin-start, 0)
-    );
-    margin-block-end: var(
-        --mod-heading-margin-end,
-        var(--spectrum-heading-margin-end, 0)
-    );
+    color: var(--highcontrast-heading-font-color, var(--mod-heading-font-color, var(--spectrum-heading-font-color)));
+    line-height: var(--mod-heading-line-height, var(--spectrum-heading-line-height));
+    margin-block-start: var(--mod-heading-margin-start, var(--spectrum-heading-margin-start, 0));
+    margin-block-end: var(--mod-heading-margin-end, var(--spectrum-heading-margin-end, 0));
 }
 
 .spectrum-Heading .spectrum-Heading-strong,
 .spectrum-Heading strong {
-    font-style: var(
-        --mod-heading-sans-serif-strong-font-style,
-        var(--spectrum-heading-sans-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-strong-font-weight,
-        var(--spectrum-heading-sans-serif-strong-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-strong-font-style, var(--spectrum-heading-sans-serif-strong-font-style));
+    font-weight: var(--mod-heading-sans-serif-strong-font-weight, var(--spectrum-heading-sans-serif-strong-font-weight));
 }
 
 .spectrum-Heading .spectrum-Heading-emphasized,
 .spectrum-Heading em {
-    font-style: var(
-        --mod-heading-sans-serif-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-emphasized-font-style, var(--spectrum-heading-sans-serif-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-emphasized-font-weight, var(--spectrum-heading-sans-serif-emphasized-font-weight));
 }
 
 .spectrum-Heading .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading em strong,
 .spectrum-Heading strong em {
-    font-style: var(
-        --mod-heading-sans-serif-strong-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-strong-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-strong-emphasized-font-style, var(--spectrum-heading-sans-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-strong-emphasized-font-weight, var(--spectrum-heading-sans-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading:lang(ja),
 .spectrum-Heading:lang(ko),
 .spectrum-Heading:lang(zh) {
-    font-family: var(
-        --mod-heading-cjk-font-family,
-        var(--spectrum-heading-cjk-font-family)
-    );
-    font-style: var(
-        --mod-heading-cjk-font-style,
-        var(--spectrum-heading-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-font-weight,
-        var(--spectrum-heading-cjk-font-weight)
-    );
-    font-size: var(
-        --mod-heading-cjk-font-size,
-        var(--spectrum-heading-cjk-font-size)
-    );
-    line-height: var(
-        --mod-heading-cjk-line-height,
-        var(--spectrum-heading-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-heading-cjk-letter-spacing,
-        var(--spectrum-heading-cjk-letter-spacing)
-    );
+    font-family: var(--mod-heading-cjk-font-family, var(--spectrum-heading-cjk-font-family));
+    font-style: var(--mod-heading-cjk-font-style, var(--spectrum-heading-cjk-font-style));
+    font-weight: var(--mod-heading-cjk-font-weight, var(--spectrum-heading-cjk-font-weight));
+    font-size: var(--mod-heading-cjk-font-size, var(--spectrum-heading-cjk-font-size));
+    line-height: var(--mod-heading-cjk-line-height, var(--spectrum-heading-cjk-line-height));
+    letter-spacing: var(--mod-heading-cjk-letter-spacing, var(--spectrum-heading-cjk-letter-spacing));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-emphasized,
@@ -145,14 +73,8 @@
 .spectrum-Heading:lang(ko) em,
 .spectrum-Heading:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-emphasized-font-style,
-        var(--spectrum-heading-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-emphasized-font-weight,
-        var(--spectrum-heading-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-emphasized-font-style, var(--spectrum-heading-cjk-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-emphasized-font-weight, var(--spectrum-heading-cjk-emphasized-font-weight));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-strong,
@@ -161,14 +83,8 @@
 .spectrum-Heading:lang(ko) strong,
 .spectrum-Heading:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-strong-font-style,
-        var(--spectrum-heading-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-strong-font-weight,
-        var(--spectrum-heading-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-strong-font-style, var(--spectrum-heading-cjk-strong-font-style));
+    font-weight: var(--mod-heading-cjk-strong-font-weight, var(--spectrum-heading-cjk-strong-font-weight));
 }
 
 .spectrum-Heading:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
@@ -180,75 +96,39 @@
 .spectrum-Heading:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading:lang(zh) em strong,
 .spectrum-Heading:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-strong-emphasized-font-style, var(--spectrum-heading-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-strong-emphasized-font-weight, var(--spectrum-heading-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-font-style,
-        var(--spectrum-heading-sans-serif-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-font-style, var(--spectrum-heading-sans-serif-heavy-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-font-weight, var(--spectrum-heading-sans-serif-heavy-font-weight));
 }
 
 .spectrum-Heading--heavy .spectrum-Heading-strong,
 .spectrum-Heading--heavy strong {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-strong-font-style,
-        var(--spectrum-heading-sans-serif-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-strong-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-strong-font-style, var(--spectrum-heading-sans-serif-heavy-strong-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-strong-font-weight, var(--spectrum-heading-sans-serif-heavy-strong-font-weight));
 }
 
 .spectrum-Heading--heavy .spectrum-Heading-emphasized,
 .spectrum-Heading--heavy em {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-emphasized-font-style, var(--spectrum-heading-sans-serif-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-emphasized-font-weight, var(--spectrum-heading-sans-serif-heavy-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy em strong,
 .spectrum-Heading--heavy strong em {
-    font-style: var(
-        --mod-heading-sans-serif-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-heavy-strong-emphasized-font-style, var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-heavy-strong-emphasized-font-weight, var(--spectrum-heading-sans-serif-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja),
 .spectrum-Heading--heavy:lang(ko),
 .spectrum-Heading--heavy:lang(zh) {
-    font-style: var(
-        --mod-heading-cjk-heavy-font-style,
-        var(--spectrum-heading-cjk-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-font-weight,
-        var(--spectrum-heading-cjk-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-font-style, var(--spectrum-heading-cjk-heavy-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-font-weight, var(--spectrum-heading-cjk-heavy-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja) .spectrum-Heading-emphasized,
@@ -257,14 +137,8 @@
 .spectrum-Heading--heavy:lang(ko) em,
 .spectrum-Heading--heavy:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-heavy-emphasized-font-style,
-        var(--spectrum-heading-cjk-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-emphasized-font-weight,
-        var(--spectrum-heading-cjk-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-emphasized-font-style, var(--spectrum-heading-cjk-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-emphasized-font-weight, var(--spectrum-heading-cjk-heavy-emphasized-font-weight));
 }
 
 .spectrum-Heading--heavy:lang(ja) .spectrum-Heading-strong,
@@ -273,97 +147,52 @@
 .spectrum-Heading--heavy:lang(ko) strong,
 .spectrum-Heading--heavy:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading--heavy:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-heavy-strong-font-style,
-        var(--spectrum-heading-cjk-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-strong-font-weight,
-        var(--spectrum-heading-cjk-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-strong-font-style, var(--spectrum-heading-cjk-heavy-strong-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-strong-font-weight, var(--spectrum-heading-cjk-heavy-strong-font-weight));
 }
 
-.spectrum-Heading--heavy:lang(ja)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(ja) em strong,
 .spectrum-Heading--heavy:lang(ja) strong em,
-.spectrum-Heading--heavy:lang(ko)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(ko) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(ko) em strong,
 .spectrum-Heading--heavy:lang(ko) strong em,
-.spectrum-Heading--heavy:lang(zh)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--heavy:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--heavy:lang(zh) em strong,
 .spectrum-Heading--heavy:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-heavy-strong-emphasized-font-style, var(--spectrum-heading-cjk-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-heavy-strong-emphasized-font-weight, var(--spectrum-heading-cjk-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--light {
-    font-style: var(
-        --mod-heading-sans-serif-light-font-style,
-        var(--spectrum-heading-sans-serif-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-font-weight,
-        var(--spectrum-heading-sans-serif-light-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-font-style, var(--spectrum-heading-sans-serif-light-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-font-weight, var(--spectrum-heading-sans-serif-light-font-weight));
 }
 
 .spectrum-Heading--light .spectrum-Heading-emphasized,
 .spectrum-Heading--light em {
-    font-style: var(
-        --mod-heading-sans-serif-light-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-emphasized-font-style, var(--spectrum-heading-sans-serif-light-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-emphasized-font-weight, var(--spectrum-heading-sans-serif-light-emphasized-font-weight));
 }
 
 .spectrum-Heading--light .spectrum-Heading-strong,
 .spectrum-Heading--light strong {
-    font-style: var(
-        --mod-heading-sans-serif-light-strong-font-style,
-        var(--spectrum-heading-sans-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-strong-font-weight,
-        var(--spectrum-heading-sans-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-strong-font-style, var(--spectrum-heading-sans-serif-light-strong-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-strong-font-weight, var(--spectrum-heading-sans-serif-light-strong-font-weight));
 }
 
 .spectrum-Heading--light .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light em strong,
 .spectrum-Heading--light strong em {
-    font-style: var(
-        --mod-heading-sans-serif-light-strong-emphasized-font-style,
-        var(--spectrum-heading-sans-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-sans-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-sans-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-sans-serif-light-strong-emphasized-font-style, var(--spectrum-heading-sans-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-sans-serif-light-strong-emphasized-font-weight, var(--spectrum-heading-sans-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja),
 .spectrum-Heading--light:lang(ko),
 .spectrum-Heading--light:lang(zh) {
-    font-style: var(
-        --mod-heading-cjk-light-font-style,
-        var(--spectrum-heading-cjk-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-font-weight,
-        var(--spectrum-heading-cjk-light-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-font-style, var(--spectrum-heading-cjk-light-font-style));
+    font-weight: var(--mod-heading-cjk-light-font-weight, var(--spectrum-heading-cjk-light-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja) .spectrum-Heading-strong,
@@ -372,14 +201,8 @@
 .spectrum-Heading--light:lang(ko) strong,
 .spectrum-Heading--light:lang(zh) .spectrum-Heading-strong,
 .spectrum-Heading--light:lang(zh) strong {
-    font-style: var(
-        --mod-heading-cjk-light-strong-font-style,
-        var(--spectrum-heading-cjk-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-strong-font-weight,
-        var(--spectrum-heading-cjk-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-strong-font-style, var(--spectrum-heading-cjk-light-strong-font-style));
+    font-weight: var(--mod-heading-cjk-light-strong-font-weight, var(--spectrum-heading-cjk-light-strong-font-weight));
 }
 
 .spectrum-Heading--light:lang(ja) .spectrum-Heading-emphasized,
@@ -388,277 +211,134 @@
 .spectrum-Heading--light:lang(ko) em,
 .spectrum-Heading--light:lang(zh) .spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(zh) em {
-    font-style: var(
-        --mod-heading-cjk-light-emphasized-font-style,
-        var(--spectrum-heading-cjk-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-emphasized-font-weight,
-        var(--spectrum-heading-cjk-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-emphasized-font-style, var(--spectrum-heading-cjk-light-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-light-emphasized-font-weight, var(--spectrum-heading-cjk-light-emphasized-font-weight));
 }
 
-.spectrum-Heading--light:lang(ja)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(ja) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(ja) em strong,
 .spectrum-Heading--light:lang(ja) strong em,
-.spectrum-Heading--light:lang(ko)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(ko) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(ko) em strong,
 .spectrum-Heading--light:lang(ko) strong em,
-.spectrum-Heading--light:lang(zh)
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--light:lang(zh) .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--light:lang(zh) em strong,
 .spectrum-Heading--light:lang(zh) strong em {
-    font-style: var(
-        --mod-heading-cjk-light-strong-emphasized-font-style,
-        var(--spectrum-heading-cjk-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-cjk-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-cjk-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-cjk-light-strong-emphasized-font-style, var(--spectrum-heading-cjk-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-cjk-light-strong-emphasized-font-weight, var(--spectrum-heading-cjk-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif {
-    font-family: var(
-        --mod-heading-serif-font-family,
-        var(--spectrum-heading-serif-font-family)
-    );
-    font-style: var(
-        --mod-heading-serif-font-style,
-        var(--spectrum-heading-serif-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-font-weight,
-        var(--spectrum-heading-serif-font-weight)
-    );
+    font-family: var(--mod-heading-serif-font-family, var(--spectrum-heading-serif-font-family));
+    font-style: var(--mod-heading-serif-font-style, var(--spectrum-heading-serif-font-style));
+    font-weight: var(--mod-heading-serif-font-weight, var(--spectrum-heading-serif-font-weight));
 }
 
 .spectrum-Heading--serif .spectrum-Heading-emphasized,
 .spectrum-Heading--serif em {
-    font-style: var(
-        --mod-heading-serif-emphasized-font-style,
-        var(--spectrum-heading-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-emphasized-font-weight,
-        var(--spectrum-heading-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-emphasized-font-style, var(--spectrum-heading-serif-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-emphasized-font-weight, var(--spectrum-heading-serif-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif .spectrum-Heading-strong,
 .spectrum-Heading--serif strong {
-    font-style: var(
-        --mod-heading-serif-strong-font-style,
-        var(--spectrum-heading-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-strong-font-weight,
-        var(--spectrum-heading-serif-strong-font-weight)
-    );
+    font-style: var(--mod-heading-serif-strong-font-style, var(--spectrum-heading-serif-strong-font-style));
+    font-weight: var(--mod-heading-serif-strong-font-weight, var(--spectrum-heading-serif-strong-font-weight));
 }
 
 .spectrum-Heading--serif .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--serif em strong,
 .spectrum-Heading--serif strong em {
-    font-style: var(
-        --mod-heading-serif-strong-emphasized-font-style,
-        var(--spectrum-heading-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-strong-emphasized-font-weight,
-        var(--spectrum-heading-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-strong-emphasized-font-style, var(--spectrum-heading-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-strong-emphasized-font-weight, var(--spectrum-heading-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--heavy {
-    font-style: var(
-        --mod-heading-serif-heavy-font-style,
-        var(--spectrum-heading-serif-heavy-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-font-weight,
-        var(--spectrum-heading-serif-heavy-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-font-style, var(--spectrum-heading-serif-heavy-font-style));
+    font-weight: var(--mod-heading-serif-heavy-font-weight, var(--spectrum-heading-serif-heavy-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--heavy .spectrum-Heading-strong,
 .spectrum-Heading--serif.spectrum-Heading--heavy strong {
-    font-style: var(
-        --mod-heading-serif-heavy-strong-font-style,
-        var(--spectrum-heading-serif-heavy-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-strong-font-weight,
-        var(--spectrum-heading-serif-heavy-strong-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-strong-font-style, var(--spectrum-heading-serif-heavy-strong-font-style));
+    font-weight: var(--mod-heading-serif-heavy-strong-font-weight, var(--spectrum-heading-serif-heavy-strong-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--heavy .spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--heavy em {
-    font-style: var(
-        --mod-heading-serif-heavy-emphasized-font-style,
-        var(--spectrum-heading-serif-heavy-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-emphasized-font-weight,
-        var(--spectrum-heading-serif-heavy-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-emphasized-font-style, var(--spectrum-heading-serif-heavy-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-heavy-emphasized-font-weight, var(--spectrum-heading-serif-heavy-emphasized-font-weight));
 }
 
-.spectrum-Heading--serif.spectrum-Heading--heavy
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--serif.spectrum-Heading--heavy .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--heavy em strong,
 .spectrum-Heading--serif.spectrum-Heading--heavy strong em {
-    font-style: var(
-        --mod-heading-serif-heavy-strong-emphasized-font-style,
-        var(--spectrum-heading-serif-heavy-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-heavy-strong-emphasized-font-weight,
-        var(--spectrum-heading-serif-heavy-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-heavy-strong-emphasized-font-style, var(--spectrum-heading-serif-heavy-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-heavy-strong-emphasized-font-weight, var(--spectrum-heading-serif-heavy-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--light {
-    font-style: var(
-        --mod-heading-serif-light-font-style,
-        var(--spectrum-heading-serif-light-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-font-weight,
-        var(--spectrum-heading-serif-light-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-font-style, var(--spectrum-heading-serif-light-font-style));
+    font-weight: var(--mod-heading-serif-light-font-weight, var(--spectrum-heading-serif-light-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--light .spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--light em {
-    font-style: var(
-        --mod-heading-serif-light-emphasized-font-style,
-        var(--spectrum-heading-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-emphasized-font-weight,
-        var(--spectrum-heading-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-emphasized-font-style, var(--spectrum-heading-serif-light-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-light-emphasized-font-weight, var(--spectrum-heading-serif-light-emphasized-font-weight));
 }
 
 .spectrum-Heading--serif.spectrum-Heading--light .spectrum-Heading-strong,
 .spectrum-Heading--serif.spectrum-Heading--light strong {
-    font-style: var(
-        --mod-heading-serif-light-strong-font-style,
-        var(--spectrum-heading-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-strong-font-weight,
-        var(--spectrum-heading-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-strong-font-style, var(--spectrum-heading-serif-light-strong-font-style));
+    font-weight: var(--mod-heading-serif-light-strong-font-weight, var(--spectrum-heading-serif-light-strong-font-weight));
 }
 
-.spectrum-Heading--serif.spectrum-Heading--light
-    .spectrum-Heading-strong.spectrum-Heading-emphasized,
+.spectrum-Heading--serif.spectrum-Heading--light .spectrum-Heading-strong.spectrum-Heading-emphasized,
 .spectrum-Heading--serif.spectrum-Heading--light em strong,
 .spectrum-Heading--serif.spectrum-Heading--light strong em {
-    font-style: var(
-        --mod-heading-serif-light-strong-emphasized-font-style,
-        var(--spectrum-heading-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-heading-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-heading-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-heading-serif-light-strong-emphasized-font-style, var(--spectrum-heading-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-heading-serif-light-strong-emphasized-font-weight, var(--spectrum-heading-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Body {
-    font-family: var(
-        --mod-body-sans-serif-font-family,
-        var(--spectrum-body-sans-serif-font-family)
-    );
-    font-style: var(
-        --mod-body-sans-serif-font-style,
-        var(--spectrum-body-sans-serif-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-font-weight,
-        var(--spectrum-body-sans-serif-font-weight)
-    );
+    font-family: var(--mod-body-sans-serif-font-family, var(--spectrum-body-sans-serif-font-family));
+    font-style: var(--mod-body-sans-serif-font-style, var(--spectrum-body-sans-serif-font-style));
+    font-weight: var(--mod-body-sans-serif-font-weight, var(--spectrum-body-sans-serif-font-weight));
     font-size: var(--mod-body-font-size, var(--spectrum-body-font-size));
-    color: var(
-        --highcontrast-body-font-color,
-        var(--mod-body-font-color, var(--spectrum-body-font-color))
-    );
+    color: var(--highcontrast-body-font-color, var(--mod-body-font-color, var(--spectrum-body-font-color)));
     line-height: var(--mod-body-line-height, var(--spectrum-body-line-height));
-    margin-block-start: var(
-        --mod-body-margin-start,
-        var(--mod-body-margin, var(--spectrum-body-margin-start, 0))
-    );
-    margin-block-end: var(
-        --mod-body-margin-end,
-        var(--mod-body-margin, var(--spectrum-body-margin-end, 0))
-    );
+    margin-block-start: var(--mod-body-margin-start, var(--mod-body-margin, var(--spectrum-body-margin-start, 0)));
+    margin-block-end: var(--mod-body-margin-end, var(--mod-body-margin, var(--spectrum-body-margin-end, 0)));
 }
 
 .spectrum-Body .spectrum-Body-strong,
 .spectrum-Body strong {
-    font-style: var(
-        --mod-body-sans-serif-strong-font-style,
-        var(--spectrum-body-sans-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-strong-font-weight,
-        var(--spectrum-body-sans-serif-strong-font-weight)
-    );
+    font-style: var(--mod-body-sans-serif-strong-font-style, var(--spectrum-body-sans-serif-strong-font-style));
+    font-weight: var(--mod-body-sans-serif-strong-font-weight, var(--spectrum-body-sans-serif-strong-font-weight));
 }
 
 .spectrum-Body .spectrum-Body-emphasized,
 .spectrum-Body em {
-    font-style: var(
-        --mod-body-sans-serif-emphasized-font-style,
-        var(--spectrum-body-sans-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-emphasized-font-weight,
-        var(--spectrum-body-sans-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-sans-serif-emphasized-font-style, var(--spectrum-body-sans-serif-emphasized-font-style));
+    font-weight: var(--mod-body-sans-serif-emphasized-font-weight, var(--spectrum-body-sans-serif-emphasized-font-weight));
 }
 
 .spectrum-Body .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body em strong,
 .spectrum-Body strong em {
-    font-style: var(
-        --mod-body-sans-serif-strong-emphasized-font-style,
-        var(--spectrum-body-sans-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-sans-serif-strong-emphasized-font-weight,
-        var(--spectrum-body-sans-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-sans-serif-strong-emphasized-font-style, var(--spectrum-body-sans-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-body-sans-serif-strong-emphasized-font-weight, var(--spectrum-body-sans-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Body:lang(ja),
 .spectrum-Body:lang(ko),
 .spectrum-Body:lang(zh) {
-    font-family: var(
-        --mod-body-cjk-font-family,
-        var(--spectrum-body-cjk-font-family)
-    );
-    font-style: var(
-        --mod-body-cjk-font-style,
-        var(--spectrum-body-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-font-weight,
-        var(--spectrum-body-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-body-cjk-line-height,
-        var(--spectrum-body-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-body-cjk-letter-spacing,
-        var(--spectrum-body-cjk-letter-spacing)
-    );
+    font-family: var(--mod-body-cjk-font-family, var(--spectrum-body-cjk-font-family));
+    font-style: var(--mod-body-cjk-font-style, var(--spectrum-body-cjk-font-style));
+    font-weight: var(--mod-body-cjk-font-weight, var(--spectrum-body-cjk-font-weight));
+    line-height: var(--mod-body-cjk-line-height, var(--spectrum-body-cjk-line-height));
+    letter-spacing: var(--mod-body-cjk-letter-spacing, var(--spectrum-body-cjk-letter-spacing));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-strong,
@@ -667,14 +347,8 @@
 .spectrum-Body:lang(ko) strong,
 .spectrum-Body:lang(zh) .spectrum-Body-strong,
 .spectrum-Body:lang(zh) strong {
-    font-style: var(
-        --mod-body-cjk-strong-font-style,
-        var(--spectrum-body-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-strong-font-weight,
-        var(--spectrum-body-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-body-cjk-strong-font-style, var(--spectrum-body-cjk-strong-font-style));
+    font-weight: var(--mod-body-cjk-strong-font-weight, var(--spectrum-body-cjk-strong-font-weight));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-emphasized,
@@ -683,14 +357,8 @@
 .spectrum-Body:lang(ko) em,
 .spectrum-Body:lang(zh) .spectrum-Body-emphasized,
 .spectrum-Body:lang(zh) em {
-    font-style: var(
-        --mod-body-cjk-emphasized-font-style,
-        var(--spectrum-body-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-emphasized-font-weight,
-        var(--spectrum-body-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-cjk-emphasized-font-style, var(--spectrum-body-cjk-emphasized-font-style));
+    font-weight: var(--mod-body-cjk-emphasized-font-weight, var(--spectrum-body-cjk-emphasized-font-weight));
 }
 
 .spectrum-Body:lang(ja) .spectrum-Body-strong.spectrum-Body-emphasized,
@@ -702,161 +370,74 @@
 .spectrum-Body:lang(zh) .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body:lang(zh) em strong,
 .spectrum-Body:lang(zh) strong em {
-    font-style: var(
-        --mod-body-cjk-strong-emphasized-font-style,
-        var(--spectrum-body-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-cjk-strong-emphasized-font-weight,
-        var(--spectrum-body-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-cjk-strong-emphasized-font-style, var(--spectrum-body-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-body-cjk-strong-emphasized-font-weight, var(--spectrum-body-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Body--serif {
-    font-family: var(
-        --mod-body-serif-font-family,
-        var(--spectrum-body-serif-font-family)
-    );
-    font-weight: var(
-        --mod-body-serif-font-weight,
-        var(--spectrum-body-serif-font-weight)
-    );
-    font-style: var(
-        --mod-body-serif-font-style,
-        var(--spectrum-body-serif-font-style)
-    );
+    font-family: var(--mod-body-serif-font-family, var(--spectrum-body-serif-font-family));
+    font-weight: var(--mod-body-serif-font-weight, var(--spectrum-body-serif-font-weight));
+    font-style: var(--mod-body-serif-font-style, var(--spectrum-body-serif-font-style));
 }
 
 .spectrum-Body--serif .spectrum-Body-strong,
 .spectrum-Body--serif strong {
-    font-style: var(
-        --mod-body-serif-strong-font-style,
-        var(--spectrum-body-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-body-serif-strong-font-weight,
-        var(--spectrum-body-serif-strong-font-weight)
-    );
+    font-style: var(--mod-body-serif-strong-font-style, var(--spectrum-body-serif-strong-font-style));
+    font-weight: var(--mod-body-serif-strong-font-weight, var(--spectrum-body-serif-strong-font-weight));
 }
 
 .spectrum-Body--serif .spectrum-Body-emphasized,
 .spectrum-Body--serif em {
-    font-style: var(
-        --mod-body-serif-emphasized-font-style,
-        var(--spectrum-body-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-serif-emphasized-font-weight,
-        var(--spectrum-body-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-serif-emphasized-font-style, var(--spectrum-body-serif-emphasized-font-style));
+    font-weight: var(--mod-body-serif-emphasized-font-weight, var(--spectrum-body-serif-emphasized-font-weight));
 }
 
 .spectrum-Body--serif .spectrum-Body-strong.spectrum-Body-emphasized,
 .spectrum-Body--serif em strong,
 .spectrum-Body--serif strong em {
-    font-style: var(
-        --mod-body-serif-strong-emphasized-font-style,
-        var(--spectrum-body-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-body-serif-strong-emphasized-font-weight,
-        var(--spectrum-body-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-body-serif-strong-emphasized-font-style, var(--spectrum-body-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-body-serif-strong-emphasized-font-weight, var(--spectrum-body-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail {
-    font-family: var(
-        --mod-detail-sans-serif-font-family,
-        var(--spectrum-detail-sans-serif-font-family)
-    );
-    font-style: var(
-        --mod-detail-sans-serif-font-style,
-        var(--spectrum-detail-sans-serif-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-font-weight,
-        var(--spectrum-detail-sans-serif-font-weight)
-    );
+    font-family: var(--mod-detail-sans-serif-font-family, var(--spectrum-detail-sans-serif-font-family));
+    font-style: var(--mod-detail-sans-serif-font-style, var(--spectrum-detail-sans-serif-font-style));
+    font-weight: var(--mod-detail-sans-serif-font-weight, var(--spectrum-detail-sans-serif-font-weight));
     font-size: var(--mod-detail-font-size, var(--spectrum-detail-font-size));
-    color: var(
-        --highcontrast-detail-font-color,
-        var(--mod-detail-font-color, var(--spectrum-detail-font-color))
-    );
-    line-height: var(
-        --mod-detail-line-height,
-        var(--spectrum-detail-line-height)
-    );
-    letter-spacing: var(
-        --mod-detail-letter-spacing,
-        var(--spectrum-detail-letter-spacing)
-    );
+    color: var(--highcontrast-detail-font-color, var(--mod-detail-font-color, var(--spectrum-detail-font-color)));
+    line-height: var(--mod-detail-line-height, var(--spectrum-detail-line-height));
+    letter-spacing: var(--mod-detail-letter-spacing, var(--spectrum-detail-letter-spacing));
     text-transform: uppercase;
-    margin-block-start: var(
-        --mod-detail-margin-start,
-        var(--spectrum-detail-margin-start, 0)
-    );
-    margin-block-end: var(
-        --mod-detail-margin-end,
-        var(--spectrum-detail-margin-end, 0)
-    );
+    margin-block-start: var(--mod-detail-margin-start, var(--spectrum-detail-margin-start, 0));
+    margin-block-end: var(--mod-detail-margin-end, var(--spectrum-detail-margin-end, 0));
 }
 
 .spectrum-Detail .spectrum-Detail-strong,
 .spectrum-Detail strong {
-    font-style: var(
-        --mod-detail-sans-serif-strong-font-style,
-        var(--spectrum-detail-sans-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-strong-font-weight,
-        var(--spectrum-detail-sans-serif-strong-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-strong-font-style, var(--spectrum-detail-sans-serif-strong-font-style));
+    font-weight: var(--mod-detail-sans-serif-strong-font-weight, var(--spectrum-detail-sans-serif-strong-font-weight));
 }
 
 .spectrum-Detail .spectrum-Detail-emphasized,
 .spectrum-Detail em {
-    font-style: var(
-        --mod-detail-sans-serif-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-emphasized-font-style, var(--spectrum-detail-sans-serif-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-emphasized-font-weight, var(--spectrum-detail-sans-serif-emphasized-font-weight));
 }
 
 .spectrum-Detail .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail em strong,
 .spectrum-Detail strong em {
-    font-style: var(
-        --mod-detail-sans-serif-strong-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-strong-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-strong-emphasized-font-style, var(--spectrum-detail-sans-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-strong-emphasized-font-weight, var(--spectrum-detail-sans-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail:lang(ja),
 .spectrum-Detail:lang(ko),
 .spectrum-Detail:lang(zh) {
-    font-family: var(
-        --mod-detail-cjk-font-family,
-        var(--spectrum-detail-cjk-font-family)
-    );
-    font-style: var(
-        --mod-detail-cjk-font-style,
-        var(--spectrum-detail-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-font-weight,
-        var(--spectrum-detail-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-detail-cjk-line-height,
-        var(--spectrum-detail-cjk-line-height)
-    );
+    font-family: var(--mod-detail-cjk-font-family, var(--spectrum-detail-cjk-font-family));
+    font-style: var(--mod-detail-cjk-font-style, var(--spectrum-detail-cjk-font-style));
+    font-weight: var(--mod-detail-cjk-font-weight, var(--spectrum-detail-cjk-font-weight));
+    line-height: var(--mod-detail-cjk-line-height, var(--spectrum-detail-cjk-line-height));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-strong,
@@ -865,14 +446,8 @@
 .spectrum-Detail:lang(ko) strong,
 .spectrum-Detail:lang(zh) .spectrum-Detail-strong,
 .spectrum-Detail:lang(zh) strong {
-    font-style: var(
-        --mod-detail-cjk-strong-font-style,
-        var(--spectrum-detail-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-strong-font-weight,
-        var(--spectrum-detail-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-strong-font-style, var(--spectrum-detail-cjk-strong-font-style));
+    font-weight: var(--mod-detail-cjk-strong-font-weight, var(--spectrum-detail-cjk-strong-font-weight));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-emphasized,
@@ -881,14 +456,8 @@
 .spectrum-Detail:lang(ko) em,
 .spectrum-Detail:lang(zh) .spectrum-Detail-emphasized,
 .spectrum-Detail:lang(zh) em {
-    font-style: var(
-        --mod-detail-cjk-emphasized-font-style,
-        var(--spectrum-detail-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-emphasized-font-weight,
-        var(--spectrum-detail-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-emphasized-font-style, var(--spectrum-detail-cjk-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-emphasized-font-weight, var(--spectrum-detail-cjk-emphasized-font-weight));
 }
 
 .spectrum-Detail:lang(ja) .spectrum-Detail-strong.spectrum-Detail-emphasized,
@@ -900,127 +469,64 @@
 .spectrum-Detail:lang(zh) .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail:lang(zh) em strong,
 .spectrum-Detail:lang(zh) strong em {
-    font-style: var(
-        --mod-detail-cjk-strong-emphasized-font-style,
-        var(--spectrum-detail-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-strong-emphasized-font-weight,
-        var(--spectrum-detail-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-strong-emphasized-font-style, var(--spectrum-detail-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-strong-emphasized-font-weight, var(--spectrum-detail-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--serif {
-    font-family: var(
-        --mod-detail-serif-font-family,
-        var(--spectrum-detail-serif-font-family)
-    );
-    font-style: var(
-        --mod-detail-serif-font-style,
-        var(--spectrum-detail-serif-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-font-weight,
-        var(--spectrum-detail-serif-font-weight)
-    );
+    font-family: var(--mod-detail-serif-font-family, var(--spectrum-detail-serif-font-family));
+    font-style: var(--mod-detail-serif-font-style, var(--spectrum-detail-serif-font-style));
+    font-weight: var(--mod-detail-serif-font-weight, var(--spectrum-detail-serif-font-weight));
 }
 
 .spectrum-Detail--serif .spectrum-Detail-strong,
 .spectrum-Detail--serif strong {
-    font-style: var(
-        --mod-detail-serif-strong-font-style,
-        var(--spectrum-detail-serif-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-strong-font-weight,
-        var(--spectrum-detail-serif-strong-font-weight)
-    );
+    font-style: var(--mod-detail-serif-strong-font-style, var(--spectrum-detail-serif-strong-font-style));
+    font-weight: var(--mod-detail-serif-strong-font-weight, var(--spectrum-detail-serif-strong-font-weight));
 }
 
 .spectrum-Detail--serif .spectrum-Detail-emphasized,
 .spectrum-Detail--serif em {
-    font-style: var(
-        --mod-detail-serif-emphasized-font-style,
-        var(--spectrum-detail-serif-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-emphasized-font-weight,
-        var(--spectrum-detail-serif-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-emphasized-font-style, var(--spectrum-detail-serif-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-emphasized-font-weight, var(--spectrum-detail-serif-emphasized-font-weight));
 }
 
 .spectrum-Detail--serif .spectrum-Detail-strong.spectrum-Detail-emphasized,
 .spectrum-Detail--serif em strong,
 .spectrum-Detail--serif strong em {
-    font-style: var(
-        --mod-detail-serif-strong-emphasized-font-style,
-        var(--spectrum-detail-serif-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-strong-emphasized-font-weight,
-        var(--spectrum-detail-serif-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-strong-emphasized-font-style, var(--spectrum-detail-serif-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-strong-emphasized-font-weight, var(--spectrum-detail-serif-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--light {
-    font-style: var(
-        --mod-detail-sans-serif-light-font-style,
-        var(--spectrum-detail-sans-serif-light-font-style)
-    );
-    font-weight: var(
-        --spectrum-detail-sans-serif-light-font-weight,
-        var(--spectrum-detail-sans-serif-light-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-font-style, var(--spectrum-detail-sans-serif-light-font-style));
+    font-weight: var(--spectrum-detail-sans-serif-light-font-weight, var(--spectrum-detail-sans-serif-light-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-strong,
 .spectrum-Detail--light strong {
-    font-style: var(
-        --mod-detail-sans-serif-light-strong-font-style,
-        var(--spectrum-detail-sans-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-strong-font-weight,
-        var(--spectrum-detail-sans-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-strong-font-style, var(--spectrum-detail-sans-serif-light-strong-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-strong-font-weight, var(--spectrum-detail-sans-serif-light-strong-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-emphasized,
 .spectrum-Detail--light em {
-    font-style: var(
-        --mod-detail-sans-serif-light-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-emphasized-font-style, var(--spectrum-detail-sans-serif-light-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-emphasized-font-weight, var(--spectrum-detail-sans-serif-light-emphasized-font-weight));
 }
 
 .spectrum-Detail--light .spectrum-Detail-strong.spectrum-Body-emphasized,
 .spectrum-Detail--light em strong,
 .spectrum-Detail--light strong em {
-    font-style: var(
-        --mod-detail-sans-serif-light-strong-emphasized-font-style,
-        var(--spectrum-detail-sans-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-sans-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-sans-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-sans-serif-light-strong-emphasized-font-style, var(--spectrum-detail-sans-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-sans-serif-light-strong-emphasized-font-weight, var(--spectrum-detail-sans-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja),
 .spectrum-Detail--light:lang(ko),
 .spectrum-Detail--light:lang(zh) {
-    font-style: var(
-        --mod-detail-cjk-light-font-style,
-        var(--spectrum-detail-cjk-light-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-font-weight,
-        var(--spectrum-detail-cjk-light-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-font-style, var(--spectrum-detail-cjk-light-font-style));
+    font-weight: var(--mod-detail-cjk-light-font-weight, var(--spectrum-detail-cjk-light-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja) .spectrum-Detail-strong,
@@ -1029,14 +535,8 @@
 .spectrum-Detail--light:lang(ko) strong,
 .spectrum-Detail--light:lang(zh) .spectrum-Detail-strong,
 .spectrum-Detail--light:lang(zh) strong {
-    font-style: var(
-        --mod-detail-cjk-light-strong-font-style,
-        var(--spectrum-detail-cjk-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-strong-font-weight,
-        var(--spectrum-detail-cjk-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-strong-font-style, var(--spectrum-detail-cjk-light-strong-font-style));
+    font-weight: var(--mod-detail-cjk-light-strong-font-weight, var(--spectrum-detail-cjk-light-strong-font-weight));
 }
 
 .spectrum-Detail--light:lang(ja) .spectrum-Detail-emphasized,
@@ -1045,79 +545,39 @@
 .spectrum-Detail--light:lang(ko) em,
 .spectrum-Detail--light:lang(zh) .spectrum-Detail-emphasized,
 .spectrum-Detail--light:lang(zh) em {
-    font-style: var(
-        --mod-detail-cjk-light-emphasized-font-style,
-        var(--spectrum-detail-cjk-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-emphasized-font-weight,
-        var(--spectrum-detail-cjk-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-cjk-light-emphasized-font-style, var(--spectrum-detail-cjk-light-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-light-emphasized-font-weight, var(--spectrum-detail-cjk-light-emphasized-font-weight));
 }
 
-.spectrum-Detail--light:lang(ja)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized,
-.spectrum-Detail--light:lang(ko)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized,
-.spectrum-Detail--light:lang(zh)
-    .spectrum-Detail-strong.spectrum-Detail-emphasized {
-    font-style: var(
-        --mod-detail-cjk-light-strong-emphasized-font-style,
-        var(--spectrum-detail-cjk-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-cjk-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-cjk-light-strong-emphasized-font-weight)
-    );
+.spectrum-Detail--light:lang(ja) .spectrum-Detail-strong.spectrum-Detail-emphasized,
+.spectrum-Detail--light:lang(ko) .spectrum-Detail-strong.spectrum-Detail-emphasized,
+.spectrum-Detail--light:lang(zh) .spectrum-Detail-strong.spectrum-Detail-emphasized {
+    font-style: var(--mod-detail-cjk-light-strong-emphasized-font-style, var(--spectrum-detail-cjk-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-cjk-light-strong-emphasized-font-weight, var(--spectrum-detail-cjk-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Detail--serif.spectrum-Detail--light {
-    font-style: var(
-        --mod-detail-serif-light-font-style,
-        var(--spectrum-detail-serif-light-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-font-weight,
-        var(--spectrum-detail-serif-light-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-font-style, var(--spectrum-detail-serif-light-font-style));
+    font-weight: var(--mod-detail-serif-light-font-weight, var(--spectrum-detail-serif-light-font-weight));
 }
 
 .spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-strong,
 .spectrum-Detail--serif.spectrum-Detail--light strong {
-    font-style: var(
-        --mod-detail-serif-light-strong-font-style,
-        var(--spectrum-detail-serif-light-strong-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-strong-font-weight,
-        var(--spectrum-detail-serif-light-strong-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-strong-font-style, var(--spectrum-detail-serif-light-strong-font-style));
+    font-weight: var(--mod-detail-serif-light-strong-font-weight, var(--spectrum-detail-serif-light-strong-font-weight));
 }
 
 .spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-emphasized,
 .spectrum-Detail--serif.spectrum-Detail--light em {
-    font-style: var(
-        --mod-detail-serif-light-emphasized-font-style,
-        var(--spectrum-detail-serif-light-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-emphasized-font-weight,
-        var(--spectrum-detail-serif-light-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-emphasized-font-style, var(--spectrum-detail-serif-light-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-light-emphasized-font-weight, var(--spectrum-detail-serif-light-emphasized-font-weight));
 }
 
-.spectrum-Detail--serif.spectrum-Detail--light
-    .spectrum-Detail-strong.spectrum-Body-emphasized,
+.spectrum-Detail--serif.spectrum-Detail--light .spectrum-Detail-strong.spectrum-Body-emphasized,
 .spectrum-Detail--serif.spectrum-Detail--light em strong,
 .spectrum-Detail--serif.spectrum-Detail--light strong em {
-    font-style: var(
-        --mod-detail-serif-light-strong-emphasized-font-style,
-        var(--spectrum-detail-serif-light-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-detail-serif-light-strong-emphasized-font-weight,
-        var(--spectrum-detail-serif-light-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-detail-serif-light-strong-emphasized-font-style, var(--spectrum-detail-serif-light-strong-emphasized-font-style));
+    font-weight: var(--mod-detail-serif-light-strong-emphasized-font-weight, var(--spectrum-detail-serif-light-strong-emphasized-font-weight));
 }
 
 .spectrum-Code {
@@ -1126,80 +586,38 @@
     font-weight: var(--mod-code-font-weight, var(--spectrum-code-font-weight));
     font-size: var(--mod-code-font-size, var(--spectrum-code-font-size));
     line-height: var(--mod-code-line-height, var(--spectrum-code-line-height));
-    color: var(
-        --highcontrast-code-font-color,
-        var(--mod-code-font-color, var(--spectrum-code-font-color))
-    );
-    margin-block-start: var(
-        --mod-code-margin-start,
-        var(--spectrum-code-margin-end, 0)
-    );
-    margin-block-end: var(
-        --mod-code-margin-end,
-        var(--spectrum-code-margin-end, 0)
-    );
+    color: var(--highcontrast-code-font-color, var(--mod-code-font-color, var(--spectrum-code-font-color)));
+    margin-block-start: var(--mod-code-margin-start, var(--spectrum-code-margin-end, 0));
+    margin-block-end: var(--mod-code-margin-end, var(--spectrum-code-margin-end, 0));
 }
 
 .spectrum-Code .spectrum-Code-strong,
 .spectrum-Code strong {
-    font-style: var(
-        --mod-code-strong-font-style,
-        var(--spectrum-code-strong-font-style)
-    );
-    font-weight: var(
-        --mod-code-strong-font-weight,
-        var(--spectrum-code-strong-font-weight)
-    );
+    font-style: var(--mod-code-strong-font-style, var(--spectrum-code-strong-font-style));
+    font-weight: var(--mod-code-strong-font-weight, var(--spectrum-code-strong-font-weight));
 }
 
 .spectrum-Code .spectrum-Code-emphasized,
 .spectrum-Code em {
-    font-style: var(
-        --mod-code-emphasized-font-style,
-        var(--spectrum-code-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-emphasized-font-weight,
-        var(--spectrum-code-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-emphasized-font-style, var(--spectrum-code-emphasized-font-style));
+    font-weight: var(--mod-code-emphasized-font-weight, var(--spectrum-code-emphasized-font-weight));
 }
 
 .spectrum-Code .spectrum-Code-strong.spectrum-Code-emphasized,
 .spectrum-Code em strong,
 .spectrum-Code strong em {
-    font-style: var(
-        --mod-code-strong-emphasized-font-style,
-        var(--spectrum-code-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-strong-emphasized-font-weight,
-        var(--spectrum-code-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-strong-emphasized-font-style, var(--spectrum-code-strong-emphasized-font-style));
+    font-weight: var(--mod-code-strong-emphasized-font-weight, var(--spectrum-code-strong-emphasized-font-weight));
 }
 
 .spectrum-Code:lang(ja),
 .spectrum-Code:lang(ko),
 .spectrum-Code:lang(zh) {
-    font-family: var(
-        --mod-code-cjk-font-family,
-        var(--spectrum-code-cjk-font-family)
-    );
-    font-style: var(
-        --mod-code-cjk-font-style,
-        var(--spectrum-code-cjk-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-font-weight,
-        var(--spectrum-code-cjk-font-weight)
-    );
-    line-height: var(
-        --mod-code-cjk-line-height,
-        var(--spectrum-code-cjk-line-height)
-    );
-    letter-spacing: var(
-        --mod-code-cjk-letter-spacing,
-        var(--spectrum-code-cjk-letter-spacing)
-    );
+    font-family: var(--mod-code-cjk-font-family, var(--spectrum-code-cjk-font-family));
+    font-style: var(--mod-code-cjk-font-style, var(--spectrum-code-cjk-font-style));
+    font-weight: var(--mod-code-cjk-font-weight, var(--spectrum-code-cjk-font-weight));
+    line-height: var(--mod-code-cjk-line-height, var(--spectrum-code-cjk-line-height));
+    letter-spacing: var(--mod-code-cjk-letter-spacing, var(--spectrum-code-cjk-letter-spacing));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-strong,
@@ -1208,14 +626,8 @@
 .spectrum-Code:lang(ko) strong,
 .spectrum-Code:lang(zh) .spectrum-Code-strong,
 .spectrum-Code:lang(zh) strong {
-    font-style: var(
-        --mod-code-cjk-strong-font-style,
-        var(--spectrum-code-cjk-strong-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-strong-font-weight,
-        var(--spectrum-code-cjk-strong-font-weight)
-    );
+    font-style: var(--mod-code-cjk-strong-font-style, var(--spectrum-code-cjk-strong-font-style));
+    font-weight: var(--mod-code-cjk-strong-font-weight, var(--spectrum-code-cjk-strong-font-weight));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-emphasized,
@@ -1224,14 +636,8 @@
 .spectrum-Code:lang(ko) em,
 .spectrum-Code:lang(zh) .spectrum-Code-emphasized,
 .spectrum-Code:lang(zh) em {
-    font-style: var(
-        --mod-code-cjk-emphasized-font-style,
-        var(--spectrum-code-cjk-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-emphasized-font-weight,
-        var(--spectrum-code-cjk-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-cjk-emphasized-font-style, var(--spectrum-code-cjk-emphasized-font-style));
+    font-weight: var(--mod-code-cjk-emphasized-font-weight, var(--spectrum-code-cjk-emphasized-font-weight));
 }
 
 .spectrum-Code:lang(ja) .spectrum-Code-strong.spectrum-Code-emphasized,
@@ -1243,27 +649,15 @@
 .spectrum-Code:lang(zh) .spectrum-Code-strong.spectrum-Code-emphasized,
 .spectrum-Code:lang(zh) em strong,
 .spectrum-Code:lang(zh) strong em {
-    font-style: var(
-        --mod-code-cjk-strong-emphasized-font-style,
-        var(--spectrum-code-cjk-strong-emphasized-font-style)
-    );
-    font-weight: var(
-        --mod-code-cjk-strong-emphasized-font-weight,
-        var(--spectrum-code-cjk-strong-emphasized-font-weight)
-    );
+    font-style: var(--mod-code-cjk-strong-emphasized-font-style, var(--spectrum-code-cjk-strong-emphasized-font-style));
+    font-weight: var(--mod-code-cjk-strong-emphasized-font-weight, var(--spectrum-code-cjk-strong-emphasized-font-weight));
 }
 
 .spectrum-Heading {
-    --spectrum-heading-sans-serif-font-family: var(
-        --system-heading-sans-serif-font-family
-    );
-    --spectrum-heading-serif-font-family: var(
-        --system-heading-serif-font-family
-    );
+    --spectrum-heading-sans-serif-font-family: var(--system-heading-sans-serif-font-family);
+    --spectrum-heading-serif-font-family: var(--system-heading-serif-font-family);
     --spectrum-heading-cjk-font-family: var(--system-heading-cjk-font-family);
-    --spectrum-heading-cjk-letter-spacing: var(
-        --system-heading-cjk-letter-spacing
-    );
+    --spectrum-heading-cjk-letter-spacing: var(--system-heading-cjk-letter-spacing);
     --spectrum-heading-font-color: var(--system-heading-font-color);
     --spectrum-heading-font-size: var(--system-heading-font-size);
     --spectrum-heading-cjk-font-size: var(--system-heading-cjk-font-size);
@@ -1271,64 +665,46 @@
 
 .spectrum-Heading--sizeXXS {
     --spectrum-heading-font-size: var(--system-heading-size-xxs-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xxs-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xxs-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXS {
     --spectrum-heading-font-size: var(--system-heading-size-xs-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xs-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xs-cjk-font-size);
 }
 
 .spectrum-Heading--sizeS {
     --spectrum-heading-font-size: var(--system-heading-size-s-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-s-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-s-cjk-font-size);
 }
 
 .spectrum-Heading--sizeM {
     --spectrum-heading-font-size: var(--system-heading-size-m-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-m-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-m-cjk-font-size);
 }
 
 .spectrum-Heading--sizeL {
     --spectrum-heading-font-size: var(--system-heading-size-l-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-l-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-l-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXL {
     --spectrum-heading-font-size: var(--system-heading-size-xl-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xl-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xl-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXXL {
     --spectrum-heading-font-size: var(--system-heading-size-xxl-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xxl-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xxl-cjk-font-size);
 }
 
 .spectrum-Heading--sizeXXXL {
     --spectrum-heading-font-size: var(--system-heading-size-xxxl-font-size);
-    --spectrum-heading-cjk-font-size: var(
-        --system-heading-size-xxxl-cjk-font-size
-    );
+    --spectrum-heading-cjk-font-size: var(--system-heading-size-xxxl-cjk-font-size);
 }
 
 .spectrum-Body {
-    --spectrum-body-sans-serif-font-family: var(
-        --system-body-sans-serif-font-family
-    );
+    --spectrum-body-sans-serif-font-family: var(--system-body-sans-serif-font-family);
     --spectrum-body-serif-font-family: var(--system-body-serif-font-family);
     --spectrum-body-cjk-font-family: var(--system-body-cjk-font-family);
     --spectrum-body-cjk-letter-spacing: var(--system-body-cjk-letter-spacing);
@@ -1365,9 +741,7 @@
 }
 
 .spectrum-Detail {
-    --spectrum-detail-sans-serif-font-family: var(
-        --system-detail-sans-serif-font-family
-    );
+    --spectrum-detail-sans-serif-font-family: var(--system-detail-sans-serif-font-family);
     --spectrum-detail-serif-font-family: var(--system-detail-serif-font-family);
     --spectrum-detail-cjk-font-family: var(--system-detail-cjk-font-family);
     --spectrum-detail-font-color: var(--system-detail-font-color);


### PR DESCRIPTION
## Description

Updating our prettier settings to cover all CSS files as they all benefit from the extended line-length in order to prevent var functions from having whitespace introduced (this makes it difficult to minify downstream).

I also updated quotes to use double quotes which is a more standard CSS best-practice and matches what is done in Spectrum CSS.

## Related issue(s)

-   Minor tooling enhancement

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [n/a] I have added automated tests to cover my changes.
-   [n/a] I have included a well-written changeset if my change needs to be published.
-   [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before author can update Golden Hash

### Manual review test cases

-   [ ] _yarn build_

    1. Expect the CSS build to run linting
    2. Expect linting to retain var functions on one line
    3. Expect linting to use double quotes instead of single in attribute selectors
