### PR TITLE
docs(picker): updated docs with allowed menu content

### DIFF
--- a/packages/picker/README.md
+++ b/packages/picker/README.md
@@ -32,6 +32,8 @@ import { Picker } from '@spectrum-web-components/picker';
 
 ### Anatomy
 
+A picker includes a label and a menu..
+
 #### Labels
 
 To render accessibly, an `<sp-picker>` element should be paired with an `<sp-field-label>` element that has the `for` attribute referencing the `id` of the `<sp-picker>` element.
@@ -90,6 +92,32 @@ For an accessible label that renders within the bounds of the picker itself, but
 
 </sp-tab-panel>
 </sp-tabs>
+
+#### Menu
+
+The picker menu is a menu element that is used to display the options for the picker. A picker menu can include menu items, menu dividers, and menu groups. A picker menu should never contain submenus, as doing so would render it in accessible.
+
+If you require a submenu, use and [action menu](./action-menu) instead.
+
+```html demo
+<sp-picker>
+    <span slot="label">Select a free food item:</span>
+    <sp-menu-group>
+        <span slot="header">Fruits</span>
+        <sp-menu-item>Apple</sp-menu-item>
+        <sp-menu-item>Banana</sp-menu-item>
+        <sp-menu-item>Pear</sp-menu-item>
+    </sp-menu-group>
+    <sp-menu-divider></sp-menu-divider>
+    <sp-menu-group>
+        <span slot="header">Vegetables</span>
+        <sp-menu-item>Artichoke</sp-menu-item>
+        <sp-menu-item>Carrot</sp-menu-item>
+        <sp-menu-item>Potato</sp-menu-item>
+    </sp-menu-group>
+    <sp-menu-group>
+</sp-picker>
+```
 
 #### Icons
 
@@ -660,3 +688,7 @@ Use [`<sp-help-text>`](../help-text/) to add help text and error text:
 
 </sp-tab-panel>
 </sp-tabs>
+
+#### Do not use submenus
+
+A picker menu should never contain submenus, as doing so would render it in accessible. A picker's menu role is a listbox and it's menu items are listbox options, which are not allowed to have submenus.


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

- added example of picker using `sp-menu-group` 
- added accessbility warning not to use submenus

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

While answering Slack support questions about `sp-picker`, I noticed we do not have examples of `sp-picker` with grouped menu items using `sp-menu-group`. This is a valid use case, so we should show it in the docs.

Additionally, I had a number of questions about using submenus and other interactive items in a`sp-picker`. This is not accessible, and we should note that in the accessibility section of the docs.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   SWC-848

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes. _(N/A docs update only)_
-   [ ] I have included a well-written changeset if my change needs to be published. _(N/A docs update only)_
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features _(N/A docs update only)_
-   [ ] Automated tests cover all use cases and follow best practices for writing _(N/A docs update only)_
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Picker Docs_

    1. Go to the [picker docs](https://nikkimk-picker-group-submenu-docs--spectrum-wc.netlify.app/components/picker/)
    2. Does the documentation include that picker can be used with `sp-menu-group` elements in its menu?
    3. Does the documentation make it clear that picker should not contain submenus, as they will render it inaccessible?
    4. Does the documentation suggest using an action menu instead of a picker if submenus are needed?

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
