### PR TITLE
chore: add jira to issue template [SWC-580]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -79,3 +79,10 @@ body:
       attributes:
           label: Logs taken while reproducing problem
           description: You can attach log files by clicking this area to highlight it and then dragging files in.
+    - type: checkboxes
+      id: jira-number
+      attributes:
+          label: Would you like to track this issue in Jira?
+          description: We will share the Jira ticket ID in a comment on the issue once it has been triaged.
+          options:
+              - label: Yes, please tell me the ticket number!

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -37,3 +37,10 @@ body:
       id: code
       attributes:
           label: Implementation notes or ideas
+    - type: checkboxes
+      id: jira-number
+      attributes:
+          label: Would you like to track this issue in Jira?
+          description: We will share the Jira ticket ID in a comment on the issue once it has been triaged.
+          options:
+              - label: Yes, please tell me the ticket number!

--- a/.github/ISSUE_TEMPLATE/general.yaml
+++ b/.github/ISSUE_TEMPLATE/general.yaml
@@ -19,3 +19,10 @@ body:
       attributes:
           label: Description of issue
           description: Please tell us about the issue. You can attach images or files by clicking this area to highlight it and then dragging files in.
+    - type: checkboxes
+      id: jira-number
+      attributes:
+          label: Would you like to track this issue in Jira?
+          description: We will share the Jira ticket ID in a comment on the issue once it has been triaged.
+          options:
+              - label: Yes, please tell me the ticket number!

--- a/.github/ISSUE_TEMPLATE/new_component.yaml
+++ b/.github/ISSUE_TEMPLATE/new_component.yaml
@@ -49,3 +49,10 @@ body:
       id: other
       attributes:
           label: Other requirements
+    - type: checkboxes
+      id: jira-number
+      attributes:
+          label: Would you like to track this issue in Jira?
+          description: We will share the Jira ticket ID in a comment on the issue once it has been triaged.
+          options:
+              - label: Yes, please tell me the ticket number!


### PR DESCRIPTION
## Description

I expect to see a new checkbox at the bottom of each of the following templates allowing users to receiving a Jira ticket notification:

- bug_report.yaml
- feature_request.yaml
- new_component.yaml
- general.yaml

## Related issue(s)

-   fixes [SWC-580]

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [n/a] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [n/a] I have added automated tests to cover my changes.
-   [n/a] I have included a well-written changeset if my change needs to be published.
-   [n/a] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

Once merged to main, we can validate this update worked by attempting to open each of the updated issue templates and see an additional Jira checkbox at the end.