### PR TITLE
chore: apply formatting updates to tools

### DIFF
--- a/tools/opacity-checkerboard/src/is-opacity-checkerboard.css
+++ b/tools/opacity-checkerboard/src/is-opacity-checkerboard.css
@@ -10,5 +10,5 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('./spectrum-is-opacity-checkerboard.css');
-@import url('./is-opacity-checkerboard-overrides.css');
+@import url("./spectrum-is-opacity-checkerboard.css");
+@import url("./is-opacity-checkerboard-overrides.css");

--- a/tools/opacity-checkerboard/src/opacity-checkerboard.css
+++ b/tools/opacity-checkerboard/src/opacity-checkerboard.css
@@ -10,5 +10,5 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('./spectrum-opacity-checkerboard.css');
-@import url('./opacity-checkerboard-overrides.css');
+@import url("./spectrum-opacity-checkerboard.css");
+@import url("./opacity-checkerboard-overrides.css");

--- a/tools/styles/all-large-dark.css
+++ b/tools/styles/all-large-dark.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import 'core-global.css';
-@import 'typography.css';
-@import 'theme-dark.css';
-@import 'scale-large.css';
+@import "core-global.css";
+@import "typography.css";
+@import "theme-dark.css";
+@import "scale-large.css";

--- a/tools/styles/all-large-darkest.css
+++ b/tools/styles/all-large-darkest.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import 'core-global.css';
-@import 'typography.css';
-@import 'theme-darkest.css';
-@import 'scale-large.css';
+@import "core-global.css";
+@import "typography.css";
+@import "theme-darkest.css";
+@import "scale-large.css";

--- a/tools/styles/all-large-light.css
+++ b/tools/styles/all-large-light.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import 'core-global.css';
-@import 'typography.css';
-@import 'theme-light.css';
-@import 'scale-large.css';
+@import "core-global.css";
+@import "typography.css";
+@import "theme-light.css";
+@import "scale-large.css";

--- a/tools/styles/all-large-lightest.css
+++ b/tools/styles/all-large-lightest.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import 'core-global.css';
-@import 'typography.css';
-@import 'theme-lightest.css';
-@import 'scale-large.css';
+@import "core-global.css";
+@import "typography.css";
+@import "theme-lightest.css";
+@import "scale-large.css";

--- a/tools/styles/all-medium-dark.css
+++ b/tools/styles/all-medium-dark.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import 'core-global.css';
-@import 'typography.css';
-@import 'theme-dark.css';
-@import 'scale-medium.css';
+@import "core-global.css";
+@import "typography.css";
+@import "theme-dark.css";
+@import "scale-medium.css";

--- a/tools/styles/all-medium-darkest.css
+++ b/tools/styles/all-medium-darkest.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import 'core-global.css';
-@import 'typography.css';
-@import 'theme-darkest.css';
-@import 'scale-medium.css';
+@import "core-global.css";
+@import "typography.css";
+@import "theme-darkest.css";
+@import "scale-medium.css";

--- a/tools/styles/all-medium-light.css
+++ b/tools/styles/all-medium-light.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import 'core-global.css';
-@import 'typography.css';
-@import 'theme-light.css';
-@import 'scale-medium.css';
+@import "core-global.css";
+@import "typography.css";
+@import "theme-light.css";
+@import "scale-medium.css";

--- a/tools/styles/all-medium-lightest.css
+++ b/tools/styles/all-medium-lightest.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import 'core-global.css';
-@import 'typography.css';
-@import 'theme-lightest.css';
-@import 'scale-medium.css';
+@import "core-global.css";
+@import "typography.css";
+@import "theme-lightest.css";
+@import "scale-medium.css";

--- a/tools/styles/core-global.css
+++ b/tools/styles/core-global.css
@@ -9,7 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-core-global.css';
+@import "./spectrum-core-global.css";
 
 :host,
 :root {

--- a/tools/styles/express/core-global.css
+++ b/tools/styles/express/core-global.css
@@ -9,7 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-core-global.css';
+@import "./spectrum-core-global.css";
 
 :host,
 :root {

--- a/tools/styles/express/scale-large.css
+++ b/tools/styles/express/scale-large.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-scale-large.css';
+@import "./spectrum-scale-large.css";
 
 :host,
 :root {

--- a/tools/styles/express/scale-medium.css
+++ b/tools/styles/express/scale-medium.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-scale-medium.css';
+@import "./spectrum-scale-medium.css";
 
 :host,
 :root {

--- a/tools/styles/express/theme-dark.css
+++ b/tools/styles/express/theme-dark.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-theme-dark.css';
+@import "./spectrum-theme-dark.css";
 
 :host,
 :root {

--- a/tools/styles/express/theme-light.css
+++ b/tools/styles/express/theme-light.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-theme-light.css';
+@import "./spectrum-theme-light.css";
 
 :host,
 :root {

--- a/tools/styles/scale-large.css
+++ b/tools/styles/scale-large.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-scale-large.css';
+@import "./spectrum-scale-large.css";
 
 :host,
 :root {

--- a/tools/styles/scale-medium.css
+++ b/tools/styles/scale-medium.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-scale-medium.css';
+@import "./spectrum-scale-medium.css";
 
 :host,
 :root {

--- a/tools/styles/spectrum-two/core-global.css
+++ b/tools/styles/spectrum-two/core-global.css
@@ -9,7 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-core-global.css';
+@import "./spectrum-core-global.css";
 
 :host,
 :root {

--- a/tools/styles/spectrum-two/scale-large.css
+++ b/tools/styles/spectrum-two/scale-large.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-scale-large.css';
+@import "./spectrum-scale-large.css";
 
 :host,
 :root {

--- a/tools/styles/spectrum-two/scale-medium.css
+++ b/tools/styles/spectrum-two/scale-medium.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-scale-medium.css';
+@import "./spectrum-scale-medium.css";
 
 :host,
 :root {

--- a/tools/styles/spectrum-two/theme-dark.css
+++ b/tools/styles/spectrum-two/theme-dark.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-theme-dark.css';
+@import "./spectrum-theme-dark.css";
 
 :host,
 :root {

--- a/tools/styles/spectrum-two/theme-light.css
+++ b/tools/styles/spectrum-two/theme-light.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-theme-light.css';
+@import "./spectrum-theme-light.css";
 
 :host,
 :root {

--- a/tools/styles/src/spectrum-base.css
+++ b/tools/styles/src/spectrum-base.css
@@ -13,14 +13,8 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .spectrum {
     color: var(--spectrum-body-m-text-color, var(--spectrum-alias-text-color));
-    font-family: var(
-        --spectrum-alias-body-text-font-family,
-        var(--spectrum-global-font-family-base)
-    ); /* .spectrum */
+    font-family: var(--spectrum-alias-body-text-font-family, var(--spectrum-global-font-family-base)); /* .spectrum */
 
-    font-size: var(
-        --spectrum-alias-font-size-default,
-        var(--spectrum-global-dimension-font-size-100)
-    ); /* .spectrum,
+    font-size: var(--spectrum-alias-font-size-default, var(--spectrum-global-dimension-font-size-100)); /* .spectrum,
    * .spectrum-Body */
 }

--- a/tools/styles/theme-dark.css
+++ b/tools/styles/theme-dark.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-theme-dark.css';
+@import "./spectrum-theme-dark.css";
 
 :host,
 :root {

--- a/tools/styles/theme-darkest.css
+++ b/tools/styles/theme-darkest.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-theme-darkest.css';
+@import "./spectrum-theme-darkest.css";
 
 :host,
 :root {

--- a/tools/styles/theme-light.css
+++ b/tools/styles/theme-light.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-theme-light.css';
+@import "./spectrum-theme-light.css";
 
 :host,
 :root {

--- a/tools/styles/theme-lightest.css
+++ b/tools/styles/theme-lightest.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import './spectrum-theme-lightest.css';
+@import "./spectrum-theme-lightest.css";
 
 :host,
 :root {

--- a/tools/styles/tokens-v2/dark-vars.css
+++ b/tools/styles/tokens-v2/dark-vars.css
@@ -2,68 +2,32 @@
 :root {
     --spectrum-overlay-opacity: 0.6;
     --spectrum-background-layer-2-color: var(--spectrum-gray-75);
-    --spectrum-neutral-subdued-background-color-default: var(
-        --spectrum-gray-500
-    );
+    --spectrum-neutral-subdued-background-color-default: var(--spectrum-gray-500);
     --spectrum-neutral-subdued-background-color-hover: var(--spectrum-gray-400);
     --spectrum-neutral-subdued-background-color-down: var(--spectrum-gray-400);
-    --spectrum-neutral-subdued-background-color-key-focus: var(
-        --spectrum-gray-400
-    );
-    --spectrum-accent-background-color-default: var(
-        --spectrum-accent-color-800
-    );
+    --spectrum-neutral-subdued-background-color-key-focus: var(--spectrum-gray-400);
+    --spectrum-accent-background-color-default: var(--spectrum-accent-color-800);
     --spectrum-accent-background-color-hover: var(--spectrum-accent-color-700);
     --spectrum-accent-background-color-down: var(--spectrum-accent-color-700);
-    --spectrum-accent-background-color-key-focus: var(
-        --spectrum-accent-color-700
-    );
-    --spectrum-informative-background-color-default: var(
-        --spectrum-informative-color-800
-    );
-    --spectrum-informative-background-color-hover: var(
-        --spectrum-informative-color-700
-    );
-    --spectrum-informative-background-color-down: var(
-        --spectrum-informative-color-700
-    );
-    --spectrum-informative-background-color-key-focus: var(
-        --spectrum-informative-color-700
-    );
-    --spectrum-negative-background-color-default: var(
-        --spectrum-negative-color-800
-    );
-    --spectrum-negative-background-color-hover: var(
-        --spectrum-negative-color-700
-    );
-    --spectrum-negative-background-color-down: var(
-        --spectrum-negative-color-700
-    );
-    --spectrum-negative-background-color-key-focus: var(
-        --spectrum-negative-color-700
-    );
-    --spectrum-positive-background-color-default: var(
-        --spectrum-positive-color-800
-    );
-    --spectrum-positive-background-color-hover: var(
-        --spectrum-positive-color-700
-    );
-    --spectrum-positive-background-color-down: var(
-        --spectrum-positive-color-700
-    );
-    --spectrum-positive-background-color-key-focus: var(
-        --spectrum-positive-color-700
-    );
-    --spectrum-notice-background-color-default: var(
-        --spectrum-notice-color-900
-    );
+    --spectrum-accent-background-color-key-focus: var(--spectrum-accent-color-700);
+    --spectrum-informative-background-color-default: var(--spectrum-informative-color-800);
+    --spectrum-informative-background-color-hover: var(--spectrum-informative-color-700);
+    --spectrum-informative-background-color-down: var(--spectrum-informative-color-700);
+    --spectrum-informative-background-color-key-focus: var(--spectrum-informative-color-700);
+    --spectrum-negative-background-color-default: var(--spectrum-negative-color-800);
+    --spectrum-negative-background-color-hover: var(--spectrum-negative-color-700);
+    --spectrum-negative-background-color-down: var(--spectrum-negative-color-700);
+    --spectrum-negative-background-color-key-focus: var(--spectrum-negative-color-700);
+    --spectrum-positive-background-color-default: var(--spectrum-positive-color-800);
+    --spectrum-positive-background-color-hover: var(--spectrum-positive-color-700);
+    --spectrum-positive-background-color-down: var(--spectrum-positive-color-700);
+    --spectrum-positive-background-color-key-focus: var(--spectrum-positive-color-700);
+    --spectrum-notice-background-color-default: var(--spectrum-notice-color-900);
     --spectrum-gray-background-color-default: var(--spectrum-gray-500);
     --spectrum-red-background-color-default: var(--spectrum-red-800);
     --spectrum-orange-background-color-default: var(--spectrum-orange-900);
     --spectrum-yellow-background-color-default: var(--spectrum-yellow-1100);
-    --spectrum-chartreuse-background-color-default: var(
-        --spectrum-chartreuse-1000
-    );
+    --spectrum-chartreuse-background-color-default: var(--spectrum-chartreuse-1000);
     --spectrum-celery-background-color-default: var(--spectrum-celery-900);
     --spectrum-green-background-color-default: var(--spectrum-green-800);
     --spectrum-seafoam-background-color-default: var(--spectrum-seafoam-800);
@@ -104,224 +68,113 @@
     --spectrum-cinnamon-background-color-default: var(--spectrum-cinnamon-800);
     --spectrum-pink-background-color-default: var(--spectrum-pink-800);
     --spectrum-silver-background-color-default: var(--spectrum-silver-800);
-    --spectrum-turquoise-background-color-default: var(
-        --spectrum-turquoise-800
-    );
+    --spectrum-turquoise-background-color-default: var(--spectrum-turquoise-800);
     --spectrum-drop-shadow-color-100-rgb: 0, 0, 0;
     --spectrum-drop-shadow-color-100-opacity: 0.36;
-    --spectrum-drop-shadow-color-100: rgba(
-        var(--spectrum-drop-shadow-color-100-rgb),
-        var(--spectrum-drop-shadow-color-100-opacity)
-    );
+    --spectrum-drop-shadow-color-100: rgba(var(--spectrum-drop-shadow-color-100-rgb), var(--spectrum-drop-shadow-color-100-opacity));
     --spectrum-drop-shadow-color-200-rgb: 0, 0, 0;
     --spectrum-drop-shadow-color-200-opacity: 0.48;
-    --spectrum-drop-shadow-color-200: rgba(
-        var(--spectrum-drop-shadow-color-200-rgb),
-        var(--spectrum-drop-shadow-color-200-opacity)
-    );
+    --spectrum-drop-shadow-color-200: rgba(var(--spectrum-drop-shadow-color-200-rgb), var(--spectrum-drop-shadow-color-200-opacity));
     --spectrum-drop-shadow-color-300-rgb: 0, 0, 0;
     --spectrum-drop-shadow-color-300-opacity: 0.6;
-    --spectrum-drop-shadow-color-300: rgba(
-        var(--spectrum-drop-shadow-color-300-rgb),
-        var(--spectrum-drop-shadow-color-300-opacity)
-    );
-    --spectrum-neutral-subtle-background-color-default: var(
-        --spectrum-gray-300
-    );
+    --spectrum-drop-shadow-color-300: rgba(var(--spectrum-drop-shadow-color-300-rgb), var(--spectrum-drop-shadow-color-300-opacity));
+    --spectrum-neutral-subtle-background-color-default: var(--spectrum-gray-300);
     --spectrum-gray-subtle-background-color-default: var(--spectrum-gray-300);
     --spectrum-blue-subtle-background-color-default: var(--spectrum-blue-300);
     --spectrum-green-subtle-background-color-default: var(--spectrum-green-300);
-    --spectrum-orange-subtle-background-color-default: var(
-        --spectrum-orange-300
-    );
+    --spectrum-orange-subtle-background-color-default: var(--spectrum-orange-300);
     --spectrum-red-subtle-background-color-default: var(--spectrum-red-300);
     --spectrum-brown-subtle-background-color-default: var(--spectrum-brown-300);
-    --spectrum-cinnamon-subtle-background-color-default: var(
-        --spectrum-cinnamon-300
-    );
-    --spectrum-celery-subtle-background-color-default: var(
-        --spectrum-celery-300
-    );
-    --spectrum-chartreuse-subtle-background-color-default: var(
-        --spectrum-chartreuse-300
-    );
+    --spectrum-cinnamon-subtle-background-color-default: var(--spectrum-cinnamon-300);
+    --spectrum-celery-subtle-background-color-default: var(--spectrum-celery-300);
+    --spectrum-chartreuse-subtle-background-color-default: var(--spectrum-chartreuse-300);
     --spectrum-cyan-subtle-background-color-default: var(--spectrum-cyan-300);
-    --spectrum-fuchsia-subtle-background-color-default: var(
-        --spectrum-fuchsia-300
-    );
-    --spectrum-indigo-subtle-background-color-default: var(
-        --spectrum-indigo-300
-    );
-    --spectrum-magenta-subtle-background-color-default: var(
-        --spectrum-magenta-300
-    );
+    --spectrum-fuchsia-subtle-background-color-default: var(--spectrum-fuchsia-300);
+    --spectrum-indigo-subtle-background-color-default: var(--spectrum-indigo-300);
+    --spectrum-magenta-subtle-background-color-default: var(--spectrum-magenta-300);
     --spectrum-pink-subtle-background-color-default: var(--spectrum-pink-300);
-    --spectrum-purple-subtle-background-color-default: var(
-        --spectrum-purple-300
-    );
-    --spectrum-seafoam-subtle-background-color-default: var(
-        --spectrum-seafoam-300
-    );
-    --spectrum-silver-subtle-background-color-default: var(
-        --spectrum-silver-300
-    );
-    --spectrum-turquoise-subtle-background-color-default: var(
-        --spectrum-turquoise-300
-    );
-    --spectrum-yellow-subtle-background-color-default: var(
-        --spectrum-yellow-300
-    );
+    --spectrum-purple-subtle-background-color-default: var(--spectrum-purple-300);
+    --spectrum-seafoam-subtle-background-color-default: var(--spectrum-seafoam-300);
+    --spectrum-silver-subtle-background-color-default: var(--spectrum-silver-300);
+    --spectrum-turquoise-subtle-background-color-default: var(--spectrum-turquoise-300);
+    --spectrum-yellow-subtle-background-color-default: var(--spectrum-yellow-300);
     --spectrum-opacity-checkerboard-square-dark: var(--spectrum-gray-800);
     --spectrum-white-rgb: 255, 255, 255;
     --spectrum-white: rgba(var(--spectrum-white-rgb));
     --spectrum-transparent-white-25-rgb: 255, 255, 255;
     --spectrum-transparent-white-25-opacity: 0;
-    --spectrum-transparent-white-25: rgba(
-        var(--spectrum-transparent-white-25-rgb),
-        var(--spectrum-transparent-white-25-opacity)
-    );
+    --spectrum-transparent-white-25: rgba(var(--spectrum-transparent-white-25-rgb), var(--spectrum-transparent-white-25-opacity));
     --spectrum-transparent-white-50-rgb: 255, 255, 255;
     --spectrum-transparent-white-50-opacity: 0.04;
-    --spectrum-transparent-white-50: rgba(
-        var(--spectrum-transparent-white-50-rgb),
-        var(--spectrum-transparent-white-50-opacity)
-    );
+    --spectrum-transparent-white-50: rgba(var(--spectrum-transparent-white-50-rgb), var(--spectrum-transparent-white-50-opacity));
     --spectrum-transparent-white-75-rgb: 255, 255, 255;
     --spectrum-transparent-white-75-opacity: 0.07;
-    --spectrum-transparent-white-75: rgba(
-        var(--spectrum-transparent-white-75-rgb),
-        var(--spectrum-transparent-white-75-opacity)
-    );
+    --spectrum-transparent-white-75: rgba(var(--spectrum-transparent-white-75-rgb), var(--spectrum-transparent-white-75-opacity));
     --spectrum-transparent-white-100-rgb: 255, 255, 255;
     --spectrum-transparent-white-100-opacity: 0.11;
-    --spectrum-transparent-white-100: rgba(
-        var(--spectrum-transparent-white-100-rgb),
-        var(--spectrum-transparent-white-100-opacity)
-    );
+    --spectrum-transparent-white-100: rgba(var(--spectrum-transparent-white-100-rgb), var(--spectrum-transparent-white-100-opacity));
     --spectrum-transparent-white-200-rgb: 255, 255, 255;
     --spectrum-transparent-white-200-opacity: 0.14;
-    --spectrum-transparent-white-200: rgba(
-        var(--spectrum-transparent-white-200-rgb),
-        var(--spectrum-transparent-white-200-opacity)
-    );
+    --spectrum-transparent-white-200: rgba(var(--spectrum-transparent-white-200-rgb), var(--spectrum-transparent-white-200-opacity));
     --spectrum-transparent-white-300-rgb: 255, 255, 255;
     --spectrum-transparent-white-300-opacity: 0.17;
-    --spectrum-transparent-white-300: rgba(
-        var(--spectrum-transparent-white-300-rgb),
-        var(--spectrum-transparent-white-300-opacity)
-    );
+    --spectrum-transparent-white-300: rgba(var(--spectrum-transparent-white-300-rgb), var(--spectrum-transparent-white-300-opacity));
     --spectrum-transparent-white-400-rgb: 255, 255, 255;
     --spectrum-transparent-white-400-opacity: 0.21;
-    --spectrum-transparent-white-400: rgba(
-        var(--spectrum-transparent-white-400-rgb),
-        var(--spectrum-transparent-white-400-opacity)
-    );
+    --spectrum-transparent-white-400: rgba(var(--spectrum-transparent-white-400-rgb), var(--spectrum-transparent-white-400-opacity));
     --spectrum-transparent-white-500-rgb: 255, 255, 255;
     --spectrum-transparent-white-500-opacity: 0.39;
-    --spectrum-transparent-white-500: rgba(
-        var(--spectrum-transparent-white-500-rgb),
-        var(--spectrum-transparent-white-500-opacity)
-    );
+    --spectrum-transparent-white-500: rgba(var(--spectrum-transparent-white-500-rgb), var(--spectrum-transparent-white-500-opacity));
     --spectrum-transparent-white-600-rgb: 255, 255, 255;
     --spectrum-transparent-white-600-opacity: 0.51;
-    --spectrum-transparent-white-600: rgba(
-        var(--spectrum-transparent-white-600-rgb),
-        var(--spectrum-transparent-white-600-opacity)
-    );
+    --spectrum-transparent-white-600: rgba(var(--spectrum-transparent-white-600-rgb), var(--spectrum-transparent-white-600-opacity));
     --spectrum-transparent-white-700-rgb: 255, 255, 255;
     --spectrum-transparent-white-700-opacity: 0.66;
-    --spectrum-transparent-white-700: rgba(
-        var(--spectrum-transparent-white-700-rgb),
-        var(--spectrum-transparent-white-700-opacity)
-    );
+    --spectrum-transparent-white-700: rgba(var(--spectrum-transparent-white-700-rgb), var(--spectrum-transparent-white-700-opacity));
     --spectrum-transparent-white-800-rgb: 255, 255, 255;
     --spectrum-transparent-white-800-opacity: 0.85;
-    --spectrum-transparent-white-800: rgba(
-        var(--spectrum-transparent-white-800-rgb),
-        var(--spectrum-transparent-white-800-opacity)
-    );
+    --spectrum-transparent-white-800: rgba(var(--spectrum-transparent-white-800-rgb), var(--spectrum-transparent-white-800-opacity));
     --spectrum-transparent-white-900-rgb: 255, 255, 255;
     --spectrum-transparent-white-900-opacity: 0.94;
-    --spectrum-transparent-white-900: rgba(
-        var(--spectrum-transparent-white-900-rgb),
-        var(--spectrum-transparent-white-900-opacity)
-    );
+    --spectrum-transparent-white-900: rgba(var(--spectrum-transparent-white-900-rgb), var(--spectrum-transparent-white-900-opacity));
     --spectrum-transparent-white-1000-rgb: 255, 255, 255;
-    --spectrum-transparent-white-1000: rgba(
-        var(--spectrum-transparent-white-1000-rgb)
-    );
+    --spectrum-transparent-white-1000: rgba(var(--spectrum-transparent-white-1000-rgb));
     --spectrum-transparent-black-25-rgb: 0, 0, 0;
     --spectrum-transparent-black-25-opacity: 0;
-    --spectrum-transparent-black-25: rgba(
-        var(--spectrum-transparent-black-25-rgb),
-        var(--spectrum-transparent-black-25-opacity)
-    );
+    --spectrum-transparent-black-25: rgba(var(--spectrum-transparent-black-25-rgb), var(--spectrum-transparent-black-25-opacity));
     --spectrum-transparent-black-50-rgb: 0, 0, 0;
     --spectrum-transparent-black-50-opacity: 0.03;
-    --spectrum-transparent-black-50: rgba(
-        var(--spectrum-transparent-black-50-rgb),
-        var(--spectrum-transparent-black-50-opacity)
-    );
+    --spectrum-transparent-black-50: rgba(var(--spectrum-transparent-black-50-rgb), var(--spectrum-transparent-black-50-opacity));
     --spectrum-transparent-black-75-rgb: 0, 0, 0;
     --spectrum-transparent-black-75-opacity: 0.05;
-    --spectrum-transparent-black-75: rgba(
-        var(--spectrum-transparent-black-75-rgb),
-        var(--spectrum-transparent-black-75-opacity)
-    );
+    --spectrum-transparent-black-75: rgba(var(--spectrum-transparent-black-75-rgb), var(--spectrum-transparent-black-75-opacity));
     --spectrum-transparent-black-100-rgb: 0, 0, 0;
     --spectrum-transparent-black-100-opacity: 0.09;
-    --spectrum-transparent-black-100: rgba(
-        var(--spectrum-transparent-black-100-rgb),
-        var(--spectrum-transparent-black-100-opacity)
-    );
+    --spectrum-transparent-black-100: rgba(var(--spectrum-transparent-black-100-rgb), var(--spectrum-transparent-black-100-opacity));
     --spectrum-transparent-black-200-rgb: 0, 0, 0;
     --spectrum-transparent-black-200-opacity: 0.12;
-    --spectrum-transparent-black-200: rgba(
-        var(--spectrum-transparent-black-200-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
+    --spectrum-transparent-black-200: rgba(var(--spectrum-transparent-black-200-rgb), var(--spectrum-transparent-black-200-opacity));
     --spectrum-transparent-black-300-rgb: 0, 0, 0;
     --spectrum-transparent-black-300-opacity: 0.15;
-    --spectrum-transparent-black-300: rgba(
-        var(--spectrum-transparent-black-300-rgb),
-        var(--spectrum-transparent-black-300-opacity)
-    );
+    --spectrum-transparent-black-300: rgba(var(--spectrum-transparent-black-300-rgb), var(--spectrum-transparent-black-300-opacity));
     --spectrum-transparent-black-400-rgb: 0, 0, 0;
     --spectrum-transparent-black-400-opacity: 0.22;
-    --spectrum-transparent-black-400: rgba(
-        var(--spectrum-transparent-black-400-rgb),
-        var(--spectrum-transparent-black-400-opacity)
-    );
+    --spectrum-transparent-black-400: rgba(var(--spectrum-transparent-black-400-rgb), var(--spectrum-transparent-black-400-opacity));
     --spectrum-transparent-black-500-rgb: 0, 0, 0;
     --spectrum-transparent-black-500-opacity: 0.44;
-    --spectrum-transparent-black-500: rgba(
-        var(--spectrum-transparent-black-500-rgb),
-        var(--spectrum-transparent-black-500-opacity)
-    );
+    --spectrum-transparent-black-500: rgba(var(--spectrum-transparent-black-500-rgb), var(--spectrum-transparent-black-500-opacity));
     --spectrum-transparent-black-600-rgb: 0, 0, 0;
     --spectrum-transparent-black-600-opacity: 0.56;
-    --spectrum-transparent-black-600: rgba(
-        var(--spectrum-transparent-black-600-rgb),
-        var(--spectrum-transparent-black-600-opacity)
-    );
+    --spectrum-transparent-black-600: rgba(var(--spectrum-transparent-black-600-rgb), var(--spectrum-transparent-black-600-opacity));
     --spectrum-transparent-black-700-rgb: 0, 0, 0;
     --spectrum-transparent-black-700-opacity: 0.69;
-    --spectrum-transparent-black-700: rgba(
-        var(--spectrum-transparent-black-700-rgb),
-        var(--spectrum-transparent-black-700-opacity)
-    );
+    --spectrum-transparent-black-700: rgba(var(--spectrum-transparent-black-700-rgb), var(--spectrum-transparent-black-700-opacity));
     --spectrum-transparent-black-800-rgb: 0, 0, 0;
     --spectrum-transparent-black-800-opacity: 0.84;
-    --spectrum-transparent-black-800: rgba(
-        var(--spectrum-transparent-black-800-rgb),
-        var(--spectrum-transparent-black-800-opacity)
-    );
+    --spectrum-transparent-black-800: rgba(var(--spectrum-transparent-black-800-rgb), var(--spectrum-transparent-black-800-opacity));
     --spectrum-transparent-black-900-rgb: 0, 0, 0;
     --spectrum-transparent-black-900-opacity: 0.93;
-    --spectrum-transparent-black-900: rgba(
-        var(--spectrum-transparent-black-900-rgb),
-        var(--spectrum-transparent-black-900-opacity)
-    );
+    --spectrum-transparent-black-900: rgba(var(--spectrum-transparent-black-900-rgb), var(--spectrum-transparent-black-900-opacity));
     --spectrum-gray-25-rgb: 17, 17, 17;
     --spectrum-gray-25: rgba(var(--spectrum-gray-25-rgb));
     --spectrum-gray-50-rgb: 27, 27, 27;
@@ -928,69 +781,29 @@
     --spectrum-icon-color-green-primary-default: var(--spectrum-green-800);
     --spectrum-icon-color-red-primary-default: var(--spectrum-red-700);
     --spectrum-icon-color-yellow-primary-default: var(--spectrum-yellow-1000);
-    --spectrum-negative-subdued-background-color-default: var(
-        --spectrum-negative-subtle-background-color-default
-    );
-    --spectrum-accent-subtle-background-color-default: var(
-        --spectrum-accent-color-300
-    );
-    --spectrum-informative-subtle-background-color-default: var(
-        --spectrum-informative-color-300
-    );
-    --spectrum-positive-subtle-background-color-default: var(
-        --spectrum-positive-color-300
-    );
-    --spectrum-notice-subtle-background-color-default: var(
-        --spectrum-notice-color-300
-    );
-    --spectrum-negative-subtle-background-color-default: var(
-        --spectrum-negative-color-300
-    );
+    --spectrum-negative-subdued-background-color-default: var(--spectrum-negative-subtle-background-color-default);
+    --spectrum-accent-subtle-background-color-default: var(--spectrum-accent-color-300);
+    --spectrum-informative-subtle-background-color-default: var(--spectrum-informative-color-300);
+    --spectrum-positive-subtle-background-color-default: var(--spectrum-positive-color-300);
+    --spectrum-notice-subtle-background-color-default: var(--spectrum-notice-color-300);
+    --spectrum-negative-subtle-background-color-default: var(--spectrum-negative-color-300);
     --color-scheme: dark;
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-800
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
     --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-white-rgb),
-        0.07
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-white-rgb),
-        0.07
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.07);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.07);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
     --spectrum-card-selected-background-color-rgb: var(--spectrum-blue-500-rgb);
     --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
@@ -998,37 +811,19 @@
     --spectrum-dropindicator-color: var(--spectrum-blue-700);
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1000
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-900
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-700
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
     --spectrum-swatch-border-color-rgb: 255, 255, 255;
     --spectrum-swatch-border-color-opacity: 0.51;
-    --spectrum-swatch-border-color: rgba(
-        var(--spectrum-swatch-border-color-rgb),
-        var(--spectrum-swatch-border-color-opacity)
-    );
+    --spectrum-swatch-border-color: rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
     --spectrum-swatch-border-color-light-rgb: 255, 255, 255;
     --spectrum-swatch-border-color-light-opacity: 0.2;
-    --spectrum-swatch-border-color-light: rgba(
-        var(--spectrum-swatch-border-color-light-rgb),
-        var(--spectrum-swatch-border-color-light-opacity)
-    );
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.07
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
+    --spectrum-swatch-border-color-light: rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.07);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
 }

--- a/tools/styles/tokens-v2/large-vars.css
+++ b/tools/styles/tokens-v2/large-vars.css
@@ -240,9 +240,7 @@
     --spectrum-color-slider-length: 240px;
     --spectrum-color-slider-minimum-length: 100px;
     --spectrum-illustrated-message-title-size: var(--spectrum-heading-size-s);
-    --spectrum-illustrated-message-cjk-title-size: var(
-        --spectrum-heading-cjk-size-s
-    );
+    --spectrum-illustrated-message-cjk-title-size: var(--spectrum-heading-cjk-size-s);
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-xs);
     --spectrum-coach-mark-width: 216px;
     --spectrum-coach-mark-minimum-width: 216px;
@@ -542,17 +540,13 @@
     --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);
     --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-200);
     --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-200);
-    --spectrum-alert-banner-text-to-button-vertical: var(
-        --spectrum-spacing-200
-    );
+    --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-200);
     --spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
     --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
     --spectrum-assetcard-focus-ring-border-radius: 9px;
     --spectrum-assetcard-selectionindicator-margin: 15px;
     --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xxs);
-    --spectrum-assetcard-header-content-font-size: var(
-        --spectrum-heading-size-xxs
-    );
+    --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xxs);
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
     --spectrum-button-top-to-text-small: 6px;
     --spectrum-button-bottom-to-text-small: 5px;
@@ -569,8 +563,8 @@
     --spectrum-coachmark-buttongroup-mobile-display: flex;
     --spectrum-coachmark-menu-display: none;
     --spectrum-coachmark-menu-mobile-display: inline-flex;
-    --spectrum-colorwheel-path: 'M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0';
-    --spectrum-colorwheel-path-borders: 'M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0';
+    --spectrum-colorwheel-path: "M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
+    --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
     --spectrum-colorwheel-colorarea-container-size: 182px;
     --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-secondary);
     --spectrum-contextual-help-content-spacing: var(--spectrum-spacing-200);

--- a/tools/styles/tokens-v2/light-vars.css
+++ b/tools/styles/tokens-v2/light-vars.css
@@ -2,68 +2,32 @@
 :root {
     --spectrum-overlay-opacity: 0.4;
     --spectrum-background-layer-2-color: var(--spectrum-gray-25);
-    --spectrum-neutral-subdued-background-color-default: var(
-        --spectrum-gray-700
-    );
+    --spectrum-neutral-subdued-background-color-default: var(--spectrum-gray-700);
     --spectrum-neutral-subdued-background-color-hover: var(--spectrum-gray-800);
     --spectrum-neutral-subdued-background-color-down: var(--spectrum-gray-800);
-    --spectrum-neutral-subdued-background-color-key-focus: var(
-        --spectrum-gray-800
-    );
-    --spectrum-accent-background-color-default: var(
-        --spectrum-accent-color-900
-    );
+    --spectrum-neutral-subdued-background-color-key-focus: var(--spectrum-gray-800);
+    --spectrum-accent-background-color-default: var(--spectrum-accent-color-900);
     --spectrum-accent-background-color-hover: var(--spectrum-accent-color-1000);
     --spectrum-accent-background-color-down: var(--spectrum-accent-color-1000);
-    --spectrum-accent-background-color-key-focus: var(
-        --spectrum-accent-color-1000
-    );
-    --spectrum-informative-background-color-default: var(
-        --spectrum-informative-color-900
-    );
-    --spectrum-informative-background-color-hover: var(
-        --spectrum-informative-color-1000
-    );
-    --spectrum-informative-background-color-down: var(
-        --spectrum-informative-color-1000
-    );
-    --spectrum-informative-background-color-key-focus: var(
-        --spectrum-informative-color-1000
-    );
-    --spectrum-negative-background-color-default: var(
-        --spectrum-negative-color-900
-    );
-    --spectrum-negative-background-color-hover: var(
-        --spectrum-negative-color-1000
-    );
-    --spectrum-negative-background-color-down: var(
-        --spectrum-negative-color-1000
-    );
-    --spectrum-negative-background-color-key-focus: var(
-        --spectrum-negative-color-1000
-    );
-    --spectrum-positive-background-color-default: var(
-        --spectrum-positive-color-900
-    );
-    --spectrum-positive-background-color-hover: var(
-        --spectrum-positive-color-1000
-    );
-    --spectrum-positive-background-color-down: var(
-        --spectrum-positive-color-1000
-    );
-    --spectrum-positive-background-color-key-focus: var(
-        --spectrum-positive-color-1000
-    );
-    --spectrum-notice-background-color-default: var(
-        --spectrum-notice-color-600
-    );
+    --spectrum-accent-background-color-key-focus: var(--spectrum-accent-color-1000);
+    --spectrum-informative-background-color-default: var(--spectrum-informative-color-900);
+    --spectrum-informative-background-color-hover: var(--spectrum-informative-color-1000);
+    --spectrum-informative-background-color-down: var(--spectrum-informative-color-1000);
+    --spectrum-informative-background-color-key-focus: var(--spectrum-informative-color-1000);
+    --spectrum-negative-background-color-default: var(--spectrum-negative-color-900);
+    --spectrum-negative-background-color-hover: var(--spectrum-negative-color-1000);
+    --spectrum-negative-background-color-down: var(--spectrum-negative-color-1000);
+    --spectrum-negative-background-color-key-focus: var(--spectrum-negative-color-1000);
+    --spectrum-positive-background-color-default: var(--spectrum-positive-color-900);
+    --spectrum-positive-background-color-hover: var(--spectrum-positive-color-1000);
+    --spectrum-positive-background-color-down: var(--spectrum-positive-color-1000);
+    --spectrum-positive-background-color-key-focus: var(--spectrum-positive-color-1000);
+    --spectrum-notice-background-color-default: var(--spectrum-notice-color-600);
     --spectrum-gray-background-color-default: var(--spectrum-gray-700);
     --spectrum-red-background-color-default: var(--spectrum-red-900);
     --spectrum-orange-background-color-default: var(--spectrum-orange-600);
     --spectrum-yellow-background-color-default: var(--spectrum-yellow-400);
-    --spectrum-chartreuse-background-color-default: var(
-        --spectrum-chartreuse-500
-    );
+    --spectrum-chartreuse-background-color-default: var(--spectrum-chartreuse-500);
     --spectrum-celery-background-color-default: var(--spectrum-celery-600);
     --spectrum-green-background-color-default: var(--spectrum-green-900);
     --spectrum-seafoam-background-color-default: var(--spectrum-seafoam-900);
@@ -104,224 +68,113 @@
     --spectrum-cinnamon-background-color-default: var(--spectrum-cinnamon-900);
     --spectrum-pink-background-color-default: var(--spectrum-pink-900);
     --spectrum-silver-background-color-default: var(--spectrum-silver-900);
-    --spectrum-turquoise-background-color-default: var(
-        --spectrum-turquoise-900
-    );
+    --spectrum-turquoise-background-color-default: var(--spectrum-turquoise-900);
     --spectrum-drop-shadow-color-100-rgb: 0, 0, 0;
     --spectrum-drop-shadow-color-100-opacity: 0.12;
-    --spectrum-drop-shadow-color-100: rgba(
-        var(--spectrum-drop-shadow-color-100-rgb),
-        var(--spectrum-drop-shadow-color-100-opacity)
-    );
+    --spectrum-drop-shadow-color-100: rgba(var(--spectrum-drop-shadow-color-100-rgb), var(--spectrum-drop-shadow-color-100-opacity));
     --spectrum-drop-shadow-color-200-rgb: 0, 0, 0;
     --spectrum-drop-shadow-color-200-opacity: 0.16;
-    --spectrum-drop-shadow-color-200: rgba(
-        var(--spectrum-drop-shadow-color-200-rgb),
-        var(--spectrum-drop-shadow-color-200-opacity)
-    );
+    --spectrum-drop-shadow-color-200: rgba(var(--spectrum-drop-shadow-color-200-rgb), var(--spectrum-drop-shadow-color-200-opacity));
     --spectrum-drop-shadow-color-300-rgb: 0, 0, 0;
     --spectrum-drop-shadow-color-300-opacity: 0.2;
-    --spectrum-drop-shadow-color-300: rgba(
-        var(--spectrum-drop-shadow-color-300-rgb),
-        var(--spectrum-drop-shadow-color-300-opacity)
-    );
-    --spectrum-neutral-subtle-background-color-default: var(
-        --spectrum-gray-100
-    );
+    --spectrum-drop-shadow-color-300: rgba(var(--spectrum-drop-shadow-color-300-rgb), var(--spectrum-drop-shadow-color-300-opacity));
+    --spectrum-neutral-subtle-background-color-default: var(--spectrum-gray-100);
     --spectrum-gray-subtle-background-color-default: var(--spectrum-gray-100);
     --spectrum-blue-subtle-background-color-default: var(--spectrum-blue-200);
     --spectrum-green-subtle-background-color-default: var(--spectrum-green-200);
-    --spectrum-orange-subtle-background-color-default: var(
-        --spectrum-orange-200
-    );
+    --spectrum-orange-subtle-background-color-default: var(--spectrum-orange-200);
     --spectrum-red-subtle-background-color-default: var(--spectrum-red-200);
     --spectrum-brown-subtle-background-color-default: var(--spectrum-brown-200);
-    --spectrum-cinnamon-subtle-background-color-default: var(
-        --spectrum-cinnamon-200
-    );
-    --spectrum-celery-subtle-background-color-default: var(
-        --spectrum-celery-200
-    );
-    --spectrum-chartreuse-subtle-background-color-default: var(
-        --spectrum-chartreuse-200
-    );
+    --spectrum-cinnamon-subtle-background-color-default: var(--spectrum-cinnamon-200);
+    --spectrum-celery-subtle-background-color-default: var(--spectrum-celery-200);
+    --spectrum-chartreuse-subtle-background-color-default: var(--spectrum-chartreuse-200);
     --spectrum-cyan-subtle-background-color-default: var(--spectrum-cyan-200);
-    --spectrum-fuchsia-subtle-background-color-default: var(
-        --spectrum-fuchsia-200
-    );
-    --spectrum-indigo-subtle-background-color-default: var(
-        --spectrum-indigo-200
-    );
-    --spectrum-magenta-subtle-background-color-default: var(
-        --spectrum-magenta-200
-    );
+    --spectrum-fuchsia-subtle-background-color-default: var(--spectrum-fuchsia-200);
+    --spectrum-indigo-subtle-background-color-default: var(--spectrum-indigo-200);
+    --spectrum-magenta-subtle-background-color-default: var(--spectrum-magenta-200);
     --spectrum-pink-subtle-background-color-default: var(--spectrum-pink-200);
-    --spectrum-purple-subtle-background-color-default: var(
-        --spectrum-purple-200
-    );
-    --spectrum-seafoam-subtle-background-color-default: var(
-        --spectrum-seafoam-200
-    );
-    --spectrum-silver-subtle-background-color-default: var(
-        --spectrum-silver-200
-    );
-    --spectrum-turquoise-subtle-background-color-default: var(
-        --spectrum-turquoise-200
-    );
-    --spectrum-yellow-subtle-background-color-default: var(
-        --spectrum-yellow-200
-    );
+    --spectrum-purple-subtle-background-color-default: var(--spectrum-purple-200);
+    --spectrum-seafoam-subtle-background-color-default: var(--spectrum-seafoam-200);
+    --spectrum-silver-subtle-background-color-default: var(--spectrum-silver-200);
+    --spectrum-turquoise-subtle-background-color-default: var(--spectrum-turquoise-200);
+    --spectrum-yellow-subtle-background-color-default: var(--spectrum-yellow-200);
     --spectrum-opacity-checkerboard-square-dark: var(--spectrum-gray-200);
     --spectrum-white-rgb: 255, 255, 255;
     --spectrum-white: rgba(var(--spectrum-white-rgb));
     --spectrum-transparent-white-25-rgb: 255, 255, 255;
     --spectrum-transparent-white-25-opacity: 0;
-    --spectrum-transparent-white-25: rgba(
-        var(--spectrum-transparent-white-25-rgb),
-        var(--spectrum-transparent-white-25-opacity)
-    );
+    --spectrum-transparent-white-25: rgba(var(--spectrum-transparent-white-25-rgb), var(--spectrum-transparent-white-25-opacity));
     --spectrum-transparent-white-50-rgb: 255, 255, 255;
     --spectrum-transparent-white-50-opacity: 0.04;
-    --spectrum-transparent-white-50: rgba(
-        var(--spectrum-transparent-white-50-rgb),
-        var(--spectrum-transparent-white-50-opacity)
-    );
+    --spectrum-transparent-white-50: rgba(var(--spectrum-transparent-white-50-rgb), var(--spectrum-transparent-white-50-opacity));
     --spectrum-transparent-white-75-rgb: 255, 255, 255;
     --spectrum-transparent-white-75-opacity: 0.07;
-    --spectrum-transparent-white-75: rgba(
-        var(--spectrum-transparent-white-75-rgb),
-        var(--spectrum-transparent-white-75-opacity)
-    );
+    --spectrum-transparent-white-75: rgba(var(--spectrum-transparent-white-75-rgb), var(--spectrum-transparent-white-75-opacity));
     --spectrum-transparent-white-100-rgb: 255, 255, 255;
     --spectrum-transparent-white-100-opacity: 0.11;
-    --spectrum-transparent-white-100: rgba(
-        var(--spectrum-transparent-white-100-rgb),
-        var(--spectrum-transparent-white-100-opacity)
-    );
+    --spectrum-transparent-white-100: rgba(var(--spectrum-transparent-white-100-rgb), var(--spectrum-transparent-white-100-opacity));
     --spectrum-transparent-white-200-rgb: 255, 255, 255;
     --spectrum-transparent-white-200-opacity: 0.14;
-    --spectrum-transparent-white-200: rgba(
-        var(--spectrum-transparent-white-200-rgb),
-        var(--spectrum-transparent-white-200-opacity)
-    );
+    --spectrum-transparent-white-200: rgba(var(--spectrum-transparent-white-200-rgb), var(--spectrum-transparent-white-200-opacity));
     --spectrum-transparent-white-300-rgb: 255, 255, 255;
     --spectrum-transparent-white-300-opacity: 0.17;
-    --spectrum-transparent-white-300: rgba(
-        var(--spectrum-transparent-white-300-rgb),
-        var(--spectrum-transparent-white-300-opacity)
-    );
+    --spectrum-transparent-white-300: rgba(var(--spectrum-transparent-white-300-rgb), var(--spectrum-transparent-white-300-opacity));
     --spectrum-transparent-white-400-rgb: 255, 255, 255;
     --spectrum-transparent-white-400-opacity: 0.21;
-    --spectrum-transparent-white-400: rgba(
-        var(--spectrum-transparent-white-400-rgb),
-        var(--spectrum-transparent-white-400-opacity)
-    );
+    --spectrum-transparent-white-400: rgba(var(--spectrum-transparent-white-400-rgb), var(--spectrum-transparent-white-400-opacity));
     --spectrum-transparent-white-500-rgb: 255, 255, 255;
     --spectrum-transparent-white-500-opacity: 0.39;
-    --spectrum-transparent-white-500: rgba(
-        var(--spectrum-transparent-white-500-rgb),
-        var(--spectrum-transparent-white-500-opacity)
-    );
+    --spectrum-transparent-white-500: rgba(var(--spectrum-transparent-white-500-rgb), var(--spectrum-transparent-white-500-opacity));
     --spectrum-transparent-white-600-rgb: 255, 255, 255;
     --spectrum-transparent-white-600-opacity: 0.51;
-    --spectrum-transparent-white-600: rgba(
-        var(--spectrum-transparent-white-600-rgb),
-        var(--spectrum-transparent-white-600-opacity)
-    );
+    --spectrum-transparent-white-600: rgba(var(--spectrum-transparent-white-600-rgb), var(--spectrum-transparent-white-600-opacity));
     --spectrum-transparent-white-700-rgb: 255, 255, 255;
     --spectrum-transparent-white-700-opacity: 0.66;
-    --spectrum-transparent-white-700: rgba(
-        var(--spectrum-transparent-white-700-rgb),
-        var(--spectrum-transparent-white-700-opacity)
-    );
+    --spectrum-transparent-white-700: rgba(var(--spectrum-transparent-white-700-rgb), var(--spectrum-transparent-white-700-opacity));
     --spectrum-transparent-white-800-rgb: 255, 255, 255;
     --spectrum-transparent-white-800-opacity: 0.85;
-    --spectrum-transparent-white-800: rgba(
-        var(--spectrum-transparent-white-800-rgb),
-        var(--spectrum-transparent-white-800-opacity)
-    );
+    --spectrum-transparent-white-800: rgba(var(--spectrum-transparent-white-800-rgb), var(--spectrum-transparent-white-800-opacity));
     --spectrum-transparent-white-900-rgb: 255, 255, 255;
     --spectrum-transparent-white-900-opacity: 0.94;
-    --spectrum-transparent-white-900: rgba(
-        var(--spectrum-transparent-white-900-rgb),
-        var(--spectrum-transparent-white-900-opacity)
-    );
+    --spectrum-transparent-white-900: rgba(var(--spectrum-transparent-white-900-rgb), var(--spectrum-transparent-white-900-opacity));
     --spectrum-transparent-white-1000-rgb: 255, 255, 255;
-    --spectrum-transparent-white-1000: rgba(
-        var(--spectrum-transparent-white-1000-rgb)
-    );
+    --spectrum-transparent-white-1000: rgba(var(--spectrum-transparent-white-1000-rgb));
     --spectrum-transparent-black-25-rgb: 0, 0, 0;
     --spectrum-transparent-black-25-opacity: 0;
-    --spectrum-transparent-black-25: rgba(
-        var(--spectrum-transparent-black-25-rgb),
-        var(--spectrum-transparent-black-25-opacity)
-    );
+    --spectrum-transparent-black-25: rgba(var(--spectrum-transparent-black-25-rgb), var(--spectrum-transparent-black-25-opacity));
     --spectrum-transparent-black-50-rgb: 0, 0, 0;
     --spectrum-transparent-black-50-opacity: 0.03;
-    --spectrum-transparent-black-50: rgba(
-        var(--spectrum-transparent-black-50-rgb),
-        var(--spectrum-transparent-black-50-opacity)
-    );
+    --spectrum-transparent-black-50: rgba(var(--spectrum-transparent-black-50-rgb), var(--spectrum-transparent-black-50-opacity));
     --spectrum-transparent-black-75-rgb: 0, 0, 0;
     --spectrum-transparent-black-75-opacity: 0.05;
-    --spectrum-transparent-black-75: rgba(
-        var(--spectrum-transparent-black-75-rgb),
-        var(--spectrum-transparent-black-75-opacity)
-    );
+    --spectrum-transparent-black-75: rgba(var(--spectrum-transparent-black-75-rgb), var(--spectrum-transparent-black-75-opacity));
     --spectrum-transparent-black-100-rgb: 0, 0, 0;
     --spectrum-transparent-black-100-opacity: 0.09;
-    --spectrum-transparent-black-100: rgba(
-        var(--spectrum-transparent-black-100-rgb),
-        var(--spectrum-transparent-black-100-opacity)
-    );
+    --spectrum-transparent-black-100: rgba(var(--spectrum-transparent-black-100-rgb), var(--spectrum-transparent-black-100-opacity));
     --spectrum-transparent-black-200-rgb: 0, 0, 0;
     --spectrum-transparent-black-200-opacity: 0.12;
-    --spectrum-transparent-black-200: rgba(
-        var(--spectrum-transparent-black-200-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
+    --spectrum-transparent-black-200: rgba(var(--spectrum-transparent-black-200-rgb), var(--spectrum-transparent-black-200-opacity));
     --spectrum-transparent-black-300-rgb: 0, 0, 0;
     --spectrum-transparent-black-300-opacity: 0.15;
-    --spectrum-transparent-black-300: rgba(
-        var(--spectrum-transparent-black-300-rgb),
-        var(--spectrum-transparent-black-300-opacity)
-    );
+    --spectrum-transparent-black-300: rgba(var(--spectrum-transparent-black-300-rgb), var(--spectrum-transparent-black-300-opacity));
     --spectrum-transparent-black-400-rgb: 0, 0, 0;
     --spectrum-transparent-black-400-opacity: 0.22;
-    --spectrum-transparent-black-400: rgba(
-        var(--spectrum-transparent-black-400-rgb),
-        var(--spectrum-transparent-black-400-opacity)
-    );
+    --spectrum-transparent-black-400: rgba(var(--spectrum-transparent-black-400-rgb), var(--spectrum-transparent-black-400-opacity));
     --spectrum-transparent-black-500-rgb: 0, 0, 0;
     --spectrum-transparent-black-500-opacity: 0.44;
-    --spectrum-transparent-black-500: rgba(
-        var(--spectrum-transparent-black-500-rgb),
-        var(--spectrum-transparent-black-500-opacity)
-    );
+    --spectrum-transparent-black-500: rgba(var(--spectrum-transparent-black-500-rgb), var(--spectrum-transparent-black-500-opacity));
     --spectrum-transparent-black-600-rgb: 0, 0, 0;
     --spectrum-transparent-black-600-opacity: 0.56;
-    --spectrum-transparent-black-600: rgba(
-        var(--spectrum-transparent-black-600-rgb),
-        var(--spectrum-transparent-black-600-opacity)
-    );
+    --spectrum-transparent-black-600: rgba(var(--spectrum-transparent-black-600-rgb), var(--spectrum-transparent-black-600-opacity));
     --spectrum-transparent-black-700-rgb: 0, 0, 0;
     --spectrum-transparent-black-700-opacity: 0.69;
-    --spectrum-transparent-black-700: rgba(
-        var(--spectrum-transparent-black-700-rgb),
-        var(--spectrum-transparent-black-700-opacity)
-    );
+    --spectrum-transparent-black-700: rgba(var(--spectrum-transparent-black-700-rgb), var(--spectrum-transparent-black-700-opacity));
     --spectrum-transparent-black-800-rgb: 0, 0, 0;
     --spectrum-transparent-black-800-opacity: 0.84;
-    --spectrum-transparent-black-800: rgba(
-        var(--spectrum-transparent-black-800-rgb),
-        var(--spectrum-transparent-black-800-opacity)
-    );
+    --spectrum-transparent-black-800: rgba(var(--spectrum-transparent-black-800-rgb), var(--spectrum-transparent-black-800-opacity));
     --spectrum-transparent-black-900-rgb: 0, 0, 0;
     --spectrum-transparent-black-900-opacity: 0.93;
-    --spectrum-transparent-black-900: rgba(
-        var(--spectrum-transparent-black-900-rgb),
-        var(--spectrum-transparent-black-900-opacity)
-    );
+    --spectrum-transparent-black-900: rgba(var(--spectrum-transparent-black-900-rgb), var(--spectrum-transparent-black-900-opacity));
     --spectrum-gray-25-rgb: 255, 255, 255;
     --spectrum-gray-25: rgba(var(--spectrum-gray-25-rgb));
     --spectrum-gray-50-rgb: 248, 248, 248;
@@ -928,69 +781,29 @@
     --spectrum-icon-color-green-primary-default: var(--spectrum-green-900);
     --spectrum-icon-color-red-primary-default: var(--spectrum-red-900);
     --spectrum-icon-color-yellow-primary-default: var(--spectrum-yellow-400);
-    --spectrum-negative-subdued-background-color-default: var(
-        --spectrum-negative-subtle-background-color-default
-    );
-    --spectrum-accent-subtle-background-color-default: var(
-        --spectrum-accent-color-200
-    );
-    --spectrum-informative-subtle-background-color-default: var(
-        --spectrum-informative-color-200
-    );
-    --spectrum-positive-subtle-background-color-default: var(
-        --spectrum-positive-color-200
-    );
-    --spectrum-notice-subtle-background-color-default: var(
-        --spectrum-notice-color-200
-    );
-    --spectrum-negative-subtle-background-color-default: var(
-        --spectrum-negative-color-200
-    );
+    --spectrum-negative-subdued-background-color-default: var(--spectrum-negative-subtle-background-color-default);
+    --spectrum-accent-subtle-background-color-default: var(--spectrum-accent-color-200);
+    --spectrum-informative-subtle-background-color-default: var(--spectrum-informative-color-200);
+    --spectrum-positive-subtle-background-color-default: var(--spectrum-positive-color-200);
+    --spectrum-notice-subtle-background-color-default: var(--spectrum-notice-color-200);
+    --spectrum-negative-subtle-background-color-default: var(--spectrum-negative-color-200);
     --color-scheme: light;
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-900);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-900);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-1000);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-900
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-900);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-800);
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-800);
     --spectrum-badge-label-icon-color-primary: var(--spectrum-white);
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-black-rgb),
-        0.06
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-black-rgb),
-        0.06
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-black-rgb), 0.06);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-black-200);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-black-rgb), 0.06);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-800);
     --spectrum-card-selected-background-color-rgb: var(--spectrum-blue-900-rgb);
     --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-800);
@@ -998,37 +811,19 @@
     --spectrum-dropindicator-color: var(--spectrum-blue-800);
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-900);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-900);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1100
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1100);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1100);
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-900);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-1100
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-1100);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-1100);
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-800
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-800);
     --spectrum-swatch-border-color-rgb: 0, 0, 0;
     --spectrum-swatch-border-color-opacity: 0.51;
-    --spectrum-swatch-border-color: rgba(
-        var(--spectrum-swatch-border-color-rgb),
-        var(--spectrum-swatch-border-color-opacity)
-    );
+    --spectrum-swatch-border-color: rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
     --spectrum-swatch-border-color-light-rgb: 0, 0, 0;
     --spectrum-swatch-border-color-light-opacity: 0.2;
-    --spectrum-swatch-border-color-light: rgba(
-        var(--spectrum-swatch-border-color-light-rgb),
-        var(--spectrum-swatch-border-color-light-opacity)
-    );
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.06
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
+    --spectrum-swatch-border-color-light: rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.06);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
 }

--- a/tools/styles/tokens-v2/medium-vars.css
+++ b/tools/styles/tokens-v2/medium-vars.css
@@ -240,9 +240,7 @@
     --spectrum-color-slider-length: 192px;
     --spectrum-color-slider-minimum-length: 80px;
     --spectrum-illustrated-message-title-size: var(--spectrum-heading-size-m);
-    --spectrum-illustrated-message-cjk-title-size: var(
-        --spectrum-heading-cjk-size-m
-    );
+    --spectrum-illustrated-message-cjk-title-size: var(--spectrum-heading-cjk-size-m);
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-s);
     --spectrum-coach-mark-width: 296px;
     --spectrum-coach-mark-minimum-width: 296px;
@@ -542,16 +540,12 @@
     --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);
     --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-100);
     --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-100);
-    --spectrum-alert-banner-text-to-button-vertical: var(
-        --spectrum-spacing-100
-    );
+    --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-100);
     --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
     --spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
     --spectrum-assetcard-focus-ring-border-radius: 8px;
-    --spectrum-assetcard-header-content-font-size: var(
-        --spectrum-heading-size-xs
-    );
+    --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xs);
     --spectrum-assetcard-selectionindicator-margin: 12px;
     --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xs);
     --spectrum-button-bottom-to-text-small: 4px;
@@ -571,8 +565,8 @@
     --spectrum-coachmark-menu-mobile-display: none;
     --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-primary);
     --spectrum-colorwheel-colorarea-container-size: 144px;
-    --spectrum-colorwheel-path: 'M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0';
-    --spectrum-colorwheel-path-borders: 'M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0';
+    --spectrum-colorwheel-path: "M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
+    --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
     --spectrum-contextual-help-content-spacing: var(--spectrum-spacing-100);
     --spectrum-datepicker-dash-line-height: 24px;
     --spectrum-datepicker-datetime-width-first: 36px;
@@ -617,9 +611,7 @@
     --spectrum-treeview-item-indentation-small: var(--spectrum-spacing-200);
     --spectrum-treeview-item-indentation-medium: var(--spectrum-spacing-300);
     --spectrum-treeview-item-indentation-large: 20px;
-    --spectrum-treeview-item-indentation-extra-large: var(
-        --spectrum-spacing-400
-    );
+    --spectrum-treeview-item-indentation-extra-large: var(--spectrum-spacing-400);
     --spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 0px;
     --spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);
     --spectrum-ui-icon-medium-display: block;

--- a/tools/styles/tokens-v2/spectrum/custom-dark-vars.css
+++ b/tools/styles/tokens-v2/spectrum/custom-dark-vars.css
@@ -3,55 +3,24 @@
 :root {
     --spectrum-menu-item-background-color-default-rgb: 255, 255, 255;
     --spectrum-menu-item-background-color-default-opacity: 0;
-    --spectrum-menu-item-background-color-default: rgba(
-        var(--spectrum-menu-item-background-color-default-rgb),
-        var(--spectrum-menu-item-background-color-default-opacity)
-    ); /* --spectrum-gray-900 */
-    --spectrum-menu-item-background-color-hover: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --spectrum-transparent-white-200
-    );
+    --spectrum-menu-item-background-color-default: rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity)); /* --spectrum-gray-900 */
+    --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
 
     /* Drop Zone background color rgb */
-    --spectrum-drop-zone-background-color-rgb: var(
-        --spectrum-blue-900-rgb
-    ); /* var(--spectrum-accent-color-900);*/
+    --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-900-rgb); /* var(--spectrum-accent-color-900);*/
 
     /* Drop Indicator color rgb */
     --spectrum-dropindicator-color: var(--spectrum-blue-700);
 
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-white-rgb),
-        0.07
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-white-rgb),
-        0.07
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.07);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.07);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
 
     --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
@@ -62,48 +31,28 @@
 
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
 
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-700
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
 
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.07
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.07);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
 
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1000
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
 
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-900
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
 
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-800
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
 
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
 }

--- a/tools/styles/tokens-v2/spectrum/custom-darkest-vars.css
+++ b/tools/styles/tokens-v2/spectrum/custom-darkest-vars.css
@@ -3,56 +3,24 @@
 :root {
     --spectrum-menu-item-background-color-default-rgb: 255, 255, 255;
     --spectrum-menu-item-background-color-default-opacity: 0;
-    --spectrum-menu-item-background-color-default: rgba(
-        var(--spectrum-menu-item-background-color-default-rgb),
-        var(--spectrum-menu-item-background-color-default-opacity)
-    ); /* --spectrum-gray-900 */
-    --spectrum-menu-item-background-color-hover: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --spectrum-transparent-white-200
-    );
+    --spectrum-menu-item-background-color-default: rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity)); /* --spectrum-gray-900 */
+    --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
 
     /* Drop Zone background color rgb */
-    --spectrum-drop-zone-background-color-rgb: var(
-        --spectrum-blue-900-rgb
-    ); /* var(--spectrum-accent-color-900);*/
+    --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-900-rgb); /* var(--spectrum-accent-color-900);*/
 
     /* Drop Indicator color rgb */
     --spectrum-dropindicator-color: var(--spectrum-blue-700);
 
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-white-rgb),
-        0.08
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-calendar-day-background-color-down: rgba(
-        var(--spectrum-white-rgb),
-        0.15
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-white-rgb),
-        0.08
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.08);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-calendar-day-background-color-down: rgba(var(--spectrum-white-rgb), 0.15);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.08);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
 
     --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
@@ -63,48 +31,28 @@
 
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
 
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-700
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
 
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.08
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.2
-    );
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.08);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
 
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1000
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
 
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-900
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
 
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-800
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
 
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.2
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
 }

--- a/tools/styles/tokens-v2/spectrum/custom-large-vars.css
+++ b/tools/styles/tokens-v2/spectrum/custom-large-vars.css
@@ -10,8 +10,8 @@
     --spectrum-slider-tick-mark-height: 13px;
     --spectrum-slider-ramp-track-height: 20px;
 
-    --spectrum-colorwheel-path: 'M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0';
-    --spectrum-colorwheel-path-borders: 'M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0';
+    --spectrum-colorwheel-path: "M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
+    --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
     --spectrum-colorwheel-colorarea-container-size: 182px;
 
     --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-secondary);
@@ -45,9 +45,7 @@
     --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);
     --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-200);
     --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-200);
-    --spectrum-alert-banner-text-to-button-vertical: var(
-        --spectrum-spacing-200
-    );
+    --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-200);
 
     --spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
     --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
@@ -109,9 +107,7 @@
     --spectrum-assetcard-focus-ring-border-radius: 9px;
     --spectrum-assetcard-selectionindicator-margin: 15px;
     --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xxs);
-    --spectrum-assetcard-header-content-font-size: var(
-        --spectrum-heading-size-xxs
-    );
+    --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xxs);
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
 
     --spectrum-tooltip-animation-distance: 5px;

--- a/tools/styles/tokens-v2/spectrum/custom-light-vars.css
+++ b/tools/styles/tokens-v2/spectrum/custom-light-vars.css
@@ -3,55 +3,24 @@
 :root {
     --spectrum-menu-item-background-color-default-rgb: 0, 0, 0;
     --spectrum-menu-item-background-color-default-opacity: 0;
-    --spectrum-menu-item-background-color-default: rgba(
-        var(--spectrum-menu-item-background-color-default-rgb),
-        var(--spectrum-menu-item-background-color-default-opacity)
-    ); /* --spectrum-gray-900 */
-    --spectrum-menu-item-background-color-hover: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --spectrum-transparent-black-200
-    );
+    --spectrum-menu-item-background-color-default: rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity)); /* --spectrum-gray-900 */
+    --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-black-200);
+    --spectrum-menu-item-background-color-down: var(--spectrum-transparent-black-200);
+    --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-black-200);
 
     /* Drop Zone background color rgb */
-    --spectrum-drop-zone-background-color-rgb: var(
-        --spectrum-blue-800-rgb
-    ); /* var(--spectrum-accent-color-800);*/
+    --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-800-rgb); /* var(--spectrum-accent-color-800);*/
 
     /* Drop Indicator color rgb */
     --spectrum-dropindicator-color: var(--spectrum-blue-800);
 
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-black-rgb),
-        0.06
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-black-rgb),
-        0.06
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-black-rgb), 0.06);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-black-200);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-black-rgb), 0.06);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-800);
 
     --spectrum-badge-label-icon-color-primary: var(--spectrum-white);
@@ -62,48 +31,28 @@
 
     --spectrum-well-border-color: var(--spectrum-black-rgb);
 
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-800
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-800);
 
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.06
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.06);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
 
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-900);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-900);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1100
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1100);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1100);
 
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-900);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-1100
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-1100);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-1100);
 
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-900);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-900);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-1000);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-900
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-900);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-800);
 
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-800);
 }

--- a/tools/styles/tokens-v2/spectrum/custom-medium-vars.css
+++ b/tools/styles/tokens-v2/spectrum/custom-medium-vars.css
@@ -10,8 +10,8 @@
     --spectrum-slider-tick-mark-height: 10px;
     --spectrum-slider-ramp-track-height: 16px;
 
-    --spectrum-colorwheel-path: 'M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0';
-    --spectrum-colorwheel-path-borders: 'M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0';
+    --spectrum-colorwheel-path: "M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
+    --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
     --spectrum-colorwheel-colorarea-container-size: 144px;
 
     --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-primary);
@@ -45,9 +45,7 @@
     --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);
     --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-100);
     --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-100);
-    --spectrum-alert-banner-text-to-button-vertical: var(
-        --spectrum-spacing-100
-    );
+    --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-100);
 
     --spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
     --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
@@ -73,9 +71,7 @@
     --spectrum-treeview-item-indentation-medium: var(--spectrum-spacing-300);
     --spectrum-treeview-item-indentation-small: var(--spectrum-spacing-200);
     --spectrum-treeview-item-indentation-large: 20px;
-    --spectrum-treeview-item-indentation-extra-large: var(
-        --spectrum-spacing-400
-    );
+    --spectrum-treeview-item-indentation-extra-large: var(--spectrum-spacing-400);
     --spectrum-treeview-indicator-inset-block-start: 5px;
     --spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 0px;
 
@@ -110,9 +106,7 @@
     --spectrum-assetcard-focus-ring-border-radius: 8px;
     --spectrum-assetcard-selectionindicator-margin: 12px;
     --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xs);
-    --spectrum-assetcard-header-content-font-size: var(
-        --spectrum-heading-size-xs
-    );
+    --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xs);
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
 
     --spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);

--- a/tools/styles/tokens-v2/spectrum/custom-vars.css
+++ b/tools/styles/tokens-v2/spectrum/custom-vars.css
@@ -22,31 +22,22 @@
     --spectrum-animation-ease-out: cubic-bezier(0, 0, 0.4, 1);
     --spectrum-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
 
-    --spectrum-sans-font-family-stack: adobe-clean,
-        var(--spectrum-sans-serif-font-family), 'Source Sans Pro', -apple-system,
-        BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Trebuchet MS',
-        'Lucida Grande', sans-serif;
+    --spectrum-sans-font-family-stack: adobe-clean, var(--spectrum-sans-serif-font-family), "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
     --spectrum-sans-serif-font: var(--spectrum-sans-font-family-stack);
 
-    --spectrum-serif-font-family-stack: adobe-clean-serif,
-        var(--spectrum-serif-font-family), 'Source Serif Pro', Georgia, serif;
+    --spectrum-serif-font-family-stack: adobe-clean-serif, var(--spectrum-serif-font-family), "Source Serif Pro", Georgia, serif;
     --spectrum-serif-font: var(--spectrum-serif-font-family-stack);
 
-    --spectrum-code-font-family-stack: 'Source Code Pro', Monaco, monospace;
+    --spectrum-code-font-family-stack: "Source Code Pro", Monaco, monospace;
 
-    --spectrum-cjk-font-family-stack: adobe-clean-han-japanese,
-        var(--spectrum-cjk-font-family), sans-serif;
+    --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
     --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
 
     /* static white / black background color for docs containers */
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;
-    --spectrum-docs-static-white-background-color: rgba(
-        var(--spectrum-docs-static-white-background-color-rgb)
-    );
+    --spectrum-docs-static-white-background-color: rgba(var(--spectrum-docs-static-white-background-color-rgb));
     --spectrum-docs-static-black-background-color-rgb: 206, 247, 243;
-    --spectrum-docs-static-black-background-color: rgba(
-        var(--spectrum-docs-static-black-background-color-rgb)
-    );
+    --spectrum-docs-static-black-background-color: rgba(var(--spectrum-docs-static-black-background-color-rgb));
 
     /* override for Spectrum Tokens value until a Style Dictionary transform gets written for our usage */
     --spectrum-corner-radius-1000: 9999px;

--- a/tools/styles/tokens-v2/system-theme-bridge.css
+++ b/tools/styles/tokens-v2/system-theme-bridge.css
@@ -1,9 +1,7 @@
 :host,
 :root {
     --system-accordion-divider-color: var(--spectrum-gray-200);
-    --system-accordion-item-content-disabled-color: var(
-        --spectrum-disabled-content-color
-    );
+    --system-accordion-item-content-disabled-color: var(--spectrum-disabled-content-color);
     --system-accordion-item-content-color: var(--spectrum-body-color);
     --system-action-bar-popover-background-color: var(--spectrum-gray-25);
     --system-action-bar-popover-border-color: var(--spectrum-gray-400);
@@ -11,130 +9,64 @@
     --system-action-button-background-color-hover: var(--spectrum-gray-200);
     --system-action-button-background-color-down: var(--spectrum-gray-200);
     --system-action-button-background-color-focus: var(--spectrum-gray-200);
-    --system-action-button-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --system-action-button-background-color-selected: var(
-        --spectrum-neutral-background-color-selected-default
-    );
-    --system-action-button-background-color-selected-hover: var(
-        --spectrum-neutral-background-color-selected-hover
-    );
-    --system-action-button-background-color-selected-down: var(
-        --spectrum-neutral-background-color-selected-down
-    );
-    --system-action-button-background-color-selected-focus: var(
-        --spectrum-neutral-background-color-selected-key-focus
-    );
+    --system-action-button-background-color-disabled: var(--spectrum-disabled-background-color);
+    --system-action-button-background-color-selected: var(--spectrum-neutral-background-color-selected-default);
+    --system-action-button-background-color-selected-hover: var(--spectrum-neutral-background-color-selected-hover);
+    --system-action-button-background-color-selected-down: var(--spectrum-neutral-background-color-selected-down);
+    --system-action-button-background-color-selected-focus: var(--spectrum-neutral-background-color-selected-key-focus);
     --system-action-button-border-color-default: transparent;
     --system-action-button-border-color-hover: transparent;
     --system-action-button-border-color-down: transparent;
     --system-action-button-border-color-focus: transparent;
     --system-action-button-border-color-disabled: transparent;
     --system-action-button-content-color-selected: var(--spectrum-gray-50);
-    --system-action-button-size-m-border-radius-default: var(
-        --spectrum-corner-radius-medium-size-medium
-    );
-    --system-action-button-size-xs-border-radius-default: var(
-        --spectrum-corner-radius-medium-size-extra-small
-    );
-    --system-action-button-size-s-border-radius-default: var(
-        --spectrum-corner-radius-medium-size-small
-    );
-    --system-action-button-size-l-border-radius-default: var(
-        --spectrum-corner-radius-medium-size-large
-    );
-    --system-action-button-size-xl-border-radius-default: var(
-        --spectrum-corner-radius-medium-size-extra-large
-    );
+    --system-action-button-size-m-border-radius-default: var(--spectrum-corner-radius-medium-size-medium);
+    --system-action-button-size-xs-border-radius-default: var(--spectrum-corner-radius-medium-size-extra-small);
+    --system-action-button-size-s-border-radius-default: var(--spectrum-corner-radius-medium-size-small);
+    --system-action-button-size-l-border-radius-default: var(--spectrum-corner-radius-medium-size-large);
+    --system-action-button-size-xl-border-radius-default: var(--spectrum-corner-radius-medium-size-extra-large);
     --system-action-button-quiet-background-color-default: transparent;
-    --system-action-button-quiet-background-color-hover: var(
-        --spectrum-gray-200
-    );
-    --system-action-button-quiet-background-color-down: var(
-        --spectrum-gray-200
-    );
-    --system-action-button-quiet-background-color-focus: var(
-        --spectrum-gray-200
-    );
+    --system-action-button-quiet-background-color-hover: var(--spectrum-gray-200);
+    --system-action-button-quiet-background-color-down: var(--spectrum-gray-200);
+    --system-action-button-quiet-background-color-focus: var(--spectrum-gray-200);
     --system-action-button-quiet-background-color-disabled: transparent;
-    --system-action-button-quiet-background-color-selected-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-action-button-quiet-background-color-selected-disabled: var(--spectrum-disabled-background-color);
     --system-action-button-static-black-border-color-default: transparent;
     --system-action-button-static-black-border-color-hover: transparent;
     --system-action-button-static-black-border-color-down: transparent;
     --system-action-button-static-black-border-color-focus: transparent;
     --system-action-button-static-black-border-color-disabled: transparent;
-    --system-action-button-static-black-background-color-disabled: var(
-        --spectrum-disabled-static-black-background-color
-    );
-    --system-action-button-static-black-background-color-selected-disabled: var(
-        --spectrum-disabled-static-black-background-color
-    );
-    --system-action-button-static-black-background-color-default: var(
-        --spectrum-transparent-black-100
-    );
-    --system-action-button-static-black-background-color-hover: var(
-        --spectrum-transparent-black-200
-    );
-    --system-action-button-static-black-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --system-action-button-static-black-background-color-focus: var(
-        --spectrum-transparent-black-200
-    );
+    --system-action-button-static-black-background-color-disabled: var(--spectrum-disabled-static-black-background-color);
+    --system-action-button-static-black-background-color-selected-disabled: var(--spectrum-disabled-static-black-background-color);
+    --system-action-button-static-black-background-color-default: var(--spectrum-transparent-black-100);
+    --system-action-button-static-black-background-color-hover: var(--spectrum-transparent-black-200);
+    --system-action-button-static-black-background-color-down: var(--spectrum-transparent-black-200);
+    --system-action-button-static-black-background-color-focus: var(--spectrum-transparent-black-200);
     --system-action-button-static-black-quiet-background-color-default: transparent;
-    --system-action-button-static-black-quiet-background-color-hover: var(
-        --spectrum-transparent-black-200
-    );
-    --system-action-button-static-black-quiet-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --system-action-button-static-black-quiet-background-color-focus: var(
-        --spectrum-transparent-black-200
-    );
+    --system-action-button-static-black-quiet-background-color-hover: var(--spectrum-transparent-black-200);
+    --system-action-button-static-black-quiet-background-color-down: var(--spectrum-transparent-black-200);
+    --system-action-button-static-black-quiet-background-color-focus: var(--spectrum-transparent-black-200);
     --system-action-button-static-black-quiet-background-color-disabled: transparent;
     --system-action-button-static-white-border-color-default: transparent;
     --system-action-button-static-white-border-color-hover: transparent;
     --system-action-button-static-white-border-color-down: transparent;
     --system-action-button-static-white-border-color-focus: transparent;
     --system-action-button-static-white-border-color-disabled: transparent;
-    --system-action-button-static-white-background-color-disabled: var(
-        --spectrum-disabled-static-white-background-color
-    );
-    --system-action-button-static-white-background-color-selected-disabled: var(
-        --spectrum-disabled-static-white-background-color
-    );
-    --system-action-button-static-white-background-color-default: var(
-        --spectrum-transparent-white-100
-    );
-    --system-action-button-static-white-background-color-hover: var(
-        --spectrum-transparent-white-200
-    );
-    --system-action-button-static-white-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --system-action-button-static-white-background-color-focus: var(
-        --spectrum-transparent-white-200
-    );
+    --system-action-button-static-white-background-color-disabled: var(--spectrum-disabled-static-white-background-color);
+    --system-action-button-static-white-background-color-selected-disabled: var(--spectrum-disabled-static-white-background-color);
+    --system-action-button-static-white-background-color-default: var(--spectrum-transparent-white-100);
+    --system-action-button-static-white-background-color-hover: var(--spectrum-transparent-white-200);
+    --system-action-button-static-white-background-color-down: var(--spectrum-transparent-white-200);
+    --system-action-button-static-white-background-color-focus: var(--spectrum-transparent-white-200);
     --system-action-button-static-white-quiet-background-color-default: transparent;
-    --system-action-button-static-white-quiet-background-color-hover: var(
-        --spectrum-transparent-white-200
-    );
-    --system-action-button-static-white-quiet-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --system-action-button-static-white-quiet-background-color-focus: var(
-        --spectrum-transparent-white-200
-    );
+    --system-action-button-static-white-quiet-background-color-hover: var(--spectrum-transparent-white-200);
+    --system-action-button-static-white-quiet-background-color-down: var(--spectrum-transparent-white-200);
+    --system-action-button-static-white-quiet-background-color-focus: var(--spectrum-transparent-white-200);
     --system-action-button-static-white-quiet-background-color-disabled: transparent;
     --system-action-group-gap-size-compact: 0;
     --system-action-group-horizontal-spacing-compact: -1px;
     --system-action-group-vertical-spacing-compact: -1px;
-    --system-alert-banner-neutral-background: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
+    --system-alert-banner-neutral-background: var(--spectrum-neutral-subdued-background-color-default);
     --system-asset-folder-background-color: var(--spectrum-gray-200);
     --system-asset-file-background-color: var(--spectrum-gray-25);
     --system-asset-icon-outline-color: var(--spectrum-gray-500);
@@ -147,258 +79,100 @@
     --system-button-border-color-down: var(--spectrum-gray-600);
     --system-button-border-color-focus: var(--spectrum-gray-500);
     --system-button-background-color-disabled: transparent;
-    --system-button-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
-    --system-button-selected-background-color-default: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
-    --system-button-selected-background-color-hover: var(
-        --spectrum-neutral-subdued-background-color-hover
-    );
-    --system-button-selected-background-color-down: var(
-        --spectrum-neutral-subdued-background-color-down
-    );
-    --system-button-selected-background-color-focus: var(
-        --spectrum-neutral-subdued-background-color-key-focus
-    );
+    --system-button-border-color-disabled: var(--spectrum-disabled-border-color);
+    --system-button-selected-background-color-default: var(--spectrum-neutral-subdued-background-color-default);
+    --system-button-selected-background-color-hover: var(--spectrum-neutral-subdued-background-color-hover);
+    --system-button-selected-background-color-down: var(--spectrum-neutral-subdued-background-color-down);
+    --system-button-selected-background-color-focus: var(--spectrum-neutral-subdued-background-color-key-focus);
     --system-button-primary-content-color-default: var(--spectrum-gray-25);
     --system-button-primary-content-color-hover: var(--spectrum-gray-25);
     --system-button-primary-content-color-down: var(--spectrum-gray-25);
     --system-button-primary-content-color-focus: var(--spectrum-gray-25);
-    --system-button-primary-outline-background-color-hover: var(
-        --spectrum-gray-100
-    );
-    --system-button-primary-outline-background-color-down: var(
-        --spectrum-gray-100
-    );
-    --system-button-primary-outline-background-color-focus: var(
-        --spectrum-gray-100
-    );
-    --system-button-secondary-background-color-default: var(
-        --spectrum-gray-100
-    );
+    --system-button-primary-outline-background-color-hover: var(--spectrum-gray-100);
+    --system-button-primary-outline-background-color-down: var(--spectrum-gray-100);
+    --system-button-primary-outline-background-color-focus: var(--spectrum-gray-100);
+    --system-button-secondary-background-color-default: var(--spectrum-gray-100);
     --system-button-secondary-background-color-hover: var(--spectrum-gray-200);
     --system-button-secondary-background-color-down: var(--spectrum-gray-200);
     --system-button-secondary-background-color-focus: var(--spectrum-gray-200);
-    --system-button-secondary-outline-background-color-hover: var(
-        --spectrum-gray-100
-    );
-    --system-button-secondary-outline-background-color-down: var(
-        --spectrum-gray-100
-    );
-    --system-button-secondary-outline-background-color-focus: var(
-        --spectrum-gray-100
-    );
-    --system-button-secondary-outline-border-color-default: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-outline-border-color-down: var(
-        --spectrum-gray-400
-    );
-    --system-button-static-white-background-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-background-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-background-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-background-color-focus: var(
-        --spectrum-transparent-white-900
-    );
+    --system-button-secondary-outline-background-color-hover: var(--spectrum-gray-100);
+    --system-button-secondary-outline-background-color-down: var(--spectrum-gray-100);
+    --system-button-secondary-outline-background-color-focus: var(--spectrum-gray-100);
+    --system-button-secondary-outline-border-color-default: var(--spectrum-gray-300);
+    --system-button-secondary-outline-border-color-down: var(--spectrum-gray-400);
+    --system-button-static-white-background-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-background-color-hover: var(--spectrum-transparent-white-900);
+    --system-button-static-white-background-color-down: var(--spectrum-transparent-white-900);
+    --system-button-static-white-background-color-focus: var(--spectrum-transparent-white-900);
     --system-button-static-white-content-color-default: var(--spectrum-black);
     --system-button-static-white-content-color-hover: var(--spectrum-black);
     --system-button-static-white-content-color-down: var(--spectrum-black);
     --system-button-static-white-content-color-focus: var(--spectrum-black);
-    --system-button-static-white-outline-background-color-default: var(
-        --spectrum-transparent-white-25
-    );
-    --system-button-static-white-outline-background-color-hover: var(
-        --spectrum-transparent-white-100
-    );
-    --system-button-static-white-outline-background-color-down: var(
-        --spectrum-transparent-white-100
-    );
-    --system-button-static-white-outline-background-color-focus: var(
-        --spectrum-transparent-white-100
-    );
-    --system-button-static-white-outline-content-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-outline-content-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-content-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-content-color-focus: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-border-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-outline-border-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-border-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-border-color-focus: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-secondary-background-color-default: var(
-        --spectrum-transparent-white-100
-    );
-    --system-button-static-white-secondary-background-color-hover: var(
-        --spectrum-transparent-white-200
-    );
-    --system-button-static-white-secondary-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --system-button-static-white-secondary-background-color-focus: var(
-        --spectrum-transparent-white-200
-    );
-    --system-button-static-white-secondary-content-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-secondary-content-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-secondary-content-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-secondary-content-color-focus: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-secondary-outline-border-color-default: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-secondary-outline-border-color-hover: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-border-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-border-color-focus: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-background-color-default: var(
-        --spectrum-transparent-white-25
-    );
-    --system-button-static-white-secondary-outline-background-color-hover: var(
-        --spectrum-transparent-white-100
-    );
-    --system-button-static-white-secondary-outline-background-color-down: var(
-        --spectrum-transparent-white-100
-    );
-    --system-button-static-white-secondary-outline-background-color-focus: var(
-        --spectrum-transparent-white-100
-    );
-    --system-button-static-black-background-color-default: var(
-        --spectrum-transparent-black-800
-    );
-    --system-button-static-black-background-color-hover: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-background-color-down: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-background-color-focus: var(
-        --spectrum-transparent-black-900
-    );
+    --system-button-static-white-outline-background-color-default: var(--spectrum-transparent-white-25);
+    --system-button-static-white-outline-background-color-hover: var(--spectrum-transparent-white-100);
+    --system-button-static-white-outline-background-color-down: var(--spectrum-transparent-white-100);
+    --system-button-static-white-outline-background-color-focus: var(--spectrum-transparent-white-100);
+    --system-button-static-white-outline-content-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-outline-content-color-hover: var(--spectrum-transparent-white-900);
+    --system-button-static-white-outline-content-color-down: var(--spectrum-transparent-white-900);
+    --system-button-static-white-outline-content-color-focus: var(--spectrum-transparent-white-900);
+    --system-button-static-white-outline-border-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-outline-border-color-hover: var(--spectrum-transparent-white-900);
+    --system-button-static-white-outline-border-color-down: var(--spectrum-transparent-white-900);
+    --system-button-static-white-outline-border-color-focus: var(--spectrum-transparent-white-900);
+    --system-button-static-white-secondary-background-color-default: var(--spectrum-transparent-white-100);
+    --system-button-static-white-secondary-background-color-hover: var(--spectrum-transparent-white-200);
+    --system-button-static-white-secondary-background-color-down: var(--spectrum-transparent-white-200);
+    --system-button-static-white-secondary-background-color-focus: var(--spectrum-transparent-white-200);
+    --system-button-static-white-secondary-content-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-secondary-content-color-hover: var(--spectrum-transparent-white-900);
+    --system-button-static-white-secondary-content-color-down: var(--spectrum-transparent-white-900);
+    --system-button-static-white-secondary-content-color-focus: var(--spectrum-transparent-white-900);
+    --system-button-static-white-secondary-outline-border-color-default: var(--spectrum-transparent-white-300);
+    --system-button-static-white-secondary-outline-border-color-hover: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-outline-border-color-down: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-outline-border-color-focus: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-outline-background-color-default: var(--spectrum-transparent-white-25);
+    --system-button-static-white-secondary-outline-background-color-hover: var(--spectrum-transparent-white-100);
+    --system-button-static-white-secondary-outline-background-color-down: var(--spectrum-transparent-white-100);
+    --system-button-static-white-secondary-outline-background-color-focus: var(--spectrum-transparent-white-100);
+    --system-button-static-black-background-color-default: var(--spectrum-transparent-black-800);
+    --system-button-static-black-background-color-hover: var(--spectrum-transparent-black-900);
+    --system-button-static-black-background-color-down: var(--spectrum-transparent-black-900);
+    --system-button-static-black-background-color-focus: var(--spectrum-transparent-black-900);
     --system-button-static-black-content-color-default: var(--spectrum-white);
     --system-button-static-black-content-color-hover: var(--spectrum-white);
     --system-button-static-black-content-color-down: var(--spectrum-white);
     --system-button-static-black-content-color-focus: var(--spectrum-white);
-    --system-button-static-black-outline-background-color-default: var(
-        --spectrum-transparent-black-25
-    );
-    --system-button-static-black-outline-background-color-hover: var(
-        --spectrum-transparent-black-100
-    );
-    --system-button-static-black-outline-background-color-down: var(
-        --spectrum-transparent-black-100
-    );
-    --system-button-static-black-outline-background-color-focus: var(
-        --spectrum-transparent-black-100
-    );
-    --system-button-static-black-outline-content-color-default: var(
-        --spectrum-transparent-black-800
-    );
-    --system-button-static-black-outline-content-color-hover: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-outline-content-color-down: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-outline-content-color-focus: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-outline-border-color-default: var(
-        --spectrum-transparent-black-800
-    );
-    --system-button-static-black-outline-border-color-hover: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-outline-border-color-down: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-outline-border-color-focus: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-secondary-background-color-default: var(
-        --spectrum-transparent-black-100
-    );
-    --system-button-static-black-secondary-background-color-hover: var(
-        --spectrum-transparent-black-200
-    );
-    --system-button-static-black-secondary-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --system-button-static-black-secondary-background-color-focus: var(
-        --spectrum-transparent-black-200
-    );
-    --system-button-static-black-secondary-content-color-default: var(
-        --spectrum-transparent-black-800
-    );
-    --system-button-static-black-secondary-content-color-hover: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-secondary-content-color-down: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-secondary-content-color-focus: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-secondary-outline-border-color-default: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-secondary-outline-border-color-hover: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-border-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-border-color-focus: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-background-color-default: var(
-        --spectrum-transparent-black-25
-    );
-    --system-button-static-black-secondary-outline-background-color-hover: var(
-        --spectrum-transparent-black-100
-    );
-    --system-button-static-black-secondary-outline-background-color-down: var(
-        --spectrum-transparent-black-100
-    );
-    --system-button-static-black-secondary-outline-background-color-focus: var(
-        --spectrum-transparent-black-100
-    );
-    --system-checkbox-control-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
+    --system-button-static-black-outline-background-color-default: var(--spectrum-transparent-black-25);
+    --system-button-static-black-outline-background-color-hover: var(--spectrum-transparent-black-100);
+    --system-button-static-black-outline-background-color-down: var(--spectrum-transparent-black-100);
+    --system-button-static-black-outline-background-color-focus: var(--spectrum-transparent-black-100);
+    --system-button-static-black-outline-content-color-default: var(--spectrum-transparent-black-800);
+    --system-button-static-black-outline-content-color-hover: var(--spectrum-transparent-black-900);
+    --system-button-static-black-outline-content-color-down: var(--spectrum-transparent-black-900);
+    --system-button-static-black-outline-content-color-focus: var(--spectrum-transparent-black-900);
+    --system-button-static-black-outline-border-color-default: var(--spectrum-transparent-black-800);
+    --system-button-static-black-outline-border-color-hover: var(--spectrum-transparent-black-900);
+    --system-button-static-black-outline-border-color-down: var(--spectrum-transparent-black-900);
+    --system-button-static-black-outline-border-color-focus: var(--spectrum-transparent-black-900);
+    --system-button-static-black-secondary-background-color-default: var(--spectrum-transparent-black-100);
+    --system-button-static-black-secondary-background-color-hover: var(--spectrum-transparent-black-200);
+    --system-button-static-black-secondary-background-color-down: var(--spectrum-transparent-black-200);
+    --system-button-static-black-secondary-background-color-focus: var(--spectrum-transparent-black-200);
+    --system-button-static-black-secondary-content-color-default: var(--spectrum-transparent-black-800);
+    --system-button-static-black-secondary-content-color-hover: var(--spectrum-transparent-black-900);
+    --system-button-static-black-secondary-content-color-down: var(--spectrum-transparent-black-900);
+    --system-button-static-black-secondary-content-color-focus: var(--spectrum-transparent-black-900);
+    --system-button-static-black-secondary-outline-border-color-default: var(--spectrum-transparent-black-300);
+    --system-button-static-black-secondary-outline-border-color-hover: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-outline-border-color-down: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-outline-border-color-focus: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-outline-background-color-default: var(--spectrum-transparent-black-25);
+    --system-button-static-black-secondary-outline-background-color-hover: var(--spectrum-transparent-black-100);
+    --system-button-static-black-secondary-outline-background-color-down: var(--spectrum-transparent-black-100);
+    --system-button-static-black-secondary-outline-background-color-focus: var(--spectrum-transparent-black-100);
+    --system-checkbox-control-color-default: var(--spectrum-neutral-content-color-default);
     --system-checkbox-control-color-hover: var(--spectrum-gray-700);
     --system-checkbox-control-color-down: var(--spectrum-gray-800);
     --system-checkbox-control-color-focus: var(--spectrum-gray-700);
@@ -416,146 +190,60 @@
     --system-clear-button-height: var(--spectrum-component-height-100);
     --system-clear-button-width: var(--spectrum-component-height-100);
     --system-clear-button-padding: var(--spectrum-in-field-button-edge-to-fill);
-    --system-clear-button-icon-color: var(
-        --spectrum-neutral-content-color-default
-    );
-    --system-clear-button-icon-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --system-clear-button-icon-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --system-clear-button-icon-color-key-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
+    --system-clear-button-icon-color: var(--spectrum-neutral-content-color-default);
+    --system-clear-button-icon-color-hover: var(--spectrum-neutral-content-color-hover);
+    --system-clear-button-icon-color-down: var(--spectrum-neutral-content-color-down);
+    --system-clear-button-icon-color-key-focus: var(--spectrum-neutral-content-color-key-focus);
     --system-clear-button-size-s-height: var(--spectrum-component-height-75);
     --system-clear-button-size-s-width: var(--spectrum-component-height-75);
     --system-clear-button-size-l-height: var(--spectrum-component-height-200);
     --system-clear-button-size-l-width: var(--spectrum-component-height-200);
     --system-clear-button-size-xl-height: var(--spectrum-component-height-300);
     --system-clear-button-size-xl-width: var(--spectrum-component-height-300);
-    --system-clear-button-quiet-background-color: var(
-        --spectrum-clear-button-background-color-quiet,
-        transparent
-    );
-    --system-clear-button-quiet-background-color-hover: var(
-        --spectrum-clear-button-background-color-hover-quiet,
-        transparent
-    );
-    --system-clear-button-quiet-background-color-down: var(
-        --spectrum-clear-button-background-color-down-quiet,
-        transparent
-    );
-    --system-clear-button-quiet-background-color-key-focus: var(
-        --spectrum-clear-button-background-color-key-focus-quiet,
-        transparent
-    );
-    --system-clear-button-over-background-icon-color: var(
-        --spectrum-clear-button-icon-color-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-icon-color-hover: var(
-        --spectrum-clear-button-icon-color-hover-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-icon-color-down: var(
-        --spectrum-clear-button-icon-color-down-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-icon-color-key-focus: var(
-        --spectrum-clear-button-icon-color-key-focus-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-background-color: var(
-        --spectrum-clear-button-background-color-over-background,
-        transparent
-    );
-    --system-clear-button-over-background-background-color-hover: var(
-        --spectrum-clear-button-background-color-hover-over-background,
-        var(--spectrum-transparent-white-400)
-    );
-    --system-clear-button-over-background-background-color-down: var(
-        --spectrum-clear-button-background-color-hover-over-background,
-        var(--spectrum-transparent-white-500)
-    );
-    --system-clear-button-over-background-background-color-key-focus: var(
-        --spectrum-clear-button-background-color-hover-over-background,
-        var(--spectrum-transparent-white-400)
-    );
-    --system-clear-button-disabled-icon-color: var(
-        --spectrum-disabled-content-color
-    );
-    --system-clear-button-disabled-icon-color-hover: var(
-        --spectrum-clear-button-icon-color-hover-disabled,
-        var(--spectrum-disabled-content-color)
-    );
-    --system-clear-button-disabled-icon-color-down: var(
-        --spectrum-clear-button-icon-color-down-disabled,
-        var(--spectrum-disabled-content-color)
-    );
+    --system-clear-button-quiet-background-color: var(--spectrum-clear-button-background-color-quiet, transparent);
+    --system-clear-button-quiet-background-color-hover: var(--spectrum-clear-button-background-color-hover-quiet, transparent);
+    --system-clear-button-quiet-background-color-down: var(--spectrum-clear-button-background-color-down-quiet, transparent);
+    --system-clear-button-quiet-background-color-key-focus: var(--spectrum-clear-button-background-color-key-focus-quiet, transparent);
+    --system-clear-button-over-background-icon-color: var(--spectrum-clear-button-icon-color-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-icon-color-hover: var(--spectrum-clear-button-icon-color-hover-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-icon-color-down: var(--spectrum-clear-button-icon-color-down-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-icon-color-key-focus: var(--spectrum-clear-button-icon-color-key-focus-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-background-color: var(--spectrum-clear-button-background-color-over-background, transparent);
+    --system-clear-button-over-background-background-color-hover: var(--spectrum-clear-button-background-color-hover-over-background, var(--spectrum-transparent-white-400));
+    --system-clear-button-over-background-background-color-down: var(--spectrum-clear-button-background-color-hover-over-background, var(--spectrum-transparent-white-500));
+    --system-clear-button-over-background-background-color-key-focus: var(--spectrum-clear-button-background-color-hover-over-background, var(--spectrum-transparent-white-400));
+    --system-clear-button-disabled-icon-color: var(--spectrum-disabled-content-color);
+    --system-clear-button-disabled-icon-color-hover: var(--spectrum-clear-button-icon-color-hover-disabled, var(--spectrum-disabled-content-color));
+    --system-clear-button-disabled-icon-color-down: var(--spectrum-clear-button-icon-color-down-disabled, var(--spectrum-disabled-content-color));
     --system-clear-button-disabled-background-color: transparent;
     --system-close-button-background-color-default: transparent;
     --system-close-button-background-color-hover: var(--spectrum-gray-100);
     --system-close-button-background-color-down: var(--spectrum-gray-200);
     --system-close-button-background-color-focus: var(--spectrum-gray-100);
-    --system-close-button-static-white-static-background-color-hover: var(
-        --spectrum-transparent-white-400
-    );
-    --system-close-button-static-white-static-background-color-down: var(
-        --spectrum-transparent-white-500
-    );
-    --system-close-button-static-white-static-background-color-focus: var(
-        --spectrum-transparent-white-400
-    );
-    --system-close-button-static-black-static-background-color-hover: var(
-        --spectrum-transparent-black-400
-    );
-    --system-close-button-static-black-static-background-color-down: var(
-        --spectrum-transparent-black-500
-    );
-    --system-close-button-static-black-static-background-color-focus: var(
-        --spectrum-transparent-black-400
-    );
+    --system-close-button-static-white-static-background-color-hover: var(--spectrum-transparent-white-400);
+    --system-close-button-static-white-static-background-color-down: var(--spectrum-transparent-white-500);
+    --system-close-button-static-white-static-background-color-focus: var(--spectrum-transparent-white-400);
+    --system-close-button-static-black-static-background-color-hover: var(--spectrum-transparent-black-400);
+    --system-close-button-static-black-static-background-color-down: var(--spectrum-transparent-black-500);
+    --system-close-button-static-black-static-background-color-focus: var(--spectrum-transparent-black-400);
     --system-coach-indicator-ring-border-size: var(--spectrum-border-width-200);
-    --system-coach-indicator-min-inline-size: calc(
-        var(--spectrum-coach-indicator-ring-diameter) * 3
-    );
-    --system-coach-indicator-min-block-size: calc(
-        var(--spectrum-coach-indicator-ring-diameter) * 3
-    );
-    --system-coach-indicator-inline-size: var(
-        --system-coach-indicator-min-inline-size
-    );
-    --system-coach-indicator-block-size: var(
-        --system-coach-indicator-min-block-size
-    );
-    --system-coach-indicator-ring-inline-size: var(
-        --spectrum-coach-indicator-ring-diameter
-    );
-    --system-coach-indicator-ring-block-size: var(
-        --spectrum-coach-indicator-ring-diameter
-    );
+    --system-coach-indicator-min-inline-size: calc(var(--spectrum-coach-indicator-ring-diameter) * 3);
+    --system-coach-indicator-min-block-size: calc(var(--spectrum-coach-indicator-ring-diameter) * 3);
+    --system-coach-indicator-inline-size: var(--system-coach-indicator-min-inline-size);
+    --system-coach-indicator-block-size: var(--system-coach-indicator-min-block-size);
+    --system-coach-indicator-ring-inline-size: var(--spectrum-coach-indicator-ring-diameter);
+    --system-coach-indicator-ring-block-size: var(--spectrum-coach-indicator-ring-diameter);
     --system-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
     --system-coach-indicator-ring-light-color: var(--spectrum-gray-25);
-    --system-coach-indicator-top: calc(
-        var(--system-coach-indicator-block-size) / 3 -
-            var(--system-coach-indicator-ring-border-size)
-    );
-    --system-coach-indicator-left: calc(
-        var(--system-coach-indicator-inline-size) / 3 -
-            var(--system-coach-indicator-ring-border-size)
-    );
-    --system-coach-indicator-coach-animation-indicator-ring-duration: var(
-        --spectrum-animation-duration-6000
-    );
+    --system-coach-indicator-top: calc(var(--system-coach-indicator-block-size) / 3 - var(--system-coach-indicator-ring-border-size));
+    --system-coach-indicator-left: calc(var(--system-coach-indicator-inline-size) / 3 - var(--system-coach-indicator-ring-border-size));
+    --system-coach-indicator-coach-animation-indicator-ring-duration: var(--spectrum-animation-duration-6000);
     --system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple: -0.5;
     --system-coach-indicator-coach-animation-indicator-ring-center-delay-multiple: -0.66;
     --system-coach-indicator-coach-animation-indicator-ring-outer-delay-multiple: -1;
     --system-coach-indicator-quiet-animation-ring-inner-delay-multiple: -0.33;
     --system-coach-indicator-animation-name: pulse;
-    --system-coach-indicator-inner-animation-delay-multiple: var(
-        --system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple
-    );
+    --system-coach-indicator-inner-animation-delay-multiple: var(--system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple);
     --system-coach-indicator-animation-keyframe-0-scale: 1;
     --system-coach-indicator-animation-keyframe-0-opacity: 0;
     --system-coach-indicator-animation-keyframe-50-scale: 1.5;
@@ -563,65 +251,39 @@
     --system-coach-indicator-animation-keyframe-100-scale: 2;
     --system-coach-indicator-animation-keyframe-100-opacity: 0;
     --system-coach-indicator-quiet-animation-keyframe-0-scale: 0.8;
-    --system-coach-indicator-quiet-quiet-ring-diameter-size: var(
-        --spectrum-coach-indicator-quiet-ring-diameter
-    );
+    --system-coach-indicator-quiet-quiet-ring-diameter-size: var(--spectrum-coach-indicator-quiet-ring-diameter);
     --system-coach-indicator-quiet-animation-name: pulse-quiet;
     --system-coach-mark-min-width: var(--spectrum-coach-mark-minimum-width);
     --system-coach-mark-width: var(--spectrum-coach-mark-width);
     --system-coach-mark-max-width: var(--spectrum-coach-mark-maximum-width);
     --system-coach-mark-media-height: var(--spectrum-coach-mark-media-height);
-    --system-coach-mark-media-min-height: var(
-        --spectrum-coach-mark-media-minimum-height
-    );
+    --system-coach-mark-media-min-height: var(--spectrum-coach-mark-media-minimum-height);
     --system-coach-mark-padding: var(--spectrum-coach-mark-edge-to-content);
     --system-coach-mark-heading-to-action-button: var(--spectrum-spacing-300);
     --system-coach-mark-header-to-body: var(--spectrum-spacing-200);
     --system-coach-mark-body-to-footer: var(--spectrum-spacing-300);
     --system-coach-mark-title-color: var(--spectrum-heading-color);
     --system-coach-mark-title-font-family: var(--spectrum-sans-serif-font);
-    --system-coach-mark-title-font-style: var(
-        --spectrum-heading-serif-font-style
-    );
-    --system-coach-mark-title-text-font-weight: var(
-        --spectrum-heading-sans-serif-font-weight
-    );
+    --system-coach-mark-title-font-style: var(--spectrum-heading-serif-font-style);
+    --system-coach-mark-title-text-font-weight: var(--spectrum-heading-sans-serif-font-weight);
     --system-coach-mark-title-font-size: var(--spectrum-coach-mark-title-size);
-    --system-coach-mark-title-text-line-height: var(
-        --spectrum-heading-line-height
-    );
+    --system-coach-mark-title-text-line-height: var(--spectrum-heading-line-height);
     --system-coach-mark-content-font-color: var(--spectrum-body-color);
-    --system-coach-mark-content-font-weight: var(
-        --spectrum-body-sans-serif-font-weight
-    );
+    --system-coach-mark-content-font-weight: var(--spectrum-body-sans-serif-font-weight);
     --system-coach-mark-content-font-family: var(--spectrum-sans-serif-font);
-    --system-coach-mark-content-font-style: var(
-        --spectrum-body-sans-serif-font-style
-    );
+    --system-coach-mark-content-font-style: var(--spectrum-body-sans-serif-font-style);
     --system-coach-mark-content-line-height: var(--spectrum-body-line-height);
     --system-coach-mark-content-font-size: var(--spectrum-coach-mark-body-size);
     --system-coach-mark-step-color: var(--spectrum-coach-mark-pagination-color);
-    --system-coach-mark-step-font-weight: var(
-        --spectrum-body-medium-font-weight
-    );
+    --system-coach-mark-step-font-weight: var(--spectrum-body-medium-font-weight);
     --system-coach-mark-step-font-family: var(--spectrum-sans-serif-font);
-    --system-coach-mark-step-font-style: var(
-        --spectrum-body-sans-serif-font-style
-    );
+    --system-coach-mark-step-font-style: var(--spectrum-body-sans-serif-font-style);
     --system-coach-mark-step-line-height: var(--spectrum-body-line-height);
-    --system-coach-mark-step-font-size: var(
-        --spectrum-coach-mark-pagination-body-size
-    );
-    --system-coach-mark-step-to-bottom: var(
-        --spectrum-coach-mark-pagination-text-to-bottom-edge
-    );
+    --system-coach-mark-step-font-size: var(--spectrum-coach-mark-pagination-body-size);
+    --system-coach-mark-step-to-bottom: var(--spectrum-coach-mark-pagination-text-to-bottom-edge);
     --system-coach-mark-popover-border-width: var(--spectrum-border-width-100);
-    --system-coach-mark-popover-corner-radius: var(
-        --spectrum-corner-radius-100
-    );
-    --system-coach-mark-buttongroup-spacing-horizontal: var(
-        --spectrum-spacing-100
-    );
+    --system-coach-mark-popover-corner-radius: var(--spectrum-corner-radius-100);
+    --system-coach-mark-buttongroup-spacing-horizontal: var(--spectrum-spacing-100);
     --system-color-wheel-border-color: var(--spectrum-transparent-black-300);
     --system-combobox-border-color-default: var(--spectrum-gray-500);
     --system-combobox-border-color-hover: var(--spectrum-gray-600);
@@ -630,88 +292,47 @@
     --system-combobox-border-color-key-focus: var(--spectrum-gray-800);
     --system-combobox-readonly-input-border-color: var(--spectrum-gray-500);
     --system-combobox-background-color-disabled: var(--spectrum-gray-25);
-    --system-combobox-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
+    --system-combobox-border-color-disabled: var(--spectrum-disabled-border-color);
     --system-dialog-fullscreen-header-text-size: 28px;
     --system-dialog-min-inline-size: 288px;
     --system-dialog-confirm-small-width: 400px;
     --system-dialog-confirm-medium-width: 480px;
     --system-dialog-confirm-large-width: 640px;
-    --system-dialog-confirm-divider-block-spacing-start: var(
-        --spectrum-spacing-300
-    );
-    --system-dialog-confirm-divider-block-spacing-end: var(
-        --spectrum-spacing-200
-    );
+    --system-dialog-confirm-divider-block-spacing-start: var(--spectrum-spacing-300);
+    --system-dialog-confirm-divider-block-spacing-end: var(--spectrum-spacing-200);
     --system-dialog-confirm-description-text-color: var(--spectrum-gray-800);
     --system-dialog-confirm-title-text-color: var(--spectrum-gray-900);
-    --system-dialog-confirm-description-text-line-height: var(
-        --spectrum-line-height-100
-    );
-    --system-dialog-confirm-title-text-line-height: var(
-        --spectrum-line-height-100
-    );
-    --system-dialog-heading-font-weight: var(
-        --spectrum-heading-sans-serif-font-weight
-    );
+    --system-dialog-confirm-description-text-line-height: var(--spectrum-line-height-100);
+    --system-dialog-confirm-title-text-line-height: var(--spectrum-line-height-100);
+    --system-dialog-heading-font-weight: var(--spectrum-heading-sans-serif-font-weight);
     --system-dialog-confirm-description-padding: var(--spectrum-spacing-50);
-    --system-dialog-confirm-description-margin: calc(
-        var(--spectrum-spacing-50) * -1
-    );
+    --system-dialog-confirm-description-margin: calc(var(--spectrum-spacing-50) * -1);
     --system-dialog-confirm-footer-padding-top: var(--spectrum-spacing-600);
-    --system-dialog-confirm-gap-size: var(
-        --spectrum-component-pill-edge-to-text-100
-    );
-    --system-dialog-confirm-buttongroup-padding-top: var(
-        --spectrum-spacing-600
-    );
-    --system-dialog-confirm-close-button-size: var(
-        --spectrum-component-height-100
-    );
-    --system-dialog-confirm-close-button-padding: calc(
-        26px - var(--spectrum-component-bottom-to-text-300)
-    );
+    --system-dialog-confirm-gap-size: var(--spectrum-component-pill-edge-to-text-100);
+    --system-dialog-confirm-buttongroup-padding-top: var(--spectrum-spacing-600);
+    --system-dialog-confirm-close-button-size: var(--spectrum-component-height-100);
+    --system-dialog-confirm-close-button-padding: calc(26px - var(--spectrum-component-bottom-to-text-300));
     --system-dialog-confirm-divider-height: var(--spectrum-spacing-50);
     --system-divider-background-color: var(--spectrum-gray-200);
-    --system-divider-background-color-static-white: var(
-        --spectrum-transparent-white-200
-    );
-    --system-divider-background-color-static-black: var(
-        --spectrum-transparent-black-200
-    );
+    --system-divider-background-color-static-white: var(--spectrum-transparent-white-200);
+    --system-divider-background-color-static-black: var(--spectrum-transparent-black-200);
     --system-drop-zone-border-color: var(--spectrum-gray-200);
     --system-field-group-margin: var(--spectrum-spacing-300);
-    --system-field-group-readonly-delimiter: ',';
+    --system-field-group-readonly-delimiter: ",";
     --system-infield-button-border-width: var(--spectrum-border-width-100);
     --system-infield-button-border-color: inherit;
     --system-infield-button-border-radius: var(--spectrum-corner-radius-100);
     --system-infield-button-border-radius-reset: 0;
-    --system-infield-button-stacked-top-border-radius-start-start: var(
-        --system-infield-button-border-radius-reset
-    );
-    --system-infield-button-stacked-bottom-border-radius-end-start: var(
-        --system-infield-button-border-radius-reset
-    );
+    --system-infield-button-stacked-top-border-radius-start-start: var(--system-infield-button-border-radius-reset);
+    --system-infield-button-stacked-bottom-border-radius-end-start: var(--system-infield-button-border-radius-reset);
     --system-infield-button-background-color: var(--spectrum-gray-100);
     --system-infield-button-background-color-hover: var(--spectrum-gray-200);
     --system-infield-button-background-color-down: var(--spectrum-gray-200);
-    --system-infield-button-background-color-key-focus: var(
-        --spectrum-gray-200
-    );
+    --system-infield-button-background-color-key-focus: var(--spectrum-gray-200);
     --system-infield-button-disabled-border-color: var(--spectrum-gray-300);
-    --system-menu-item-background-color-hover: rgba(
-        var(--spectrum-gray-1000-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
-    --system-menu-item-background-color-down: rgba(
-        var(--spectrum-gray-1000-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
-    --system-menu-item-background-color-key-focus: rgba(
-        var(--spectrum-gray-1000-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
+    --system-menu-item-background-color-hover: rgba(var(--spectrum-gray-1000-rgb), var(--spectrum-transparent-black-200-opacity));
+    --system-menu-item-background-color-down: rgba(var(--spectrum-gray-1000-rgb), var(--spectrum-transparent-black-200-opacity));
+    --system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-1000-rgb), var(--spectrum-transparent-black-200-opacity));
     --system-menu-item-corner-radius: var(--spectrum-corner-radius-100);
     --system-menu-item-focus-indicator-shadow: none;
     --system-menu-item-focus-indicator-offset: var(--spectrum-spacing-50);
@@ -735,9 +356,7 @@
     --system-meter-font-size: var(--spectrum-font-size-100);
     --system-meter-size-l-font-size: var(--spectrum-font-size-100);
     --system-meter-top-to-text: var(--spectrum-component-top-to-text-200);
-    --system-meter-size-l-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
+    --system-meter-size-l-top-to-text: var(--spectrum-component-top-to-text-200);
     --system-modal-background-color: var(--spectrum-background-layer-2-color);
     --system-picker-background-color-default: var(--spectrum-gray-100);
     --system-picker-background-color-default-open: var(--spectrum-gray-200);
@@ -759,21 +378,13 @@
     --system-picker-button-background-color-key-focus: var(--spectrum-gray-200);
     --system-picker-button-border-color: none;
     --system-picker-button-border-radius: var(--spectrum-corner-radius-75);
-    --system-picker-button-border-radius-rounded-sided: var(
-        --spectrum-corner-radius-200
-    );
-    --system-picker-button-border-radius-sided: var(
-        --spectrum-corner-radius-75
-    );
+    --system-picker-button-border-radius-rounded-sided: var(--spectrum-corner-radius-200);
+    --system-picker-button-border-radius-sided: var(--spectrum-corner-radius-75);
     --system-picker-button-border-width: 0px;
     --system-picker-button-padding: 4px;
     --system-popover-border-width: var(--spectrum-border-width-100);
-    --system-progress-bar-animation-ease-in-out-indeterminate: var(
-        --spectrum-animation-ease-in-out
-    );
-    --system-progress-bar-animation-duration-indeterminate: var(
-        --spectrum-animation-duration-2000
-    );
+    --system-progress-bar-animation-ease-in-out-indeterminate: var(--spectrum-animation-ease-in-out);
+    --system-progress-bar-animation-duration-indeterminate: var(--spectrum-animation-duration-2000);
     --system-progress-bar-corner-radius: var(--spectrum-corner-radius-100);
     --system-progress-bar-fill-size-indeterminate: 70%;
     --system-progress-bar-size-2400: 192px;
@@ -785,122 +396,58 @@
     --system-progress-bar-line-height: var(--spectrum-line-height-100);
     --system-progress-bar-spacing-label-to: var(--spectrum-spacing-75);
     --system-progress-bar-spacing-label-to-text: var(--spectrum-spacing-200);
-    --system-progress-bar-text-color: var(
-        --spectrum-neutral-content-color-default
-    );
+    --system-progress-bar-text-color: var(--spectrum-neutral-content-color-default);
     --system-progress-bar-track-color: var(--spectrum-gray-200);
     --system-progress-bar-fill-color: var(--spectrum-accent-color-900);
     --system-progress-bar-label-and-value-white: var(--spectrum-white);
-    --system-progress-bar-track-color-white: var(
-        --spectrum-transparent-white-400
-    );
+    --system-progress-bar-track-color-white: var(--spectrum-transparent-white-400);
     --system-progress-bar-fill-color-white: var(--spectrum-white);
     --system-progress-bar-size-default: var(--system-progress-bar-size-2400);
-    --system-progress-bar-size-m-size-default: var(
-        --system-progress-bar-size-2400
-    );
+    --system-progress-bar-size-m-size-default: var(--system-progress-bar-size-2400);
     --system-progress-bar-font-size: var(--spectrum-font-size-75);
     --system-progress-bar-size-m-font-size: var(--spectrum-font-size-75);
-    --system-progress-bar-thickness: var(
-        --spectrum-progress-bar-thickness-large
-    );
-    --system-progress-bar-size-m-thickness: var(
-        --spectrum-progress-bar-thickness-large
-    );
-    --system-progress-bar-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-progress-bar-size-m-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-progress-bar-size-s-size-default: var(
-        --system-progress-bar-size-2400
-    );
+    --system-progress-bar-thickness: var(--spectrum-progress-bar-thickness-large);
+    --system-progress-bar-size-m-thickness: var(--spectrum-progress-bar-thickness-large);
+    --system-progress-bar-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-progress-bar-size-m-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-progress-bar-size-s-size-default: var(--system-progress-bar-size-2400);
     --system-progress-bar-size-s-font-size: var(--spectrum-font-size-75);
-    --system-progress-bar-size-s-thickness: var(
-        --spectrum-progress-bar-thickness-small
-    );
-    --system-progress-bar-size-s-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-progress-bar-size-l-size-default: var(
-        --system-progress-bar-size-2500
-    );
+    --system-progress-bar-size-s-thickness: var(--spectrum-progress-bar-thickness-small);
+    --system-progress-bar-size-s-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-progress-bar-size-l-size-default: var(--system-progress-bar-size-2500);
     --system-progress-bar-size-l-font-size: var(--spectrum-font-size-100);
-    --system-progress-bar-size-l-thickness: var(
-        --spectrum-progress-bar-thickness-large
-    );
-    --system-progress-bar-size-l-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --system-progress-bar-size-xl-size-default: var(
-        --system-progress-bar-size-2800
-    );
+    --system-progress-bar-size-l-thickness: var(--spectrum-progress-bar-thickness-large);
+    --system-progress-bar-size-l-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
+    --system-progress-bar-size-xl-size-default: var(--system-progress-bar-size-2800);
     --system-progress-bar-size-xl-font-size: var(--spectrum-font-size-200);
-    --system-progress-bar-size-xl-thickness: var(
-        --spectrum-progress-bar-thickness-extra-large
-    );
-    --system-progress-bar-size-xl-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-300
-    );
+    --system-progress-bar-size-xl-thickness: var(--spectrum-progress-bar-thickness-extra-large);
+    --system-progress-bar-size-xl-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
     --system-progress-circle-track-border-color: var(--spectrum-gray-200);
-    --system-progress-circle-track-border-color-over-background: var(
-        --spectrum-transparent-white-400
-    );
-    --system-progress-circle-fill-border-color-over-background: var(
-        --spectrum-transparent-white-1000
-    );
+    --system-progress-circle-track-border-color-over-background: var(--spectrum-transparent-white-400);
+    --system-progress-circle-fill-border-color-over-background: var(--spectrum-transparent-white-1000);
     --system-radio-button-border-color-default: var(--spectrum-gray-600);
     --system-radio-button-border-color-hover: var(--spectrum-gray-700);
     --system-radio-button-border-color-down: var(--spectrum-gray-800);
     --system-radio-button-border-color-focus: var(--spectrum-gray-700);
-    --system-radio-neutral-content-color: var(
-        --spectrum-neutral-content-color-default
-    );
-    --system-radio-neutral-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --system-radio-neutral-content-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --system-radio-neutral-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
-    --system-radio-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
+    --system-radio-neutral-content-color: var(--spectrum-neutral-content-color-default);
+    --system-radio-neutral-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --system-radio-neutral-content-color-down: var(--spectrum-neutral-content-color-down);
+    --system-radio-neutral-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --system-radio-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
     --system-radio-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
     --system-radio-focus-indicator-color: var(--spectrum-focus-indicator-color);
-    --system-radio-disabled-content-color: var(
-        --spectrum-disabled-content-color
-    );
-    --system-radio-disabled-border-color: var(
-        --spectrum-disabled-content-color
-    );
+    --system-radio-disabled-content-color: var(--spectrum-disabled-content-color);
+    --system-radio-disabled-border-color: var(--spectrum-disabled-content-color);
     --system-radio-emphasized-accent-color: var(--spectrum-accent-color-900);
-    --system-radio-emphasized-accent-color-hover: var(
-        --spectrum-accent-color-1000
-    );
-    --system-radio-emphasized-accent-color-down: var(
-        --spectrum-accent-color-1100
-    );
-    --system-radio-emphasized-accent-color-focus: var(
-        --spectrum-accent-color-1000
-    );
+    --system-radio-emphasized-accent-color-hover: var(--spectrum-accent-color-1000);
+    --system-radio-emphasized-accent-color-down: var(--spectrum-accent-color-1100);
+    --system-radio-emphasized-accent-color-focus: var(--spectrum-accent-color-1000);
     --system-radio-border-width: var(--spectrum-border-width-200);
     --system-radio-button-background-color: var(--spectrum-gray-50);
-    --system-radio-button-checked-border-color-default: var(
-        --spectrum-neutral-background-color-selected-default
-    );
-    --system-radio-button-checked-border-color-hover: var(
-        --spectrum-neutral-background-color-selected-hover
-    );
-    --system-radio-button-checked-border-color-down: var(
-        --spectrum-neutral-background-color-selected-down
-    );
-    --system-radio-button-checked-border-color-focus: var(
-        --spectrum-neutral-background-color-selected-focus
-    );
+    --system-radio-button-checked-border-color-default: var(--spectrum-neutral-background-color-selected-default);
+    --system-radio-button-checked-border-color-hover: var(--spectrum-neutral-background-color-selected-hover);
+    --system-radio-button-checked-border-color-down: var(--spectrum-neutral-background-color-selected-down);
+    --system-radio-button-checked-border-color-focus: var(--spectrum-neutral-background-color-selected-focus);
     --system-radio-line-height: var(--spectrum-line-height-100);
     --system-radio-animation-duration: var(--spectrum-animation-duration-100);
     --system-radio-lang-ja-line-height-cjk: var(--spectrum-cjk-line-height-100);
@@ -908,89 +455,43 @@
     --system-radio-lang-ko-line-height-cjk: var(--spectrum-cjk-line-height-100);
     --system-radio-height: var(--spectrum-component-height-100);
     --system-radio-size-m-height: var(--spectrum-component-height-100);
-    --system-radio-button-control-size: var(
-        --spectrum-radio-button-control-size-medium
-    );
-    --system-radio-size-m-button-control-size: var(
-        --spectrum-radio-button-control-size-medium
-    );
+    --system-radio-button-control-size: var(--spectrum-radio-button-control-size-medium);
+    --system-radio-size-m-button-control-size: var(--spectrum-radio-button-control-size-medium);
     --system-radio-text-to-control: var(--spectrum-text-to-control-100);
     --system-radio-size-m-text-to-control: var(--spectrum-text-to-control-100);
     --system-radio-label-top-to-text: var(--spectrum-component-top-to-text-100);
-    --system-radio-size-m-label-top-to-text: var(
-        --spectrum-component-top-to-text-100
-    );
-    --system-radio-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --system-radio-size-m-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --system-radio-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-medium
-    );
-    --system-radio-size-m-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-medium
-    );
+    --system-radio-size-m-label-top-to-text: var(--spectrum-component-top-to-text-100);
+    --system-radio-label-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
+    --system-radio-size-m-label-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
+    --system-radio-button-top-to-control: var(--spectrum-radio-button-top-to-control-medium);
+    --system-radio-size-m-button-top-to-control: var(--spectrum-radio-button-top-to-control-medium);
     --system-radio-font-size: var(--spectrum-font-size-100);
     --system-radio-size-m-font-size: var(--spectrum-font-size-100);
     --system-radio-size-s-height: var(--spectrum-component-height-75);
-    --system-radio-size-s-button-control-size: var(
-        --spectrum-radio-button-control-size-small
-    );
+    --system-radio-size-s-button-control-size: var(--spectrum-radio-button-control-size-small);
     --system-radio-size-s-text-to-control: var(--spectrum-text-to-control-75);
-    --system-radio-size-s-label-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-radio-size-s-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-75
-    );
-    --system-radio-size-s-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-small
-    );
+    --system-radio-size-s-label-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-radio-size-s-label-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
+    --system-radio-size-s-button-top-to-control: var(--spectrum-radio-button-top-to-control-small);
     --system-radio-size-s-font-size: var(--spectrum-font-size-75);
     --system-radio-size-l-height: var(--spectrum-component-height-200);
-    --system-radio-size-l-button-control-size: var(
-        --spectrum-radio-button-control-size-large
-    );
+    --system-radio-size-l-button-control-size: var(--spectrum-radio-button-control-size-large);
     --system-radio-size-l-text-to-control: var(--spectrum-text-to-control-200);
-    --system-radio-size-l-label-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --system-radio-size-l-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-200
-    );
-    --system-radio-size-l-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-large
-    );
+    --system-radio-size-l-label-top-to-text: var(--spectrum-component-top-to-text-200);
+    --system-radio-size-l-label-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
+    --system-radio-size-l-button-top-to-control: var(--spectrum-radio-button-top-to-control-large);
     --system-radio-size-l-font-size: var(--spectrum-font-size-200);
     --system-radio-size-xl-height: var(--spectrum-component-height-300);
-    --system-radio-size-xl-button-control-size: var(
-        --spectrum-radio-button-control-size-extra-large
-    );
+    --system-radio-size-xl-button-control-size: var(--spectrum-radio-button-control-size-extra-large);
     --system-radio-size-xl-text-to-control: var(--spectrum-text-to-control-300);
-    --system-radio-size-xl-label-top-to-text: var(
-        --spectrum-component-top-to-text-300
-    );
-    --system-radio-size-xl-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-300
-    );
-    --system-radio-size-xl-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-extra-large
-    );
+    --system-radio-size-xl-label-top-to-text: var(--spectrum-component-top-to-text-300);
+    --system-radio-size-xl-label-bottom-to-text: var(--spectrum-component-bottom-to-text-300);
+    --system-radio-size-xl-button-top-to-control: var(--spectrum-radio-button-top-to-control-extra-large);
     --system-radio-size-xl-font-size: var(--spectrum-font-size-300);
-    --system-radio-emphasized-button-checked-border-color-default: var(
-        --spectrum-accent-color-900
-    );
-    --system-radio-emphasized-button-checked-border-color-hover: var(
-        --spectrum-accent-color-1000
-    );
-    --system-radio-emphasized-button-checked-border-color-down: var(
-        --spectrum-accent-color-1100
-    );
-    --system-radio-emphasized-button-checked-border-color-focus: var(
-        --spectrum-accent-color-1000
-    );
+    --system-radio-emphasized-button-checked-border-color-default: var(--spectrum-accent-color-900);
+    --system-radio-emphasized-button-checked-border-color-hover: var(--spectrum-accent-color-1000);
+    --system-radio-emphasized-button-checked-border-color-down: var(--spectrum-accent-color-1100);
+    --system-radio-emphasized-button-checked-border-color-focus: var(--spectrum-accent-color-1000);
     --system-search-border-color-default: var(--spectrum-gray-500);
     --system-search-border-color-hover: var(--spectrum-gray-600);
     --system-search-border-color-focus: var(--spectrum-gray-800);
@@ -1001,34 +502,20 @@
     --system-search-border-color-disabled: var(--spectrum-gray-300);
     --system-search-border-radius: var(--spectrum-corner-radius-100);
     --system-search-size-m-border-radius: var(--spectrum-corner-radius-100);
-    --system-search-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-100
-    );
-    --system-search-size-m-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-100
-    );
+    --system-search-edge-to-visual: var(--spectrum-component-edge-to-visual-100);
+    --system-search-size-m-edge-to-visual: var(--spectrum-component-edge-to-visual-100);
     --system-search-size-s-border-radius: var(--spectrum-corner-radius-100);
-    --system-search-size-s-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-75
-    );
+    --system-search-size-s-edge-to-visual: var(--spectrum-component-edge-to-visual-75);
     --system-search-size-l-border-radius: var(--spectrum-corner-radius-100);
-    --system-search-size-l-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-200
-    );
+    --system-search-size-l-edge-to-visual: var(--spectrum-component-edge-to-visual-200);
     --system-search-size-xl-border-radius: var(--spectrum-corner-radius-100);
-    --system-search-size-xl-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-300
-    );
+    --system-search-size-xl-edge-to-visual: var(--spectrum-component-edge-to-visual-300);
     --system-search-quiet-background-color-disabled: transparent;
-    --system-search-quiet-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
+    --system-search-quiet-border-color-disabled: var(--spectrum-disabled-border-color);
     --system-side-nav-background-hover: var(--spectrum-gray-100);
     --system-side-nav-item-background-down: var(--spectrum-gray-200);
     --system-side-nav-background-key-focus: var(--spectrum-gray-100);
-    --system-side-nav-item-background-default-selected: var(
-        --spectrum-gray-100
-    );
+    --system-side-nav-item-background-default-selected: var(--spectrum-gray-100);
     --system-side-nav-background-hover-selected: var(--spectrum-gray-200);
     --system-side-nav-item-background-down-selected: var(--spectrum-gray-200);
     --system-side-nav-background-key-focus-selected: var(--spectrum-gray-100);
@@ -1046,23 +533,13 @@
     --system-slider-handle-border-color-hover: var(--spectrum-gray-800);
     --system-slider-handle-border-color-down: var(--spectrum-gray-800);
     --system-slider-handle-border-color-key-focus: var(--spectrum-gray-800);
-    --system-slider-handle-focus-ring-color-key-focus: var(
-        --spectrum-focus-indicator-color
-    );
+    --system-slider-handle-focus-ring-color-key-focus: var(--spectrum-focus-indicator-color);
     --system-slider-track-corner-radius: 2px;
     --system-slider-handle-border-radius: var(--spectrum-corner-radius-500);
-    --system-slider-size-m-handle-border-radius: var(
-        --spectrum-corner-radius-500
-    );
-    --system-slider-size-s-handle-border-radius: var(
-        --spectrum-corner-radius-500
-    );
-    --system-slider-size-l-handle-border-radius: calc(
-        var(--spectrum-corner-radius-500) * 4
-    );
-    --system-slider-size-xl-handle-border-radius: calc(
-        var(--spectrum-corner-radius-500) * 4
-    );
+    --system-slider-size-m-handle-border-radius: var(--spectrum-corner-radius-500);
+    --system-slider-size-s-handle-border-radius: var(--spectrum-corner-radius-500);
+    --system-slider-size-l-handle-border-radius: calc(var(--spectrum-corner-radius-500) * 4);
+    --system-slider-size-xl-handle-border-radius: calc(var(--spectrum-corner-radius-500) * 4);
     --system-split-view-background-color: var(--spectrum-gray-75);
     --system-split-view-handle-background-color: var(--spectrum-gray-200);
     --system-split-view-gripper-border-radius: 2px;
@@ -1078,94 +555,49 @@
     --system-stepper-buttons-background-color: var(--spectrum-gray-100);
     --system-stepper-buttons-border-color-hover: var(--spectrum-gray-600);
     --system-stepper-buttons-border-color-focus: var(--spectrum-gray-800);
-    --system-stepper-buttons-border-color-keyboard-focus: var(
-        --spectrum-gray-800
-    );
+    --system-stepper-buttons-border-color-keyboard-focus: var(--spectrum-gray-800);
     --system-stepper-button-border-width: var(--spectrum-border-width-100);
-    --system-stepper-border-color-invalid: var(
-        --spectrum-negative-border-color-default
-    );
-    --system-stepper-border-color-focus-invalid: var(
-        --spectrum-negative-border-color-focus
-    );
-    --system-stepper-border-color-focus-hover-invalid: var(
-        --spectrum-negative-border-color-focus-hover
-    );
-    --system-stepper-border-color-keyboard-focus-invalid: var(
-        --spectrum-negative-border-color-key-focus
-    );
+    --system-stepper-border-color-invalid: var(--spectrum-negative-border-color-default);
+    --system-stepper-border-color-focus-invalid: var(--spectrum-negative-border-color-focus);
+    --system-stepper-border-color-focus-hover-invalid: var(--spectrum-negative-border-color-focus-hover);
+    --system-stepper-border-color-keyboard-focus-invalid: var(--spectrum-negative-border-color-key-focus);
     --system-stepper-border-color-disabled: var(--spectrum-gray-300);
-    --system-stepper-button-border-width-disabled: var(
-        --spectrum-border-width-200
-    );
+    --system-stepper-button-border-width-disabled: var(--spectrum-border-width-200);
     --system-stepper-buttons-background-color-disabled: var(--spectrum-gray-50);
     --system-stepper-quiet-buttons-border-style: none;
     --system-stepper-quiet-button-edge-to-fill: 0;
     --system-swatch-border-radius: var(--spectrum-corner-radius-100);
-    --system-swatch-focus-indicator-border-radius: var(
-        --spectrum-corner-radius-200
-    );
+    --system-swatch-focus-indicator-border-radius: var(--spectrum-corner-radius-200);
     --system-swatch-border-thickness: var(--spectrum-border-width-100);
     --system-swatch-border-thickness-selected: var(--spectrum-border-width-200);
-    --system-swatch-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
+    --system-swatch-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
     --system-swatch-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
     --system-swatch-border-color-opacity: 0.51;
     --system-swatch-border-color-light-opacity: 0.2;
-    --system-swatch-border-color: rgba(
-        var(--spectrum-gray-1000-rgb),
-        var(--system-swatch-border-color-opacity)
-    );
-    --system-swatch-icon-border-color: rgba(
-        var(--spectrum-black-rgb),
-        var(--system-swatch-border-color-opacity)
-    );
-    --system-swatch-border-color-light: rgba(
-        var(--spectrum-black-rgb),
-        var(--system-swatch-border-color-light-opacity)
-    );
+    --system-swatch-border-color: rgba(var(--spectrum-gray-1000-rgb), var(--system-swatch-border-color-opacity));
+    --system-swatch-icon-border-color: rgba(var(--spectrum-black-rgb), var(--system-swatch-border-color-opacity));
+    --system-swatch-border-color-light: rgba(var(--spectrum-black-rgb), var(--system-swatch-border-color-light-opacity));
     --system-swatch-border-color-selected: var(--spectrum-gray-900);
     --system-swatch-inner-border-color-selected: var(--spectrum-gray-25);
     --system-swatch-disabled-icon-color: var(--spectrum-gray-25);
     --system-swatch-dash-icon-color: var(--spectrum-gray-800);
     --system-swatch-slash-icon-color: var(--spectrum-red-900);
-    --system-swatch-focus-indicator-color: var(
-        --spectrum-focus-indicator-color
-    );
+    --system-swatch-focus-indicator-color: var(--spectrum-focus-indicator-color);
     --system-swatch-size: var(--spectrum-swatch-size-medium);
     --system-swatch-size-m-size: var(--spectrum-swatch-size-medium);
     --system-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-100);
-    --system-swatch-size-m-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-100
-    );
-    --system-swatch-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-medium
-    );
-    --system-swatch-size-m-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-medium
-    );
+    --system-swatch-size-m-disabled-icon-size: var(--spectrum-workflow-icon-size-100);
+    --system-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-medium);
+    --system-swatch-size-m-slash-thickness: var(--spectrum-swatch-slash-thickness-medium);
     --system-swatch-size-xs-size: var(--spectrum-swatch-size-extra-small);
-    --system-swatch-size-xs-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-50
-    );
-    --system-swatch-size-xs-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-extra-small
-    );
+    --system-swatch-size-xs-disabled-icon-size: var(--spectrum-workflow-icon-size-50);
+    --system-swatch-size-xs-slash-thickness: var(--spectrum-swatch-slash-thickness-extra-small);
     --system-swatch-size-s-size: var(--spectrum-swatch-size-small);
-    --system-swatch-size-s-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-75
-    );
-    --system-swatch-size-s-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-small
-    );
+    --system-swatch-size-s-disabled-icon-size: var(--spectrum-workflow-icon-size-75);
+    --system-swatch-size-s-slash-thickness: var(--spectrum-swatch-slash-thickness-small);
     --system-swatch-size-l-size: var(--spectrum-swatch-size-large);
-    --system-swatch-size-l-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-200
-    );
-    --system-swatch-size-l-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-large
-    );
+    --system-swatch-size-l-disabled-icon-size: var(--spectrum-workflow-icon-size-200);
+    --system-swatch-size-l-slash-thickness: var(--spectrum-swatch-slash-thickness-large);
     --system-swatch-group-spacing-compact: var(--spectrum-spacing-50);
     --system-swatch-group-spacing-regular: var(--spectrum-spacing-75);
     --system-swatch-group-spacing-spacious: var(--spectrum-spacing-100);
@@ -1173,39 +605,23 @@
     --system-switch-handle-border-color-hover: var(--spectrum-gray-700);
     --system-switch-handle-border-color-down: var(--spectrum-gray-800);
     --system-switch-handle-border-color-focus: var(--spectrum-gray-700);
-    --system-switch-handle-border-color-selected-default: var(
-        --spectrum-gray-700
-    );
-    --system-switch-handle-border-color-selected-hover: var(
-        --spectrum-gray-800
-    );
+    --system-switch-handle-border-color-selected-default: var(--spectrum-gray-700);
+    --system-switch-handle-border-color-selected-hover: var(--spectrum-gray-800);
     --system-switch-handle-border-color-selected-down: var(--spectrum-gray-900);
-    --system-switch-handle-border-color-selected-focus: var(
-        --spectrum-gray-800
-    );
+    --system-switch-handle-border-color-selected-focus: var(--spectrum-gray-800);
     --system-switch-background-color: var(--spectrum-gray-200);
     --system-switch-background-color-disabled: var(--spectrum-gray-200);
     --system-switch-handle-background-color: var(--spectrum-gray-50);
-    --system-table-header-background-color: var(
-        --spectrum-transparent-white-25
-    );
+    --system-table-header-background-color: var(--spectrum-transparent-white-25);
     --system-table-border-color: var(--spectrum-gray-200);
     --system-table-divider-color: var(--spectrum-gray-200);
     --system-table-row-background-color: var(--spectrum-gray-25);
     --system-table-summary-row-background-color: var(--spectrum-gray-100);
     --system-table-section-header-background-color: var(--spectrum-gray-100);
-    --system-table-icon-color-focus: var(
-        --spectrum-neutral-subdued-content-color-key-focus
-    );
-    --system-table-icon-color-focus-hover: var(
-        --spectrum-neutral-subdued-content-color-hover
-    );
-    --system-table-quiet-header-background-color: var(
-        --spectrum-transparent-white-25
-    );
-    --system-table-quiet-row-background-color: var(
-        --spectrum-transparent-white-25
-    );
+    --system-table-icon-color-focus: var(--spectrum-neutral-subdued-content-color-key-focus);
+    --system-table-icon-color-focus-hover: var(--spectrum-neutral-subdued-content-color-hover);
+    --system-table-quiet-header-background-color: var(--spectrum-transparent-white-25);
+    --system-table-quiet-row-background-color: var(--spectrum-transparent-white-25);
     --system-tabs-font-weight: var(--spectrum-regular-font-weight);
     --system-tabs-divider-background-color: var(--spectrum-gray-200);
     --system-tag-background-color: var(--spectrum-gray-50);
@@ -1219,62 +635,26 @@
     --system-tag-border-color-hover: var(--spectrum-gray-800);
     --system-tag-border-color-active: var(--spectrum-gray-900);
     --system-tag-border-color-focus: var(--spectrum-gray-800);
-    --system-tag-content-color: var(
-        --spectrum-neutral-subdued-content-color-default
-    );
-    --system-tag-content-color-hover: var(
-        --spectrum-neutral-subdued-content-color-hover
-    );
-    --system-tag-content-color-active: var(
-        --spectrum-neutral-subdued-content-color-down
-    );
-    --system-tag-content-color-focus: var(
-        --spectrum-neutral-subdued-content-color-key-focus
-    );
+    --system-tag-content-color: var(--spectrum-neutral-subdued-content-color-default);
+    --system-tag-content-color-hover: var(--spectrum-neutral-subdued-content-color-hover);
+    --system-tag-content-color-active: var(--spectrum-neutral-subdued-content-color-down);
+    --system-tag-content-color-focus: var(--spectrum-neutral-subdued-content-color-key-focus);
     --system-tag-content-color-selected: var(--spectrum-gray-25);
-    --system-tag-border-color-selected: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
-    --system-tag-border-color-selected-hover: var(
-        --spectrum-neutral-subdued-background-color-hover
-    );
-    --system-tag-border-color-selected-active: var(
-        --spectrum-neutral-subdued-background-color-down
-    );
-    --system-tag-border-color-selected-focus: var(
-        --spectrum-neutral-subdued-background-color-key-focus
-    );
+    --system-tag-border-color-selected: var(--spectrum-neutral-subdued-background-color-default);
+    --system-tag-border-color-selected-hover: var(--spectrum-neutral-subdued-background-color-hover);
+    --system-tag-border-color-selected-active: var(--spectrum-neutral-subdued-background-color-down);
+    --system-tag-border-color-selected-focus: var(--spectrum-neutral-subdued-background-color-key-focus);
     --system-tag-border-color-disabled: transparent;
-    --system-tag-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --system-tag-size-small-spacing-inline-start: var(
-        --spectrum-component-edge-to-visual-75
-    );
-    --system-tag-size-small-label-spacing-inline-end: var(
-        --spectrum-component-edge-to-text-75
-    );
-    --system-tag-size-small-clear-button-spacing-inline-end: var(
-        --spectrum-component-edge-to-visual-75
-    );
-    --system-tag-size-medium-spacing-inline-start: var(
-        --spectrum-component-edge-to-visual-100
-    );
-    --system-tag-size-medium-label-spacing-inline-end: var(
-        --spectrum-component-edge-to-text-100
-    );
-    --system-tag-size-medium-clear-button-spacing-inline-end: var(
-        --spectrum-component-edge-to-visual-100
-    );
-    --system-tag-size-large-spacing-inline-start: var(
-        --spectrum-component-edge-to-visual-200
-    );
-    --system-tag-size-large-label-spacing-inline-end: var(
-        --spectrum-component-edge-to-text-200
-    );
-    --system-tag-size-large-clear-button-spacing-inline-end: var(
-        --spectrum-component-edge-to-visual-200
-    );
+    --system-tag-background-color-disabled: var(--spectrum-disabled-background-color);
+    --system-tag-size-small-spacing-inline-start: var(--spectrum-component-edge-to-visual-75);
+    --system-tag-size-small-label-spacing-inline-end: var(--spectrum-component-edge-to-text-75);
+    --system-tag-size-small-clear-button-spacing-inline-end: var(--spectrum-component-edge-to-visual-75);
+    --system-tag-size-medium-spacing-inline-start: var(--spectrum-component-edge-to-visual-100);
+    --system-tag-size-medium-label-spacing-inline-end: var(--spectrum-component-edge-to-text-100);
+    --system-tag-size-medium-clear-button-spacing-inline-end: var(--spectrum-component-edge-to-visual-100);
+    --system-tag-size-large-spacing-inline-start: var(--spectrum-component-edge-to-visual-200);
+    --system-tag-size-large-label-spacing-inline-end: var(--spectrum-component-edge-to-text-200);
+    --system-tag-size-large-clear-button-spacing-inline-end: var(--spectrum-component-edge-to-visual-200);
     --system-textfield-background-color: var(--spectrum-gray-25);
     --system-textfield-background-color-disabled: var(--spectrum-gray-25);
     --system-textfield-border-color: var(--spectrum-gray-500);
@@ -1284,25 +664,13 @@
     --system-textfield-border-color-keyboard-focus: var(--spectrum-gray-800);
     --system-textfield-border-color-disabled: var(--spectrum-gray-300);
     --system-textfield-border-width: var(--spectrum-border-width-100);
-    --system-textfield-icon-spacing-block-invalid: var(
-        --spectrum-component-top-to-workflow-icon-100
-    );
-    --system-textfield-size-s-icon-spacing-block-invalid: var(
-        --spectrum-component-top-to-workflow-icon-75
-    );
-    --system-textfield-size-l-icon-spacing-block-invalid: var(
-        --spectrum-component-top-to-workflow-icon-200
-    );
-    --system-textfield-size-xl-icon-spacing-block-invalid: var(
-        --spectrum-component-top-to-workflow-icon-300
-    );
+    --system-textfield-icon-spacing-block-invalid: var(--spectrum-component-top-to-workflow-icon-100);
+    --system-textfield-size-s-icon-spacing-block-invalid: var(--spectrum-component-top-to-workflow-icon-75);
+    --system-textfield-size-l-icon-spacing-block-invalid: var(--spectrum-component-top-to-workflow-icon-200);
+    --system-textfield-size-xl-icon-spacing-block-invalid: var(--spectrum-component-top-to-workflow-icon-300);
     --system-textfield-quiet-border-color-disabled: var(--spectrum-gray-300);
     --system-thumbnail-border-radius: 2px;
-    --system-toast-background-color-default: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
+    --system-toast-background-color-default: var(--spectrum-neutral-subdued-background-color-default);
     --system-toast-divider-color: var(--spectrum-transparent-white-400);
-    --system-tooltip-backgound-color-default-neutral: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
+    --system-tooltip-backgound-color-default-neutral: var(--spectrum-neutral-subdued-background-color-default);
 }

--- a/tools/styles/tokens/dark-vars.css
+++ b/tools/styles/tokens/dark-vars.css
@@ -3,10 +3,7 @@
     --spectrum-overlay-opacity: 0.5;
     --spectrum-drop-shadow-color-rgb: 0, 0, 0;
     --spectrum-drop-shadow-color-opacity: 0.5;
-    --spectrum-drop-shadow-color: rgba(
-        var(--spectrum-drop-shadow-color-rgb),
-        var(--spectrum-drop-shadow-color-opacity)
-    );
+    --spectrum-drop-shadow-color: rgba(var(--spectrum-drop-shadow-color-rgb), var(--spectrum-drop-shadow-color-opacity));
     --spectrum-background-base-color: var(--spectrum-gray-50);
     --spectrum-background-layer-1-color: var(--spectrum-gray-75);
     --spectrum-background-layer-2-color: var(--spectrum-gray-100);
@@ -14,68 +11,32 @@
     --spectrum-neutral-background-color-hover: var(--spectrum-gray-300);
     --spectrum-neutral-background-color-down: var(--spectrum-gray-200);
     --spectrum-neutral-background-color-key-focus: var(--spectrum-gray-300);
-    --spectrum-neutral-subdued-background-color-default: var(
-        --spectrum-gray-400
-    );
+    --spectrum-neutral-subdued-background-color-default: var(--spectrum-gray-400);
     --spectrum-neutral-subdued-background-color-hover: var(--spectrum-gray-300);
     --spectrum-neutral-subdued-background-color-down: var(--spectrum-gray-200);
-    --spectrum-neutral-subdued-background-color-key-focus: var(
-        --spectrum-gray-300
-    );
-    --spectrum-accent-background-color-default: var(
-        --spectrum-accent-color-500
-    );
+    --spectrum-neutral-subdued-background-color-key-focus: var(--spectrum-gray-300);
+    --spectrum-accent-background-color-default: var(--spectrum-accent-color-500);
     --spectrum-accent-background-color-hover: var(--spectrum-accent-color-400);
     --spectrum-accent-background-color-down: var(--spectrum-accent-color-300);
-    --spectrum-accent-background-color-key-focus: var(
-        --spectrum-accent-color-400
-    );
-    --spectrum-informative-background-color-default: var(
-        --spectrum-informative-color-500
-    );
-    --spectrum-informative-background-color-hover: var(
-        --spectrum-informative-color-400
-    );
-    --spectrum-informative-background-color-down: var(
-        --spectrum-informative-color-300
-    );
-    --spectrum-informative-background-color-key-focus: var(
-        --spectrum-informative-color-400
-    );
-    --spectrum-negative-background-color-default: var(
-        --spectrum-negative-color-500
-    );
-    --spectrum-negative-background-color-hover: var(
-        --spectrum-negative-color-400
-    );
-    --spectrum-negative-background-color-down: var(
-        --spectrum-negative-color-300
-    );
-    --spectrum-negative-background-color-key-focus: var(
-        --spectrum-negative-color-400
-    );
-    --spectrum-positive-background-color-default: var(
-        --spectrum-positive-color-500
-    );
-    --spectrum-positive-background-color-hover: var(
-        --spectrum-positive-color-400
-    );
-    --spectrum-positive-background-color-down: var(
-        --spectrum-positive-color-300
-    );
-    --spectrum-positive-background-color-key-focus: var(
-        --spectrum-positive-color-400
-    );
-    --spectrum-notice-background-color-default: var(
-        --spectrum-notice-color-800
-    );
+    --spectrum-accent-background-color-key-focus: var(--spectrum-accent-color-400);
+    --spectrum-informative-background-color-default: var(--spectrum-informative-color-500);
+    --spectrum-informative-background-color-hover: var(--spectrum-informative-color-400);
+    --spectrum-informative-background-color-down: var(--spectrum-informative-color-300);
+    --spectrum-informative-background-color-key-focus: var(--spectrum-informative-color-400);
+    --spectrum-negative-background-color-default: var(--spectrum-negative-color-500);
+    --spectrum-negative-background-color-hover: var(--spectrum-negative-color-400);
+    --spectrum-negative-background-color-down: var(--spectrum-negative-color-300);
+    --spectrum-negative-background-color-key-focus: var(--spectrum-negative-color-400);
+    --spectrum-positive-background-color-default: var(--spectrum-positive-color-500);
+    --spectrum-positive-background-color-hover: var(--spectrum-positive-color-400);
+    --spectrum-positive-background-color-down: var(--spectrum-positive-color-300);
+    --spectrum-positive-background-color-key-focus: var(--spectrum-positive-color-400);
+    --spectrum-notice-background-color-default: var(--spectrum-notice-color-800);
     --spectrum-gray-background-color-default: var(--spectrum-gray-700);
     --spectrum-red-background-color-default: var(--spectrum-red-700);
     --spectrum-orange-background-color-default: var(--spectrum-orange-800);
     --spectrum-yellow-background-color-default: var(--spectrum-yellow-1000);
-    --spectrum-chartreuse-background-color-default: var(
-        --spectrum-chartreuse-900
-    );
+    --spectrum-chartreuse-background-color-default: var(--spectrum-chartreuse-900);
     --spectrum-celery-background-color-default: var(--spectrum-celery-800);
     --spectrum-green-background-color-default: var(--spectrum-green-700);
     --spectrum-seafoam-background-color-default: var(--spectrum-seafoam-700);

--- a/tools/styles/tokens/darkest-vars.css
+++ b/tools/styles/tokens/darkest-vars.css
@@ -3,10 +3,7 @@
     --spectrum-overlay-opacity: 0.6;
     --spectrum-drop-shadow-color-rgb: 0, 0, 0;
     --spectrum-drop-shadow-color-opacity: 0.8;
-    --spectrum-drop-shadow-color: rgba(
-        var(--spectrum-drop-shadow-color-rgb),
-        var(--spectrum-drop-shadow-color-opacity)
-    );
+    --spectrum-drop-shadow-color: rgba(var(--spectrum-drop-shadow-color-rgb), var(--spectrum-drop-shadow-color-opacity));
     --spectrum-background-base-color: var(--spectrum-gray-50);
     --spectrum-background-layer-1-color: var(--spectrum-gray-75);
     --spectrum-background-layer-2-color: var(--spectrum-gray-100);
@@ -14,68 +11,32 @@
     --spectrum-neutral-background-color-hover: var(--spectrum-gray-300);
     --spectrum-neutral-background-color-down: var(--spectrum-gray-200);
     --spectrum-neutral-background-color-key-focus: var(--spectrum-gray-300);
-    --spectrum-neutral-subdued-background-color-default: var(
-        --spectrum-gray-400
-    );
+    --spectrum-neutral-subdued-background-color-default: var(--spectrum-gray-400);
     --spectrum-neutral-subdued-background-color-hover: var(--spectrum-gray-300);
     --spectrum-neutral-subdued-background-color-down: var(--spectrum-gray-200);
-    --spectrum-neutral-subdued-background-color-key-focus: var(
-        --spectrum-gray-300
-    );
-    --spectrum-accent-background-color-default: var(
-        --spectrum-accent-color-600
-    );
+    --spectrum-neutral-subdued-background-color-key-focus: var(--spectrum-gray-300);
+    --spectrum-accent-background-color-default: var(--spectrum-accent-color-600);
     --spectrum-accent-background-color-hover: var(--spectrum-accent-color-500);
     --spectrum-accent-background-color-down: var(--spectrum-accent-color-400);
-    --spectrum-accent-background-color-key-focus: var(
-        --spectrum-accent-color-500
-    );
-    --spectrum-informative-background-color-default: var(
-        --spectrum-informative-color-600
-    );
-    --spectrum-informative-background-color-hover: var(
-        --spectrum-informative-color-500
-    );
-    --spectrum-informative-background-color-down: var(
-        --spectrum-informative-color-400
-    );
-    --spectrum-informative-background-color-key-focus: var(
-        --spectrum-informative-color-500
-    );
-    --spectrum-negative-background-color-default: var(
-        --spectrum-negative-color-600
-    );
-    --spectrum-negative-background-color-hover: var(
-        --spectrum-negative-color-500
-    );
-    --spectrum-negative-background-color-down: var(
-        --spectrum-negative-color-400
-    );
-    --spectrum-negative-background-color-key-focus: var(
-        --spectrum-negative-color-500
-    );
-    --spectrum-positive-background-color-default: var(
-        --spectrum-positive-color-600
-    );
-    --spectrum-positive-background-color-hover: var(
-        --spectrum-positive-color-500
-    );
-    --spectrum-positive-background-color-down: var(
-        --spectrum-positive-color-400
-    );
-    --spectrum-positive-background-color-key-focus: var(
-        --spectrum-positive-color-500
-    );
-    --spectrum-notice-background-color-default: var(
-        --spectrum-notice-color-800
-    );
+    --spectrum-accent-background-color-key-focus: var(--spectrum-accent-color-500);
+    --spectrum-informative-background-color-default: var(--spectrum-informative-color-600);
+    --spectrum-informative-background-color-hover: var(--spectrum-informative-color-500);
+    --spectrum-informative-background-color-down: var(--spectrum-informative-color-400);
+    --spectrum-informative-background-color-key-focus: var(--spectrum-informative-color-500);
+    --spectrum-negative-background-color-default: var(--spectrum-negative-color-600);
+    --spectrum-negative-background-color-hover: var(--spectrum-negative-color-500);
+    --spectrum-negative-background-color-down: var(--spectrum-negative-color-400);
+    --spectrum-negative-background-color-key-focus: var(--spectrum-negative-color-500);
+    --spectrum-positive-background-color-default: var(--spectrum-positive-color-600);
+    --spectrum-positive-background-color-hover: var(--spectrum-positive-color-500);
+    --spectrum-positive-background-color-down: var(--spectrum-positive-color-400);
+    --spectrum-positive-background-color-key-focus: var(--spectrum-positive-color-500);
+    --spectrum-notice-background-color-default: var(--spectrum-notice-color-800);
     --spectrum-gray-background-color-default: var(--spectrum-gray-700);
     --spectrum-red-background-color-default: var(--spectrum-red-700);
     --spectrum-orange-background-color-default: var(--spectrum-orange-800);
     --spectrum-yellow-background-color-default: var(--spectrum-yellow-1000);
-    --spectrum-chartreuse-background-color-default: var(
-        --spectrum-chartreuse-900
-    );
+    --spectrum-chartreuse-background-color-default: var(--spectrum-chartreuse-900);
     --spectrum-celery-background-color-default: var(--spectrum-celery-800);
     --spectrum-green-background-color-default: var(--spectrum-green-700);
     --spectrum-seafoam-background-color-default: var(--spectrum-seafoam-700);

--- a/tools/styles/tokens/express/custom-dark-vars.css
+++ b/tools/styles/tokens/express/custom-dark-vars.css
@@ -4,11 +4,7 @@
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb);
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
     --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-700);
-    --spectrum-assetcard-border-color-selected-hover: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-700);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-800);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-700);
 }

--- a/tools/styles/tokens/express/custom-darkest-vars.css
+++ b/tools/styles/tokens/express/custom-darkest-vars.css
@@ -4,11 +4,7 @@
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb);
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
     --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-700);
-    --spectrum-assetcard-border-color-selected-hover: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-700);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-800);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-700);
 }

--- a/tools/styles/tokens/express/custom-large-vars.css
+++ b/tools/styles/tokens/express/custom-large-vars.css
@@ -1,8 +1,8 @@
 /* @deprecated these assets should not be used; the custom override values exist in express/large-vars.css */
 :host,
 :root {
-    --spectrum-colorwheel-path: 'M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0';
-    --spectrum-colorwheel-path-borders: 'M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0';
+    --spectrum-colorwheel-path: "M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
+    --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
 
     --spectrum-dialog-confirm-border-radius: 8px;
 

--- a/tools/styles/tokens/express/custom-light-vars.css
+++ b/tools/styles/tokens/express/custom-light-vars.css
@@ -4,13 +4,7 @@
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-800-rgb);
     --spectrum-well-border-color: rgba(var(--spectrum-black-rgb), 0.05);
     --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-900);
-    --spectrum-assetcard-border-color-selected-hover: var(
-        --spectrum-indigo-900
-    );
-    --spectrum-assetcard-border-color-selected-down: var(
-        --spectrum-indigo-1000
-    );
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-indigo-900
-    );
+    --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-900);
+    --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-1000);
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-900);
 }

--- a/tools/styles/tokens/express/custom-medium-vars.css
+++ b/tools/styles/tokens/express/custom-medium-vars.css
@@ -1,8 +1,8 @@
 /* @deprecated these assets should not be used; the custom override values exist in express/medium-vars.css */
 :host,
 :root {
-    --spectrum-colorwheel-path: 'M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0';
-    --spectrum-colorwheel-path-borders: 'M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0';
+    --spectrum-colorwheel-path: "M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
+    --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
 
     --spectrum-dialog-confirm-border-radius: 6px;
 

--- a/tools/styles/tokens/express/dark-vars.css
+++ b/tools/styles/tokens/express/dark-vars.css
@@ -3,11 +3,7 @@
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb);
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
     --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-700);
-    --spectrum-assetcard-border-color-selected-hover: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-700);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-800);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-700);
 }

--- a/tools/styles/tokens/express/darkest-vars.css
+++ b/tools/styles/tokens/express/darkest-vars.css
@@ -3,11 +3,7 @@
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb);
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
     --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-700);
-    --spectrum-assetcard-border-color-selected-hover: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-700);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-800);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-700);
 }

--- a/tools/styles/tokens/express/global-vars.css
+++ b/tools/styles/tokens/express/global-vars.css
@@ -1,15 +1,9 @@
 :host,
 :root {
-    --spectrum-neutral-background-color-selected-default: var(
-        --spectrum-gray-800
-    );
-    --spectrum-neutral-background-color-selected-hover: var(
-        --spectrum-gray-900
-    );
+    --spectrum-neutral-background-color-selected-default: var(--spectrum-gray-800);
+    --spectrum-neutral-background-color-selected-hover: var(--spectrum-gray-900);
     --spectrum-neutral-background-color-selected-down: var(--spectrum-gray-900);
-    --spectrum-neutral-background-color-selected-key-focus: var(
-        --spectrum-gray-900
-    );
+    --spectrum-neutral-background-color-selected-key-focus: var(--spectrum-gray-900);
     --spectrum-slider-track-thickness: 4px;
     --spectrum-slider-handle-gap: 0px;
     --spectrum-picker-border-width: 0;
@@ -38,16 +32,10 @@
     --spectrum-accent-color-1200: var(--spectrum-indigo-1200);
     --spectrum-accent-color-1300: var(--spectrum-indigo-1300);
     --spectrum-accent-color-1400: var(--spectrum-indigo-1400);
-    --spectrum-heading-sans-serif-font-weight: var(
-        --spectrum-black-font-weight
-    );
+    --spectrum-heading-sans-serif-font-weight: var(--spectrum-black-font-weight);
     --spectrum-heading-serif-font-weight: var(--spectrum-black-font-weight);
     --spectrum-heading-cjk-font-weight: var(--spectrum-black-font-weight);
-    --spectrum-heading-sans-serif-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-serif-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
+    --spectrum-heading-sans-serif-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-serif-emphasized-font-weight: var(--spectrum-black-font-weight);
     --system: express;
 }

--- a/tools/styles/tokens/express/index.css
+++ b/tools/styles/tokens/express/index.css
@@ -3,26 +3,16 @@
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-900-rgb);
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
     --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-700);
-    --spectrum-assetcard-border-color-selected-hover: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-700);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-800);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-indigo-700
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-700);
 }
 :host,
 :root {
-    --spectrum-neutral-background-color-selected-default: var(
-        --spectrum-gray-800
-    );
-    --spectrum-neutral-background-color-selected-hover: var(
-        --spectrum-gray-900
-    );
+    --spectrum-neutral-background-color-selected-default: var(--spectrum-gray-800);
+    --spectrum-neutral-background-color-selected-hover: var(--spectrum-gray-900);
     --spectrum-neutral-background-color-selected-down: var(--spectrum-gray-900);
-    --spectrum-neutral-background-color-selected-key-focus: var(
-        --spectrum-gray-900
-    );
+    --spectrum-neutral-background-color-selected-key-focus: var(--spectrum-gray-900);
     --spectrum-slider-track-thickness: 4px;
     --spectrum-slider-handle-gap: 0px;
     --spectrum-picker-border-width: 0;
@@ -51,17 +41,11 @@
     --spectrum-accent-color-1200: var(--spectrum-indigo-1200);
     --spectrum-accent-color-1300: var(--spectrum-indigo-1300);
     --spectrum-accent-color-1400: var(--spectrum-indigo-1400);
-    --spectrum-heading-sans-serif-font-weight: var(
-        --spectrum-black-font-weight
-    );
+    --spectrum-heading-sans-serif-font-weight: var(--spectrum-black-font-weight);
     --spectrum-heading-serif-font-weight: var(--spectrum-black-font-weight);
     --spectrum-heading-cjk-font-weight: var(--spectrum-black-font-weight);
-    --spectrum-heading-sans-serif-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-serif-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
+    --spectrum-heading-sans-serif-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-serif-emphasized-font-weight: var(--spectrum-black-font-weight);
     --system: express;
 }
 :host,
@@ -102,18 +86,10 @@
     --spectrum-slider-handle-size-medium: 24px;
     --spectrum-slider-handle-size-large: 28px;
     --spectrum-slider-handle-size-extra-large: 30px;
-    --spectrum-slider-handle-border-width-down-small: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-medium: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-large: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-extra-large: var(
-        --spectrum-border-width-200
-    );
+    --spectrum-slider-handle-border-width-down-small: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-medium: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-large: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-extra-large: var(--spectrum-border-width-200);
     --spectrum-slider-bottom-to-handle-small: 4px;
     --spectrum-slider-bottom-to-handle-medium: 8px;
     --spectrum-slider-bottom-to-handle-large: 12px;
@@ -124,8 +100,8 @@
     --spectrum-drop-shadow-x: 0px;
     --spectrum-drop-shadow-y: 4px;
     --spectrum-drop-shadow-blur: 16px;
-    --spectrum-colorwheel-path: 'M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0';
-    --spectrum-colorwheel-path-borders: 'M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0';
+    --spectrum-colorwheel-path: "M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
+    --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
     --spectrum-dialog-confirm-border-radius: 8px;
     --spectrum-dial-border-radius: 15px;
     --spectrum-assetcard-focus-ring-border-radius: 12px;
@@ -135,15 +111,9 @@
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-800-rgb);
     --spectrum-well-border-color: rgba(var(--spectrum-black-rgb), 0.05);
     --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-900);
-    --spectrum-assetcard-border-color-selected-hover: var(
-        --spectrum-indigo-900
-    );
-    --spectrum-assetcard-border-color-selected-down: var(
-        --spectrum-indigo-1000
-    );
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-indigo-900
-    );
+    --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-900);
+    --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-1000);
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-900);
 }
 :host,
 :root {
@@ -183,18 +153,10 @@
     --spectrum-slider-handle-size-medium: 20px;
     --spectrum-slider-handle-size-large: 22px;
     --spectrum-slider-handle-size-extra-large: 24px;
-    --spectrum-slider-handle-border-width-down-small: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-medium: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-large: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-extra-large: var(
-        --spectrum-border-width-200
-    );
+    --spectrum-slider-handle-border-width-down-small: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-medium: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-large: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-extra-large: var(--spectrum-border-width-200);
     --spectrum-slider-bottom-to-handle-small: 3px;
     --spectrum-slider-bottom-to-handle-medium: 6px;
     --spectrum-slider-bottom-to-handle-large: 9px;
@@ -205,8 +167,8 @@
     --spectrum-drop-shadow-x: 0px;
     --spectrum-drop-shadow-y: 4px;
     --spectrum-drop-shadow-blur: 16px;
-    --spectrum-colorwheel-path: 'M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0';
-    --spectrum-colorwheel-path-borders: 'M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0';
+    --spectrum-colorwheel-path: "M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
+    --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
     --spectrum-dialog-confirm-border-radius: 6px;
     --spectrum-dial-border-radius: 12px;
     --spectrum-assetcard-focus-ring-border-radius: 10px;

--- a/tools/styles/tokens/express/large-vars.css
+++ b/tools/styles/tokens/express/large-vars.css
@@ -36,18 +36,10 @@
     --spectrum-slider-handle-size-medium: 24px;
     --spectrum-slider-handle-size-large: 28px;
     --spectrum-slider-handle-size-extra-large: 30px;
-    --spectrum-slider-handle-border-width-down-small: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-medium: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-large: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-extra-large: var(
-        --spectrum-border-width-200
-    );
+    --spectrum-slider-handle-border-width-down-small: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-medium: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-large: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-extra-large: var(--spectrum-border-width-200);
     --spectrum-slider-bottom-to-handle-small: 4px;
     --spectrum-slider-bottom-to-handle-medium: 8px;
     --spectrum-slider-bottom-to-handle-large: 12px;
@@ -58,8 +50,8 @@
     --spectrum-drop-shadow-x: 0px;
     --spectrum-drop-shadow-y: 4px;
     --spectrum-drop-shadow-blur: 16px;
-    --spectrum-colorwheel-path: 'M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0';
-    --spectrum-colorwheel-path-borders: 'M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0';
+    --spectrum-colorwheel-path: "M 118 118 m -118 0 a 118 118 0 1 0 236 0 a 118 118 0 1 0 -236 0.2 M 118 118 m -92 0 a 92 92 0 1 0 184 0 a 92 92 0 1 0 -184 0";
+    --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
     --spectrum-dialog-confirm-border-radius: 8px;
     --spectrum-dial-border-radius: 15px;
     --spectrum-assetcard-focus-ring-border-radius: 12px;

--- a/tools/styles/tokens/express/light-vars.css
+++ b/tools/styles/tokens/express/light-vars.css
@@ -3,13 +3,7 @@
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-indigo-800-rgb);
     --spectrum-well-border-color: rgba(var(--spectrum-black-rgb), 0.05);
     --spectrum-assetcard-border-color-selected: var(--spectrum-indigo-900);
-    --spectrum-assetcard-border-color-selected-hover: var(
-        --spectrum-indigo-900
-    );
-    --spectrum-assetcard-border-color-selected-down: var(
-        --spectrum-indigo-1000
-    );
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-indigo-900
-    );
+    --spectrum-assetcard-border-color-selected-hover: var(--spectrum-indigo-900);
+    --spectrum-assetcard-border-color-selected-down: var(--spectrum-indigo-1000);
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-indigo-900);
 }

--- a/tools/styles/tokens/express/medium-vars.css
+++ b/tools/styles/tokens/express/medium-vars.css
@@ -36,18 +36,10 @@
     --spectrum-slider-handle-size-medium: 20px;
     --spectrum-slider-handle-size-large: 22px;
     --spectrum-slider-handle-size-extra-large: 24px;
-    --spectrum-slider-handle-border-width-down-small: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-medium: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-large: var(
-        --spectrum-border-width-200
-    );
-    --spectrum-slider-handle-border-width-down-extra-large: var(
-        --spectrum-border-width-200
-    );
+    --spectrum-slider-handle-border-width-down-small: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-medium: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-large: var(--spectrum-border-width-200);
+    --spectrum-slider-handle-border-width-down-extra-large: var(--spectrum-border-width-200);
     --spectrum-slider-bottom-to-handle-small: 3px;
     --spectrum-slider-bottom-to-handle-medium: 6px;
     --spectrum-slider-bottom-to-handle-large: 9px;
@@ -58,8 +50,8 @@
     --spectrum-drop-shadow-x: 0px;
     --spectrum-drop-shadow-y: 4px;
     --spectrum-drop-shadow-blur: 16px;
-    --spectrum-colorwheel-path: 'M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0';
-    --spectrum-colorwheel-path-borders: 'M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0';
+    --spectrum-colorwheel-path: "M 94 94 m -94 0 a 94 94 0 1 0 188 0 a 94 94 0 1 0 -188 0.2 M 94 94 m -74 0 a 74 74 0 1 0 148 0 a 74 74 0 1 0 -148 0";
+    --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
     --spectrum-dialog-confirm-border-radius: 6px;
     --spectrum-dial-border-radius: 12px;
     --spectrum-assetcard-focus-ring-border-radius: 10px;

--- a/tools/styles/tokens/express/system-theme-bridge.css
+++ b/tools/styles/tokens/express/system-theme-bridge.css
@@ -10,138 +10,64 @@
     --system-action-button-background-color-down: var(--spectrum-gray-400);
     --system-action-button-background-color-focus: var(--spectrum-gray-300);
     --system-action-button-background-color-disabled: var(--spectrum-gray-200);
-    --system-action-button-background-color-selected: var(
-        --spectrum-neutral-background-color-selected-default
-    );
-    --system-action-button-background-color-selected-hover: var(
-        --spectrum-neutral-background-color-selected-hover
-    );
-    --system-action-button-background-color-selected-down: var(
-        --spectrum-neutral-background-color-selected-down
-    );
-    --system-action-button-background-color-selected-focus: var(
-        --spectrum-neutral-background-color-selected-key-focus
-    );
+    --system-action-button-background-color-selected: var(--spectrum-neutral-background-color-selected-default);
+    --system-action-button-background-color-selected-hover: var(--spectrum-neutral-background-color-selected-hover);
+    --system-action-button-background-color-selected-down: var(--spectrum-neutral-background-color-selected-down);
+    --system-action-button-background-color-selected-focus: var(--spectrum-neutral-background-color-selected-key-focus);
     --system-action-button-border-color-default: transparent;
     --system-action-button-border-color-hover: transparent;
     --system-action-button-border-color-down: transparent;
     --system-action-button-border-color-focus: transparent;
     --system-action-button-border-color-disabled: transparent;
     --system-action-button-content-color-selected: var(--spectrum-gray-75);
-    --system-action-button-size-m-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
-    --system-action-button-size-xs-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
-    --system-action-button-size-s-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
-    --system-action-button-size-l-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
-    --system-action-button-size-xl-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
+    --system-action-button-size-m-border-radius-default: var(--spectrum-corner-radius-100);
+    --system-action-button-size-xs-border-radius-default: var(--spectrum-corner-radius-100);
+    --system-action-button-size-s-border-radius-default: var(--spectrum-corner-radius-100);
+    --system-action-button-size-l-border-radius-default: var(--spectrum-corner-radius-100);
+    --system-action-button-size-xl-border-radius-default: var(--spectrum-corner-radius-100);
     --system-action-button-quiet-background-color-default: transparent;
-    --system-action-button-quiet-background-color-hover: var(
-        --spectrum-gray-300
-    );
-    --system-action-button-quiet-background-color-down: var(
-        --spectrum-gray-400
-    );
-    --system-action-button-quiet-background-color-focus: var(
-        --spectrum-gray-300
-    );
+    --system-action-button-quiet-background-color-hover: var(--spectrum-gray-300);
+    --system-action-button-quiet-background-color-down: var(--spectrum-gray-400);
+    --system-action-button-quiet-background-color-focus: var(--spectrum-gray-300);
     --system-action-button-quiet-background-color-disabled: transparent;
-    --system-action-button-quiet-background-color-selected-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-action-button-quiet-background-color-selected-disabled: var(--spectrum-disabled-background-color);
     --system-action-button-static-black-border-color-default: transparent;
     --system-action-button-static-black-border-color-hover: transparent;
     --system-action-button-static-black-border-color-down: transparent;
     --system-action-button-static-black-border-color-focus: transparent;
-    --system-action-button-static-black-border-color-disabled: var(
-        --spectrum-disabled-static-black-border-color
-    );
+    --system-action-button-static-black-border-color-disabled: var(--spectrum-disabled-static-black-border-color);
     --system-action-button-static-black-background-color-disabled: transparent;
-    --system-action-button-static-black-background-color-selected-disabled: var(
-        --spectrum-disabled-static-black-background-color
-    );
-    --system-action-button-static-black-background-color-default: var(
-        --spectrum-transparent-black-200
-    );
-    --system-action-button-static-black-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-action-button-static-black-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-action-button-static-black-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
-    --system-action-button-static-black-quiet-background-color-default: var(
-        --spectrum-transparent-black-200
-    );
-    --system-action-button-static-black-quiet-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-action-button-static-black-quiet-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-action-button-static-black-quiet-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
+    --system-action-button-static-black-background-color-selected-disabled: var(--spectrum-disabled-static-black-background-color);
+    --system-action-button-static-black-background-color-default: var(--spectrum-transparent-black-200);
+    --system-action-button-static-black-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-action-button-static-black-background-color-down: var(--spectrum-transparent-black-400);
+    --system-action-button-static-black-background-color-focus: var(--spectrum-transparent-black-300);
+    --system-action-button-static-black-quiet-background-color-default: var(--spectrum-transparent-black-200);
+    --system-action-button-static-black-quiet-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-action-button-static-black-quiet-background-color-down: var(--spectrum-transparent-black-400);
+    --system-action-button-static-black-quiet-background-color-focus: var(--spectrum-transparent-black-300);
     --system-action-button-static-black-quiet-background-color-disabled: transparent;
     --system-action-button-static-white-border-color-default: transparent;
     --system-action-button-static-white-border-color-hover: transparent;
     --system-action-button-static-white-border-color-down: transparent;
     --system-action-button-static-white-border-color-focus: transparent;
-    --system-action-button-static-white-border-color-disabled: var(
-        --spectrum-disabled-static-white-border-color
-    );
+    --system-action-button-static-white-border-color-disabled: var(--spectrum-disabled-static-white-border-color);
     --system-action-button-static-white-background-color-disabled: transparent;
-    --system-action-button-static-white-background-color-selected-disabled: var(
-        --spectrum-disabled-static-white-background-color
-    );
-    --system-action-button-static-white-background-color-default: var(
-        --spectrum-transparent-white-200
-    );
-    --system-action-button-static-white-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-action-button-static-white-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-action-button-static-white-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-action-button-static-white-quiet-background-color-default: var(
-        --spectrum-transparent-white-200
-    );
-    --system-action-button-static-white-quiet-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-action-button-static-white-quiet-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-action-button-static-white-quiet-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
+    --system-action-button-static-white-background-color-selected-disabled: var(--spectrum-disabled-static-white-background-color);
+    --system-action-button-static-white-background-color-default: var(--spectrum-transparent-white-200);
+    --system-action-button-static-white-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-action-button-static-white-background-color-down: var(--spectrum-transparent-white-400);
+    --system-action-button-static-white-background-color-focus: var(--spectrum-transparent-white-300);
+    --system-action-button-static-white-quiet-background-color-default: var(--spectrum-transparent-white-200);
+    --system-action-button-static-white-quiet-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-action-button-static-white-quiet-background-color-down: var(--spectrum-transparent-white-400);
+    --system-action-button-static-white-quiet-background-color-focus: var(--spectrum-transparent-white-300);
     --system-action-button-static-white-quiet-background-color-disabled: transparent;
-    --system-action-button-background-color-selected-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-action-button-background-color-selected-disabled: var(--spectrum-disabled-background-color);
     --system-action-group-gap-size-compact: var(--spectrum-spacing-50);
-    --system-action-group-horizontal-spacing-compact: calc(
-        -1px * var(--spectrum-spacing-50)
-    );
-    --system-action-group-vertical-spacing-compact: calc(
-        -1px * var(--spectrum-spacing-50)
-    );
-    --system-alert-banner-neutral-background: var(
-        --spectrum-neutral-background-color-default
-    );
+    --system-action-group-horizontal-spacing-compact: calc(-1px * var(--spectrum-spacing-50));
+    --system-action-group-vertical-spacing-compact: calc(-1px * var(--spectrum-spacing-50));
+    --system-alert-banner-neutral-background: var(--spectrum-neutral-background-color-default);
     --system-asset-folder-background-color: var(--spectrum-gray-300);
     --system-asset-file-background-color: var(--spectrum-gray-50);
     --system-asset-icon-outline-color: var(--spectrum-gray-500);
@@ -154,255 +80,99 @@
     --system-button-border-color-down: transparent;
     --system-button-border-color-focus: transparent;
     --system-button-background-color-disabled: transparent;
-    --system-button-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
-    --system-button-selected-background-color-default: var(
-        --spectrum-neutral-background-color-default
-    );
-    --system-button-selected-background-color-hover: var(
-        --spectrum-neutral-background-color-hover
-    );
-    --system-button-selected-background-color-down: var(
-        --spectrum-neutral-background-color-down
-    );
-    --system-button-selected-background-color-focus: var(
-        --spectrum-neutral-background-color-key-focus
-    );
+    --system-button-border-color-disabled: var(--spectrum-disabled-border-color);
+    --system-button-selected-background-color-default: var(--spectrum-neutral-background-color-default);
+    --system-button-selected-background-color-hover: var(--spectrum-neutral-background-color-hover);
+    --system-button-selected-background-color-down: var(--spectrum-neutral-background-color-down);
+    --system-button-selected-background-color-focus: var(--spectrum-neutral-background-color-key-focus);
     --system-button-primary-content-color-default: var(--spectrum-white);
     --system-button-primary-content-color-hover: var(--spectrum-white);
     --system-button-primary-content-color-down: var(--spectrum-white);
     --system-button-primary-content-color-focus: var(--spectrum-white);
-    --system-button-primary-outline-background-color-hover: var(
-        --spectrum-gray-300
-    );
-    --system-button-primary-outline-background-color-down: var(
-        --spectrum-gray-400
-    );
-    --system-button-primary-outline-background-color-focus: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-background-color-default: var(
-        --spectrum-gray-200
-    );
+    --system-button-primary-outline-background-color-hover: var(--spectrum-gray-300);
+    --system-button-primary-outline-background-color-down: var(--spectrum-gray-400);
+    --system-button-primary-outline-background-color-focus: var(--spectrum-gray-300);
+    --system-button-secondary-background-color-default: var(--spectrum-gray-200);
     --system-button-secondary-background-color-hover: var(--spectrum-gray-300);
     --system-button-secondary-background-color-down: var(--spectrum-gray-400);
     --system-button-secondary-background-color-focus: var(--spectrum-gray-300);
-    --system-button-secondary-outline-background-color-hover: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-outline-background-color-down: var(
-        --spectrum-gray-400
-    );
-    --system-button-secondary-outline-background-color-focus: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-outline-border-color-default: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-outline-border-color-down: var(
-        --spectrum-gray-500
-    );
-    --system-button-static-white-background-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-background-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-background-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-background-color-focus: var(
-        --spectrum-transparent-white-900
-    );
+    --system-button-secondary-outline-background-color-hover: var(--spectrum-gray-300);
+    --system-button-secondary-outline-background-color-down: var(--spectrum-gray-400);
+    --system-button-secondary-outline-background-color-focus: var(--spectrum-gray-300);
+    --system-button-secondary-outline-border-color-default: var(--spectrum-gray-300);
+    --system-button-secondary-outline-border-color-down: var(--spectrum-gray-500);
+    --system-button-static-white-background-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-background-color-hover: var(--spectrum-transparent-white-900);
+    --system-button-static-white-background-color-down: var(--spectrum-transparent-white-900);
+    --system-button-static-white-background-color-focus: var(--spectrum-transparent-white-900);
     --system-button-static-white-content-color-default: var(--spectrum-black);
     --system-button-static-white-content-color-hover: var(--spectrum-black);
     --system-button-static-white-content-color-down: var(--spectrum-black);
     --system-button-static-white-content-color-focus: var(--spectrum-black);
-    --system-button-static-white-outline-background-color-default: var(
-        --spectrum-transparent-white-25
-    );
-    --system-button-static-white-outline-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-outline-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-outline-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-outline-content-color-default: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-content-color-down: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-content-color-focus: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-border-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-outline-border-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-border-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-border-color-focus: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-secondary-background-color-default: var(
-        --spectrum-transparent-white-200
-    );
-    --system-button-static-white-secondary-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-secondary-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-secondary-content-color-default: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-content-color-down: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-content-color-focus: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-outline-border-color-default: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-secondary-outline-border-color-hover: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-border-color-down: var(
-        --spectrum-transparent-white-500
-    );
-    --system-button-static-white-secondary-outline-border-color-focus: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-background-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-secondary-outline-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-secondary-outline-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-black-background-color-default: var(
-        --spectrum-transparent-black-800
-    );
-    --system-button-static-black-background-color-hover: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-background-color-down: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-background-color-focus: var(
-        --spectrum-transparent-black-900
-    );
+    --system-button-static-white-outline-background-color-default: var(--spectrum-transparent-white-25);
+    --system-button-static-white-outline-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-button-static-white-outline-background-color-down: var(--spectrum-transparent-white-400);
+    --system-button-static-white-outline-background-color-focus: var(--spectrum-transparent-white-300);
+    --system-button-static-white-outline-content-color-default: var(--spectrum-white);
+    --system-button-static-white-outline-content-color-hover: var(--spectrum-white);
+    --system-button-static-white-outline-content-color-down: var(--spectrum-white);
+    --system-button-static-white-outline-content-color-focus: var(--spectrum-white);
+    --system-button-static-white-outline-border-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-outline-border-color-hover: var(--spectrum-transparent-white-900);
+    --system-button-static-white-outline-border-color-down: var(--spectrum-transparent-white-900);
+    --system-button-static-white-outline-border-color-focus: var(--spectrum-transparent-white-900);
+    --system-button-static-white-secondary-background-color-default: var(--spectrum-transparent-white-200);
+    --system-button-static-white-secondary-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-button-static-white-secondary-background-color-down: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-background-color-focus: var(--spectrum-transparent-white-300);
+    --system-button-static-white-secondary-content-color-default: var(--spectrum-white);
+    --system-button-static-white-secondary-content-color-hover: var(--spectrum-white);
+    --system-button-static-white-secondary-content-color-down: var(--spectrum-white);
+    --system-button-static-white-secondary-content-color-focus: var(--spectrum-white);
+    --system-button-static-white-secondary-outline-border-color-default: var(--spectrum-transparent-white-300);
+    --system-button-static-white-secondary-outline-border-color-hover: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-outline-border-color-down: var(--spectrum-transparent-white-500);
+    --system-button-static-white-secondary-outline-border-color-focus: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-outline-background-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-secondary-outline-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-button-static-white-secondary-outline-background-color-down: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-outline-background-color-focus: var(--spectrum-transparent-white-300);
+    --system-button-static-black-background-color-default: var(--spectrum-transparent-black-800);
+    --system-button-static-black-background-color-hover: var(--spectrum-transparent-black-900);
+    --system-button-static-black-background-color-down: var(--spectrum-transparent-black-900);
+    --system-button-static-black-background-color-focus: var(--spectrum-transparent-black-900);
     --system-button-static-black-content-color-default: var(--spectrum-white);
     --system-button-static-black-content-color-hover: var(--spectrum-white);
     --system-button-static-black-content-color-down: var(--spectrum-white);
     --system-button-static-black-content-color-focus: var(--spectrum-white);
-    --system-button-static-black-outline-background-color-default: var(
-        --spectrum-transparent-black-25
-    );
-    --system-button-static-black-outline-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-outline-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-outline-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-outline-content-color-default: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-content-color-hover: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-content-color-down: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-content-color-focus: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-border-color-default: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-outline-border-color-hover: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-outline-border-color-down: var(
-        --spectrum-transparent-black-600
-    );
-    --system-button-static-black-outline-border-color-focus: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-secondary-background-color-default: var(
-        --spectrum-transparent-black-200
-    );
-    --system-button-static-black-secondary-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-secondary-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-secondary-content-color-default: var(
-        --spectrum-black
-    );
-    --system-button-static-black-secondary-content-color-hover: var(
-        --spectrum-black
-    );
-    --system-button-static-black-secondary-content-color-down: var(
-        --spectrum-black
-    );
-    --system-button-static-black-secondary-content-color-focus: var(
-        --spectrum-black
-    );
-    --system-button-static-black-secondary-outline-border-color-default: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-secondary-outline-border-color-hover: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-border-color-down: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-secondary-outline-border-color-focus: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-background-color-default: var(
-        --spectrum-transparent-black-800
-    );
-    --system-button-static-black-secondary-outline-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-secondary-outline-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
+    --system-button-static-black-outline-background-color-default: var(--spectrum-transparent-black-25);
+    --system-button-static-black-outline-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-button-static-black-outline-background-color-down: var(--spectrum-transparent-black-400);
+    --system-button-static-black-outline-background-color-focus: var(--spectrum-transparent-black-300);
+    --system-button-static-black-outline-content-color-default: var(--spectrum-black);
+    --system-button-static-black-outline-content-color-hover: var(--spectrum-black);
+    --system-button-static-black-outline-content-color-down: var(--spectrum-black);
+    --system-button-static-black-outline-content-color-focus: var(--spectrum-black);
+    --system-button-static-black-outline-border-color-default: var(--spectrum-transparent-black-400);
+    --system-button-static-black-outline-border-color-hover: var(--spectrum-transparent-black-500);
+    --system-button-static-black-outline-border-color-down: var(--spectrum-transparent-black-600);
+    --system-button-static-black-outline-border-color-focus: var(--spectrum-transparent-black-500);
+    --system-button-static-black-secondary-background-color-default: var(--spectrum-transparent-black-200);
+    --system-button-static-black-secondary-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-button-static-black-secondary-background-color-down: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-background-color-focus: var(--spectrum-transparent-black-300);
+    --system-button-static-black-secondary-content-color-default: var(--spectrum-black);
+    --system-button-static-black-secondary-content-color-hover: var(--spectrum-black);
+    --system-button-static-black-secondary-content-color-down: var(--spectrum-black);
+    --system-button-static-black-secondary-content-color-focus: var(--spectrum-black);
+    --system-button-static-black-secondary-outline-border-color-default: var(--spectrum-transparent-black-300);
+    --system-button-static-black-secondary-outline-border-color-hover: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-outline-border-color-down: var(--spectrum-transparent-black-500);
+    --system-button-static-black-secondary-outline-border-color-focus: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-outline-background-color-default: var(--spectrum-transparent-black-800);
+    --system-button-static-black-secondary-outline-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-button-static-black-secondary-outline-background-color-down: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-outline-background-color-focus: var(--spectrum-transparent-black-300);
     --system-checkbox-control-color-default: var(--spectrum-gray-800);
     --system-checkbox-control-color-hover: var(--spectrum-gray-900);
     --system-checkbox-control-color-down: var(--spectrum-gray-900);
@@ -412,9 +182,7 @@
     --system-card-border-color: var(--spectrum-gray-200);
     --system-card-border-color-hover: var(--spectrum-gray-300);
     --system-card-divider-color: var(--spectrum-gray-300);
-    --system-card-preview-background-color: var(
-        --spectrum-background-base-color
-    );
+    --system-card-preview-background-color: var(--spectrum-background-base-color);
     --system-card-preview-background-color-hover: var(--spectrum-gray-300);
     --system-clear-button-background-color: var(--spectrum-gray-200);
     --system-clear-button-background-color-hover: var(--spectrum-gray-300);
@@ -423,146 +191,60 @@
     --system-clear-button-height: var(--spectrum-component-height-100);
     --system-clear-button-width: var(--spectrum-component-height-100);
     --system-clear-button-padding: var(--spectrum-in-field-button-edge-to-fill);
-    --system-clear-button-icon-color: var(
-        --spectrum-neutral-content-color-default
-    );
-    --system-clear-button-icon-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --system-clear-button-icon-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --system-clear-button-icon-color-key-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
+    --system-clear-button-icon-color: var(--spectrum-neutral-content-color-default);
+    --system-clear-button-icon-color-hover: var(--spectrum-neutral-content-color-hover);
+    --system-clear-button-icon-color-down: var(--spectrum-neutral-content-color-down);
+    --system-clear-button-icon-color-key-focus: var(--spectrum-neutral-content-color-key-focus);
     --system-clear-button-size-s-height: var(--spectrum-component-height-75);
     --system-clear-button-size-s-width: var(--spectrum-component-height-75);
     --system-clear-button-size-l-height: var(--spectrum-component-height-200);
     --system-clear-button-size-l-width: var(--spectrum-component-height-200);
     --system-clear-button-size-xl-height: var(--spectrum-component-height-300);
     --system-clear-button-size-xl-width: var(--spectrum-component-height-300);
-    --system-clear-button-quiet-background-color: var(
-        --spectrum-clear-button-background-color-quiet,
-        transparent
-    );
-    --system-clear-button-quiet-background-color-hover: var(
-        --spectrum-clear-button-background-color-hover-quiet,
-        transparent
-    );
-    --system-clear-button-quiet-background-color-down: var(
-        --spectrum-clear-button-background-color-down-quiet,
-        transparent
-    );
-    --system-clear-button-quiet-background-color-key-focus: var(
-        --spectrum-clear-button-background-color-key-focus-quiet,
-        transparent
-    );
-    --system-clear-button-over-background-icon-color: var(
-        --spectrum-clear-button-icon-color-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-icon-color-hover: var(
-        --spectrum-clear-button-icon-color-hover-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-icon-color-down: var(
-        --spectrum-clear-button-icon-color-down-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-icon-color-key-focus: var(
-        --spectrum-clear-button-icon-color-key-focus-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-background-color: var(
-        --spectrum-clear-button-background-color-over-background,
-        transparent
-    );
-    --system-clear-button-over-background-background-color-hover: var(
-        --spectrum-clear-button-background-color-hover-over-background,
-        var(--spectrum-transparent-white-300)
-    );
-    --system-clear-button-over-background-background-color-down: var(
-        --spectrum-clear-button-background-color-hover-over-background,
-        var(--spectrum-transparent-white-400)
-    );
-    --system-clear-button-over-background-background-color-key-focus: var(
-        --spectrum-clear-button-background-color-hover-over-background,
-        var(--spectrum-transparent-white-300)
-    );
-    --system-clear-button-disabled-icon-color: var(
-        --spectrum-disabled-content-color
-    );
-    --system-clear-button-disabled-icon-color-hover: var(
-        --spectrum-clear-button-icon-color-hover-disabled,
-        var(--spectrum-disabled-content-color)
-    );
-    --system-clear-button-disabled-icon-color-down: var(
-        --spectrum-clear-button-icon-color-down-disabled,
-        var(--spectrum-disabled-content-color)
-    );
+    --system-clear-button-quiet-background-color: var(--spectrum-clear-button-background-color-quiet, transparent);
+    --system-clear-button-quiet-background-color-hover: var(--spectrum-clear-button-background-color-hover-quiet, transparent);
+    --system-clear-button-quiet-background-color-down: var(--spectrum-clear-button-background-color-down-quiet, transparent);
+    --system-clear-button-quiet-background-color-key-focus: var(--spectrum-clear-button-background-color-key-focus-quiet, transparent);
+    --system-clear-button-over-background-icon-color: var(--spectrum-clear-button-icon-color-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-icon-color-hover: var(--spectrum-clear-button-icon-color-hover-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-icon-color-down: var(--spectrum-clear-button-icon-color-down-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-icon-color-key-focus: var(--spectrum-clear-button-icon-color-key-focus-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-background-color: var(--spectrum-clear-button-background-color-over-background, transparent);
+    --system-clear-button-over-background-background-color-hover: var(--spectrum-clear-button-background-color-hover-over-background, var(--spectrum-transparent-white-300));
+    --system-clear-button-over-background-background-color-down: var(--spectrum-clear-button-background-color-hover-over-background, var(--spectrum-transparent-white-400));
+    --system-clear-button-over-background-background-color-key-focus: var(--spectrum-clear-button-background-color-hover-over-background, var(--spectrum-transparent-white-300));
+    --system-clear-button-disabled-icon-color: var(--spectrum-disabled-content-color);
+    --system-clear-button-disabled-icon-color-hover: var(--spectrum-clear-button-icon-color-hover-disabled, var(--spectrum-disabled-content-color));
+    --system-clear-button-disabled-icon-color-down: var(--spectrum-clear-button-icon-color-down-disabled, var(--spectrum-disabled-content-color));
     --system-clear-button-disabled-background-color: transparent;
     --system-close-button-background-color-default: transparent;
     --system-close-button-background-color-hover: var(--spectrum-gray-300);
     --system-close-button-background-color-down: var(--spectrum-gray-400);
     --system-close-button-background-color-focus: var(--spectrum-gray-300);
-    --system-close-button-static-white-static-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-close-button-static-white-static-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-close-button-static-white-static-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-close-button-static-black-static-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-close-button-static-black-static-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-close-button-static-black-static-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
+    --system-close-button-static-white-static-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-close-button-static-white-static-background-color-down: var(--spectrum-transparent-white-400);
+    --system-close-button-static-white-static-background-color-focus: var(--spectrum-transparent-white-300);
+    --system-close-button-static-black-static-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-close-button-static-black-static-background-color-down: var(--spectrum-transparent-black-400);
+    --system-close-button-static-black-static-background-color-focus: var(--spectrum-transparent-black-300);
     --system-coach-indicator-ring-border-size: var(--spectrum-border-width-200);
-    --system-coach-indicator-min-inline-size: calc(
-        var(--spectrum-coach-indicator-ring-diameter) * 3
-    );
-    --system-coach-indicator-min-block-size: calc(
-        var(--spectrum-coach-indicator-ring-diameter) * 3
-    );
-    --system-coach-indicator-inline-size: var(
-        --system-coach-indicator-min-inline-size
-    );
-    --system-coach-indicator-block-size: var(
-        --system-coach-indicator-min-block-size
-    );
-    --system-coach-indicator-ring-inline-size: var(
-        --spectrum-coach-indicator-ring-diameter
-    );
-    --system-coach-indicator-ring-block-size: var(
-        --spectrum-coach-indicator-ring-diameter
-    );
+    --system-coach-indicator-min-inline-size: calc(var(--spectrum-coach-indicator-ring-diameter) * 3);
+    --system-coach-indicator-min-block-size: calc(var(--spectrum-coach-indicator-ring-diameter) * 3);
+    --system-coach-indicator-inline-size: var(--system-coach-indicator-min-inline-size);
+    --system-coach-indicator-block-size: var(--system-coach-indicator-min-block-size);
+    --system-coach-indicator-ring-inline-size: var(--spectrum-coach-indicator-ring-diameter);
+    --system-coach-indicator-ring-block-size: var(--spectrum-coach-indicator-ring-diameter);
     --system-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
     --system-coach-indicator-ring-light-color: var(--spectrum-gray-50);
-    --system-coach-indicator-top: calc(
-        var(--system-coach-indicator-block-size) / 3 -
-            var(--system-coach-indicator-ring-border-size)
-    );
-    --system-coach-indicator-left: calc(
-        var(--system-coach-indicator-inline-size) / 3 -
-            var(--system-coach-indicator-ring-border-size)
-    );
-    --system-coach-indicator-coach-animation-indicator-ring-duration: var(
-        --spectrum-animation-duration-6000
-    );
+    --system-coach-indicator-top: calc(var(--system-coach-indicator-block-size) / 3 - var(--system-coach-indicator-ring-border-size));
+    --system-coach-indicator-left: calc(var(--system-coach-indicator-inline-size) / 3 - var(--system-coach-indicator-ring-border-size));
+    --system-coach-indicator-coach-animation-indicator-ring-duration: var(--spectrum-animation-duration-6000);
     --system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple: -0.5;
     --system-coach-indicator-coach-animation-indicator-ring-center-delay-multiple: -0.66;
     --system-coach-indicator-coach-animation-indicator-ring-outer-delay-multiple: -1;
     --system-coach-indicator-quiet-animation-ring-inner-delay-multiple: -0.33;
     --system-coach-indicator-animation-name: pulse;
-    --system-coach-indicator-inner-animation-delay-multiple: var(
-        --system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple
-    );
+    --system-coach-indicator-inner-animation-delay-multiple: var(--system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple);
     --system-coach-indicator-animation-keyframe-0-scale: 1;
     --system-coach-indicator-animation-keyframe-0-opacity: 0;
     --system-coach-indicator-animation-keyframe-50-scale: 1.5;
@@ -570,65 +252,39 @@
     --system-coach-indicator-animation-keyframe-100-scale: 2;
     --system-coach-indicator-animation-keyframe-100-opacity: 0;
     --system-coach-indicator-quiet-animation-keyframe-0-scale: 0.8;
-    --system-coach-indicator-quiet-quiet-ring-diameter-size: var(
-        --spectrum-coach-indicator-quiet-ring-diameter
-    );
+    --system-coach-indicator-quiet-quiet-ring-diameter-size: var(--spectrum-coach-indicator-quiet-ring-diameter);
     --system-coach-indicator-quiet-animation-name: pulse-quiet;
     --system-coach-mark-min-width: var(--spectrum-coach-mark-minimum-width);
     --system-coach-mark-width: var(--spectrum-coach-mark-width);
     --system-coach-mark-max-width: var(--spectrum-coach-mark-maximum-width);
     --system-coach-mark-media-height: var(--spectrum-coach-mark-media-height);
-    --system-coach-mark-media-min-height: var(
-        --spectrum-coach-mark-media-minimum-height
-    );
+    --system-coach-mark-media-min-height: var(--spectrum-coach-mark-media-minimum-height);
     --system-coach-mark-padding: var(--spectrum-coach-mark-edge-to-content);
     --system-coach-mark-heading-to-action-button: var(--spectrum-spacing-300);
     --system-coach-mark-header-to-body: var(--spectrum-spacing-200);
     --system-coach-mark-body-to-footer: var(--spectrum-spacing-300);
     --system-coach-mark-title-color: var(--spectrum-heading-color);
     --system-coach-mark-title-font-family: var(--spectrum-sans-serif-font);
-    --system-coach-mark-title-font-style: var(
-        --spectrum-heading-serif-font-style
-    );
-    --system-coach-mark-title-text-font-weight: var(
-        --spectrum-heading-sans-serif-font-weight
-    );
+    --system-coach-mark-title-font-style: var(--spectrum-heading-serif-font-style);
+    --system-coach-mark-title-text-font-weight: var(--spectrum-heading-sans-serif-font-weight);
     --system-coach-mark-title-font-size: var(--spectrum-coach-mark-title-size);
-    --system-coach-mark-title-text-line-height: var(
-        --spectrum-heading-line-height
-    );
+    --system-coach-mark-title-text-line-height: var(--spectrum-heading-line-height);
     --system-coach-mark-content-font-color: var(--spectrum-body-color);
-    --system-coach-mark-content-font-weight: var(
-        --spectrum-body-sans-serif-font-weight
-    );
+    --system-coach-mark-content-font-weight: var(--spectrum-body-sans-serif-font-weight);
     --system-coach-mark-content-font-family: var(--spectrum-sans-serif-font);
-    --system-coach-mark-content-font-style: var(
-        --spectrum-body-sans-serif-font-style
-    );
+    --system-coach-mark-content-font-style: var(--spectrum-body-sans-serif-font-style);
     --system-coach-mark-content-line-height: var(--spectrum-body-line-height);
     --system-coach-mark-content-font-size: var(--spectrum-coach-mark-body-size);
     --system-coach-mark-step-color: var(--spectrum-coach-mark-pagination-color);
-    --system-coach-mark-step-font-weight: var(
-        --spectrum-body-medium-font-weight
-    );
+    --system-coach-mark-step-font-weight: var(--spectrum-body-medium-font-weight);
     --system-coach-mark-step-font-family: var(--spectrum-sans-serif-font);
-    --system-coach-mark-step-font-style: var(
-        --spectrum-body-sans-serif-font-style
-    );
+    --system-coach-mark-step-font-style: var(--spectrum-body-sans-serif-font-style);
     --system-coach-mark-step-line-height: var(--spectrum-body-line-height);
-    --system-coach-mark-step-font-size: var(
-        --spectrum-coach-mark-pagination-body-size
-    );
-    --system-coach-mark-step-to-bottom: var(
-        --spectrum-coach-mark-pagination-text-to-bottom-edge
-    );
+    --system-coach-mark-step-font-size: var(--spectrum-coach-mark-pagination-body-size);
+    --system-coach-mark-step-to-bottom: var(--spectrum-coach-mark-pagination-text-to-bottom-edge);
     --system-coach-mark-popover-border-width: var(--spectrum-border-width-100);
-    --system-coach-mark-popover-corner-radius: var(
-        --spectrum-corner-radius-100
-    );
-    --system-coach-mark-buttongroup-spacing-horizontal: var(
-        --spectrum-spacing-100
-    );
+    --system-coach-mark-popover-corner-radius: var(--spectrum-corner-radius-100);
+    --system-coach-mark-buttongroup-spacing-horizontal: var(--spectrum-spacing-100);
     --system-color-wheel-border-color: var(--spectrum-transparent-black-200);
     --system-combobox-border-color-default: var(--spectrum-gray-400);
     --system-combobox-border-color-hover: var(--spectrum-gray-500);
@@ -636,91 +292,48 @@
     --system-combobox-border-color-focus-hover: var(--spectrum-gray-800);
     --system-combobox-border-color-key-focus: var(--spectrum-gray-900);
     --system-combobox-readonly-input-border-color: var(--spectrum-gray-400);
-    --system-combobox-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-combobox-background-color-disabled: var(--spectrum-disabled-background-color);
     --system-combobox-border-color-disabled: transparent;
     --system-dialog-fullscreen-header-text-size: 28px;
     --system-dialog-min-inline-size: 288px;
     --system-dialog-confirm-small-width: 400px;
     --system-dialog-confirm-medium-width: 480px;
     --system-dialog-confirm-large-width: 640px;
-    --system-dialog-confirm-divider-block-spacing-start: var(
-        --spectrum-spacing-300
-    );
-    --system-dialog-confirm-divider-block-spacing-end: var(
-        --spectrum-spacing-200
-    );
+    --system-dialog-confirm-divider-block-spacing-start: var(--spectrum-spacing-300);
+    --system-dialog-confirm-divider-block-spacing-end: var(--spectrum-spacing-200);
     --system-dialog-confirm-description-text-color: var(--spectrum-gray-800);
     --system-dialog-confirm-title-text-color: var(--spectrum-gray-900);
-    --system-dialog-confirm-description-text-line-height: var(
-        --spectrum-line-height-100
-    );
-    --system-dialog-confirm-title-text-line-height: var(
-        --spectrum-line-height-100
-    );
-    --system-dialog-heading-font-weight: var(
-        --spectrum-heading-sans-serif-font-weight
-    );
+    --system-dialog-confirm-description-text-line-height: var(--spectrum-line-height-100);
+    --system-dialog-confirm-title-text-line-height: var(--spectrum-line-height-100);
+    --system-dialog-heading-font-weight: var(--spectrum-heading-sans-serif-font-weight);
     --system-dialog-confirm-description-padding: var(--spectrum-spacing-50);
-    --system-dialog-confirm-description-margin: calc(
-        var(--spectrum-spacing-50) * -1
-    );
+    --system-dialog-confirm-description-margin: calc(var(--spectrum-spacing-50) * -1);
     --system-dialog-confirm-footer-padding-top: var(--spectrum-spacing-600);
-    --system-dialog-confirm-gap-size: var(
-        --spectrum-component-pill-edge-to-text-100
-    );
-    --system-dialog-confirm-buttongroup-padding-top: var(
-        --spectrum-spacing-600
-    );
-    --system-dialog-confirm-close-button-size: var(
-        --spectrum-component-height-100
-    );
-    --system-dialog-confirm-close-button-padding: calc(
-        26px - var(--spectrum-component-bottom-to-text-300)
-    );
+    --system-dialog-confirm-gap-size: var(--spectrum-component-pill-edge-to-text-100);
+    --system-dialog-confirm-buttongroup-padding-top: var(--spectrum-spacing-600);
+    --system-dialog-confirm-close-button-size: var(--spectrum-component-height-100);
+    --system-dialog-confirm-close-button-padding: calc(26px - var(--spectrum-component-bottom-to-text-300));
     --system-dialog-confirm-divider-height: var(--spectrum-spacing-50);
     --system-divider-background-color: var(--spectrum-gray-300);
-    --system-divider-background-color-static-white: var(
-        --spectrum-transparent-white-300
-    );
-    --system-divider-background-color-static-black: var(
-        --spectrum-transparent-black-300
-    );
+    --system-divider-background-color-static-white: var(--spectrum-transparent-white-300);
+    --system-divider-background-color-static-black: var(--spectrum-transparent-black-300);
     --system-drop-zone-border-color: var(--spectrum-gray-300);
     --system-field-group-margin: var(--spectrum-spacing-300);
-    --system-field-group-readonly-delimiter: ',';
+    --system-field-group-readonly-delimiter: ",";
     --system-infield-button-border-width: 0;
     --system-infield-button-border-color: transparent;
     --system-infield-button-border-radius: var(--spectrum-corner-radius-75);
-    --system-infield-button-border-radius-reset: var(
-        --spectrum-corner-radius-75
-    );
-    --system-infield-button-stacked-top-border-radius-start-start: var(
-        --spectrum-corner-radius-75
-    );
-    --system-infield-button-stacked-bottom-border-radius-end-start: var(
-        --spectrum-corner-radius-75
-    );
+    --system-infield-button-border-radius-reset: var(--spectrum-corner-radius-75);
+    --system-infield-button-stacked-top-border-radius-start-start: var(--spectrum-corner-radius-75);
+    --system-infield-button-stacked-bottom-border-radius-end-start: var(--spectrum-corner-radius-75);
     --system-infield-button-background-color: var(--spectrum-gray-200);
     --system-infield-button-background-color-hover: var(--spectrum-gray-300);
     --system-infield-button-background-color-down: var(--spectrum-gray-400);
-    --system-infield-button-background-color-key-focus: var(
-        --spectrum-gray-300
-    );
+    --system-infield-button-background-color-key-focus: var(--spectrum-gray-300);
     --system-infield-button-disabled-border-color: var(--spectrum-gray-200);
-    --system-menu-item-background-color-hover: rgba(
-        var(--spectrum-gray-900-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
-    --system-menu-item-background-color-down: rgba(
-        var(--spectrum-gray-900-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
-    --system-menu-item-background-color-key-focus: rgba(
-        var(--spectrum-gray-900-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
+    --system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
+    --system-menu-item-background-color-down: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
+    --system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
     --system-menu-item-corner-radius: 0;
     --system-menu-item-focus-indicator-shadow: inset;
     --system-menu-item-focus-indicator-offset: 0;
@@ -742,9 +355,7 @@
     --system-meter-size-l-inline-size: var(--spectrum-progressbar-size-2500);
     --system-meter-font-size: var(--spectrum-font-size-100);
     --system-meter-size-l-font-size: var(--spectrum-font-size-100);
-    --system-meter-size-l-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
+    --system-meter-size-l-top-to-text: var(--spectrum-component-top-to-text-200);
     --system-modal-background-color: var(--spectrum-gray-100);
     --system-picker-background-color-default: var(--spectrum-gray-200);
     --system-picker-background-color-default-open: var(--spectrum-gray-300);
@@ -766,23 +377,13 @@
     --system-picker-button-background-color-key-focus: var(--spectrum-gray-300);
     --system-picker-button-border-color: none;
     --system-picker-button-border-radius: var(--spectrum-corner-radius-75);
-    --system-picker-button-border-radius-rounded-sided: var(
-        --spectrum-corner-radius-200
-    );
-    --system-picker-button-border-radius-sided: var(
-        --spectrum-corner-radius-75
-    );
+    --system-picker-button-border-radius-rounded-sided: var(--spectrum-corner-radius-200);
+    --system-picker-button-border-radius-sided: var(--spectrum-corner-radius-75);
     --system-picker-button-border-width: 0px;
-    --system-picker-button-padding: var(
-        --spectrum-in-field-button-edge-to-fill
-    );
+    --system-picker-button-padding: var(--spectrum-in-field-button-edge-to-fill);
     --system-popover-border-width: 0;
-    --system-progress-bar-animation-ease-in-out-indeterminate: var(
-        --spectrum-animation-ease-in-out
-    );
-    --system-progress-bar-animation-duration-indeterminate: var(
-        --spectrum-animation-duration-2000
-    );
+    --system-progress-bar-animation-ease-in-out-indeterminate: var(--spectrum-animation-ease-in-out);
+    --system-progress-bar-animation-duration-indeterminate: var(--spectrum-animation-duration-2000);
     --system-progress-bar-corner-radius: var(--spectrum-corner-radius-100);
     --system-progress-bar-fill-size-indeterminate: 70%;
     --system-progress-bar-size-2400: 192px;
@@ -794,122 +395,58 @@
     --system-progress-bar-line-height: var(--spectrum-line-height-100);
     --system-progress-bar-spacing-label-to: var(--spectrum-spacing-75);
     --system-progress-bar-spacing-label-to-text: var(--spectrum-spacing-200);
-    --system-progress-bar-text-color: var(
-        --spectrum-neutral-content-color-default
-    );
+    --system-progress-bar-text-color: var(--spectrum-neutral-content-color-default);
     --system-progress-bar-track-color: var(--spectrum-gray-300);
     --system-progress-bar-fill-color: var(--spectrum-accent-color-900);
     --system-progress-bar-label-and-value-white: var(--spectrum-white);
-    --system-progress-bar-track-color-white: var(
-        --spectrum-transparent-white-300
-    );
+    --system-progress-bar-track-color-white: var(--spectrum-transparent-white-300);
     --system-progress-bar-fill-color-white: var(--spectrum-white);
     --system-progress-bar-size-default: var(--system-progress-bar-size-2400);
-    --system-progress-bar-size-m-size-default: var(
-        --system-progress-bar-size-2400
-    );
+    --system-progress-bar-size-m-size-default: var(--system-progress-bar-size-2400);
     --system-progress-bar-font-size: var(--spectrum-font-size-75);
     --system-progress-bar-size-m-font-size: var(--spectrum-font-size-75);
-    --system-progress-bar-thickness: var(
-        --spectrum-progress-bar-thickness-large
-    );
-    --system-progress-bar-size-m-thickness: var(
-        --spectrum-progress-bar-thickness-large
-    );
-    --system-progress-bar-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-progress-bar-size-m-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-progress-bar-size-s-size-default: var(
-        --system-progress-bar-size-2400
-    );
+    --system-progress-bar-thickness: var(--spectrum-progress-bar-thickness-large);
+    --system-progress-bar-size-m-thickness: var(--spectrum-progress-bar-thickness-large);
+    --system-progress-bar-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-progress-bar-size-m-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-progress-bar-size-s-size-default: var(--system-progress-bar-size-2400);
     --system-progress-bar-size-s-font-size: var(--spectrum-font-size-75);
-    --system-progress-bar-size-s-thickness: var(
-        --spectrum-progress-bar-thickness-small
-    );
-    --system-progress-bar-size-s-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-progress-bar-size-l-size-default: var(
-        --system-progress-bar-size-2500
-    );
+    --system-progress-bar-size-s-thickness: var(--spectrum-progress-bar-thickness-small);
+    --system-progress-bar-size-s-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-progress-bar-size-l-size-default: var(--system-progress-bar-size-2500);
     --system-progress-bar-size-l-font-size: var(--spectrum-font-size-100);
-    --system-progress-bar-size-l-thickness: var(
-        --spectrum-progress-bar-thickness-large
-    );
-    --system-progress-bar-size-l-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --system-progress-bar-size-xl-size-default: var(
-        --system-progress-bar-size-2800
-    );
+    --system-progress-bar-size-l-thickness: var(--spectrum-progress-bar-thickness-large);
+    --system-progress-bar-size-l-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
+    --system-progress-bar-size-xl-size-default: var(--system-progress-bar-size-2800);
     --system-progress-bar-size-xl-font-size: var(--spectrum-font-size-200);
-    --system-progress-bar-size-xl-thickness: var(
-        --spectrum-progress-bar-thickness-extra-large
-    );
-    --system-progress-bar-size-xl-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-300
-    );
+    --system-progress-bar-size-xl-thickness: var(--spectrum-progress-bar-thickness-extra-large);
+    --system-progress-bar-size-xl-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
     --system-progress-circle-track-border-color: var(--spectrum-gray-300);
-    --system-progress-circle-track-border-color-over-background: var(
-        --spectrum-transparent-white-300
-    );
-    --system-progress-circle-fill-border-color-over-background: var(
-        --spectrum-transparent-white-900
-    );
+    --system-progress-circle-track-border-color-over-background: var(--spectrum-transparent-white-300);
+    --system-progress-circle-fill-border-color-over-background: var(--spectrum-transparent-white-900);
     --system-radio-button-border-color-default: var(--spectrum-gray-800);
     --system-radio-button-border-color-hover: var(--spectrum-gray-900);
     --system-radio-button-border-color-down: var(--spectrum-gray-900);
     --system-radio-button-border-color-focus: var(--spectrum-gray-900);
-    --system-radio-neutral-content-color: var(
-        --spectrum-neutral-content-color-default
-    );
-    --system-radio-neutral-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --system-radio-neutral-content-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --system-radio-neutral-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
-    --system-radio-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
+    --system-radio-neutral-content-color: var(--spectrum-neutral-content-color-default);
+    --system-radio-neutral-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --system-radio-neutral-content-color-down: var(--spectrum-neutral-content-color-down);
+    --system-radio-neutral-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --system-radio-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
     --system-radio-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
     --system-radio-focus-indicator-color: var(--spectrum-focus-indicator-color);
-    --system-radio-disabled-content-color: var(
-        --spectrum-disabled-content-color
-    );
-    --system-radio-disabled-border-color: var(
-        --spectrum-disabled-content-color
-    );
+    --system-radio-disabled-content-color: var(--spectrum-disabled-content-color);
+    --system-radio-disabled-border-color: var(--spectrum-disabled-content-color);
     --system-radio-emphasized-accent-color: var(--spectrum-accent-color-900);
-    --system-radio-emphasized-accent-color-hover: var(
-        --spectrum-accent-color-1000
-    );
-    --system-radio-emphasized-accent-color-down: var(
-        --spectrum-accent-color-1100
-    );
-    --system-radio-emphasized-accent-color-focus: var(
-        --spectrum-accent-color-1000
-    );
+    --system-radio-emphasized-accent-color-hover: var(--spectrum-accent-color-1000);
+    --system-radio-emphasized-accent-color-down: var(--spectrum-accent-color-1100);
+    --system-radio-emphasized-accent-color-focus: var(--spectrum-accent-color-1000);
     --system-radio-border-width: var(--spectrum-border-width-200);
     --system-radio-button-background-color: var(--spectrum-gray-50);
-    --system-radio-button-checked-border-color-default: var(
-        --spectrum-neutral-background-color-selected-default
-    );
-    --system-radio-button-checked-border-color-hover: var(
-        --spectrum-neutral-background-color-selected-hover
-    );
-    --system-radio-button-checked-border-color-down: var(
-        --spectrum-neutral-background-color-selected-down
-    );
-    --system-radio-button-checked-border-color-focus: var(
-        --spectrum-neutral-background-color-selected-focus
-    );
+    --system-radio-button-checked-border-color-default: var(--spectrum-neutral-background-color-selected-default);
+    --system-radio-button-checked-border-color-hover: var(--spectrum-neutral-background-color-selected-hover);
+    --system-radio-button-checked-border-color-down: var(--spectrum-neutral-background-color-selected-down);
+    --system-radio-button-checked-border-color-focus: var(--spectrum-neutral-background-color-selected-focus);
     --system-radio-line-height: var(--spectrum-line-height-100);
     --system-radio-animation-duration: var(--spectrum-animation-duration-100);
     --system-radio-lang-ja-line-height-cjk: var(--spectrum-cjk-line-height-100);
@@ -917,141 +454,67 @@
     --system-radio-lang-ko-line-height-cjk: var(--spectrum-cjk-line-height-100);
     --system-radio-height: var(--spectrum-component-height-100);
     --system-radio-size-m-height: var(--spectrum-component-height-100);
-    --system-radio-button-control-size: var(
-        --spectrum-radio-button-control-size-medium
-    );
-    --system-radio-size-m-button-control-size: var(
-        --spectrum-radio-button-control-size-medium
-    );
+    --system-radio-button-control-size: var(--spectrum-radio-button-control-size-medium);
+    --system-radio-size-m-button-control-size: var(--spectrum-radio-button-control-size-medium);
     --system-radio-text-to-control: var(--spectrum-text-to-control-100);
     --system-radio-size-m-text-to-control: var(--spectrum-text-to-control-100);
     --system-radio-label-top-to-text: var(--spectrum-component-top-to-text-100);
-    --system-radio-size-m-label-top-to-text: var(
-        --spectrum-component-top-to-text-100
-    );
-    --system-radio-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --system-radio-size-m-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --system-radio-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-medium
-    );
-    --system-radio-size-m-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-medium
-    );
+    --system-radio-size-m-label-top-to-text: var(--spectrum-component-top-to-text-100);
+    --system-radio-label-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
+    --system-radio-size-m-label-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
+    --system-radio-button-top-to-control: var(--spectrum-radio-button-top-to-control-medium);
+    --system-radio-size-m-button-top-to-control: var(--spectrum-radio-button-top-to-control-medium);
     --system-radio-font-size: var(--spectrum-font-size-100);
     --system-radio-size-m-font-size: var(--spectrum-font-size-100);
     --system-radio-size-s-height: var(--spectrum-component-height-75);
-    --system-radio-size-s-button-control-size: var(
-        --spectrum-radio-button-control-size-small
-    );
+    --system-radio-size-s-button-control-size: var(--spectrum-radio-button-control-size-small);
     --system-radio-size-s-text-to-control: var(--spectrum-text-to-control-75);
-    --system-radio-size-s-label-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-radio-size-s-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-75
-    );
-    --system-radio-size-s-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-small
-    );
+    --system-radio-size-s-label-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-radio-size-s-label-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
+    --system-radio-size-s-button-top-to-control: var(--spectrum-radio-button-top-to-control-small);
     --system-radio-size-s-font-size: var(--spectrum-font-size-75);
     --system-radio-size-l-height: var(--spectrum-component-height-200);
-    --system-radio-size-l-button-control-size: var(
-        --spectrum-radio-button-control-size-large
-    );
+    --system-radio-size-l-button-control-size: var(--spectrum-radio-button-control-size-large);
     --system-radio-size-l-text-to-control: var(--spectrum-text-to-control-200);
-    --system-radio-size-l-label-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --system-radio-size-l-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-200
-    );
-    --system-radio-size-l-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-large
-    );
+    --system-radio-size-l-label-top-to-text: var(--spectrum-component-top-to-text-200);
+    --system-radio-size-l-label-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
+    --system-radio-size-l-button-top-to-control: var(--spectrum-radio-button-top-to-control-large);
     --system-radio-size-l-font-size: var(--spectrum-font-size-200);
     --system-radio-size-xl-height: var(--spectrum-component-height-300);
-    --system-radio-size-xl-button-control-size: var(
-        --spectrum-radio-button-control-size-extra-large
-    );
+    --system-radio-size-xl-button-control-size: var(--spectrum-radio-button-control-size-extra-large);
     --system-radio-size-xl-text-to-control: var(--spectrum-text-to-control-300);
-    --system-radio-size-xl-label-top-to-text: var(
-        --spectrum-component-top-to-text-300
-    );
-    --system-radio-size-xl-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-300
-    );
-    --system-radio-size-xl-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-extra-large
-    );
+    --system-radio-size-xl-label-top-to-text: var(--spectrum-component-top-to-text-300);
+    --system-radio-size-xl-label-bottom-to-text: var(--spectrum-component-bottom-to-text-300);
+    --system-radio-size-xl-button-top-to-control: var(--spectrum-radio-button-top-to-control-extra-large);
     --system-radio-size-xl-font-size: var(--spectrum-font-size-300);
-    --system-radio-emphasized-button-checked-border-color-default: var(
-        --spectrum-accent-color-900
-    );
-    --system-radio-emphasized-button-checked-border-color-hover: var(
-        --spectrum-accent-color-1000
-    );
-    --system-radio-emphasized-button-checked-border-color-down: var(
-        --spectrum-accent-color-1100
-    );
-    --system-radio-emphasized-button-checked-border-color-focus: var(
-        --spectrum-accent-color-1000
-    );
+    --system-radio-emphasized-button-checked-border-color-default: var(--spectrum-accent-color-900);
+    --system-radio-emphasized-button-checked-border-color-hover: var(--spectrum-accent-color-1000);
+    --system-radio-emphasized-button-checked-border-color-down: var(--spectrum-accent-color-1100);
+    --system-radio-emphasized-button-checked-border-color-focus: var(--spectrum-accent-color-1000);
     --system-search-border-color-default: var(--spectrum-gray-400);
     --system-search-border-color-hover: var(--spectrum-gray-500);
     --system-search-border-color-focus: var(--spectrum-gray-800);
     --system-search-border-color-focus-hover: var(--spectrum-gray-900);
     --system-search-border-color-key-focus: var(--spectrum-gray-900);
     --system-search-background-color: var(--spectrum-gray-50);
-    --system-search-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --system-search-border-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --system-search-border-radius: calc(
-        var(--spectrum-component-height-100) / 2
-    );
-    --system-search-size-m-border-radius: calc(
-        var(--spectrum-component-height-100) / 2
-    );
-    --system-search-edge-to-visual: var(
-        --spectrum-component-pill-edge-to-visual-100
-    );
-    --system-search-size-m-edge-to-visual: var(
-        --spectrum-component-pill-edge-to-visual-100
-    );
-    --system-search-size-s-border-radius: calc(
-        var(--spectrum-component-height-75) / 2
-    );
-    --system-search-size-s-edge-to-visual: var(
-        --spectrum-component-pill-edge-to-visual-75
-    );
-    --system-search-size-l-border-radius: calc(
-        var(--spectrum-component-height-200) / 2
-    );
-    --system-search-size-l-edge-to-visual: var(
-        --spectrum-component-pill-edge-to-visual-200
-    );
-    --system-search-size-xl-border-radius: calc(
-        var(--spectrum-component-height-300) / 2
-    );
-    --system-search-size-xl-edge-to-visual: var(
-        --spectrum-component-pill-edge-to-visual-300
-    );
+    --system-search-background-color-disabled: var(--spectrum-disabled-background-color);
+    --system-search-border-color-disabled: var(--spectrum-disabled-background-color);
+    --system-search-border-radius: calc(var(--spectrum-component-height-100) / 2);
+    --system-search-size-m-border-radius: calc(var(--spectrum-component-height-100) / 2);
+    --system-search-edge-to-visual: var(--spectrum-component-pill-edge-to-visual-100);
+    --system-search-size-m-edge-to-visual: var(--spectrum-component-pill-edge-to-visual-100);
+    --system-search-size-s-border-radius: calc(var(--spectrum-component-height-75) / 2);
+    --system-search-size-s-edge-to-visual: var(--spectrum-component-pill-edge-to-visual-75);
+    --system-search-size-l-border-radius: calc(var(--spectrum-component-height-200) / 2);
+    --system-search-size-l-edge-to-visual: var(--spectrum-component-pill-edge-to-visual-200);
+    --system-search-size-xl-border-radius: calc(var(--spectrum-component-height-300) / 2);
+    --system-search-size-xl-edge-to-visual: var(--spectrum-component-pill-edge-to-visual-300);
     --system-search-quiet-background-color-disabled: transparent;
-    --system-search-quiet-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
+    --system-search-quiet-border-color-disabled: var(--spectrum-disabled-border-color);
     --system-side-nav-background-hover: var(--spectrum-gray-200);
     --system-side-nav-item-background-down: var(--spectrum-gray-300);
     --system-side-nav-background-key-focus: var(--spectrum-gray-200);
-    --system-side-nav-item-background-default-selected: var(
-        --spectrum-gray-200
-    );
+    --system-side-nav-item-background-default-selected: var(--spectrum-gray-200);
     --system-side-nav-background-hover-selected: var(--spectrum-gray-300);
     --system-side-nav-item-background-down-selected: var(--spectrum-gray-300);
     --system-side-nav-background-key-focus-selected: var(--spectrum-gray-200);
@@ -1069,23 +532,13 @@
     --system-slider-handle-border-color-hover: var(--spectrum-gray-900);
     --system-slider-handle-border-color-down: var(--spectrum-gray-900);
     --system-slider-handle-border-color-key-focus: var(--spectrum-gray-900);
-    --system-slider-handle-focus-ring-color-key-focus: var(
-        --spectrum-focus-indicator-color
-    );
+    --system-slider-handle-focus-ring-color-key-focus: var(--spectrum-focus-indicator-color);
     --system-slider-track-corner-radius: var(--spectrum-corner-radius-75);
     --system-slider-handle-border-radius: var(--spectrum-corner-radius-200);
-    --system-slider-size-m-handle-border-radius: var(
-        --spectrum-corner-radius-200
-    );
-    --system-slider-size-s-handle-border-radius: var(
-        --spectrum-corner-radius-200
-    );
-    --system-slider-size-l-handle-border-radius: calc(
-        var(--spectrum-corner-radius-200) * 4
-    );
-    --system-slider-size-xl-handle-border-radius: calc(
-        var(--spectrum-corner-radius-200) * 4
-    );
+    --system-slider-size-m-handle-border-radius: var(--spectrum-corner-radius-200);
+    --system-slider-size-s-handle-border-radius: var(--spectrum-corner-radius-200);
+    --system-slider-size-l-handle-border-radius: calc(var(--spectrum-corner-radius-200) * 4);
+    --system-slider-size-xl-handle-border-radius: calc(var(--spectrum-corner-radius-200) * 4);
     --system-split-view-background-color: var(--spectrum-gray-100);
     --system-split-view-handle-background-color: var(--spectrum-gray-300);
     --system-split-view-gripper-border-radius: var(--spectrum-corner-radius-75);
@@ -1107,80 +560,43 @@
     --system-stepper-border-color-focus-invalid: transparent;
     --system-stepper-border-color-focus-hover-invalid: transparent;
     --system-stepper-border-color-keyboard-focus-invalid: transparent;
-    --system-stepper-border-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-stepper-border-color-disabled: var(--spectrum-disabled-background-color);
     --system-stepper-button-border-width-disabled: 0;
-    --system-stepper-buttons-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-stepper-buttons-background-color-disabled: var(--spectrum-disabled-background-color);
     --system-stepper-quiet-buttons-border-style: none;
     --system-stepper-quiet-button-edge-to-fill: 0;
     --system-swatch-border-radius: var(--spectrum-corner-radius-100);
-    --system-swatch-focus-indicator-border-radius: var(
-        --spectrum-corner-radius-200
-    );
+    --system-swatch-focus-indicator-border-radius: var(--spectrum-corner-radius-200);
     --system-swatch-border-thickness: var(--spectrum-border-width-100);
     --system-swatch-border-thickness-selected: var(--spectrum-border-width-200);
-    --system-swatch-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
+    --system-swatch-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
     --system-swatch-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
     --system-swatch-border-color-opacity: 0.51;
     --system-swatch-border-color-light-opacity: 0.2;
-    --system-swatch-border-color: rgba(
-        var(--spectrum-gray-900-rgb),
-        var(--system-swatch-border-color-opacity)
-    );
-    --system-swatch-icon-border-color: rgba(
-        var(--spectrum-black-rgb),
-        var(--system-swatch-border-color-opacity)
-    );
-    --system-swatch-border-color-light: rgba(
-        var(--spectrum-black-rgb),
-        var(--system-swatch-border-color-light-opacity)
-    );
+    --system-swatch-border-color: rgba(var(--spectrum-gray-900-rgb), var(--system-swatch-border-color-opacity));
+    --system-swatch-icon-border-color: rgba(var(--spectrum-black-rgb), var(--system-swatch-border-color-opacity));
+    --system-swatch-border-color-light: rgba(var(--spectrum-black-rgb), var(--system-swatch-border-color-light-opacity));
     --system-swatch-border-color-selected: var(--spectrum-gray-900);
     --system-swatch-inner-border-color-selected: var(--spectrum-gray-50);
     --system-swatch-disabled-icon-color: var(--spectrum-gray-50);
     --system-swatch-dash-icon-color: var(--spectrum-gray-800);
     --system-swatch-slash-icon-color: var(--spectrum-red-900);
-    --system-swatch-focus-indicator-color: var(
-        --spectrum-focus-indicator-color
-    );
+    --system-swatch-focus-indicator-color: var(--spectrum-focus-indicator-color);
     --system-swatch-size: var(--spectrum-swatch-size-medium);
     --system-swatch-size-m-size: var(--spectrum-swatch-size-medium);
     --system-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-100);
-    --system-swatch-size-m-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-100
-    );
-    --system-swatch-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-medium
-    );
-    --system-swatch-size-m-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-medium
-    );
+    --system-swatch-size-m-disabled-icon-size: var(--spectrum-workflow-icon-size-100);
+    --system-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-medium);
+    --system-swatch-size-m-slash-thickness: var(--spectrum-swatch-slash-thickness-medium);
     --system-swatch-size-xs-size: var(--spectrum-swatch-size-extra-small);
-    --system-swatch-size-xs-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-50
-    );
-    --system-swatch-size-xs-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-extra-small
-    );
+    --system-swatch-size-xs-disabled-icon-size: var(--spectrum-workflow-icon-size-50);
+    --system-swatch-size-xs-slash-thickness: var(--spectrum-swatch-slash-thickness-extra-small);
     --system-swatch-size-s-size: var(--spectrum-swatch-size-small);
-    --system-swatch-size-s-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-75
-    );
-    --system-swatch-size-s-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-small
-    );
+    --system-swatch-size-s-disabled-icon-size: var(--spectrum-workflow-icon-size-75);
+    --system-swatch-size-s-slash-thickness: var(--spectrum-swatch-slash-thickness-small);
     --system-swatch-size-l-size: var(--spectrum-swatch-size-large);
-    --system-swatch-size-l-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-200
-    );
-    --system-swatch-size-l-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-large
-    );
+    --system-swatch-size-l-disabled-icon-size: var(--spectrum-workflow-icon-size-200);
+    --system-swatch-size-l-slash-thickness: var(--spectrum-swatch-slash-thickness-large);
     --system-swatch-group-spacing-compact: var(--spectrum-spacing-50);
     --system-swatch-group-spacing-regular: var(--spectrum-spacing-75);
     --system-swatch-group-spacing-spacious: var(--spectrum-spacing-100);
@@ -1188,39 +604,23 @@
     --system-switch-handle-border-color-hover: var(--spectrum-gray-900);
     --system-switch-handle-border-color-down: var(--spectrum-gray-900);
     --system-switch-handle-border-color-focus: var(--spectrum-gray-900);
-    --system-switch-handle-border-color-selected-default: var(
-        --spectrum-gray-800
-    );
-    --system-switch-handle-border-color-selected-hover: var(
-        --spectrum-gray-900
-    );
+    --system-switch-handle-border-color-selected-default: var(--spectrum-gray-800);
+    --system-switch-handle-border-color-selected-hover: var(--spectrum-gray-900);
     --system-switch-handle-border-color-selected-down: var(--spectrum-gray-900);
-    --system-switch-handle-border-color-selected-focus: var(
-        --spectrum-gray-900
-    );
+    --system-switch-handle-border-color-selected-focus: var(--spectrum-gray-900);
     --system-switch-background-color: var(--spectrum-gray-300);
     --system-switch-background-color-disabled: var(--spectrum-gray-300);
     --system-switch-handle-background-color: var(--spectrum-gray-75);
-    --system-table-header-background-color: var(
-        --spectrum-transparent-white-100
-    );
+    --system-table-header-background-color: var(--spectrum-transparent-white-100);
     --system-table-border-color: var(--spectrum-gray-300);
     --system-table-divider-color: var(--spectrum-gray-300);
     --system-table-row-background-color: var(--spectrum-gray-50);
     --system-table-summary-row-background-color: var(--spectrum-gray-200);
     --system-table-section-header-background-color: var(--spectrum-gray-200);
-    --system-table-icon-color-focus: var(
-        --spectrum-neutral-subdued-content-color-key-focus
-    );
-    --system-table-icon-color-focus-hover: var(
-        --spectrum-neutral-subdued-content-down
-    );
-    --system-table-quiet-header-background-color: var(
-        --spectrum-transparent-white-100
-    );
-    --system-table-quiet-row-background-color: var(
-        --spectrum-transparent-white-100
-    );
+    --system-table-icon-color-focus: var(--spectrum-neutral-subdued-content-color-key-focus);
+    --system-table-icon-color-focus-hover: var(--spectrum-neutral-subdued-content-down);
+    --system-table-quiet-header-background-color: var(--spectrum-transparent-white-100);
+    --system-table-quiet-row-background-color: var(--spectrum-transparent-white-100);
     --system-tabs-font-weight: var(--spectrum-bold-font-weight);
     --system-tabs-divider-background-color: var(--spectrum-gray-300);
     --system-tag-background-color: transparent;
@@ -1228,70 +628,34 @@
     --system-tag-background-color-active: var(--spectrum-gray-400);
     --system-tag-background-color-focus: var(--spectrum-gray-300);
     --system-tag-size-small-corner-radius: var(--spectrum-component-height-75);
-    --system-tag-size-medium-corner-radius: var(
-        --spectrum-component-height-100
-    );
+    --system-tag-size-medium-corner-radius: var(--spectrum-component-height-100);
     --system-tag-size-large-corner-radius: var(--spectrum-component-height-200);
     --system-tag-border-color: var(--spectrum-gray-300);
     --system-tag-border-color-hover: var(--spectrum-gray-400);
     --system-tag-border-color-active: var(--spectrum-gray-500);
     --system-tag-border-color-focus: var(--spectrum-gray-400);
     --system-tag-content-color: var(--spectrum-neutral-content-color-default);
-    --system-tag-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --system-tag-content-color-active: var(
-        --spectrum-neutral-content-color-down
-    );
-    --system-tag-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
+    --system-tag-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --system-tag-content-color-active: var(--spectrum-neutral-content-color-down);
+    --system-tag-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
     --system-tag-content-color-selected: var(--spectrum-gray-50);
-    --system-tag-border-color-selected: var(
-        --spectrum-neutral-background-color-default
-    );
-    --system-tag-border-color-selected-hover: var(
-        --spectrum-neutral-background-color-hover
-    );
-    --system-tag-border-color-selected-active: var(
-        --spectrum-neutral-background-color-down
-    );
-    --system-tag-border-color-selected-focus: var(
-        --spectrum-neutral-background-color-key-focus
-    );
+    --system-tag-border-color-selected: var(--spectrum-neutral-background-color-default);
+    --system-tag-border-color-selected-hover: var(--spectrum-neutral-background-color-hover);
+    --system-tag-border-color-selected-active: var(--spectrum-neutral-background-color-down);
+    --system-tag-border-color-selected-focus: var(--spectrum-neutral-background-color-key-focus);
     --system-tag-border-color-disabled: var(--spectrum-disabled-border-color);
     --system-tag-background-color-disabled: transparent;
-    --system-tag-size-small-spacing-inline-start: var(
-        --spectrum-component-pill-edge-to-visual-75
-    );
-    --system-tag-size-small-label-spacing-inline-end: var(
-        --spectrum-component-pill-edge-to-text-75
-    );
-    --system-tag-size-small-clear-button-spacing-inline-end: var(
-        --spectrum-component-pill-edge-to-visual-75
-    );
-    --system-tag-size-medium-spacing-inline-start: var(
-        --spectrum-component-pill-edge-to-visual-100
-    );
-    --system-tag-size-medium-label-spacing-inline-end: var(
-        --spectrum-component-pill-edge-to-text-100
-    );
-    --system-tag-size-medium-clear-button-spacing-inline-end: var(
-        --spectrum-component-pill-edge-to-visual-100
-    );
-    --system-tag-size-large-spacing-inline-start: var(
-        --spectrum-component-pill-edge-to-visual-200
-    );
-    --system-tag-size-large-label-spacing-inline-end: var(
-        --spectrum-component-pill-edge-to-text-200
-    );
-    --system-tag-size-large-clear-button-spacing-inline-end: var(
-        --spectrum-component-pill-edge-to-visual-200
-    );
+    --system-tag-size-small-spacing-inline-start: var(--spectrum-component-pill-edge-to-visual-75);
+    --system-tag-size-small-label-spacing-inline-end: var(--spectrum-component-pill-edge-to-text-75);
+    --system-tag-size-small-clear-button-spacing-inline-end: var(--spectrum-component-pill-edge-to-visual-75);
+    --system-tag-size-medium-spacing-inline-start: var(--spectrum-component-pill-edge-to-visual-100);
+    --system-tag-size-medium-label-spacing-inline-end: var(--spectrum-component-pill-edge-to-text-100);
+    --system-tag-size-medium-clear-button-spacing-inline-end: var(--spectrum-component-pill-edge-to-visual-100);
+    --system-tag-size-large-spacing-inline-start: var(--spectrum-component-pill-edge-to-visual-200);
+    --system-tag-size-large-label-spacing-inline-end: var(--spectrum-component-pill-edge-to-text-200);
+    --system-tag-size-large-clear-button-spacing-inline-end: var(--spectrum-component-pill-edge-to-visual-200);
     --system-textfield-background-color: var(--spectrum-gray-50);
-    --system-textfield-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-textfield-background-color-disabled: var(--spectrum-disabled-background-color);
     --system-textfield-border-color: var(--spectrum-gray-400);
     --system-textfield-border-color-hover: var(--spectrum-gray-500);
     --system-textfield-border-color-focus: var(--spectrum-gray-800);
@@ -1299,25 +663,13 @@
     --system-textfield-border-color-keyboard-focus: var(--spectrum-gray-900);
     --system-textfield-border-color-disabled: var(--spectrum-gray-200);
     --system-textfield-border-width: var(--spectrum-border-width-200);
-    --system-textfield-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-medium
-    );
-    --system-textfield-size-s-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-small
-    );
-    --system-textfield-size-l-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-large
-    );
-    --system-textfield-size-xl-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-extra-large
-    );
+    --system-textfield-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-medium);
+    --system-textfield-size-s-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-small);
+    --system-textfield-size-l-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-large);
+    --system-textfield-size-xl-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-extra-large);
     --system-textfield-quiet-border-color-disabled: var(--spectrum-gray-300);
     --system-thumbnail-border-radius: var(--spectrum-corner-radius-75);
-    --system-toast-background-color-default: var(
-        --spectrum-neutral-background-color-default
-    );
+    --system-toast-background-color-default: var(--spectrum-neutral-background-color-default);
     --system-toast-divider-color: var(--spectrum-transparent-white-300);
-    --system-tooltip-backgound-color-default-neutral: var(
-        --spectrum-neutral-background-color-default
-    );
+    --system-tooltip-backgound-color-default-neutral: var(--spectrum-neutral-background-color-default);
 }

--- a/tools/styles/tokens/global-vars.css
+++ b/tools/styles/tokens/global-vars.css
@@ -5,19 +5,11 @@
     --spectrum-static-black-focus-indicator-color: var(--spectrum-black);
     --spectrum-overlay-color: var(--spectrum-black);
     --spectrum-opacity-disabled: 0.3;
-    --spectrum-neutral-subdued-content-color-selected: var(
-        --spectrum-neutral-subdued-content-color-down
-    );
-    --spectrum-accent-content-color-selected: var(
-        --spectrum-accent-content-color-down
-    );
+    --spectrum-neutral-subdued-content-color-selected: var(--spectrum-neutral-subdued-content-color-down);
+    --spectrum-accent-content-color-selected: var(--spectrum-accent-content-color-down);
     --spectrum-disabled-background-color: var(--spectrum-gray-200);
-    --spectrum-disabled-static-white-background-color: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-disabled-static-black-background-color: var(
-        --spectrum-transparent-black-200
-    );
+    --spectrum-disabled-static-white-background-color: var(--spectrum-transparent-white-200);
+    --spectrum-disabled-static-black-background-color: var(--spectrum-transparent-black-200);
     --spectrum-background-opacity-default: 0;
     --spectrum-background-opacity-hover: 0.1;
     --spectrum-background-opacity-down: 0.1;
@@ -25,61 +17,33 @@
     --spectrum-neutral-content-color-default: var(--spectrum-gray-800);
     --spectrum-neutral-content-color-hover: var(--spectrum-gray-900);
     --spectrum-neutral-content-color-down: var(--spectrum-gray-900);
-    --spectrum-neutral-content-color-focus-hover: var(
-        --spectrum-neutral-content-color-down
-    );
-    --spectrum-neutral-content-color-focus: var(
-        --spectrum-neutral-content-color-down
-    );
+    --spectrum-neutral-content-color-focus-hover: var(--spectrum-neutral-content-color-down);
+    --spectrum-neutral-content-color-focus: var(--spectrum-neutral-content-color-down);
     --spectrum-neutral-content-color-key-focus: var(--spectrum-gray-900);
     --spectrum-neutral-subdued-content-color-default: var(--spectrum-gray-700);
     --spectrum-neutral-subdued-content-color-hover: var(--spectrum-gray-800);
     --spectrum-neutral-subdued-content-color-down: var(--spectrum-gray-900);
-    --spectrum-neutral-subdued-content-color-key-focus: var(
-        --spectrum-gray-800
-    );
+    --spectrum-neutral-subdued-content-color-key-focus: var(--spectrum-gray-800);
     --spectrum-accent-content-color-default: var(--spectrum-accent-color-900);
     --spectrum-accent-content-color-hover: var(--spectrum-accent-color-1000);
     --spectrum-accent-content-color-down: var(--spectrum-accent-color-1100);
-    --spectrum-accent-content-color-key-focus: var(
-        --spectrum-accent-color-1000
-    );
-    --spectrum-negative-content-color-default: var(
-        --spectrum-negative-color-900
-    );
-    --spectrum-negative-content-color-hover: var(
-        --spectrum-negative-color-1000
-    );
+    --spectrum-accent-content-color-key-focus: var(--spectrum-accent-color-1000);
+    --spectrum-negative-content-color-default: var(--spectrum-negative-color-900);
+    --spectrum-negative-content-color-hover: var(--spectrum-negative-color-1000);
     --spectrum-negative-content-color-down: var(--spectrum-negative-color-1100);
-    --spectrum-negative-content-color-key-focus: var(
-        --spectrum-negative-color-1000
-    );
+    --spectrum-negative-content-color-key-focus: var(--spectrum-negative-color-1000);
     --spectrum-disabled-content-color: var(--spectrum-gray-400);
-    --spectrum-disabled-static-white-content-color: var(
-        --spectrum-transparent-white-500
-    );
-    --spectrum-disabled-static-black-content-color: var(
-        --spectrum-transparent-black-500
-    );
+    --spectrum-disabled-static-white-content-color: var(--spectrum-transparent-white-500);
+    --spectrum-disabled-static-black-content-color: var(--spectrum-transparent-black-500);
     --spectrum-disabled-border-color: var(--spectrum-gray-300);
-    --spectrum-disabled-static-white-border-color: var(
-        --spectrum-transparent-white-300
-    );
-    --spectrum-disabled-static-black-border-color: var(
-        --spectrum-transparent-black-300
-    );
-    --spectrum-negative-border-color-default: var(
-        --spectrum-negative-color-900
-    );
+    --spectrum-disabled-static-white-border-color: var(--spectrum-transparent-white-300);
+    --spectrum-disabled-static-black-border-color: var(--spectrum-transparent-black-300);
+    --spectrum-negative-border-color-default: var(--spectrum-negative-color-900);
     --spectrum-negative-border-color-hover: var(--spectrum-negative-color-1000);
     --spectrum-negative-border-color-down: var(--spectrum-negative-color-1100);
-    --spectrum-negative-border-color-focus-hover: var(
-        --spectrum-negative-border-color-down
-    );
+    --spectrum-negative-border-color-focus-hover: var(--spectrum-negative-border-color-down);
     --spectrum-negative-border-color-focus: var(--spectrum-negative-color-1000);
-    --spectrum-negative-border-color-key-focus: var(
-        --spectrum-negative-color-1000
-    );
+    --spectrum-negative-border-color-key-focus: var(--spectrum-negative-color-1000);
     --spectrum-swatch-border-color: var(--spectrum-gray-900);
     --spectrum-swatch-border-opacity: 0.51;
     --spectrum-swatch-disabled-icon-border-color: var(--spectrum-black);
@@ -93,9 +57,7 @@
     --spectrum-color-area-border-opacity: 0.1;
     --spectrum-color-slider-border-color: var(--spectrum-gray-900);
     --spectrum-color-slider-border-opacity: 0.1;
-    --spectrum-color-loupe-drop-shadow-color: var(
-        --spectrum-transparent-black-300
-    );
+    --spectrum-color-loupe-drop-shadow-color: var(--spectrum-transparent-black-300);
     --spectrum-color-loupe-inner-border: var(--spectrum-transparent-black-200);
     --spectrum-color-loupe-outer-border: var(--spectrum-white);
     --spectrum-card-selection-background-color: var(--spectrum-gray-100);
@@ -107,27 +69,15 @@
     --spectrum-color-handle-inner-border-color: var(--spectrum-black);
     --spectrum-color-handle-inner-border-opacity: 0.42;
     --spectrum-color-handle-outer-border-color: var(--spectrum-black);
-    --spectrum-color-handle-outer-border-opacity: var(
-        --spectrum-color-handle-inner-border-opacity
-    );
-    --spectrum-color-handle-drop-shadow-color: var(
-        --spectrum-drop-shadow-color
-    );
-    --spectrum-floating-action-button-drop-shadow-color: var(
-        --spectrum-transparent-black-300
-    );
-    --spectrum-floating-action-button-shadow-color: var(
-        --spectrum-floating-action-button-drop-shadow-color
-    );
+    --spectrum-color-handle-outer-border-opacity: var(--spectrum-color-handle-inner-border-opacity);
+    --spectrum-color-handle-drop-shadow-color: var(--spectrum-drop-shadow-color);
+    --spectrum-floating-action-button-drop-shadow-color: var(--spectrum-transparent-black-300);
+    --spectrum-floating-action-button-shadow-color: var(--spectrum-floating-action-button-drop-shadow-color);
     --spectrum-table-row-hover-color: var(--spectrum-gray-900);
     --spectrum-table-row-hover-opacity: 0.07;
-    --spectrum-table-selected-row-background-color: var(
-        --spectrum-informative-background-color-default
-    );
+    --spectrum-table-selected-row-background-color: var(--spectrum-informative-background-color-default);
     --spectrum-table-selected-row-background-opacity: 0.1;
-    --spectrum-table-selected-row-background-color-non-emphasized: var(
-        --spectrum-neutral-background-color-selected-default
-    );
+    --spectrum-table-selected-row-background-color-non-emphasized: var(--spectrum-neutral-background-color-selected-default);
     --spectrum-table-selected-row-background-opacity-non-emphasized: 0.1;
     --spectrum-table-row-down-opacity: 0.1;
     --spectrum-table-selected-row-background-opacity-hover: 0.15;
@@ -136,114 +86,60 @@
     --spectrum-white: rgba(var(--spectrum-white-rgb));
     --spectrum-transparent-white-100-rgb: 255, 255, 255;
     --spectrum-transparent-white-100-opacity: 0;
-    --spectrum-transparent-white-100: rgba(
-        var(--spectrum-transparent-white-100-rgb),
-        var(--spectrum-transparent-white-100-opacity)
-    );
+    --spectrum-transparent-white-100: rgba(var(--spectrum-transparent-white-100-rgb), var(--spectrum-transparent-white-100-opacity));
     --spectrum-transparent-white-200-rgb: 255, 255, 255;
     --spectrum-transparent-white-200-opacity: 0.1;
-    --spectrum-transparent-white-200: rgba(
-        var(--spectrum-transparent-white-200-rgb),
-        var(--spectrum-transparent-white-200-opacity)
-    );
+    --spectrum-transparent-white-200: rgba(var(--spectrum-transparent-white-200-rgb), var(--spectrum-transparent-white-200-opacity));
     --spectrum-transparent-white-300-rgb: 255, 255, 255;
     --spectrum-transparent-white-300-opacity: 0.25;
-    --spectrum-transparent-white-300: rgba(
-        var(--spectrum-transparent-white-300-rgb),
-        var(--spectrum-transparent-white-300-opacity)
-    );
+    --spectrum-transparent-white-300: rgba(var(--spectrum-transparent-white-300-rgb), var(--spectrum-transparent-white-300-opacity));
     --spectrum-transparent-white-400-rgb: 255, 255, 255;
     --spectrum-transparent-white-400-opacity: 0.4;
-    --spectrum-transparent-white-400: rgba(
-        var(--spectrum-transparent-white-400-rgb),
-        var(--spectrum-transparent-white-400-opacity)
-    );
+    --spectrum-transparent-white-400: rgba(var(--spectrum-transparent-white-400-rgb), var(--spectrum-transparent-white-400-opacity));
     --spectrum-transparent-white-500-rgb: 255, 255, 255;
     --spectrum-transparent-white-500-opacity: 0.55;
-    --spectrum-transparent-white-500: rgba(
-        var(--spectrum-transparent-white-500-rgb),
-        var(--spectrum-transparent-white-500-opacity)
-    );
+    --spectrum-transparent-white-500: rgba(var(--spectrum-transparent-white-500-rgb), var(--spectrum-transparent-white-500-opacity));
     --spectrum-transparent-white-600-rgb: 255, 255, 255;
     --spectrum-transparent-white-600-opacity: 0.7;
-    --spectrum-transparent-white-600: rgba(
-        var(--spectrum-transparent-white-600-rgb),
-        var(--spectrum-transparent-white-600-opacity)
-    );
+    --spectrum-transparent-white-600: rgba(var(--spectrum-transparent-white-600-rgb), var(--spectrum-transparent-white-600-opacity));
     --spectrum-transparent-white-700-rgb: 255, 255, 255;
     --spectrum-transparent-white-700-opacity: 0.8;
-    --spectrum-transparent-white-700: rgba(
-        var(--spectrum-transparent-white-700-rgb),
-        var(--spectrum-transparent-white-700-opacity)
-    );
+    --spectrum-transparent-white-700: rgba(var(--spectrum-transparent-white-700-rgb), var(--spectrum-transparent-white-700-opacity));
     --spectrum-transparent-white-800-rgb: 255, 255, 255;
     --spectrum-transparent-white-800-opacity: 0.9;
-    --spectrum-transparent-white-800: rgba(
-        var(--spectrum-transparent-white-800-rgb),
-        var(--spectrum-transparent-white-800-opacity)
-    );
+    --spectrum-transparent-white-800: rgba(var(--spectrum-transparent-white-800-rgb), var(--spectrum-transparent-white-800-opacity));
     --spectrum-transparent-white-900-rgb: 255, 255, 255;
-    --spectrum-transparent-white-900: rgba(
-        var(--spectrum-transparent-white-900-rgb)
-    );
+    --spectrum-transparent-white-900: rgba(var(--spectrum-transparent-white-900-rgb));
     --spectrum-black-rgb: 0, 0, 0;
     --spectrum-black: rgba(var(--spectrum-black-rgb));
     --spectrum-transparent-black-100-rgb: 0, 0, 0;
     --spectrum-transparent-black-100-opacity: 0;
-    --spectrum-transparent-black-100: rgba(
-        var(--spectrum-transparent-black-100-rgb),
-        var(--spectrum-transparent-black-100-opacity)
-    );
+    --spectrum-transparent-black-100: rgba(var(--spectrum-transparent-black-100-rgb), var(--spectrum-transparent-black-100-opacity));
     --spectrum-transparent-black-200-rgb: 0, 0, 0;
     --spectrum-transparent-black-200-opacity: 0.1;
-    --spectrum-transparent-black-200: rgba(
-        var(--spectrum-transparent-black-200-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
+    --spectrum-transparent-black-200: rgba(var(--spectrum-transparent-black-200-rgb), var(--spectrum-transparent-black-200-opacity));
     --spectrum-transparent-black-300-rgb: 0, 0, 0;
     --spectrum-transparent-black-300-opacity: 0.25;
-    --spectrum-transparent-black-300: rgba(
-        var(--spectrum-transparent-black-300-rgb),
-        var(--spectrum-transparent-black-300-opacity)
-    );
+    --spectrum-transparent-black-300: rgba(var(--spectrum-transparent-black-300-rgb), var(--spectrum-transparent-black-300-opacity));
     --spectrum-transparent-black-400-rgb: 0, 0, 0;
     --spectrum-transparent-black-400-opacity: 0.4;
-    --spectrum-transparent-black-400: rgba(
-        var(--spectrum-transparent-black-400-rgb),
-        var(--spectrum-transparent-black-400-opacity)
-    );
+    --spectrum-transparent-black-400: rgba(var(--spectrum-transparent-black-400-rgb), var(--spectrum-transparent-black-400-opacity));
     --spectrum-transparent-black-500-rgb: 0, 0, 0;
     --spectrum-transparent-black-500-opacity: 0.55;
-    --spectrum-transparent-black-500: rgba(
-        var(--spectrum-transparent-black-500-rgb),
-        var(--spectrum-transparent-black-500-opacity)
-    );
+    --spectrum-transparent-black-500: rgba(var(--spectrum-transparent-black-500-rgb), var(--spectrum-transparent-black-500-opacity));
     --spectrum-transparent-black-600-rgb: 0, 0, 0;
     --spectrum-transparent-black-600-opacity: 0.7;
-    --spectrum-transparent-black-600: rgba(
-        var(--spectrum-transparent-black-600-rgb),
-        var(--spectrum-transparent-black-600-opacity)
-    );
+    --spectrum-transparent-black-600: rgba(var(--spectrum-transparent-black-600-rgb), var(--spectrum-transparent-black-600-opacity));
     --spectrum-transparent-black-700-rgb: 0, 0, 0;
     --spectrum-transparent-black-700-opacity: 0.8;
-    --spectrum-transparent-black-700: rgba(
-        var(--spectrum-transparent-black-700-rgb),
-        var(--spectrum-transparent-black-700-opacity)
-    );
+    --spectrum-transparent-black-700: rgba(var(--spectrum-transparent-black-700-rgb), var(--spectrum-transparent-black-700-opacity));
     --spectrum-transparent-black-800-rgb: 0, 0, 0;
     --spectrum-transparent-black-800-opacity: 0.9;
-    --spectrum-transparent-black-800: rgba(
-        var(--spectrum-transparent-black-800-rgb),
-        var(--spectrum-transparent-black-800-opacity)
-    );
+    --spectrum-transparent-black-800: rgba(var(--spectrum-transparent-black-800-rgb), var(--spectrum-transparent-black-800-opacity));
     --spectrum-transparent-black-900-rgb: 0, 0, 0;
-    --spectrum-transparent-black-900: rgba(
-        var(--spectrum-transparent-black-900-rgb)
-    );
+    --spectrum-transparent-black-900: rgba(var(--spectrum-transparent-black-900-rgb));
     --spectrum-icon-color-inverse: var(--spectrum-gray-50);
-    --spectrum-icon-color-primary-default: var(
-        --spectrum-neutral-content-color-default
-    );
+    --spectrum-icon-color-primary-default: var(--spectrum-neutral-content-color-default);
     --spectrum-asterisk-icon-size-75: 8px;
     --spectrum-radio-button-selection-indicator: 4px;
     --spectrum-field-label-top-margin-small: 0px;
@@ -272,9 +168,7 @@
     --spectrum-menu-item-label-to-description: 1px;
     --spectrum-menu-item-section-divider-height: 8px;
     --spectrum-picker-minimum-width-multiplier: 2;
-    --spectrum-picker-end-edge-to-disclousure-icon-quiet: var(
-        --spectrum-picker-end-edge-to-disclosure-icon-quiet
-    );
+    --spectrum-picker-end-edge-to-disclousure-icon-quiet: var(--spectrum-picker-end-edge-to-disclosure-icon-quiet);
     --spectrum-picker-end-edge-to-disclosure-icon-quiet: 0px;
     --spectrum-text-field-minimum-width-multiplier: 1.5;
     --spectrum-combo-box-minimum-width-multiplier: 2.5;
@@ -289,15 +183,9 @@
     --spectrum-breadcrumbs-truncated-menu-to-separator-icon: 0px;
     --spectrum-breadcrumbs-start-edge-to-truncated-menu: 0px;
     --spectrum-breadcrumbs-truncated-menu-to-bottom-text: 0px;
-    --spectrum-alert-banner-to-top-workflow-icon: var(
-        --spectrum-alert-banner-top-to-workflow-icon
-    );
-    --spectrum-alert-banner-to-top-text: var(
-        --spectrum-alert-banner-top-to-text
-    );
-    --spectrum-alert-banner-to-bottom-text: var(
-        --spectrum-alert-banner-bottom-to-text
-    );
+    --spectrum-alert-banner-to-top-workflow-icon: var(--spectrum-alert-banner-top-to-workflow-icon);
+    --spectrum-alert-banner-to-top-text: var(--spectrum-alert-banner-top-to-text);
+    --spectrum-alert-banner-to-bottom-text: var(--spectrum-alert-banner-bottom-to-text);
     --spectrum-color-area-border-width: var(--spectrum-border-width-100);
     --spectrum-color-area-border-rounding: var(--spectrum-corner-radius-100);
     --spectrum-color-wheel-color-area-margin: 12px;
@@ -318,20 +206,12 @@
     --spectrum-card-preview-minimum-height: 130px;
     --spectrum-card-selection-background-size: 40px;
     --spectrum-drop-zone-width: 428px;
-    --spectrum-drop-zone-content-maximum-width: var(
-        --spectrum-illustrated-message-maximum-width
-    );
+    --spectrum-drop-zone-content-maximum-width: var(--spectrum-illustrated-message-maximum-width);
     --spectrum-drop-zone-border-dash-length: 8px;
     --spectrum-drop-zone-border-dash-gap: 4px;
-    --spectrum-drop-zone-title-size: var(
-        --spectrum-illustrated-message-title-size
-    );
-    --spectrum-drop-zone-cjk-title-size: var(
-        --spectrum-illustrated-message-cjk-title-size
-    );
-    --spectrum-drop-zone-body-size: var(
-        --spectrum-illustrated-message-body-size
-    );
+    --spectrum-drop-zone-title-size: var(--spectrum-illustrated-message-title-size);
+    --spectrum-drop-zone-cjk-title-size: var(--spectrum-illustrated-message-cjk-title-size);
+    --spectrum-drop-zone-body-size: var(--spectrum-illustrated-message-body-size);
     --spectrum-accordion-top-to-text-compact-small: 2px;
     --spectrum-accordion-top-to-text-compact-medium: 4px;
     --spectrum-accordion-disclosure-indicator-to-text: 0px;
@@ -344,62 +224,28 @@
     --spectrum-color-handle-drop-shadow-x: 0;
     --spectrum-color-handle-drop-shadow-y: 0;
     --spectrum-color-handle-drop-shadow-blur: 0;
-    --spectrum-table-row-height-small-compact: var(
-        --spectrum-component-height-75
-    );
-    --spectrum-table-row-height-medium-compact: var(
-        --spectrum-component-height-100
-    );
-    --spectrum-table-row-height-large-compact: var(
-        --spectrum-component-height-200
-    );
-    --spectrum-table-row-height-extra-large-compact: var(
-        --spectrum-component-height-300
-    );
-    --spectrum-table-row-top-to-text-small-compact: var(
-        --spectrum-component-top-to-text-75
-    );
-    --spectrum-table-row-top-to-text-medium-compact: var(
-        --spectrum-component-top-to-text-100
-    );
-    --spectrum-table-row-top-to-text-large-compact: var(
-        --spectrum-component-top-to-text-200
-    );
-    --spectrum-table-row-top-to-text-extra-large-compact: var(
-        --spectrum-component-top-to-text-300
-    );
-    --spectrum-table-row-bottom-to-text-small-compact: var(
-        --spectrum-component-bottom-to-text-75
-    );
-    --spectrum-table-row-bottom-to-text-medium-compact: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --spectrum-table-row-bottom-to-text-large-compact: var(
-        --spectrum-component-bottom-to-text-200
-    );
-    --spectrum-table-row-bottom-to-text-extra-large-compact: var(
-        --spectrum-component-bottom-to-text-300
-    );
+    --spectrum-table-row-height-small-compact: var(--spectrum-component-height-75);
+    --spectrum-table-row-height-medium-compact: var(--spectrum-component-height-100);
+    --spectrum-table-row-height-large-compact: var(--spectrum-component-height-200);
+    --spectrum-table-row-height-extra-large-compact: var(--spectrum-component-height-300);
+    --spectrum-table-row-top-to-text-small-compact: var(--spectrum-component-top-to-text-75);
+    --spectrum-table-row-top-to-text-medium-compact: var(--spectrum-component-top-to-text-100);
+    --spectrum-table-row-top-to-text-large-compact: var(--spectrum-component-top-to-text-200);
+    --spectrum-table-row-top-to-text-extra-large-compact: var(--spectrum-component-top-to-text-300);
+    --spectrum-table-row-bottom-to-text-small-compact: var(--spectrum-component-bottom-to-text-75);
+    --spectrum-table-row-bottom-to-text-medium-compact: var(--spectrum-component-bottom-to-text-100);
+    --spectrum-table-row-bottom-to-text-large-compact: var(--spectrum-component-bottom-to-text-200);
+    --spectrum-table-row-bottom-to-text-extra-large-compact: var(--spectrum-component-bottom-to-text-300);
     --spectrum-table-edge-to-content: 16px;
     --spectrum-table-border-divider-width: 1px;
     --spectrum-tab-item-height-small: var(--spectrum-component-height-200);
     --spectrum-tab-item-height-medium: var(--spectrum-component-height-300);
     --spectrum-tab-item-height-large: var(--spectrum-component-height-400);
-    --spectrum-tab-item-height-extra-large: var(
-        --spectrum-component-height-500
-    );
-    --spectrum-tab-item-compact-height-small: var(
-        --spectrum-component-height-75
-    );
-    --spectrum-tab-item-compact-height-medium: var(
-        --spectrum-component-height-100
-    );
-    --spectrum-tab-item-compact-height-large: var(
-        --spectrum-component-height-200
-    );
-    --spectrum-tab-item-compact-height-extra-large: var(
-        --spectrum-component-height-300
-    );
+    --spectrum-tab-item-height-extra-large: var(--spectrum-component-height-500);
+    --spectrum-tab-item-compact-height-small: var(--spectrum-component-height-75);
+    --spectrum-tab-item-compact-height-medium: var(--spectrum-component-height-100);
+    --spectrum-tab-item-compact-height-large: var(--spectrum-component-height-200);
+    --spectrum-tab-item-compact-height-extra-large: var(--spectrum-component-height-300);
     --spectrum-tab-item-start-to-edge-quiet: 0px;
     --spectrum-in-field-button-width-stacked-small: 20px;
     --spectrum-in-field-button-width-stacked-medium: 28px;
@@ -507,200 +353,76 @@
     --spectrum-cjk-line-height-100: 1.5;
     --spectrum-cjk-line-height-200: 1.7;
     --spectrum-cjk-letter-spacing: 0.05em;
-    --spectrum-heading-sans-serif-font-family: var(
-        --spectrum-sans-serif-font-family
-    );
+    --spectrum-heading-sans-serif-font-family: var(--spectrum-sans-serif-font-family);
     --spectrum-heading-serif-font-family: var(--spectrum-serif-font-family);
     --spectrum-heading-cjk-font-family: var(--spectrum-cjk-font-family);
-    --spectrum-heading-sans-serif-light-font-weight: var(
-        --spectrum-light-font-weight
-    );
-    --spectrum-heading-sans-serif-light-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-serif-light-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-heading-serif-light-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-heading-sans-serif-light-font-weight: var(--spectrum-light-font-weight);
+    --spectrum-heading-sans-serif-light-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-serif-light-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-heading-serif-light-font-style: var(--spectrum-default-font-style);
     --spectrum-heading-cjk-light-font-weight: var(--spectrum-light-font-weight);
     --spectrum-heading-cjk-light-font-style: var(--spectrum-default-font-style);
-    --spectrum-heading-sans-serif-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-heading-sans-serif-font-style: var(--spectrum-default-font-style);
     --spectrum-heading-serif-font-style: var(--spectrum-default-font-style);
     --spectrum-heading-cjk-font-style: var(--spectrum-default-font-style);
-    --spectrum-heading-sans-serif-heavy-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-sans-serif-heavy-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-serif-heavy-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-serif-heavy-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-heading-sans-serif-heavy-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-sans-serif-heavy-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-serif-heavy-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-serif-heavy-font-style: var(--spectrum-default-font-style);
     --spectrum-heading-cjk-heavy-font-weight: var(--spectrum-black-font-weight);
     --spectrum-heading-cjk-heavy-font-style: var(--spectrum-default-font-style);
-    --spectrum-heading-sans-serif-light-strong-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-heading-sans-serif-light-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-serif-light-strong-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-heading-serif-light-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-cjk-light-strong-font-weight: var(
-        --spectrum-extra-bold-font-weight
-    );
-    --spectrum-heading-cjk-light-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-sans-serif-strong-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-sans-serif-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-serif-strong-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-serif-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-cjk-strong-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-cjk-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-sans-serif-heavy-strong-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-sans-serif-heavy-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-serif-heavy-strong-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-serif-heavy-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-cjk-heavy-strong-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-cjk-heavy-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-sans-serif-light-emphasized-font-weight: var(
-        --spectrum-light-font-weight
-    );
-    --spectrum-heading-sans-serif-light-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-serif-light-emphasized-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-heading-serif-light-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-cjk-light-emphasized-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-heading-cjk-light-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-sans-serif-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-serif-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-cjk-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-cjk-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-sans-serif-heavy-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-sans-serif-heavy-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-serif-heavy-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-serif-heavy-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-cjk-heavy-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-cjk-heavy-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-sans-serif-light-strong-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-heading-sans-serif-light-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-serif-light-strong-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-heading-serif-light-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-cjk-light-strong-emphasized-font-weight: var(
-        --spectrum-extra-bold-font-weight
-    );
-    --spectrum-heading-cjk-light-strong-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-sans-serif-strong-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-sans-serif-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-serif-strong-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-serif-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-cjk-strong-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-cjk-strong-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-heading-sans-serif-heavy-strong-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-sans-serif-heavy-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-serif-heavy-strong-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-serif-heavy-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-heading-cjk-heavy-strong-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-heading-cjk-heavy-strong-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-heading-sans-serif-light-strong-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-heading-sans-serif-light-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-serif-light-strong-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-heading-serif-light-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-cjk-light-strong-font-weight: var(--spectrum-extra-bold-font-weight);
+    --spectrum-heading-cjk-light-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-sans-serif-strong-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-sans-serif-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-serif-strong-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-serif-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-cjk-strong-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-cjk-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-sans-serif-heavy-strong-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-sans-serif-heavy-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-serif-heavy-strong-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-serif-heavy-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-cjk-heavy-strong-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-cjk-heavy-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-sans-serif-light-emphasized-font-weight: var(--spectrum-light-font-weight);
+    --spectrum-heading-sans-serif-light-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-serif-light-emphasized-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-heading-serif-light-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-cjk-light-emphasized-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-heading-cjk-light-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-sans-serif-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-serif-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-cjk-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-cjk-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-sans-serif-heavy-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-sans-serif-heavy-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-serif-heavy-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-serif-heavy-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-cjk-heavy-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-cjk-heavy-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-sans-serif-light-strong-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-heading-sans-serif-light-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-serif-light-strong-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-heading-serif-light-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-cjk-light-strong-emphasized-font-weight: var(--spectrum-extra-bold-font-weight);
+    --spectrum-heading-cjk-light-strong-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-sans-serif-strong-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-sans-serif-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-serif-strong-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-serif-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-cjk-strong-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-cjk-strong-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-heading-sans-serif-heavy-strong-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-sans-serif-heavy-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-serif-heavy-strong-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-serif-heavy-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-heading-cjk-heavy-strong-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-heading-cjk-heavy-strong-emphasized-font-style: var(--spectrum-default-font-style);
     --spectrum-heading-size-xxxl: var(--spectrum-font-size-1300);
     --spectrum-heading-size-xxl: var(--spectrum-font-size-1100);
     --spectrum-heading-size-xl: var(--spectrum-font-size-900);
@@ -722,9 +444,7 @@
     --spectrum-heading-margin-top-multiplier: 0.888889;
     --spectrum-heading-margin-bottom-multiplier: 0.25;
     --spectrum-heading-color: var(--spectrum-gray-900);
-    --spectrum-body-sans-serif-font-family: var(
-        --spectrum-sans-serif-font-family
-    );
+    --spectrum-body-sans-serif-font-family: var(--spectrum-sans-serif-font-family);
     --spectrum-body-serif-font-family: var(--spectrum-serif-font-family);
     --spectrum-body-cjk-font-family: var(--spectrum-cjk-font-family);
     --spectrum-body-sans-serif-font-weight: var(--spectrum-regular-font-weight);
@@ -733,52 +453,24 @@
     --spectrum-body-serif-font-style: var(--spectrum-default-font-style);
     --spectrum-body-cjk-font-weight: var(--spectrum-regular-font-weight);
     --spectrum-body-cjk-font-style: var(--spectrum-default-font-style);
-    --spectrum-body-sans-serif-strong-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-body-sans-serif-strong-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-body-sans-serif-strong-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-body-sans-serif-strong-font-style: var(--spectrum-default-font-style);
     --spectrum-body-serif-strong-font-weight: var(--spectrum-bold-font-weight);
     --spectrum-body-serif-strong-font-style: var(--spectrum-default-font-style);
     --spectrum-body-cjk-strong-font-weight: var(--spectrum-black-font-weight);
     --spectrum-body-cjk-strong-font-style: var(--spectrum-default-font-style);
-    --spectrum-body-sans-serif-emphasized-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-body-sans-serif-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-body-serif-emphasized-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-body-serif-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-body-cjk-emphasized-font-weight: var(
-        --spectrum-extra-bold-font-weight
-    );
-    --spectrum-body-cjk-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-body-sans-serif-strong-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-body-sans-serif-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-body-serif-strong-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-body-serif-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-body-cjk-strong-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-body-cjk-strong-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-body-sans-serif-emphasized-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-body-sans-serif-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-body-serif-emphasized-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-body-serif-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-body-cjk-emphasized-font-weight: var(--spectrum-extra-bold-font-weight);
+    --spectrum-body-cjk-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-body-sans-serif-strong-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-body-sans-serif-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-body-serif-strong-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-body-serif-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-body-cjk-strong-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-body-cjk-strong-emphasized-font-style: var(--spectrum-default-font-style);
     --spectrum-body-size-xxxl: var(--spectrum-font-size-600);
     --spectrum-body-size-xxl: var(--spectrum-font-size-500);
     --spectrum-body-size-xl: var(--spectrum-font-size-400);
@@ -790,9 +482,7 @@
     --spectrum-body-cjk-line-height: var(--spectrum-cjk-line-height-200);
     --spectrum-body-margin-multiplier: 0.75;
     --spectrum-body-color: var(--spectrum-gray-800);
-    --spectrum-detail-sans-serif-font-family: var(
-        --spectrum-sans-serif-font-family
-    );
+    --spectrum-detail-sans-serif-font-family: var(--spectrum-sans-serif-font-family);
     --spectrum-detail-serif-font-family: var(--spectrum-serif-font-family);
     --spectrum-detail-cjk-font-family: var(--spectrum-cjk-font-family);
     --spectrum-detail-sans-serif-font-weight: var(--spectrum-bold-font-weight);
@@ -801,124 +491,48 @@
     --spectrum-detail-serif-font-style: var(--spectrum-default-font-style);
     --spectrum-detail-cjk-font-weight: var(--spectrum-extra-bold-font-weight);
     --spectrum-detail-cjk-font-style: var(--spectrum-default-font-style);
-    --spectrum-detail-sans-serif-light-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-detail-sans-serif-light-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-detail-serif-light-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-detail-serif-light-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-detail-sans-serif-light-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-detail-sans-serif-light-font-style: var(--spectrum-default-font-style);
+    --spectrum-detail-serif-light-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-detail-serif-light-font-style: var(--spectrum-default-font-style);
     --spectrum-detail-cjk-light-font-weight: var(--spectrum-light-font-weight);
     --spectrum-detail-cjk-light-font-style: var(--spectrum-default-font-style);
-    --spectrum-detail-sans-serif-strong-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-detail-sans-serif-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-detail-serif-strong-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-detail-serif-strong-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-detail-sans-serif-strong-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-detail-sans-serif-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-detail-serif-strong-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-detail-serif-strong-font-style: var(--spectrum-default-font-style);
     --spectrum-detail-cjk-strong-font-weight: var(--spectrum-black-font-weight);
     --spectrum-detail-cjk-strong-font-style: var(--spectrum-default-font-style);
-    --spectrum-detail-sans-serif-light-strong-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-detail-sans-serif-light-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-detail-serif-light-strong-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-detail-serif-light-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-detail-cjk-light-strong-font-weight: var(
-        --spectrum-extra-bold-font-weight
-    );
-    --spectrum-detail-cjk-light-strong-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-detail-sans-serif-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-detail-sans-serif-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-detail-serif-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-detail-serif-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-detail-cjk-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-detail-cjk-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-detail-sans-serif-light-emphasized-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-detail-sans-serif-light-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-detail-serif-light-emphasized-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-detail-serif-light-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-detail-cjk-light-emphasized-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-detail-cjk-light-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-detail-sans-serif-strong-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-detail-sans-serif-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-detail-serif-strong-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-detail-serif-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-detail-cjk-strong-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-detail-cjk-strong-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-detail-sans-serif-light-strong-emphasized-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-detail-sans-serif-light-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-detail-serif-light-strong-emphasized-font-weight: var(
-        --spectrum-regular-font-weight
-    );
-    --spectrum-detail-serif-light-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-detail-cjk-light-strong-emphasized-font-weight: var(
-        --spectrum-extra-bold-font-weight
-    );
-    --spectrum-detail-cjk-light-strong-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-detail-sans-serif-light-strong-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-detail-sans-serif-light-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-detail-serif-light-strong-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-detail-serif-light-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-detail-cjk-light-strong-font-weight: var(--spectrum-extra-bold-font-weight);
+    --spectrum-detail-cjk-light-strong-font-style: var(--spectrum-default-font-style);
+    --spectrum-detail-sans-serif-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-detail-sans-serif-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-detail-serif-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-detail-serif-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-detail-cjk-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-detail-cjk-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-detail-sans-serif-light-emphasized-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-detail-sans-serif-light-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-detail-serif-light-emphasized-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-detail-serif-light-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-detail-cjk-light-emphasized-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-detail-cjk-light-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-detail-sans-serif-strong-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-detail-sans-serif-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-detail-serif-strong-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-detail-serif-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-detail-cjk-strong-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-detail-cjk-strong-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-detail-sans-serif-light-strong-emphasized-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-detail-sans-serif-light-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-detail-serif-light-strong-emphasized-font-weight: var(--spectrum-regular-font-weight);
+    --spectrum-detail-serif-light-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-detail-cjk-light-strong-emphasized-font-weight: var(--spectrum-extra-bold-font-weight);
+    --spectrum-detail-cjk-light-strong-emphasized-font-style: var(--spectrum-default-font-style);
     --spectrum-detail-size-xl: var(--spectrum-font-size-200);
     --spectrum-detail-size-l: var(--spectrum-font-size-100);
     --spectrum-detail-size-m: var(--spectrum-font-size-75);
@@ -943,24 +557,12 @@
     --spectrum-code-cjk-strong-font-style: var(--spectrum-default-font-style);
     --spectrum-code-emphasized-font-weight: var(--spectrum-regular-font-weight);
     --spectrum-code-emphasized-font-style: var(--spectrum-italic-font-style);
-    --spectrum-code-cjk-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-code-cjk-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
-    --spectrum-code-strong-emphasized-font-weight: var(
-        --spectrum-bold-font-weight
-    );
-    --spectrum-code-strong-emphasized-font-style: var(
-        --spectrum-italic-font-style
-    );
-    --spectrum-code-cjk-strong-emphasized-font-weight: var(
-        --spectrum-black-font-weight
-    );
-    --spectrum-code-cjk-strong-emphasized-font-style: var(
-        --spectrum-default-font-style
-    );
+    --spectrum-code-cjk-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-code-cjk-emphasized-font-style: var(--spectrum-default-font-style);
+    --spectrum-code-strong-emphasized-font-weight: var(--spectrum-bold-font-weight);
+    --spectrum-code-strong-emphasized-font-style: var(--spectrum-italic-font-style);
+    --spectrum-code-cjk-strong-emphasized-font-weight: var(--spectrum-black-font-weight);
+    --spectrum-code-cjk-strong-emphasized-font-style: var(--spectrum-default-font-style);
     --spectrum-code-size-xl: var(--spectrum-font-size-400);
     --spectrum-code-size-l: var(--spectrum-font-size-300);
     --spectrum-code-size-m: var(--spectrum-font-size-200);

--- a/tools/styles/tokens/large-vars.css
+++ b/tools/styles/tokens/large-vars.css
@@ -196,9 +196,7 @@
     --spectrum-color-slider-length: 240px;
     --spectrum-color-slider-minimum-length: 100px;
     --spectrum-illustrated-message-title-size: var(--spectrum-heading-size-s);
-    --spectrum-illustrated-message-cjk-title-size: var(
-        --spectrum-heading-cjk-size-s
-    );
+    --spectrum-illustrated-message-cjk-title-size: var(--spectrum-heading-cjk-size-s);
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-xs);
     --spectrum-coach-mark-width: 216px;
     --spectrum-coach-mark-minimum-width: 216px;

--- a/tools/styles/tokens/light-vars.css
+++ b/tools/styles/tokens/light-vars.css
@@ -3,10 +3,7 @@
     --spectrum-overlay-opacity: 0.4;
     --spectrum-drop-shadow-color-rgb: 0, 0, 0;
     --spectrum-drop-shadow-color-opacity: 0.15;
-    --spectrum-drop-shadow-color: rgba(
-        var(--spectrum-drop-shadow-color-rgb),
-        var(--spectrum-drop-shadow-color-opacity)
-    );
+    --spectrum-drop-shadow-color: rgba(var(--spectrum-drop-shadow-color-rgb), var(--spectrum-drop-shadow-color-opacity));
     --spectrum-background-base-color: var(--spectrum-gray-200);
     --spectrum-background-layer-1-color: var(--spectrum-gray-100);
     --spectrum-background-layer-2-color: var(--spectrum-gray-50);
@@ -14,68 +11,32 @@
     --spectrum-neutral-background-color-hover: var(--spectrum-gray-900);
     --spectrum-neutral-background-color-down: var(--spectrum-gray-900);
     --spectrum-neutral-background-color-key-focus: var(--spectrum-gray-900);
-    --spectrum-neutral-subdued-background-color-default: var(
-        --spectrum-gray-600
-    );
+    --spectrum-neutral-subdued-background-color-default: var(--spectrum-gray-600);
     --spectrum-neutral-subdued-background-color-hover: var(--spectrum-gray-700);
     --spectrum-neutral-subdued-background-color-down: var(--spectrum-gray-800);
-    --spectrum-neutral-subdued-background-color-key-focus: var(
-        --spectrum-gray-700
-    );
-    --spectrum-accent-background-color-default: var(
-        --spectrum-accent-color-900
-    );
+    --spectrum-neutral-subdued-background-color-key-focus: var(--spectrum-gray-700);
+    --spectrum-accent-background-color-default: var(--spectrum-accent-color-900);
     --spectrum-accent-background-color-hover: var(--spectrum-accent-color-1000);
     --spectrum-accent-background-color-down: var(--spectrum-accent-color-1100);
-    --spectrum-accent-background-color-key-focus: var(
-        --spectrum-accent-color-1000
-    );
-    --spectrum-informative-background-color-default: var(
-        --spectrum-informative-color-900
-    );
-    --spectrum-informative-background-color-hover: var(
-        --spectrum-informative-color-1000
-    );
-    --spectrum-informative-background-color-down: var(
-        --spectrum-informative-color-1100
-    );
-    --spectrum-informative-background-color-key-focus: var(
-        --spectrum-informative-color-1000
-    );
-    --spectrum-negative-background-color-default: var(
-        --spectrum-negative-color-900
-    );
-    --spectrum-negative-background-color-hover: var(
-        --spectrum-negative-color-1000
-    );
-    --spectrum-negative-background-color-down: var(
-        --spectrum-negative-color-1100
-    );
-    --spectrum-negative-background-color-key-focus: var(
-        --spectrum-negative-color-1000
-    );
-    --spectrum-positive-background-color-default: var(
-        --spectrum-positive-color-900
-    );
-    --spectrum-positive-background-color-hover: var(
-        --spectrum-positive-color-1000
-    );
-    --spectrum-positive-background-color-down: var(
-        --spectrum-positive-color-1100
-    );
-    --spectrum-positive-background-color-key-focus: var(
-        --spectrum-positive-color-1000
-    );
-    --spectrum-notice-background-color-default: var(
-        --spectrum-notice-color-600
-    );
+    --spectrum-accent-background-color-key-focus: var(--spectrum-accent-color-1000);
+    --spectrum-informative-background-color-default: var(--spectrum-informative-color-900);
+    --spectrum-informative-background-color-hover: var(--spectrum-informative-color-1000);
+    --spectrum-informative-background-color-down: var(--spectrum-informative-color-1100);
+    --spectrum-informative-background-color-key-focus: var(--spectrum-informative-color-1000);
+    --spectrum-negative-background-color-default: var(--spectrum-negative-color-900);
+    --spectrum-negative-background-color-hover: var(--spectrum-negative-color-1000);
+    --spectrum-negative-background-color-down: var(--spectrum-negative-color-1100);
+    --spectrum-negative-background-color-key-focus: var(--spectrum-negative-color-1000);
+    --spectrum-positive-background-color-default: var(--spectrum-positive-color-900);
+    --spectrum-positive-background-color-hover: var(--spectrum-positive-color-1000);
+    --spectrum-positive-background-color-down: var(--spectrum-positive-color-1100);
+    --spectrum-positive-background-color-key-focus: var(--spectrum-positive-color-1000);
+    --spectrum-notice-background-color-default: var(--spectrum-notice-color-600);
     --spectrum-gray-background-color-default: var(--spectrum-gray-700);
     --spectrum-red-background-color-default: var(--spectrum-red-900);
     --spectrum-orange-background-color-default: var(--spectrum-orange-600);
     --spectrum-yellow-background-color-default: var(--spectrum-yellow-400);
-    --spectrum-chartreuse-background-color-default: var(
-        --spectrum-chartreuse-500
-    );
+    --spectrum-chartreuse-background-color-default: var(--spectrum-chartreuse-500);
     --spectrum-celery-background-color-default: var(--spectrum-celery-600);
     --spectrum-green-background-color-default: var(--spectrum-green-900);
     --spectrum-seafoam-background-color-default: var(--spectrum-seafoam-900);

--- a/tools/styles/tokens/medium-vars.css
+++ b/tools/styles/tokens/medium-vars.css
@@ -196,9 +196,7 @@
     --spectrum-color-slider-length: 192px;
     --spectrum-color-slider-minimum-length: 80px;
     --spectrum-illustrated-message-title-size: var(--spectrum-heading-size-m);
-    --spectrum-illustrated-message-cjk-title-size: var(
-        --spectrum-heading-cjk-size-m
-    );
+    --spectrum-illustrated-message-cjk-title-size: var(--spectrum-heading-cjk-size-m);
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-s);
     --spectrum-coach-mark-width: 296px;
     --spectrum-coach-mark-minimum-width: 296px;

--- a/tools/styles/tokens/spectrum/custom-dark-vars.css
+++ b/tools/styles/tokens/spectrum/custom-dark-vars.css
@@ -3,91 +3,42 @@
 :root {
     --spectrum-menu-item-background-color-default-rgb: 255, 255, 255;
     --spectrum-menu-item-background-color-default-opacity: 0;
-    --spectrum-menu-item-background-color-default: rgba(
-        var(--spectrum-menu-item-background-color-default-rgb),
-        var(--spectrum-menu-item-background-color-default-opacity)
-    );
-    --spectrum-menu-item-background-color-hover: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --spectrum-transparent-white-200
-    );
+    --spectrum-menu-item-background-color-default: rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
+    --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-900-rgb);
     --spectrum-dropindicator-color: var(--spectrum-blue-700);
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-white-rgb),
-        0.07
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-white-rgb),
-        0.07
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.07);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.07);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
     --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
     --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
     --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
     --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-700
-    );
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.07
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.07);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1000
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-900
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-800
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
 }

--- a/tools/styles/tokens/spectrum/custom-darkest-vars.css
+++ b/tools/styles/tokens/spectrum/custom-darkest-vars.css
@@ -3,92 +3,42 @@
 :root {
     --spectrum-menu-item-background-color-default-rgb: 255, 255, 255;
     --spectrum-menu-item-background-color-default-opacity: 0;
-    --spectrum-menu-item-background-color-default: rgba(
-        var(--spectrum-menu-item-background-color-default-rgb),
-        var(--spectrum-menu-item-background-color-default-opacity)
-    );
-    --spectrum-menu-item-background-color-hover: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --spectrum-transparent-white-200
-    );
+    --spectrum-menu-item-background-color-default: rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
+    --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-900-rgb);
     --spectrum-dropindicator-color: var(--spectrum-blue-700);
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-white-rgb),
-        0.08
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-calendar-day-background-color-down: rgba(
-        var(--spectrum-white-rgb),
-        0.15
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-white-rgb),
-        0.08
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.08);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-calendar-day-background-color-down: rgba(var(--spectrum-white-rgb), 0.15);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.08);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
     --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
     --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-700);
     --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
     --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-700
-    );
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.08
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.2
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.08);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1000
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-900
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-800
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.2
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
 }

--- a/tools/styles/tokens/spectrum/custom-large-vars.css
+++ b/tools/styles/tokens/spectrum/custom-large-vars.css
@@ -4,8 +4,8 @@
     --spectrum-slider-tick-mark-height: 13px;
     --spectrum-slider-ramp-track-height: 20px;
 
-    --spectrum-colorwheel-path: 'M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0';
-    --spectrum-colorwheel-path-borders: 'M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0';
+    --spectrum-colorwheel-path: "M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
+    --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
     --spectrum-colorwheel-colorarea-container-size: 182px;
 
     --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-secondary);
@@ -39,9 +39,7 @@
     --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);
     --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-200);
     --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-200);
-    --spectrum-alert-banner-text-to-button-vertical: var(
-        --spectrum-spacing-200
-    );
+    --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-200);
 
     --spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
     --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
@@ -100,9 +98,7 @@
     --spectrum-assetcard-focus-ring-border-radius: 9px;
     --spectrum-assetcard-selectionindicator-margin: 15px;
     --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xxs);
-    --spectrum-assetcard-header-content-font-size: var(
-        --spectrum-heading-size-xxs
-    );
+    --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xxs);
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
 
     --spectrum-tooltip-animation-distance: 5px;

--- a/tools/styles/tokens/spectrum/custom-light-vars.css
+++ b/tools/styles/tokens/spectrum/custom-light-vars.css
@@ -3,91 +3,42 @@
 :root {
     --spectrum-menu-item-background-color-default-rgb: 0, 0, 0;
     --spectrum-menu-item-background-color-default-opacity: 0;
-    --spectrum-menu-item-background-color-default: rgba(
-        var(--spectrum-menu-item-background-color-default-rgb),
-        var(--spectrum-menu-item-background-color-default-opacity)
-    );
-    --spectrum-menu-item-background-color-hover: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --spectrum-transparent-black-200
-    );
+    --spectrum-menu-item-background-color-default: rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
+    --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-black-200);
+    --spectrum-menu-item-background-color-down: var(--spectrum-transparent-black-200);
+    --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-black-200);
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-800-rgb);
     --spectrum-dropindicator-color: var(--spectrum-blue-800);
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-black-rgb),
-        0.06
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-black-rgb),
-        0.06
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-black-rgb), 0.06);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-black-200);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-black-rgb), 0.06);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-800);
     --spectrum-badge-label-icon-color-primary: var(--spectrum-white);
     --spectrum-coach-indicator-ring-default-color: var(--spectrum-blue-800);
     --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
     --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
     --spectrum-well-border-color: var(--spectrum-black-rgb);
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-800
-    );
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.06
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-800);
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.06);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-900);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-900);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1100
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1100);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1100);
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-900);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-1100
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-1100);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-1100);
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-900);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-900);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-1000);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-900
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-900);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-800);
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-800);
 }

--- a/tools/styles/tokens/spectrum/custom-medium-vars.css
+++ b/tools/styles/tokens/spectrum/custom-medium-vars.css
@@ -4,8 +4,8 @@
     --spectrum-slider-tick-mark-height: 10px;
     --spectrum-slider-ramp-track-height: 16px;
 
-    --spectrum-colorwheel-path: 'M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0';
-    --spectrum-colorwheel-path-borders: 'M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0';
+    --spectrum-colorwheel-path: "M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
+    --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
     --spectrum-colorwheel-colorarea-container-size: 144px;
 
     --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-primary);
@@ -39,9 +39,7 @@
     --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);
     --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-100);
     --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-100);
-    --spectrum-alert-banner-text-to-button-vertical: var(
-        --spectrum-spacing-100
-    );
+    --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-100);
 
     --spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
     --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
@@ -64,9 +62,7 @@
     --spectrum-treeview-item-indentation-medium: var(--spectrum-spacing-300);
     --spectrum-treeview-item-indentation-small: var(--spectrum-spacing-200);
     --spectrum-treeview-item-indentation-large: 20px;
-    --spectrum-treeview-item-indentation-extra-large: var(
-        --spectrum-spacing-400
-    );
+    --spectrum-treeview-item-indentation-extra-large: var(--spectrum-spacing-400);
     --spectrum-treeview-indicator-inset-block-start: 5px;
     --spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 0px;
 
@@ -101,9 +97,7 @@
     --spectrum-assetcard-focus-ring-border-radius: 8px;
     --spectrum-assetcard-selectionindicator-margin: 12px;
     --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xs);
-    --spectrum-assetcard-header-content-font-size: var(
-        --spectrum-heading-size-xs
-    );
+    --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xs);
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
 
     --spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);

--- a/tools/styles/tokens/spectrum/custom-vars.css
+++ b/tools/styles/tokens/spectrum/custom-vars.css
@@ -22,27 +22,18 @@
     --spectrum-animation-ease-out: cubic-bezier(0, 0, 0.4, 1);
     --spectrum-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
 
-    --spectrum-sans-font-family-stack: adobe-clean,
-        var(--spectrum-sans-serif-font-family), 'Source Sans Pro', -apple-system,
-        BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Trebuchet MS',
-        'Lucida Grande', sans-serif;
+    --spectrum-sans-font-family-stack: adobe-clean, var(--spectrum-sans-serif-font-family), "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif;
     --spectrum-sans-serif-font: var(--spectrum-sans-font-family-stack);
 
-    --spectrum-serif-font-family-stack: adobe-clean-serif,
-        var(--spectrum-serif-font-family), 'Source Serif Pro', Georgia, serif;
+    --spectrum-serif-font-family-stack: adobe-clean-serif, var(--spectrum-serif-font-family), "Source Serif Pro", Georgia, serif;
     --spectrum-serif-font: var(--spectrum-serif-font-family-stack);
 
-    --spectrum-code-font-family-stack: 'Source Code Pro', Monaco, monospace;
+    --spectrum-code-font-family-stack: "Source Code Pro", Monaco, monospace;
 
-    --spectrum-cjk-font-family-stack: adobe-clean-han-japanese,
-        var(--spectrum-cjk-font-family), sans-serif;
+    --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
     --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;
-    --spectrum-docs-static-white-background-color: rgba(
-        var(--spectrum-docs-static-white-background-color-rgb)
-    );
+    --spectrum-docs-static-white-background-color: rgba(var(--spectrum-docs-static-white-background-color-rgb));
     --spectrum-docs-static-black-background-color-rgb: 181, 209, 211;
-    --spectrum-docs-static-black-background-color: rgba(
-        var(--spectrum-docs-static-black-background-color-rgb)
-    );
+    --spectrum-docs-static-black-background-color: rgba(var(--spectrum-docs-static-black-background-color-rgb));
 }

--- a/tools/styles/tokens/spectrum/dark-vars.css
+++ b/tools/styles/tokens/spectrum/dark-vars.css
@@ -2,48 +2,19 @@
 :root {
     --spectrum-menu-item-background-color-default-rgb: 255, 255, 255;
     --spectrum-menu-item-background-color-default-opacity: 0;
-    --spectrum-menu-item-background-color-default: rgba(
-        var(--spectrum-menu-item-background-color-default-rgb),
-        var(--spectrum-menu-item-background-color-default-opacity)
-    );
-    --spectrum-menu-item-background-color-hover: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --spectrum-transparent-white-200
-    );
+    --spectrum-menu-item-background-color-default: rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
+    --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-900-rgb);
     --spectrum-dropindicator-color: var(--spectrum-blue-700);
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-white-rgb),
-        0.07
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-white-rgb),
-        0.07
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.07);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.07);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
     --spectrum-card-selected-background-color-rgb: var(--spectrum-blue-500-rgb);
     --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
@@ -51,55 +22,29 @@
     --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
     --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-700
-    );
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.07
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.07);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1000
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-900
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-800
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.25
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.15
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.25);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.15);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
     --spectrum-swatch-border-color-rgb: 255, 255, 255;
     --spectrum-swatch-border-color-opacity: 0.51;
-    --spectrum-swatch-border-color: rgba(
-        var(--spectrum-swatch-border-color-rgb),
-        var(--spectrum-swatch-border-color-opacity)
-    );
+    --spectrum-swatch-border-color: rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
     --spectrum-swatch-border-color-light-rgb: 255, 255, 255;
     --spectrum-swatch-border-color-light-opacity: 0.2;
-    --spectrum-swatch-border-color-light: rgba(
-        var(--spectrum-swatch-border-color-light-rgb),
-        var(--spectrum-swatch-border-color-light-opacity)
-    );
+    --spectrum-swatch-border-color-light: rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
 }

--- a/tools/styles/tokens/spectrum/darkest-vars.css
+++ b/tools/styles/tokens/spectrum/darkest-vars.css
@@ -2,49 +2,19 @@
 :root {
     --spectrum-menu-item-background-color-default-rgb: 255, 255, 255;
     --spectrum-menu-item-background-color-default-opacity: 0;
-    --spectrum-menu-item-background-color-default: rgba(
-        var(--spectrum-menu-item-background-color-default-rgb),
-        var(--spectrum-menu-item-background-color-default-opacity)
-    );
-    --spectrum-menu-item-background-color-hover: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --spectrum-transparent-white-200
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --spectrum-transparent-white-200
-    );
+    --spectrum-menu-item-background-color-default: rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
+    --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-down: var(--spectrum-transparent-white-200);
+    --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-white-200);
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-900-rgb);
     --spectrum-dropindicator-color: var(--spectrum-blue-700);
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-white-rgb),
-        0.08
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-calendar-day-background-color-down: rgba(
-        var(--spectrum-white-rgb),
-        0.15
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-white-rgb),
-        0.08
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-white-rgb), 0.08);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-calendar-day-background-color-down: rgba(var(--spectrum-white-rgb), 0.15);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-white-rgb), 0.08);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
     --spectrum-card-selected-background-color-rgb: var(--spectrum-blue-600-rgb);
     --spectrum-badge-label-icon-color-primary: var(--spectrum-black);
@@ -52,55 +22,29 @@
     --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
     --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
     --spectrum-well-border-color: rgba(var(--spectrum-white-rgb), 0.05);
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-700
-    );
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.08
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.2
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-700);
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.08);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-800);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-800);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1000
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1000);
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-700);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-700);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-900
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-900);
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-800);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-900);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-800
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-800);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-700);
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.3
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-800-rgb),
-        0.2
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-800-rgb), 0.3);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-800-rgb), 0.2);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-700);
     --spectrum-swatch-border-color-rgb: 255, 255, 255;
     --spectrum-swatch-border-color-opacity: 0.51;
-    --spectrum-swatch-border-color: rgba(
-        var(--spectrum-swatch-border-color-rgb),
-        var(--spectrum-swatch-border-color-opacity)
-    );
+    --spectrum-swatch-border-color: rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
     --spectrum-swatch-border-color-light-rgb: 255, 255, 255;
     --spectrum-swatch-border-color-light-opacity: 0.2;
-    --spectrum-swatch-border-color-light: rgba(
-        var(--spectrum-swatch-border-color-light-rgb),
-        var(--spectrum-swatch-border-color-light-opacity)
-    );
+    --spectrum-swatch-border-color-light: rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
 }

--- a/tools/styles/tokens/spectrum/large-vars.css
+++ b/tools/styles/tokens/spectrum/large-vars.css
@@ -50,8 +50,8 @@
     --spectrum-drop-shadow-blur: 6px;
     --spectrum-slider-tick-mark-height: 13px;
     --spectrum-slider-ramp-track-height: 20px;
-    --spectrum-colorwheel-path: 'M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0';
-    --spectrum-colorwheel-path-borders: 'M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0';
+    --spectrum-colorwheel-path: "M 119 119 m -119 0 a 119 119 0 1 0 238 0 a 119 119 0 1 0 -238 0.2 M 119 119 m -91 0 a 91 91 0 1 0 182 0 a 91 91 0 1 0 -182 0";
+    --spectrum-colorwheel-path-borders: "M 120 120 m -120 0 a 120 120 0 1 0 240 0 a 120 120 0 1 0 -240 0.2 M 120 120 m -90 0 a 90 90 0 1 0 180 0 a 90 90 0 1 0 -180 0";
     --spectrum-colorwheel-colorarea-container-size: 182px;
     --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-secondary);
     --spectrum-contextual-help-content-spacing: var(--spectrum-spacing-200);
@@ -79,9 +79,7 @@
     --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-200);
     --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-200);
     --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-200);
-    --spectrum-alert-banner-text-to-button-vertical: var(
-        --spectrum-spacing-200
-    );
+    --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-200);
     --spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
     --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
     --spectrum-coach-indicator-gap: 8px;
@@ -130,9 +128,7 @@
     --spectrum-assetcard-focus-ring-border-radius: 9px;
     --spectrum-assetcard-selectionindicator-margin: 15px;
     --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xxs);
-    --spectrum-assetcard-header-content-font-size: var(
-        --spectrum-heading-size-xxs
-    );
+    --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xxs);
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
     --spectrum-tooltip-animation-distance: 5px;
     --spectrum-ui-icon-medium-display: none;

--- a/tools/styles/tokens/spectrum/light-vars.css
+++ b/tools/styles/tokens/spectrum/light-vars.css
@@ -2,48 +2,19 @@
 :root {
     --spectrum-menu-item-background-color-default-rgb: 0, 0, 0;
     --spectrum-menu-item-background-color-default-opacity: 0;
-    --spectrum-menu-item-background-color-default: rgba(
-        var(--spectrum-menu-item-background-color-default-rgb),
-        var(--spectrum-menu-item-background-color-default-opacity)
-    );
-    --spectrum-menu-item-background-color-hover: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-menu-item-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-menu-item-background-color-key-focus: var(
-        --spectrum-transparent-black-200
-    );
+    --spectrum-menu-item-background-color-default: rgba(var(--spectrum-menu-item-background-color-default-rgb), var(--spectrum-menu-item-background-color-default-opacity));
+    --spectrum-menu-item-background-color-hover: var(--spectrum-transparent-black-200);
+    --spectrum-menu-item-background-color-down: var(--spectrum-transparent-black-200);
+    --spectrum-menu-item-background-color-key-focus: var(--spectrum-transparent-black-200);
     --spectrum-drop-zone-background-color-rgb: var(--spectrum-blue-800-rgb);
     --spectrum-dropindicator-color: var(--spectrum-blue-800);
-    --spectrum-calendar-day-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
-    --spectrum-calendar-day-background-color-hover: rgba(
-        var(--spectrum-black-rgb),
-        0.06
-    );
-    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-down: var(
-        --spectrum-transparent-black-200
-    );
-    --spectrum-calendar-day-background-color-cap-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-calendar-day-background-color-key-focus: rgba(
-        var(--spectrum-black-rgb),
-        0.06
-    );
+    --spectrum-calendar-day-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
+    --spectrum-calendar-day-background-color-hover: rgba(var(--spectrum-black-rgb), 0.06);
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-down: var(--spectrum-transparent-black-200);
+    --spectrum-calendar-day-background-color-cap-selected: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-calendar-day-background-color-key-focus: rgba(var(--spectrum-black-rgb), 0.06);
     --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-800);
     --spectrum-card-selected-background-color-rgb: var(--spectrum-blue-900-rgb);
     --spectrum-badge-label-icon-color-primary: var(--spectrum-white);
@@ -51,55 +22,29 @@
     --spectrum-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
     --spectrum-coach-indicator-ring-light-color: var(--spectrum-gray-50);
     --spectrum-well-border-color: var(--spectrum-black);
-    --spectrum-steplist-current-marker-color-key-focus: var(
-        --spectrum-blue-800
-    );
-    --spectrum-treeview-item-background-color-quiet-selected: rgba(
-        var(--spectrum-gray-900-rgb),
-        0.06
-    );
-    --spectrum-treeview-item-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
+    --spectrum-steplist-current-marker-color-key-focus: var(--spectrum-blue-800);
+    --spectrum-treeview-item-background-color-quiet-selected: rgba(var(--spectrum-gray-900-rgb), 0.06);
+    --spectrum-treeview-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
     --spectrum-logic-button-and-background-color: var(--spectrum-blue-900);
     --spectrum-logic-button-and-border-color: var(--spectrum-blue-900);
-    --spectrum-logic-button-and-background-color-hover: var(
-        --spectrum-blue-1100
-    );
+    --spectrum-logic-button-and-background-color-hover: var(--spectrum-blue-1100);
     --spectrum-logic-button-and-border-color-hover: var(--spectrum-blue-1100);
     --spectrum-logic-button-or-background-color: var(--spectrum-magenta-900);
     --spectrum-logic-button-or-border-color: var(--spectrum-magenta-900);
-    --spectrum-logic-button-or-background-color-hover: var(
-        --spectrum-magenta-1100
-    );
+    --spectrum-logic-button-or-background-color-hover: var(--spectrum-magenta-1100);
     --spectrum-logic-button-or-border-color-hover: var(--spectrum-magenta-1100);
     --spectrum-assetcard-border-color-selected: var(--spectrum-blue-900);
     --spectrum-assetcard-border-color-selected-hover: var(--spectrum-blue-900);
     --spectrum-assetcard-border-color-selected-down: var(--spectrum-blue-1000);
-    --spectrum-assetcard-selectionindicator-background-color-ordered: var(
-        --spectrum-blue-900
-    );
+    --spectrum-assetcard-selectionindicator-background-color-ordered: var(--spectrum-blue-900);
     --spectrum-assestcard-focus-indicator-color: var(--spectrum-blue-800);
-    --spectrum-assetlist-item-background-color-selected-hover: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.2
-    );
-    --spectrum-assetlist-item-background-color-selected: rgba(
-        var(--spectrum-blue-900-rgb),
-        0.1
-    );
+    --spectrum-assetlist-item-background-color-selected-hover: rgba(var(--spectrum-blue-900-rgb), 0.2);
+    --spectrum-assetlist-item-background-color-selected: rgba(var(--spectrum-blue-900-rgb), 0.1);
     --spectrum-assetlist-border-color-key-focus: var(--spectrum-blue-800);
     --spectrum-swatch-border-color-rgb: 0, 0, 0;
     --spectrum-swatch-border-color-opacity: 0.51;
-    --spectrum-swatch-border-color: rgba(
-        var(--spectrum-swatch-border-color-rgb),
-        var(--spectrum-swatch-border-color-opacity)
-    );
+    --spectrum-swatch-border-color: rgba(var(--spectrum-swatch-border-color-rgb), var(--spectrum-swatch-border-color-opacity));
     --spectrum-swatch-border-color-light-rgb: 0, 0, 0;
     --spectrum-swatch-border-color-light-opacity: 0.2;
-    --spectrum-swatch-border-color-light: rgba(
-        var(--spectrum-swatch-border-color-light-rgb),
-        var(--spectrum-swatch-border-color-light-opacity)
-    );
+    --spectrum-swatch-border-color-light: rgba(var(--spectrum-swatch-border-color-light-rgb), var(--spectrum-swatch-border-color-light-opacity));
 }

--- a/tools/styles/tokens/spectrum/medium-vars.css
+++ b/tools/styles/tokens/spectrum/medium-vars.css
@@ -50,8 +50,8 @@
     --spectrum-drop-shadow-blur: 4px;
     --spectrum-slider-tick-mark-height: 10px;
     --spectrum-slider-ramp-track-height: 16px;
-    --spectrum-colorwheel-path: 'M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0';
-    --spectrum-colorwheel-path-borders: 'M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0';
+    --spectrum-colorwheel-path: "M 95 95 m -95 0 a 95 95 0 1 0 190 0 a 95 95 0 1 0 -190 0.2 M 95 95 m -73 0 a 73 73 0 1 0 146 0 a 73 73 0 1 0 -146 0";
+    --spectrum-colorwheel-path-borders: "M 96 96 m -96 0 a 96 96 0 1 0 192 0 a 96 96 0 1 0 -192 0.2 M 96 96 m -72 0 a 72 72 0 1 0 144 0 a 72 72 0 1 0 -144 0";
     --spectrum-colorwheel-colorarea-container-size: 144px;
     --spectrum-colorloupe-checkerboard-fill: url(#checkerboard-primary);
     --spectrum-contextual-help-content-spacing: var(--spectrum-spacing-100);
@@ -79,9 +79,7 @@
     --spectrum-alert-banner-close-button-spacing: var(--spectrum-spacing-100);
     --spectrum-alert-banner-edge-to-divider: var(--spectrum-spacing-100);
     --spectrum-alert-banner-edge-to-button: var(--spectrum-spacing-100);
-    --spectrum-alert-banner-text-to-button-vertical: var(
-        --spectrum-spacing-100
-    );
+    --spectrum-alert-banner-text-to-button-vertical: var(--spectrum-spacing-100);
     --spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
     --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
     --spectrum-coach-indicator-gap: 6px;
@@ -100,9 +98,7 @@
     --spectrum-treeview-item-indentation-medium: var(--spectrum-spacing-300);
     --spectrum-treeview-item-indentation-small: var(--spectrum-spacing-200);
     --spectrum-treeview-item-indentation-large: 20px;
-    --spectrum-treeview-item-indentation-extra-large: var(
-        --spectrum-spacing-400
-    );
+    --spectrum-treeview-item-indentation-extra-large: var(--spectrum-spacing-400);
     --spectrum-treeview-indicator-inset-block-start: 5px;
     --spectrum-treeview-item-min-block-size-thumbnail-offset-medium: 0px;
     --spectrum-dialog-confirm-entry-animation-distance: 20px;
@@ -132,9 +128,7 @@
     --spectrum-assetcard-focus-ring-border-radius: 8px;
     --spectrum-assetcard-selectionindicator-margin: 12px;
     --spectrum-assetcard-title-font-size: var(--spectrum-heading-size-xs);
-    --spectrum-assetcard-header-content-font-size: var(
-        --spectrum-heading-size-xs
-    );
+    --spectrum-assetcard-header-content-font-size: var(--spectrum-heading-size-xs);
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
     --spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);
     --spectrum-ui-icon-medium-display: block;

--- a/tools/styles/tokens/spectrum/system-theme-bridge.css
+++ b/tools/styles/tokens/spectrum/system-theme-bridge.css
@@ -10,144 +10,64 @@
     --system-action-button-background-color-down: var(--spectrum-gray-300);
     --system-action-button-background-color-focus: var(--spectrum-gray-200);
     --system-action-button-background-color-disabled: transparent;
-    --system-action-button-background-color-selected: var(
-        --spectrum-neutral-background-color-selected-default
-    );
-    --system-action-button-background-color-selected-hover: var(
-        --spectrum-neutral-background-color-selected-hover
-    );
-    --system-action-button-background-color-selected-down: var(
-        --spectrum-neutral-background-color-selected-down
-    );
-    --system-action-button-background-color-selected-focus: var(
-        --spectrum-neutral-background-color-selected-key-focus
-    );
+    --system-action-button-background-color-selected: var(--spectrum-neutral-background-color-selected-default);
+    --system-action-button-background-color-selected-hover: var(--spectrum-neutral-background-color-selected-hover);
+    --system-action-button-background-color-selected-down: var(--spectrum-neutral-background-color-selected-down);
+    --system-action-button-background-color-selected-focus: var(--spectrum-neutral-background-color-selected-key-focus);
     --system-action-button-border-color-default: var(--spectrum-gray-400);
     --system-action-button-border-color-hover: var(--spectrum-gray-500);
     --system-action-button-border-color-down: var(--spectrum-gray-600);
     --system-action-button-border-color-focus: var(--spectrum-gray-500);
-    --system-action-button-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
+    --system-action-button-border-color-disabled: var(--spectrum-disabled-border-color);
     --system-action-button-content-color-selected: var(--spectrum-gray-75);
-    --system-action-button-size-m-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
-    --system-action-button-size-xs-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
-    --system-action-button-size-s-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
-    --system-action-button-size-l-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
-    --system-action-button-size-xl-border-radius-default: var(
-        --spectrum-corner-radius-100
-    );
+    --system-action-button-size-m-border-radius-default: var(--spectrum-corner-radius-100);
+    --system-action-button-size-xs-border-radius-default: var(--spectrum-corner-radius-100);
+    --system-action-button-size-s-border-radius-default: var(--spectrum-corner-radius-100);
+    --system-action-button-size-l-border-radius-default: var(--spectrum-corner-radius-100);
+    --system-action-button-size-xl-border-radius-default: var(--spectrum-corner-radius-100);
     --system-action-button-quiet-background-color-default: transparent;
-    --system-action-button-quiet-background-color-hover: var(
-        --spectrum-gray-200
-    );
-    --system-action-button-quiet-background-color-down: var(
-        --spectrum-gray-300
-    );
-    --system-action-button-quiet-background-color-focus: var(
-        --spectrum-gray-200
-    );
+    --system-action-button-quiet-background-color-hover: var(--spectrum-gray-200);
+    --system-action-button-quiet-background-color-down: var(--spectrum-gray-300);
+    --system-action-button-quiet-background-color-focus: var(--spectrum-gray-200);
     --system-action-button-quiet-background-color-disabled: transparent;
-    --system-action-button-quiet-background-color-selected-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --system-action-button-static-black-border-color-default: var(
-        --spectrum-transparent-black-400
-    );
-    --system-action-button-static-black-border-color-hover: var(
-        --spectrum-transparent-black-500
-    );
-    --system-action-button-static-black-border-color-down: var(
-        --spectrum-transparent-black-600
-    );
-    --system-action-button-static-black-border-color-focus: var(
-        --spectrum-transparent-black-500
-    );
-    --system-action-button-static-black-border-color-disabled: var(
-        --spectrum-disabled-static-black-border-color
-    );
+    --system-action-button-quiet-background-color-selected-disabled: var(--spectrum-disabled-background-color);
+    --system-action-button-static-black-border-color-default: var(--spectrum-transparent-black-400);
+    --system-action-button-static-black-border-color-hover: var(--spectrum-transparent-black-500);
+    --system-action-button-static-black-border-color-down: var(--spectrum-transparent-black-600);
+    --system-action-button-static-black-border-color-focus: var(--spectrum-transparent-black-500);
+    --system-action-button-static-black-border-color-disabled: var(--spectrum-disabled-static-black-border-color);
     --system-action-button-static-black-background-color-disabled: transparent;
-    --system-action-button-static-black-background-color-selected-disabled: var(
-        --spectrum-disabled-static-black-background-color
-    );
+    --system-action-button-static-black-background-color-selected-disabled: var(--spectrum-disabled-static-black-background-color);
     --system-action-button-static-black-background-color-default: transparent;
-    --system-action-button-static-black-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-action-button-static-black-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-action-button-static-black-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
+    --system-action-button-static-black-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-action-button-static-black-background-color-down: var(--spectrum-transparent-black-400);
+    --system-action-button-static-black-background-color-focus: var(--spectrum-transparent-black-300);
     --system-action-button-static-black-quiet-background-color-default: transparent;
-    --system-action-button-static-black-quiet-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-action-button-static-black-quiet-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-action-button-static-black-quiet-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
+    --system-action-button-static-black-quiet-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-action-button-static-black-quiet-background-color-down: var(--spectrum-transparent-black-400);
+    --system-action-button-static-black-quiet-background-color-focus: var(--spectrum-transparent-black-300);
     --system-action-button-static-black-quiet-background-color-disabled: transparent;
-    --system-action-button-static-white-border-color-default: var(
-        --spectrum-transparent-white-400
-    );
-    --system-action-button-static-white-border-color-hover: var(
-        --spectrum-transparent-white-500
-    );
-    --system-action-button-static-white-border-color-down: var(
-        --spectrum-transparent-white-600
-    );
-    --system-action-button-static-white-border-color-focus: var(
-        --spectrum-transparent-white-500
-    );
-    --system-action-button-static-white-border-color-disabled: var(
-        --spectrum-disabled-static-white-border-color
-    );
+    --system-action-button-static-white-border-color-default: var(--spectrum-transparent-white-400);
+    --system-action-button-static-white-border-color-hover: var(--spectrum-transparent-white-500);
+    --system-action-button-static-white-border-color-down: var(--spectrum-transparent-white-600);
+    --system-action-button-static-white-border-color-focus: var(--spectrum-transparent-white-500);
+    --system-action-button-static-white-border-color-disabled: var(--spectrum-disabled-static-white-border-color);
     --system-action-button-static-white-background-color-disabled: transparent;
-    --system-action-button-static-white-background-color-selected-disabled: var(
-        --spectrum-disabled-static-white-background-color
-    );
+    --system-action-button-static-white-background-color-selected-disabled: var(--spectrum-disabled-static-white-background-color);
     --system-action-button-static-white-background-color-default: transparent;
-    --system-action-button-static-white-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-action-button-static-white-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-action-button-static-white-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
+    --system-action-button-static-white-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-action-button-static-white-background-color-down: var(--spectrum-transparent-white-400);
+    --system-action-button-static-white-background-color-focus: var(--spectrum-transparent-white-300);
     --system-action-button-static-white-quiet-background-color-default: transparent;
-    --system-action-button-static-white-quiet-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-action-button-static-white-quiet-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-action-button-static-white-quiet-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
+    --system-action-button-static-white-quiet-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-action-button-static-white-quiet-background-color-down: var(--spectrum-transparent-white-400);
+    --system-action-button-static-white-quiet-background-color-focus: var(--spectrum-transparent-white-300);
     --system-action-button-static-white-quiet-background-color-disabled: transparent;
-    --system-action-button-background-color-selected-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-action-button-background-color-selected-disabled: var(--spectrum-disabled-background-color);
     --system-action-group-gap-size-compact: 0;
     --system-action-group-horizontal-spacing-compact: -1px;
     --system-action-group-vertical-spacing-compact: -1px;
-    --system-alert-banner-neutral-background: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
+    --system-alert-banner-neutral-background: var(--spectrum-neutral-subdued-background-color-default);
     --system-asset-folder-background-color: var(--spectrum-gray-300);
     --system-asset-file-background-color: var(--spectrum-gray-50);
     --system-asset-icon-outline-color: var(--spectrum-gray-500);
@@ -160,255 +80,99 @@
     --system-button-border-color-down: var(--spectrum-gray-600);
     --system-button-border-color-focus: var(--spectrum-gray-500);
     --system-button-background-color-disabled: transparent;
-    --system-button-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
-    --system-button-selected-background-color-default: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
-    --system-button-selected-background-color-hover: var(
-        --spectrum-neutral-subdued-background-color-hover
-    );
-    --system-button-selected-background-color-down: var(
-        --spectrum-neutral-subdued-background-color-down
-    );
-    --system-button-selected-background-color-focus: var(
-        --spectrum-neutral-subdued-background-color-key-focus
-    );
+    --system-button-border-color-disabled: var(--spectrum-disabled-border-color);
+    --system-button-selected-background-color-default: var(--spectrum-neutral-subdued-background-color-default);
+    --system-button-selected-background-color-hover: var(--spectrum-neutral-subdued-background-color-hover);
+    --system-button-selected-background-color-down: var(--spectrum-neutral-subdued-background-color-down);
+    --system-button-selected-background-color-focus: var(--spectrum-neutral-subdued-background-color-key-focus);
     --system-button-primary-content-color-default: var(--spectrum-white);
     --system-button-primary-content-color-hover: var(--spectrum-white);
     --system-button-primary-content-color-down: var(--spectrum-white);
     --system-button-primary-content-color-focus: var(--spectrum-white);
-    --system-button-primary-outline-background-color-hover: var(
-        --spectrum-gray-300
-    );
-    --system-button-primary-outline-background-color-down: var(
-        --spectrum-gray-400
-    );
-    --system-button-primary-outline-background-color-focus: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-background-color-default: var(
-        --spectrum-gray-200
-    );
+    --system-button-primary-outline-background-color-hover: var(--spectrum-gray-300);
+    --system-button-primary-outline-background-color-down: var(--spectrum-gray-400);
+    --system-button-primary-outline-background-color-focus: var(--spectrum-gray-300);
+    --system-button-secondary-background-color-default: var(--spectrum-gray-200);
     --system-button-secondary-background-color-hover: var(--spectrum-gray-300);
     --system-button-secondary-background-color-down: var(--spectrum-gray-400);
     --system-button-secondary-background-color-focus: var(--spectrum-gray-300);
-    --system-button-secondary-outline-background-color-hover: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-outline-background-color-down: var(
-        --spectrum-gray-400
-    );
-    --system-button-secondary-outline-background-color-focus: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-outline-border-color-default: var(
-        --spectrum-gray-300
-    );
-    --system-button-secondary-outline-border-color-down: var(
-        --spectrum-gray-500
-    );
-    --system-button-static-white-background-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-background-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-background-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-background-color-focus: var(
-        --spectrum-transparent-white-900
-    );
+    --system-button-secondary-outline-background-color-hover: var(--spectrum-gray-300);
+    --system-button-secondary-outline-background-color-down: var(--spectrum-gray-400);
+    --system-button-secondary-outline-background-color-focus: var(--spectrum-gray-300);
+    --system-button-secondary-outline-border-color-default: var(--spectrum-gray-300);
+    --system-button-secondary-outline-border-color-down: var(--spectrum-gray-500);
+    --system-button-static-white-background-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-background-color-hover: var(--spectrum-transparent-white-900);
+    --system-button-static-white-background-color-down: var(--spectrum-transparent-white-900);
+    --system-button-static-white-background-color-focus: var(--spectrum-transparent-white-900);
     --system-button-static-white-content-color-default: var(--spectrum-black);
     --system-button-static-white-content-color-hover: var(--spectrum-black);
     --system-button-static-white-content-color-down: var(--spectrum-black);
     --system-button-static-white-content-color-focus: var(--spectrum-black);
-    --system-button-static-white-outline-background-color-default: var(
-        --spectrum-transparent-white-25
-    );
-    --system-button-static-white-outline-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-outline-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-outline-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-outline-content-color-default: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-content-color-down: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-content-color-focus: var(
-        --spectrum-white
-    );
-    --system-button-static-white-outline-border-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-outline-border-color-hover: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-border-color-down: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-outline-border-color-focus: var(
-        --spectrum-transparent-white-900
-    );
-    --system-button-static-white-secondary-background-color-default: var(
-        --spectrum-transparent-white-200
-    );
-    --system-button-static-white-secondary-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-secondary-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-secondary-content-color-default: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-content-color-down: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-content-color-focus: var(
-        --spectrum-white
-    );
-    --system-button-static-white-secondary-outline-border-color-default: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-secondary-outline-border-color-hover: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-border-color-down: var(
-        --spectrum-transparent-white-500
-    );
-    --system-button-static-white-secondary-outline-border-color-focus: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-background-color-default: var(
-        --spectrum-transparent-white-800
-    );
-    --system-button-static-white-secondary-outline-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-white-secondary-outline-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-button-static-white-secondary-outline-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-button-static-black-background-color-default: var(
-        --spectrum-transparent-black-800
-    );
-    --system-button-static-black-background-color-hover: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-background-color-down: var(
-        --spectrum-transparent-black-900
-    );
-    --system-button-static-black-background-color-focus: var(
-        --spectrum-transparent-black-900
-    );
+    --system-button-static-white-outline-background-color-default: var(--spectrum-transparent-white-25);
+    --system-button-static-white-outline-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-button-static-white-outline-background-color-down: var(--spectrum-transparent-white-400);
+    --system-button-static-white-outline-background-color-focus: var(--spectrum-transparent-white-300);
+    --system-button-static-white-outline-content-color-default: var(--spectrum-white);
+    --system-button-static-white-outline-content-color-hover: var(--spectrum-white);
+    --system-button-static-white-outline-content-color-down: var(--spectrum-white);
+    --system-button-static-white-outline-content-color-focus: var(--spectrum-white);
+    --system-button-static-white-outline-border-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-outline-border-color-hover: var(--spectrum-transparent-white-900);
+    --system-button-static-white-outline-border-color-down: var(--spectrum-transparent-white-900);
+    --system-button-static-white-outline-border-color-focus: var(--spectrum-transparent-white-900);
+    --system-button-static-white-secondary-background-color-default: var(--spectrum-transparent-white-200);
+    --system-button-static-white-secondary-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-button-static-white-secondary-background-color-down: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-background-color-focus: var(--spectrum-transparent-white-300);
+    --system-button-static-white-secondary-content-color-default: var(--spectrum-white);
+    --system-button-static-white-secondary-content-color-hover: var(--spectrum-white);
+    --system-button-static-white-secondary-content-color-down: var(--spectrum-white);
+    --system-button-static-white-secondary-content-color-focus: var(--spectrum-white);
+    --system-button-static-white-secondary-outline-border-color-default: var(--spectrum-transparent-white-300);
+    --system-button-static-white-secondary-outline-border-color-hover: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-outline-border-color-down: var(--spectrum-transparent-white-500);
+    --system-button-static-white-secondary-outline-border-color-focus: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-outline-background-color-default: var(--spectrum-transparent-white-800);
+    --system-button-static-white-secondary-outline-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-button-static-white-secondary-outline-background-color-down: var(--spectrum-transparent-white-400);
+    --system-button-static-white-secondary-outline-background-color-focus: var(--spectrum-transparent-white-300);
+    --system-button-static-black-background-color-default: var(--spectrum-transparent-black-800);
+    --system-button-static-black-background-color-hover: var(--spectrum-transparent-black-900);
+    --system-button-static-black-background-color-down: var(--spectrum-transparent-black-900);
+    --system-button-static-black-background-color-focus: var(--spectrum-transparent-black-900);
     --system-button-static-black-content-color-default: var(--spectrum-white);
     --system-button-static-black-content-color-hover: var(--spectrum-white);
     --system-button-static-black-content-color-down: var(--spectrum-white);
     --system-button-static-black-content-color-focus: var(--spectrum-white);
-    --system-button-static-black-outline-background-color-default: var(
-        --spectrum-transparent-black-25
-    );
-    --system-button-static-black-outline-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-outline-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-outline-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-outline-content-color-default: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-content-color-hover: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-content-color-down: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-content-color-focus: var(
-        --spectrum-black
-    );
-    --system-button-static-black-outline-border-color-default: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-outline-border-color-hover: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-outline-border-color-down: var(
-        --spectrum-transparent-black-600
-    );
-    --system-button-static-black-outline-border-color-focus: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-secondary-background-color-default: var(
-        --spectrum-transparent-black-200
-    );
-    --system-button-static-black-secondary-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-secondary-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-secondary-content-color-default: var(
-        --spectrum-black
-    );
-    --system-button-static-black-secondary-content-color-hover: var(
-        --spectrum-black
-    );
-    --system-button-static-black-secondary-content-color-down: var(
-        --spectrum-black
-    );
-    --system-button-static-black-secondary-content-color-focus: var(
-        --spectrum-black
-    );
-    --system-button-static-black-secondary-outline-border-color-default: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-secondary-outline-border-color-hover: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-border-color-down: var(
-        --spectrum-transparent-black-500
-    );
-    --system-button-static-black-secondary-outline-border-color-focus: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-background-color-default: var(
-        --spectrum-transparent-black-800
-    );
-    --system-button-static-black-secondary-outline-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-button-static-black-secondary-outline-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-button-static-black-secondary-outline-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
+    --system-button-static-black-outline-background-color-default: var(--spectrum-transparent-black-25);
+    --system-button-static-black-outline-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-button-static-black-outline-background-color-down: var(--spectrum-transparent-black-400);
+    --system-button-static-black-outline-background-color-focus: var(--spectrum-transparent-black-300);
+    --system-button-static-black-outline-content-color-default: var(--spectrum-black);
+    --system-button-static-black-outline-content-color-hover: var(--spectrum-black);
+    --system-button-static-black-outline-content-color-down: var(--spectrum-black);
+    --system-button-static-black-outline-content-color-focus: var(--spectrum-black);
+    --system-button-static-black-outline-border-color-default: var(--spectrum-transparent-black-400);
+    --system-button-static-black-outline-border-color-hover: var(--spectrum-transparent-black-500);
+    --system-button-static-black-outline-border-color-down: var(--spectrum-transparent-black-600);
+    --system-button-static-black-outline-border-color-focus: var(--spectrum-transparent-black-500);
+    --system-button-static-black-secondary-background-color-default: var(--spectrum-transparent-black-200);
+    --system-button-static-black-secondary-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-button-static-black-secondary-background-color-down: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-background-color-focus: var(--spectrum-transparent-black-300);
+    --system-button-static-black-secondary-content-color-default: var(--spectrum-black);
+    --system-button-static-black-secondary-content-color-hover: var(--spectrum-black);
+    --system-button-static-black-secondary-content-color-down: var(--spectrum-black);
+    --system-button-static-black-secondary-content-color-focus: var(--spectrum-black);
+    --system-button-static-black-secondary-outline-border-color-default: var(--spectrum-transparent-black-300);
+    --system-button-static-black-secondary-outline-border-color-hover: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-outline-border-color-down: var(--spectrum-transparent-black-500);
+    --system-button-static-black-secondary-outline-border-color-focus: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-outline-background-color-default: var(--spectrum-transparent-black-800);
+    --system-button-static-black-secondary-outline-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-button-static-black-secondary-outline-background-color-down: var(--spectrum-transparent-black-400);
+    --system-button-static-black-secondary-outline-background-color-focus: var(--spectrum-transparent-black-300);
     --system-checkbox-control-color-default: var(--spectrum-gray-600);
     --system-checkbox-control-color-hover: var(--spectrum-gray-700);
     --system-checkbox-control-color-down: var(--spectrum-gray-800);
@@ -418,9 +182,7 @@
     --system-card-border-color: var(--spectrum-gray-200);
     --system-card-border-color-hover: var(--spectrum-gray-300);
     --system-card-divider-color: var(--spectrum-gray-300);
-    --system-card-preview-background-color: var(
-        --spectrum-background-base-color
-    );
+    --system-card-preview-background-color: var(--spectrum-background-base-color);
     --system-card-preview-background-color-hover: var(--spectrum-gray-300);
     --system-clear-button-background-color: transparent;
     --system-clear-button-background-color-hover: transparent;
@@ -429,146 +191,60 @@
     --system-clear-button-height: var(--spectrum-component-height-100);
     --system-clear-button-width: var(--spectrum-component-height-100);
     --system-clear-button-padding: var(--spectrum-in-field-button-edge-to-fill);
-    --system-clear-button-icon-color: var(
-        --spectrum-neutral-content-color-default
-    );
-    --system-clear-button-icon-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --system-clear-button-icon-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --system-clear-button-icon-color-key-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
+    --system-clear-button-icon-color: var(--spectrum-neutral-content-color-default);
+    --system-clear-button-icon-color-hover: var(--spectrum-neutral-content-color-hover);
+    --system-clear-button-icon-color-down: var(--spectrum-neutral-content-color-down);
+    --system-clear-button-icon-color-key-focus: var(--spectrum-neutral-content-color-key-focus);
     --system-clear-button-size-s-height: var(--spectrum-component-height-75);
     --system-clear-button-size-s-width: var(--spectrum-component-height-75);
     --system-clear-button-size-l-height: var(--spectrum-component-height-200);
     --system-clear-button-size-l-width: var(--spectrum-component-height-200);
     --system-clear-button-size-xl-height: var(--spectrum-component-height-300);
     --system-clear-button-size-xl-width: var(--spectrum-component-height-300);
-    --system-clear-button-quiet-background-color: var(
-        --spectrum-clear-button-background-color-quiet,
-        transparent
-    );
-    --system-clear-button-quiet-background-color-hover: var(
-        --spectrum-clear-button-background-color-hover-quiet,
-        transparent
-    );
-    --system-clear-button-quiet-background-color-down: var(
-        --spectrum-clear-button-background-color-down-quiet,
-        transparent
-    );
-    --system-clear-button-quiet-background-color-key-focus: var(
-        --spectrum-clear-button-background-color-key-focus-quiet,
-        transparent
-    );
-    --system-clear-button-over-background-icon-color: var(
-        --spectrum-clear-button-icon-color-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-icon-color-hover: var(
-        --spectrum-clear-button-icon-color-hover-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-icon-color-down: var(
-        --spectrum-clear-button-icon-color-down-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-icon-color-key-focus: var(
-        --spectrum-clear-button-icon-color-key-focus-over-background,
-        var(--spectrum-white)
-    );
-    --system-clear-button-over-background-background-color: var(
-        --spectrum-clear-button-background-color-over-background,
-        transparent
-    );
-    --system-clear-button-over-background-background-color-hover: var(
-        --spectrum-clear-button-background-color-hover-over-background,
-        var(--spectrum-transparent-white-300)
-    );
-    --system-clear-button-over-background-background-color-down: var(
-        --spectrum-clear-button-background-color-hover-over-background,
-        var(--spectrum-transparent-white-400)
-    );
-    --system-clear-button-over-background-background-color-key-focus: var(
-        --spectrum-clear-button-background-color-hover-over-background,
-        var(--spectrum-transparent-white-300)
-    );
-    --system-clear-button-disabled-icon-color: var(
-        --spectrum-disabled-content-color
-    );
-    --system-clear-button-disabled-icon-color-hover: var(
-        --spectrum-clear-button-icon-color-hover-disabled,
-        var(--spectrum-disabled-content-color)
-    );
-    --system-clear-button-disabled-icon-color-down: var(
-        --spectrum-clear-button-icon-color-down-disabled,
-        var(--spectrum-disabled-content-color)
-    );
+    --system-clear-button-quiet-background-color: var(--spectrum-clear-button-background-color-quiet, transparent);
+    --system-clear-button-quiet-background-color-hover: var(--spectrum-clear-button-background-color-hover-quiet, transparent);
+    --system-clear-button-quiet-background-color-down: var(--spectrum-clear-button-background-color-down-quiet, transparent);
+    --system-clear-button-quiet-background-color-key-focus: var(--spectrum-clear-button-background-color-key-focus-quiet, transparent);
+    --system-clear-button-over-background-icon-color: var(--spectrum-clear-button-icon-color-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-icon-color-hover: var(--spectrum-clear-button-icon-color-hover-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-icon-color-down: var(--spectrum-clear-button-icon-color-down-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-icon-color-key-focus: var(--spectrum-clear-button-icon-color-key-focus-over-background, var(--spectrum-white));
+    --system-clear-button-over-background-background-color: var(--spectrum-clear-button-background-color-over-background, transparent);
+    --system-clear-button-over-background-background-color-hover: var(--spectrum-clear-button-background-color-hover-over-background, var(--spectrum-transparent-white-300));
+    --system-clear-button-over-background-background-color-down: var(--spectrum-clear-button-background-color-hover-over-background, var(--spectrum-transparent-white-400));
+    --system-clear-button-over-background-background-color-key-focus: var(--spectrum-clear-button-background-color-hover-over-background, var(--spectrum-transparent-white-300));
+    --system-clear-button-disabled-icon-color: var(--spectrum-disabled-content-color);
+    --system-clear-button-disabled-icon-color-hover: var(--spectrum-clear-button-icon-color-hover-disabled, var(--spectrum-disabled-content-color));
+    --system-clear-button-disabled-icon-color-down: var(--spectrum-clear-button-icon-color-down-disabled, var(--spectrum-disabled-content-color));
     --system-clear-button-disabled-background-color: transparent;
     --system-close-button-background-color-default: transparent;
     --system-close-button-background-color-hover: var(--spectrum-gray-200);
     --system-close-button-background-color-down: var(--spectrum-gray-300);
     --system-close-button-background-color-focus: var(--spectrum-gray-200);
-    --system-close-button-static-white-static-background-color-hover: var(
-        --spectrum-transparent-white-300
-    );
-    --system-close-button-static-white-static-background-color-down: var(
-        --spectrum-transparent-white-400
-    );
-    --system-close-button-static-white-static-background-color-focus: var(
-        --spectrum-transparent-white-300
-    );
-    --system-close-button-static-black-static-background-color-hover: var(
-        --spectrum-transparent-black-300
-    );
-    --system-close-button-static-black-static-background-color-down: var(
-        --spectrum-transparent-black-400
-    );
-    --system-close-button-static-black-static-background-color-focus: var(
-        --spectrum-transparent-black-300
-    );
+    --system-close-button-static-white-static-background-color-hover: var(--spectrum-transparent-white-300);
+    --system-close-button-static-white-static-background-color-down: var(--spectrum-transparent-white-400);
+    --system-close-button-static-white-static-background-color-focus: var(--spectrum-transparent-white-300);
+    --system-close-button-static-black-static-background-color-hover: var(--spectrum-transparent-black-300);
+    --system-close-button-static-black-static-background-color-down: var(--spectrum-transparent-black-400);
+    --system-close-button-static-black-static-background-color-focus: var(--spectrum-transparent-black-300);
     --system-coach-indicator-ring-border-size: var(--spectrum-border-width-200);
-    --system-coach-indicator-min-inline-size: calc(
-        var(--spectrum-coach-indicator-ring-diameter) * 3
-    );
-    --system-coach-indicator-min-block-size: calc(
-        var(--spectrum-coach-indicator-ring-diameter) * 3
-    );
-    --system-coach-indicator-inline-size: var(
-        --system-coach-indicator-min-inline-size
-    );
-    --system-coach-indicator-block-size: var(
-        --system-coach-indicator-min-block-size
-    );
-    --system-coach-indicator-ring-inline-size: var(
-        --spectrum-coach-indicator-ring-diameter
-    );
-    --system-coach-indicator-ring-block-size: var(
-        --spectrum-coach-indicator-ring-diameter
-    );
+    --system-coach-indicator-min-inline-size: calc(var(--spectrum-coach-indicator-ring-diameter) * 3);
+    --system-coach-indicator-min-block-size: calc(var(--spectrum-coach-indicator-ring-diameter) * 3);
+    --system-coach-indicator-inline-size: var(--system-coach-indicator-min-inline-size);
+    --system-coach-indicator-block-size: var(--system-coach-indicator-min-block-size);
+    --system-coach-indicator-ring-inline-size: var(--spectrum-coach-indicator-ring-diameter);
+    --system-coach-indicator-ring-block-size: var(--spectrum-coach-indicator-ring-diameter);
     --system-coach-indicator-ring-dark-color: var(--spectrum-gray-900);
     --system-coach-indicator-ring-light-color: var(--spectrum-gray-50);
-    --system-coach-indicator-top: calc(
-        var(--system-coach-indicator-block-size) / 3 -
-            var(--system-coach-indicator-ring-border-size)
-    );
-    --system-coach-indicator-left: calc(
-        var(--system-coach-indicator-inline-size) / 3 -
-            var(--system-coach-indicator-ring-border-size)
-    );
-    --system-coach-indicator-coach-animation-indicator-ring-duration: var(
-        --spectrum-animation-duration-6000
-    );
+    --system-coach-indicator-top: calc(var(--system-coach-indicator-block-size) / 3 - var(--system-coach-indicator-ring-border-size));
+    --system-coach-indicator-left: calc(var(--system-coach-indicator-inline-size) / 3 - var(--system-coach-indicator-ring-border-size));
+    --system-coach-indicator-coach-animation-indicator-ring-duration: var(--spectrum-animation-duration-6000);
     --system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple: -0.5;
     --system-coach-indicator-coach-animation-indicator-ring-center-delay-multiple: -0.66;
     --system-coach-indicator-coach-animation-indicator-ring-outer-delay-multiple: -1;
     --system-coach-indicator-quiet-animation-ring-inner-delay-multiple: -0.33;
     --system-coach-indicator-animation-name: pulse;
-    --system-coach-indicator-inner-animation-delay-multiple: var(
-        --system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple
-    );
+    --system-coach-indicator-inner-animation-delay-multiple: var(--system-coach-indicator-coach-animation-indicator-ring-inner-delay-multiple);
     --system-coach-indicator-animation-keyframe-0-scale: 1;
     --system-coach-indicator-animation-keyframe-0-opacity: 0;
     --system-coach-indicator-animation-keyframe-50-scale: 1.5;
@@ -576,65 +252,39 @@
     --system-coach-indicator-animation-keyframe-100-scale: 2;
     --system-coach-indicator-animation-keyframe-100-opacity: 0;
     --system-coach-indicator-quiet-animation-keyframe-0-scale: 0.8;
-    --system-coach-indicator-quiet-quiet-ring-diameter-size: var(
-        --spectrum-coach-indicator-quiet-ring-diameter
-    );
+    --system-coach-indicator-quiet-quiet-ring-diameter-size: var(--spectrum-coach-indicator-quiet-ring-diameter);
     --system-coach-indicator-quiet-animation-name: pulse-quiet;
     --system-coach-mark-min-width: var(--spectrum-coach-mark-minimum-width);
     --system-coach-mark-width: var(--spectrum-coach-mark-width);
     --system-coach-mark-max-width: var(--spectrum-coach-mark-maximum-width);
     --system-coach-mark-media-height: var(--spectrum-coach-mark-media-height);
-    --system-coach-mark-media-min-height: var(
-        --spectrum-coach-mark-media-minimum-height
-    );
+    --system-coach-mark-media-min-height: var(--spectrum-coach-mark-media-minimum-height);
     --system-coach-mark-padding: var(--spectrum-coach-mark-edge-to-content);
     --system-coach-mark-heading-to-action-button: var(--spectrum-spacing-300);
     --system-coach-mark-header-to-body: var(--spectrum-spacing-200);
     --system-coach-mark-body-to-footer: var(--spectrum-spacing-300);
     --system-coach-mark-title-color: var(--spectrum-heading-color);
     --system-coach-mark-title-font-family: var(--spectrum-sans-serif-font);
-    --system-coach-mark-title-font-style: var(
-        --spectrum-heading-serif-font-style
-    );
-    --system-coach-mark-title-text-font-weight: var(
-        --spectrum-heading-sans-serif-font-weight
-    );
+    --system-coach-mark-title-font-style: var(--spectrum-heading-serif-font-style);
+    --system-coach-mark-title-text-font-weight: var(--spectrum-heading-sans-serif-font-weight);
     --system-coach-mark-title-font-size: var(--spectrum-coach-mark-title-size);
-    --system-coach-mark-title-text-line-height: var(
-        --spectrum-heading-line-height
-    );
+    --system-coach-mark-title-text-line-height: var(--spectrum-heading-line-height);
     --system-coach-mark-content-font-color: var(--spectrum-body-color);
-    --system-coach-mark-content-font-weight: var(
-        --spectrum-body-sans-serif-font-weight
-    );
+    --system-coach-mark-content-font-weight: var(--spectrum-body-sans-serif-font-weight);
     --system-coach-mark-content-font-family: var(--spectrum-sans-serif-font);
-    --system-coach-mark-content-font-style: var(
-        --spectrum-body-sans-serif-font-style
-    );
+    --system-coach-mark-content-font-style: var(--spectrum-body-sans-serif-font-style);
     --system-coach-mark-content-line-height: var(--spectrum-body-line-height);
     --system-coach-mark-content-font-size: var(--spectrum-coach-mark-body-size);
     --system-coach-mark-step-color: var(--spectrum-coach-mark-pagination-color);
-    --system-coach-mark-step-font-weight: var(
-        --spectrum-body-medium-font-weight
-    );
+    --system-coach-mark-step-font-weight: var(--spectrum-body-medium-font-weight);
     --system-coach-mark-step-font-family: var(--spectrum-sans-serif-font);
-    --system-coach-mark-step-font-style: var(
-        --spectrum-body-sans-serif-font-style
-    );
+    --system-coach-mark-step-font-style: var(--spectrum-body-sans-serif-font-style);
     --system-coach-mark-step-line-height: var(--spectrum-body-line-height);
-    --system-coach-mark-step-font-size: var(
-        --spectrum-coach-mark-pagination-body-size
-    );
-    --system-coach-mark-step-to-bottom: var(
-        --spectrum-coach-mark-pagination-text-to-bottom-edge
-    );
+    --system-coach-mark-step-font-size: var(--spectrum-coach-mark-pagination-body-size);
+    --system-coach-mark-step-to-bottom: var(--spectrum-coach-mark-pagination-text-to-bottom-edge);
     --system-coach-mark-popover-border-width: var(--spectrum-border-width-100);
-    --system-coach-mark-popover-corner-radius: var(
-        --spectrum-corner-radius-100
-    );
-    --system-coach-mark-buttongroup-spacing-horizontal: var(
-        --spectrum-spacing-100
-    );
+    --system-coach-mark-popover-corner-radius: var(--spectrum-corner-radius-100);
+    --system-coach-mark-buttongroup-spacing-horizontal: var(--spectrum-spacing-100);
     --system-color-wheel-border-color: var(--spectrum-transparent-black-200);
     --system-combobox-border-color-default: var(--spectrum-gray-500);
     --system-combobox-border-color-hover: var(--spectrum-gray-600);
@@ -642,89 +292,48 @@
     --system-combobox-border-color-focus-hover: var(--spectrum-gray-600);
     --system-combobox-border-color-key-focus: var(--spectrum-gray-600);
     --system-combobox-readonly-input-border-color: var(--spectrum-gray-500);
-    --system-combobox-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-combobox-background-color-disabled: var(--spectrum-disabled-background-color);
     --system-combobox-border-color-disabled: transparent;
     --system-dialog-fullscreen-header-text-size: 28px;
     --system-dialog-min-inline-size: 288px;
     --system-dialog-confirm-small-width: 400px;
     --system-dialog-confirm-medium-width: 480px;
     --system-dialog-confirm-large-width: 640px;
-    --system-dialog-confirm-divider-block-spacing-start: var(
-        --spectrum-spacing-300
-    );
-    --system-dialog-confirm-divider-block-spacing-end: var(
-        --spectrum-spacing-200
-    );
+    --system-dialog-confirm-divider-block-spacing-start: var(--spectrum-spacing-300);
+    --system-dialog-confirm-divider-block-spacing-end: var(--spectrum-spacing-200);
     --system-dialog-confirm-description-text-color: var(--spectrum-gray-800);
     --system-dialog-confirm-title-text-color: var(--spectrum-gray-900);
-    --system-dialog-confirm-description-text-line-height: var(
-        --spectrum-line-height-100
-    );
-    --system-dialog-confirm-title-text-line-height: var(
-        --spectrum-line-height-100
-    );
-    --system-dialog-heading-font-weight: var(
-        --spectrum-heading-sans-serif-font-weight
-    );
+    --system-dialog-confirm-description-text-line-height: var(--spectrum-line-height-100);
+    --system-dialog-confirm-title-text-line-height: var(--spectrum-line-height-100);
+    --system-dialog-heading-font-weight: var(--spectrum-heading-sans-serif-font-weight);
     --system-dialog-confirm-description-padding: var(--spectrum-spacing-50);
-    --system-dialog-confirm-description-margin: calc(
-        var(--spectrum-spacing-50) * -1
-    );
+    --system-dialog-confirm-description-margin: calc(var(--spectrum-spacing-50) * -1);
     --system-dialog-confirm-footer-padding-top: var(--spectrum-spacing-600);
-    --system-dialog-confirm-gap-size: var(
-        --spectrum-component-pill-edge-to-text-100
-    );
-    --system-dialog-confirm-buttongroup-padding-top: var(
-        --spectrum-spacing-600
-    );
-    --system-dialog-confirm-close-button-size: var(
-        --spectrum-component-height-100
-    );
-    --system-dialog-confirm-close-button-padding: calc(
-        26px - var(--spectrum-component-bottom-to-text-300)
-    );
+    --system-dialog-confirm-gap-size: var(--spectrum-component-pill-edge-to-text-100);
+    --system-dialog-confirm-buttongroup-padding-top: var(--spectrum-spacing-600);
+    --system-dialog-confirm-close-button-size: var(--spectrum-component-height-100);
+    --system-dialog-confirm-close-button-padding: calc(26px - var(--spectrum-component-bottom-to-text-300));
     --system-dialog-confirm-divider-height: var(--spectrum-spacing-50);
     --system-divider-background-color: var(--spectrum-gray-300);
-    --system-divider-background-color-static-white: var(
-        --spectrum-transparent-white-300
-    );
-    --system-divider-background-color-static-black: var(
-        --spectrum-transparent-black-300
-    );
+    --system-divider-background-color-static-white: var(--spectrum-transparent-white-300);
+    --system-divider-background-color-static-black: var(--spectrum-transparent-black-300);
     --system-drop-zone-border-color: var(--spectrum-gray-300);
     --system-field-group-margin: var(--spectrum-spacing-300);
-    --system-field-group-readonly-delimiter: ',';
+    --system-field-group-readonly-delimiter: ",";
     --system-infield-button-border-width: var(--spectrum-border-width-100);
     --system-infield-button-border-color: inherit;
     --system-infield-button-border-radius: var(--spectrum-corner-radius-100);
     --system-infield-button-border-radius-reset: 0;
-    --system-infield-button-stacked-top-border-radius-start-start: var(
-        --system-infield-button-border-radius-reset
-    );
-    --system-infield-button-stacked-bottom-border-radius-end-start: var(
-        --system-infield-button-border-radius-reset
-    );
+    --system-infield-button-stacked-top-border-radius-start-start: var(--system-infield-button-border-radius-reset);
+    --system-infield-button-stacked-bottom-border-radius-end-start: var(--system-infield-button-border-radius-reset);
     --system-infield-button-background-color: var(--spectrum-gray-75);
     --system-infield-button-background-color-hover: var(--spectrum-gray-200);
     --system-infield-button-background-color-down: var(--spectrum-gray-300);
-    --system-infield-button-background-color-key-focus: var(
-        --spectrum-gray-200
-    );
+    --system-infield-button-background-color-key-focus: var(--spectrum-gray-200);
     --system-infield-button-disabled-border-color: var(--spectrum-gray-200);
-    --system-menu-item-background-color-hover: rgba(
-        var(--spectrum-gray-900-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
-    --system-menu-item-background-color-down: rgba(
-        var(--spectrum-gray-900-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
-    --system-menu-item-background-color-key-focus: rgba(
-        var(--spectrum-gray-900-rgb),
-        var(--spectrum-transparent-black-200-opacity)
-    );
+    --system-menu-item-background-color-hover: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
+    --system-menu-item-background-color-down: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
+    --system-menu-item-background-color-key-focus: rgba(var(--spectrum-gray-900-rgb), var(--spectrum-transparent-black-200-opacity));
     --system-menu-item-corner-radius: 0;
     --system-menu-item-focus-indicator-shadow: inset;
     --system-menu-item-focus-indicator-offset: 0;
@@ -746,9 +355,7 @@
     --system-meter-size-l-inline-size: var(--spectrum-progressbar-size-2500);
     --system-meter-font-size: var(--spectrum-font-size-100);
     --system-meter-size-l-font-size: var(--spectrum-font-size-100);
-    --system-meter-size-l-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
+    --system-meter-size-l-top-to-text: var(--spectrum-component-top-to-text-200);
     --system-modal-background-color: var(--spectrum-gray-100);
     --system-picker-background-color-default: var(--spectrum-gray-75);
     --system-picker-background-color-default-open: var(--spectrum-gray-200);
@@ -773,16 +380,10 @@
     --system-picker-button-border-radius-rounded-sided: 0;
     --system-picker-button-border-radius-sided: 0;
     --system-picker-button-border-width: var(--spectrum-border-width-100);
-    --system-picker-button-padding: var(
-        --spectrum-in-field-button-edge-to-fill
-    );
+    --system-picker-button-padding: var(--spectrum-in-field-button-edge-to-fill);
     --system-popover-border-width: var(--spectrum-border-width-100);
-    --system-progress-bar-animation-ease-in-out-indeterminate: var(
-        --spectrum-animation-ease-in-out
-    );
-    --system-progress-bar-animation-duration-indeterminate: var(
-        --spectrum-animation-duration-2000
-    );
+    --system-progress-bar-animation-ease-in-out-indeterminate: var(--spectrum-animation-ease-in-out);
+    --system-progress-bar-animation-duration-indeterminate: var(--spectrum-animation-duration-2000);
     --system-progress-bar-corner-radius: var(--spectrum-corner-radius-100);
     --system-progress-bar-fill-size-indeterminate: 70%;
     --system-progress-bar-size-2400: 192px;
@@ -794,122 +395,58 @@
     --system-progress-bar-line-height: var(--spectrum-line-height-100);
     --system-progress-bar-spacing-label-to: var(--spectrum-spacing-75);
     --system-progress-bar-spacing-label-to-text: var(--spectrum-spacing-200);
-    --system-progress-bar-text-color: var(
-        --spectrum-neutral-content-color-default
-    );
+    --system-progress-bar-text-color: var(--spectrum-neutral-content-color-default);
     --system-progress-bar-track-color: var(--spectrum-gray-300);
     --system-progress-bar-fill-color: var(--spectrum-accent-color-900);
     --system-progress-bar-label-and-value-white: var(--spectrum-white);
-    --system-progress-bar-track-color-white: var(
-        --spectrum-transparent-white-300
-    );
+    --system-progress-bar-track-color-white: var(--spectrum-transparent-white-300);
     --system-progress-bar-fill-color-white: var(--spectrum-white);
     --system-progress-bar-size-default: var(--system-progress-bar-size-2400);
-    --system-progress-bar-size-m-size-default: var(
-        --system-progress-bar-size-2400
-    );
+    --system-progress-bar-size-m-size-default: var(--system-progress-bar-size-2400);
     --system-progress-bar-font-size: var(--spectrum-font-size-75);
     --system-progress-bar-size-m-font-size: var(--spectrum-font-size-75);
-    --system-progress-bar-thickness: var(
-        --spectrum-progress-bar-thickness-large
-    );
-    --system-progress-bar-size-m-thickness: var(
-        --spectrum-progress-bar-thickness-large
-    );
-    --system-progress-bar-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-progress-bar-size-m-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-progress-bar-size-s-size-default: var(
-        --system-progress-bar-size-2400
-    );
+    --system-progress-bar-thickness: var(--spectrum-progress-bar-thickness-large);
+    --system-progress-bar-size-m-thickness: var(--spectrum-progress-bar-thickness-large);
+    --system-progress-bar-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-progress-bar-size-m-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-progress-bar-size-s-size-default: var(--system-progress-bar-size-2400);
     --system-progress-bar-size-s-font-size: var(--spectrum-font-size-75);
-    --system-progress-bar-size-s-thickness: var(
-        --spectrum-progress-bar-thickness-small
-    );
-    --system-progress-bar-size-s-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-progress-bar-size-l-size-default: var(
-        --system-progress-bar-size-2500
-    );
+    --system-progress-bar-size-s-thickness: var(--spectrum-progress-bar-thickness-small);
+    --system-progress-bar-size-s-spacing-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-progress-bar-size-l-size-default: var(--system-progress-bar-size-2500);
     --system-progress-bar-size-l-font-size: var(--spectrum-font-size-100);
-    --system-progress-bar-size-l-thickness: var(
-        --spectrum-progress-bar-thickness-large
-    );
-    --system-progress-bar-size-l-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --system-progress-bar-size-xl-size-default: var(
-        --system-progress-bar-size-2800
-    );
+    --system-progress-bar-size-l-thickness: var(--spectrum-progress-bar-thickness-large);
+    --system-progress-bar-size-l-spacing-top-to-text: var(--spectrum-component-top-to-text-200);
+    --system-progress-bar-size-xl-size-default: var(--system-progress-bar-size-2800);
     --system-progress-bar-size-xl-font-size: var(--spectrum-font-size-200);
-    --system-progress-bar-size-xl-thickness: var(
-        --spectrum-progress-bar-thickness-extra-large
-    );
-    --system-progress-bar-size-xl-spacing-top-to-text: var(
-        --spectrum-component-top-to-text-300
-    );
+    --system-progress-bar-size-xl-thickness: var(--spectrum-progress-bar-thickness-extra-large);
+    --system-progress-bar-size-xl-spacing-top-to-text: var(--spectrum-component-top-to-text-300);
     --system-progress-circle-track-border-color: var(--spectrum-gray-300);
-    --system-progress-circle-track-border-color-over-background: var(
-        --spectrum-transparent-white-300
-    );
-    --system-progress-circle-fill-border-color-over-background: var(
-        --spectrum-transparent-white-900
-    );
+    --system-progress-circle-track-border-color-over-background: var(--spectrum-transparent-white-300);
+    --system-progress-circle-fill-border-color-over-background: var(--spectrum-transparent-white-900);
     --system-radio-button-border-color-default: var(--spectrum-gray-600);
     --system-radio-button-border-color-hover: var(--spectrum-gray-700);
     --system-radio-button-border-color-down: var(--spectrum-gray-800);
     --system-radio-button-border-color-focus: var(--spectrum-gray-700);
-    --system-radio-neutral-content-color: var(
-        --spectrum-neutral-content-color-default
-    );
-    --system-radio-neutral-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --system-radio-neutral-content-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --system-radio-neutral-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
-    --system-radio-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
+    --system-radio-neutral-content-color: var(--spectrum-neutral-content-color-default);
+    --system-radio-neutral-content-color-hover: var(--spectrum-neutral-content-color-hover);
+    --system-radio-neutral-content-color-down: var(--spectrum-neutral-content-color-down);
+    --system-radio-neutral-content-color-focus: var(--spectrum-neutral-content-color-key-focus);
+    --system-radio-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
     --system-radio-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
     --system-radio-focus-indicator-color: var(--spectrum-focus-indicator-color);
-    --system-radio-disabled-content-color: var(
-        --spectrum-disabled-content-color
-    );
-    --system-radio-disabled-border-color: var(
-        --spectrum-disabled-content-color
-    );
+    --system-radio-disabled-content-color: var(--spectrum-disabled-content-color);
+    --system-radio-disabled-border-color: var(--spectrum-disabled-content-color);
     --system-radio-emphasized-accent-color: var(--spectrum-accent-color-900);
-    --system-radio-emphasized-accent-color-hover: var(
-        --spectrum-accent-color-1000
-    );
-    --system-radio-emphasized-accent-color-down: var(
-        --spectrum-accent-color-1100
-    );
-    --system-radio-emphasized-accent-color-focus: var(
-        --spectrum-accent-color-1000
-    );
+    --system-radio-emphasized-accent-color-hover: var(--spectrum-accent-color-1000);
+    --system-radio-emphasized-accent-color-down: var(--spectrum-accent-color-1100);
+    --system-radio-emphasized-accent-color-focus: var(--spectrum-accent-color-1000);
     --system-radio-border-width: var(--spectrum-border-width-200);
     --system-radio-button-background-color: var(--spectrum-gray-50);
-    --system-radio-button-checked-border-color-default: var(
-        --spectrum-neutral-background-color-selected-default
-    );
-    --system-radio-button-checked-border-color-hover: var(
-        --spectrum-neutral-background-color-selected-hover
-    );
-    --system-radio-button-checked-border-color-down: var(
-        --spectrum-neutral-background-color-selected-down
-    );
-    --system-radio-button-checked-border-color-focus: var(
-        --spectrum-neutral-background-color-selected-focus
-    );
+    --system-radio-button-checked-border-color-default: var(--spectrum-neutral-background-color-selected-default);
+    --system-radio-button-checked-border-color-hover: var(--spectrum-neutral-background-color-selected-hover);
+    --system-radio-button-checked-border-color-down: var(--spectrum-neutral-background-color-selected-down);
+    --system-radio-button-checked-border-color-focus: var(--spectrum-neutral-background-color-selected-focus);
     --system-radio-line-height: var(--spectrum-line-height-100);
     --system-radio-animation-duration: var(--spectrum-animation-duration-100);
     --system-radio-lang-ja-line-height-cjk: var(--spectrum-cjk-line-height-100);
@@ -917,131 +454,67 @@
     --system-radio-lang-ko-line-height-cjk: var(--spectrum-cjk-line-height-100);
     --system-radio-height: var(--spectrum-component-height-100);
     --system-radio-size-m-height: var(--spectrum-component-height-100);
-    --system-radio-button-control-size: var(
-        --spectrum-radio-button-control-size-medium
-    );
-    --system-radio-size-m-button-control-size: var(
-        --spectrum-radio-button-control-size-medium
-    );
+    --system-radio-button-control-size: var(--spectrum-radio-button-control-size-medium);
+    --system-radio-size-m-button-control-size: var(--spectrum-radio-button-control-size-medium);
     --system-radio-text-to-control: var(--spectrum-text-to-control-100);
     --system-radio-size-m-text-to-control: var(--spectrum-text-to-control-100);
     --system-radio-label-top-to-text: var(--spectrum-component-top-to-text-100);
-    --system-radio-size-m-label-top-to-text: var(
-        --spectrum-component-top-to-text-100
-    );
-    --system-radio-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --system-radio-size-m-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --system-radio-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-medium
-    );
-    --system-radio-size-m-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-medium
-    );
+    --system-radio-size-m-label-top-to-text: var(--spectrum-component-top-to-text-100);
+    --system-radio-label-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
+    --system-radio-size-m-label-bottom-to-text: var(--spectrum-component-bottom-to-text-100);
+    --system-radio-button-top-to-control: var(--spectrum-radio-button-top-to-control-medium);
+    --system-radio-size-m-button-top-to-control: var(--spectrum-radio-button-top-to-control-medium);
     --system-radio-font-size: var(--spectrum-font-size-100);
     --system-radio-size-m-font-size: var(--spectrum-font-size-100);
     --system-radio-size-s-height: var(--spectrum-component-height-75);
-    --system-radio-size-s-button-control-size: var(
-        --spectrum-radio-button-control-size-small
-    );
+    --system-radio-size-s-button-control-size: var(--spectrum-radio-button-control-size-small);
     --system-radio-size-s-text-to-control: var(--spectrum-text-to-control-75);
-    --system-radio-size-s-label-top-to-text: var(
-        --spectrum-component-top-to-text-75
-    );
-    --system-radio-size-s-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-75
-    );
-    --system-radio-size-s-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-small
-    );
+    --system-radio-size-s-label-top-to-text: var(--spectrum-component-top-to-text-75);
+    --system-radio-size-s-label-bottom-to-text: var(--spectrum-component-bottom-to-text-75);
+    --system-radio-size-s-button-top-to-control: var(--spectrum-radio-button-top-to-control-small);
     --system-radio-size-s-font-size: var(--spectrum-font-size-75);
     --system-radio-size-l-height: var(--spectrum-component-height-200);
-    --system-radio-size-l-button-control-size: var(
-        --spectrum-radio-button-control-size-large
-    );
+    --system-radio-size-l-button-control-size: var(--spectrum-radio-button-control-size-large);
     --system-radio-size-l-text-to-control: var(--spectrum-text-to-control-200);
-    --system-radio-size-l-label-top-to-text: var(
-        --spectrum-component-top-to-text-200
-    );
-    --system-radio-size-l-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-200
-    );
-    --system-radio-size-l-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-large
-    );
+    --system-radio-size-l-label-top-to-text: var(--spectrum-component-top-to-text-200);
+    --system-radio-size-l-label-bottom-to-text: var(--spectrum-component-bottom-to-text-200);
+    --system-radio-size-l-button-top-to-control: var(--spectrum-radio-button-top-to-control-large);
     --system-radio-size-l-font-size: var(--spectrum-font-size-200);
     --system-radio-size-xl-height: var(--spectrum-component-height-300);
-    --system-radio-size-xl-button-control-size: var(
-        --spectrum-radio-button-control-size-extra-large
-    );
+    --system-radio-size-xl-button-control-size: var(--spectrum-radio-button-control-size-extra-large);
     --system-radio-size-xl-text-to-control: var(--spectrum-text-to-control-300);
-    --system-radio-size-xl-label-top-to-text: var(
-        --spectrum-component-top-to-text-300
-    );
-    --system-radio-size-xl-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-300
-    );
-    --system-radio-size-xl-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-extra-large
-    );
+    --system-radio-size-xl-label-top-to-text: var(--spectrum-component-top-to-text-300);
+    --system-radio-size-xl-label-bottom-to-text: var(--spectrum-component-bottom-to-text-300);
+    --system-radio-size-xl-button-top-to-control: var(--spectrum-radio-button-top-to-control-extra-large);
     --system-radio-size-xl-font-size: var(--spectrum-font-size-300);
-    --system-radio-emphasized-button-checked-border-color-default: var(
-        --spectrum-accent-color-900
-    );
-    --system-radio-emphasized-button-checked-border-color-hover: var(
-        --spectrum-accent-color-1000
-    );
-    --system-radio-emphasized-button-checked-border-color-down: var(
-        --spectrum-accent-color-1100
-    );
-    --system-radio-emphasized-button-checked-border-color-focus: var(
-        --spectrum-accent-color-1000
-    );
+    --system-radio-emphasized-button-checked-border-color-default: var(--spectrum-accent-color-900);
+    --system-radio-emphasized-button-checked-border-color-hover: var(--spectrum-accent-color-1000);
+    --system-radio-emphasized-button-checked-border-color-down: var(--spectrum-accent-color-1100);
+    --system-radio-emphasized-button-checked-border-color-focus: var(--spectrum-accent-color-1000);
     --system-search-border-color-default: var(--spectrum-gray-500);
     --system-search-border-color-hover: var(--spectrum-gray-600);
     --system-search-border-color-focus: var(--spectrum-gray-800);
     --system-search-border-color-focus-hover: var(--spectrum-gray-900);
     --system-search-border-color-key-focus: var(--spectrum-gray-900);
     --system-search-background-color: var(--spectrum-gray-50);
-    --system-search-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --system-search-border-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-search-background-color-disabled: var(--spectrum-disabled-background-color);
+    --system-search-border-color-disabled: var(--spectrum-disabled-background-color);
     --system-search-border-radius: var(--spectrum-corner-radius-100);
     --system-search-size-m-border-radius: var(--spectrum-corner-radius-100);
-    --system-search-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-100
-    );
-    --system-search-size-m-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-100
-    );
+    --system-search-edge-to-visual: var(--spectrum-component-edge-to-visual-100);
+    --system-search-size-m-edge-to-visual: var(--spectrum-component-edge-to-visual-100);
     --system-search-size-s-border-radius: var(--spectrum-corner-radius-100);
-    --system-search-size-s-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-75
-    );
+    --system-search-size-s-edge-to-visual: var(--spectrum-component-edge-to-visual-75);
     --system-search-size-l-border-radius: var(--spectrum-corner-radius-100);
-    --system-search-size-l-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-200
-    );
+    --system-search-size-l-edge-to-visual: var(--spectrum-component-edge-to-visual-200);
     --system-search-size-xl-border-radius: var(--spectrum-corner-radius-100);
-    --system-search-size-xl-edge-to-visual: var(
-        --spectrum-component-edge-to-visual-300
-    );
+    --system-search-size-xl-edge-to-visual: var(--spectrum-component-edge-to-visual-300);
     --system-search-quiet-background-color-disabled: transparent;
-    --system-search-quiet-border-color-disabled: var(
-        --spectrum-disabled-border-color
-    );
+    --system-search-quiet-border-color-disabled: var(--spectrum-disabled-border-color);
     --system-side-nav-background-hover: var(--spectrum-gray-200);
     --system-side-nav-item-background-down: var(--spectrum-gray-300);
     --system-side-nav-background-key-focus: var(--spectrum-gray-200);
-    --system-side-nav-item-background-default-selected: var(
-        --spectrum-gray-200
-    );
+    --system-side-nav-item-background-default-selected: var(--spectrum-gray-200);
     --system-side-nav-background-hover-selected: var(--spectrum-gray-300);
     --system-side-nav-item-background-down-selected: var(--spectrum-gray-300);
     --system-side-nav-background-key-focus-selected: var(--spectrum-gray-200);
@@ -1059,23 +532,13 @@
     --system-slider-handle-border-color-hover: var(--spectrum-gray-800);
     --system-slider-handle-border-color-down: var(--spectrum-gray-800);
     --system-slider-handle-border-color-key-focus: var(--spectrum-gray-800);
-    --system-slider-handle-focus-ring-color-key-focus: var(
-        --spectrum-focus-indicator-color
-    );
+    --system-slider-handle-focus-ring-color-key-focus: var(--spectrum-focus-indicator-color);
     --system-slider-track-corner-radius: var(--spectrum-corner-radius-75);
     --system-slider-handle-border-radius: var(--spectrum-corner-radius-200);
-    --system-slider-size-m-handle-border-radius: var(
-        --spectrum-corner-radius-200
-    );
-    --system-slider-size-s-handle-border-radius: var(
-        --spectrum-corner-radius-200
-    );
-    --system-slider-size-l-handle-border-radius: calc(
-        var(--spectrum-corner-radius-200) * 4
-    );
-    --system-slider-size-xl-handle-border-radius: calc(
-        var(--spectrum-corner-radius-200) * 4
-    );
+    --system-slider-size-m-handle-border-radius: var(--spectrum-corner-radius-200);
+    --system-slider-size-s-handle-border-radius: var(--spectrum-corner-radius-200);
+    --system-slider-size-l-handle-border-radius: calc(var(--spectrum-corner-radius-200) * 4);
+    --system-slider-size-xl-handle-border-radius: calc(var(--spectrum-corner-radius-200) * 4);
     --system-split-view-background-color: var(--spectrum-gray-100);
     --system-split-view-handle-background-color: var(--spectrum-gray-300);
     --system-split-view-gripper-border-radius: var(--spectrum-corner-radius-75);
@@ -1091,96 +554,49 @@
     --system-stepper-buttons-background-color: var(--spectrum-gray-50);
     --system-stepper-buttons-border-color-hover: var(--spectrum-gray-600);
     --system-stepper-buttons-border-color-focus: var(--spectrum-gray-800);
-    --system-stepper-buttons-border-color-keyboard-focus: var(
-        --spectrum-gray-800
-    );
+    --system-stepper-buttons-border-color-keyboard-focus: var(--spectrum-gray-800);
     --system-stepper-button-border-width: var(--spectrum-border-width-100);
-    --system-stepper-border-color-invalid: var(
-        --spectrum-negative-border-color-default
-    );
-    --system-stepper-border-color-focus-invalid: var(
-        --spectrum-negative-border-color-focus
-    );
-    --system-stepper-border-color-focus-hover-invalid: var(
-        --spectrum-negative-border-color-focus-hover
-    );
-    --system-stepper-border-color-keyboard-focus-invalid: var(
-        --spectrum-negative-border-color-key-focus
-    );
+    --system-stepper-border-color-invalid: var(--spectrum-negative-border-color-default);
+    --system-stepper-border-color-focus-invalid: var(--spectrum-negative-border-color-focus);
+    --system-stepper-border-color-focus-hover-invalid: var(--spectrum-negative-border-color-focus-hover);
+    --system-stepper-border-color-keyboard-focus-invalid: var(--spectrum-negative-border-color-key-focus);
     --system-stepper-border-color-disabled: transparent;
-    --system-stepper-button-border-width-disabled: var(
-        --spectrum-border-width-100
-    );
-    --system-stepper-buttons-background-color-disabled: var(
-        --spectrum-gray-100
-    );
+    --system-stepper-button-border-width-disabled: var(--spectrum-border-width-100);
+    --system-stepper-buttons-background-color-disabled: var(--spectrum-gray-100);
     --system-stepper-quiet-buttons-border-style: none;
     --system-stepper-quiet-button-edge-to-fill: 0;
     --system-swatch-border-radius: var(--spectrum-corner-radius-100);
-    --system-swatch-focus-indicator-border-radius: var(
-        --spectrum-corner-radius-200
-    );
+    --system-swatch-focus-indicator-border-radius: var(--spectrum-corner-radius-200);
     --system-swatch-border-thickness: var(--spectrum-border-width-100);
     --system-swatch-border-thickness-selected: var(--spectrum-border-width-200);
-    --system-swatch-focus-indicator-thickness: var(
-        --spectrum-focus-indicator-thickness
-    );
+    --system-swatch-focus-indicator-thickness: var(--spectrum-focus-indicator-thickness);
     --system-swatch-focus-indicator-gap: var(--spectrum-focus-indicator-gap);
     --system-swatch-border-color-opacity: 0.51;
     --system-swatch-border-color-light-opacity: 0.2;
-    --system-swatch-border-color: rgba(
-        var(--spectrum-gray-900-rgb),
-        var(--system-swatch-border-color-opacity)
-    );
-    --system-swatch-icon-border-color: rgba(
-        var(--spectrum-black-rgb),
-        var(--system-swatch-border-color-opacity)
-    );
-    --system-swatch-border-color-light: rgba(
-        var(--spectrum-black-rgb),
-        var(--system-swatch-border-color-light-opacity)
-    );
+    --system-swatch-border-color: rgba(var(--spectrum-gray-900-rgb), var(--system-swatch-border-color-opacity));
+    --system-swatch-icon-border-color: rgba(var(--spectrum-black-rgb), var(--system-swatch-border-color-opacity));
+    --system-swatch-border-color-light: rgba(var(--spectrum-black-rgb), var(--system-swatch-border-color-light-opacity));
     --system-swatch-border-color-selected: var(--spectrum-gray-900);
     --system-swatch-inner-border-color-selected: var(--spectrum-gray-50);
     --system-swatch-disabled-icon-color: var(--spectrum-gray-50);
     --system-swatch-dash-icon-color: var(--spectrum-gray-800);
     --system-swatch-slash-icon-color: var(--spectrum-red-900);
-    --system-swatch-focus-indicator-color: var(
-        --spectrum-focus-indicator-color
-    );
+    --system-swatch-focus-indicator-color: var(--spectrum-focus-indicator-color);
     --system-swatch-size: var(--spectrum-swatch-size-medium);
     --system-swatch-size-m-size: var(--spectrum-swatch-size-medium);
     --system-swatch-disabled-icon-size: var(--spectrum-workflow-icon-size-100);
-    --system-swatch-size-m-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-100
-    );
-    --system-swatch-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-medium
-    );
-    --system-swatch-size-m-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-medium
-    );
+    --system-swatch-size-m-disabled-icon-size: var(--spectrum-workflow-icon-size-100);
+    --system-swatch-slash-thickness: var(--spectrum-swatch-slash-thickness-medium);
+    --system-swatch-size-m-slash-thickness: var(--spectrum-swatch-slash-thickness-medium);
     --system-swatch-size-xs-size: var(--spectrum-swatch-size-extra-small);
-    --system-swatch-size-xs-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-50
-    );
-    --system-swatch-size-xs-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-extra-small
-    );
+    --system-swatch-size-xs-disabled-icon-size: var(--spectrum-workflow-icon-size-50);
+    --system-swatch-size-xs-slash-thickness: var(--spectrum-swatch-slash-thickness-extra-small);
     --system-swatch-size-s-size: var(--spectrum-swatch-size-small);
-    --system-swatch-size-s-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-75
-    );
-    --system-swatch-size-s-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-small
-    );
+    --system-swatch-size-s-disabled-icon-size: var(--spectrum-workflow-icon-size-75);
+    --system-swatch-size-s-slash-thickness: var(--spectrum-swatch-slash-thickness-small);
     --system-swatch-size-l-size: var(--spectrum-swatch-size-large);
-    --system-swatch-size-l-disabled-icon-size: var(
-        --spectrum-workflow-icon-size-200
-    );
-    --system-swatch-size-l-slash-thickness: var(
-        --spectrum-swatch-slash-thickness-large
-    );
+    --system-swatch-size-l-disabled-icon-size: var(--spectrum-workflow-icon-size-200);
+    --system-swatch-size-l-slash-thickness: var(--spectrum-swatch-slash-thickness-large);
     --system-swatch-group-spacing-compact: var(--spectrum-spacing-50);
     --system-swatch-group-spacing-regular: var(--spectrum-spacing-75);
     --system-swatch-group-spacing-spacious: var(--spectrum-spacing-100);
@@ -1188,39 +604,23 @@
     --system-switch-handle-border-color-hover: var(--spectrum-gray-700);
     --system-switch-handle-border-color-down: var(--spectrum-gray-800);
     --system-switch-handle-border-color-focus: var(--spectrum-gray-700);
-    --system-switch-handle-border-color-selected-default: var(
-        --spectrum-gray-700
-    );
-    --system-switch-handle-border-color-selected-hover: var(
-        --spectrum-gray-800
-    );
+    --system-switch-handle-border-color-selected-default: var(--spectrum-gray-700);
+    --system-switch-handle-border-color-selected-hover: var(--spectrum-gray-800);
     --system-switch-handle-border-color-selected-down: var(--spectrum-gray-900);
-    --system-switch-handle-border-color-selected-focus: var(
-        --spectrum-gray-800
-    );
+    --system-switch-handle-border-color-selected-focus: var(--spectrum-gray-800);
     --system-switch-background-color: var(--spectrum-gray-300);
     --system-switch-background-color-disabled: var(--spectrum-gray-300);
     --system-switch-handle-background-color: var(--spectrum-gray-75);
-    --system-table-header-background-color: var(
-        --spectrum-transparent-white-100
-    );
+    --system-table-header-background-color: var(--spectrum-transparent-white-100);
     --system-table-border-color: var(--spectrum-gray-300);
     --system-table-divider-color: var(--spectrum-gray-300);
     --system-table-row-background-color: var(--spectrum-gray-50);
     --system-table-summary-row-background-color: var(--spectrum-gray-200);
     --system-table-section-header-background-color: var(--spectrum-gray-200);
-    --system-table-icon-color-focus: var(
-        --spectrum-neutral-subdued-content-color-key-focus
-    );
-    --system-table-icon-color-focus-hover: var(
-        --spectrum-neutral-subdued-content-down
-    );
-    --system-table-quiet-header-background-color: var(
-        --spectrum-transparent-white-100
-    );
-    --system-table-quiet-row-background-color: var(
-        --spectrum-transparent-white-100
-    );
+    --system-table-icon-color-focus: var(--spectrum-neutral-subdued-content-color-key-focus);
+    --system-table-icon-color-focus-hover: var(--spectrum-neutral-subdued-content-down);
+    --system-table-quiet-header-background-color: var(--spectrum-transparent-white-100);
+    --system-table-quiet-row-background-color: var(--spectrum-transparent-white-100);
     --system-tabs-font-weight: var(--spectrum-regular-font-weight);
     --system-tabs-divider-background-color: var(--spectrum-gray-300);
     --system-tag-background-color: var(--spectrum-gray-75);
@@ -1234,66 +634,28 @@
     --system-tag-border-color-hover: var(--spectrum-gray-800);
     --system-tag-border-color-active: var(--spectrum-gray-900);
     --system-tag-border-color-focus: var(--spectrum-gray-800);
-    --system-tag-content-color: var(
-        --spectrum-neutral-subdued-content-color-default
-    );
-    --system-tag-content-color-hover: var(
-        --spectrum-neutral-subdued-content-color-hover
-    );
-    --system-tag-content-color-active: var(
-        --spectrum-neutral-subdued-content-color-down
-    );
-    --system-tag-content-color-focus: var(
-        --spectrum-neutral-subdued-content-color-key-focus
-    );
+    --system-tag-content-color: var(--spectrum-neutral-subdued-content-color-default);
+    --system-tag-content-color-hover: var(--spectrum-neutral-subdued-content-color-hover);
+    --system-tag-content-color-active: var(--spectrum-neutral-subdued-content-color-down);
+    --system-tag-content-color-focus: var(--spectrum-neutral-subdued-content-color-key-focus);
     --system-tag-content-color-selected: var(--spectrum-gray-50);
-    --system-tag-border-color-selected: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
-    --system-tag-border-color-selected-hover: var(
-        --spectrum-neutral-subdued-background-color-hover
-    );
-    --system-tag-border-color-selected-active: var(
-        --spectrum-neutral-subdued-background-color-down
-    );
-    --system-tag-border-color-selected-focus: var(
-        --spectrum-neutral-subdued-background-color-key-focus
-    );
+    --system-tag-border-color-selected: var(--spectrum-neutral-subdued-background-color-default);
+    --system-tag-border-color-selected-hover: var(--spectrum-neutral-subdued-background-color-hover);
+    --system-tag-border-color-selected-active: var(--spectrum-neutral-subdued-background-color-down);
+    --system-tag-border-color-selected-focus: var(--spectrum-neutral-subdued-background-color-key-focus);
     --system-tag-border-color-disabled: transparent;
-    --system-tag-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
-    --system-tag-size-small-spacing-inline-start: var(
-        --spectrum-component-edge-to-visual-75
-    );
-    --system-tag-size-small-label-spacing-inline-end: var(
-        --spectrum-component-edge-to-text-75
-    );
-    --system-tag-size-small-clear-button-spacing-inline-end: var(
-        --spectrum-component-edge-to-visual-75
-    );
-    --system-tag-size-medium-spacing-inline-start: var(
-        --spectrum-component-edge-to-visual-100
-    );
-    --system-tag-size-medium-label-spacing-inline-end: var(
-        --spectrum-component-edge-to-text-100
-    );
-    --system-tag-size-medium-clear-button-spacing-inline-end: var(
-        --spectrum-component-edge-to-visual-100
-    );
-    --system-tag-size-large-spacing-inline-start: var(
-        --spectrum-component-edge-to-visual-200
-    );
-    --system-tag-size-large-label-spacing-inline-end: var(
-        --spectrum-component-edge-to-text-200
-    );
-    --system-tag-size-large-clear-button-spacing-inline-end: var(
-        --spectrum-component-edge-to-visual-200
-    );
+    --system-tag-background-color-disabled: var(--spectrum-disabled-background-color);
+    --system-tag-size-small-spacing-inline-start: var(--spectrum-component-edge-to-visual-75);
+    --system-tag-size-small-label-spacing-inline-end: var(--spectrum-component-edge-to-text-75);
+    --system-tag-size-small-clear-button-spacing-inline-end: var(--spectrum-component-edge-to-visual-75);
+    --system-tag-size-medium-spacing-inline-start: var(--spectrum-component-edge-to-visual-100);
+    --system-tag-size-medium-label-spacing-inline-end: var(--spectrum-component-edge-to-text-100);
+    --system-tag-size-medium-clear-button-spacing-inline-end: var(--spectrum-component-edge-to-visual-100);
+    --system-tag-size-large-spacing-inline-start: var(--spectrum-component-edge-to-visual-200);
+    --system-tag-size-large-label-spacing-inline-end: var(--spectrum-component-edge-to-text-200);
+    --system-tag-size-large-clear-button-spacing-inline-end: var(--spectrum-component-edge-to-visual-200);
     --system-textfield-background-color: var(--spectrum-gray-50);
-    --system-textfield-background-color-disabled: var(
-        --spectrum-disabled-background-color
-    );
+    --system-textfield-background-color-disabled: var(--spectrum-disabled-background-color);
     --system-textfield-border-color: var(--spectrum-gray-500);
     --system-textfield-border-color-hover: var(--spectrum-gray-600);
     --system-textfield-border-color-focus: var(--spectrum-gray-800);
@@ -1301,25 +663,13 @@
     --system-textfield-border-color-keyboard-focus: var(--spectrum-gray-900);
     --system-textfield-border-color-disabled: var(--spectrum-gray-200);
     --system-textfield-border-width: var(--spectrum-border-width-100);
-    --system-textfield-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-medium
-    );
-    --system-textfield-size-s-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-small
-    );
-    --system-textfield-size-l-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-large
-    );
-    --system-textfield-size-xl-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-extra-large
-    );
+    --system-textfield-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-medium);
+    --system-textfield-size-s-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-small);
+    --system-textfield-size-l-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-large);
+    --system-textfield-size-xl-icon-spacing-block-invalid: var(--spectrum-field-top-to-alert-icon-extra-large);
     --system-textfield-quiet-border-color-disabled: var(--spectrum-gray-300);
     --system-thumbnail-border-radius: var(--spectrum-corner-radius-75);
-    --system-toast-background-color-default: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
+    --system-toast-background-color-default: var(--spectrum-neutral-subdued-background-color-default);
     --system-toast-divider-color: var(--spectrum-transparent-white-300);
-    --system-tooltip-backgound-color-default-neutral: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
+    --system-tooltip-backgound-color-default-neutral: var(--spectrum-neutral-subdued-background-color-default);
 }

--- a/tools/theme/src/express/scale-large-core-tokens.css
+++ b/tools/theme/src/express/scale-large-core-tokens.css
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/large-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/large-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/large-vars.css');
+@import url("@spectrum-web-components/styles/tokens/large-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/large-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/large-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/express/scale-large.css
+++ b/tools/theme/src/express/scale-large.css
@@ -10,10 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/express/scale-large.css');
-@import url('@spectrum-web-components/styles/tokens/large-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/large-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/large-vars.css');
+@import url("@spectrum-web-components/styles/express/scale-large.css");
+@import url("@spectrum-web-components/styles/tokens/large-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/large-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/large-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/express/scale-medium-core-tokens.css
+++ b/tools/theme/src/express/scale-medium-core-tokens.css
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/medium-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/medium-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/medium-vars.css');
+@import url("@spectrum-web-components/styles/tokens/medium-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/medium-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/medium-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/express/scale-medium.css
+++ b/tools/theme/src/express/scale-medium.css
@@ -10,10 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/medium-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/medium-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/medium-vars.css');
-@import url('@spectrum-web-components/styles/express/scale-medium.css');
+@import url("@spectrum-web-components/styles/tokens/medium-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/medium-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/medium-vars.css");
+@import url("@spectrum-web-components/styles/express/scale-medium.css");
 
 :root,
 :host {

--- a/tools/theme/src/express/theme-core-tokens.css
+++ b/tools/theme/src/express/theme-core-tokens.css
@@ -10,11 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/system-theme-bridge.css');
-@import url('@spectrum-web-components/styles/typography.css');
+@import url("@spectrum-web-components/styles/tokens/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/system-theme-bridge.css");
+@import url("@spectrum-web-components/styles/typography.css");
 
 :host {
     display: block;

--- a/tools/theme/src/express/theme-dark-core-tokens.css
+++ b/tools/theme/src/express/theme-dark-core-tokens.css
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/dark-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/dark-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/dark-vars.css');
+@import url("@spectrum-web-components/styles/tokens/dark-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/dark-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/dark-vars.css");
 
 :host,
 :root {

--- a/tools/theme/src/express/theme-dark.css
+++ b/tools/theme/src/express/theme-dark.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/express/theme-dark.css');
-@import url('@spectrum-web-components/styles/tokens/dark-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/dark-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/dark-vars.css');
+@import url("@spectrum-web-components/styles/express/theme-dark.css");
+@import url("@spectrum-web-components/styles/tokens/dark-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/dark-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/dark-vars.css");

--- a/tools/theme/src/express/theme-light-core-tokens.css
+++ b/tools/theme/src/express/theme-light-core-tokens.css
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/light-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/light-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/light-vars.css');
+@import url("@spectrum-web-components/styles/tokens/light-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/light-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/light-vars.css");
 
 :host,
 :root {

--- a/tools/theme/src/express/theme-light.css
+++ b/tools/theme/src/express/theme-light.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/express/theme-light.css');
-@import url('@spectrum-web-components/styles/tokens/light-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/light-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/light-vars.css');
+@import url("@spectrum-web-components/styles/express/theme-light.css");
+@import url("@spectrum-web-components/styles/tokens/light-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/light-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/light-vars.css");

--- a/tools/theme/src/express/theme.css
+++ b/tools/theme/src/express/theme.css
@@ -10,12 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens/express/global-vars.css');
-@import url('@spectrum-web-components/styles/express/core-global.css');
-@import url('@spectrum-web-components/styles/tokens/express/system-theme-bridge.css');
-@import url('@spectrum-web-components/styles/typography.css');
+@import url("@spectrum-web-components/styles/tokens/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens/express/global-vars.css");
+@import url("@spectrum-web-components/styles/express/core-global.css");
+@import url("@spectrum-web-components/styles/tokens/express/system-theme-bridge.css");
+@import url("@spectrum-web-components/styles/typography.css");
 
 :host {
     display: block;

--- a/tools/theme/src/scale-large-core-tokens.css
+++ b/tools/theme/src/scale-large-core-tokens.css
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/large-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/large-vars.css');
+@import url("@spectrum-web-components/styles/tokens/large-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/large-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/scale-large.css
+++ b/tools/theme/src/scale-large.css
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/scale-large.css');
-@import url('@spectrum-web-components/styles/tokens/large-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/large-vars.css');
+@import url("@spectrum-web-components/styles/scale-large.css");
+@import url("@spectrum-web-components/styles/tokens/large-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/large-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/scale-medium-core-tokens.css
+++ b/tools/theme/src/scale-medium-core-tokens.css
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/medium-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/medium-vars.css');
+@import url("@spectrum-web-components/styles/tokens/medium-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/medium-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/scale-medium.css
+++ b/tools/theme/src/scale-medium.css
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/scale-medium.css');
-@import url('@spectrum-web-components/styles/tokens/medium-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/medium-vars.css');
+@import url("@spectrum-web-components/styles/scale-medium.css");
+@import url("@spectrum-web-components/styles/tokens/medium-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/medium-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/spectrum-two/scale-large-core-tokens.css
+++ b/tools/theme/src/spectrum-two/scale-large-core-tokens.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens-v2/large-vars.css');
+@import url("@spectrum-web-components/styles/tokens-v2/large-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/spectrum-two/scale-large.css
+++ b/tools/theme/src/spectrum-two/scale-large.css
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/spectrum-two/scale-large.css');
-@import url('@spectrum-web-components/styles/tokens-v2/large-vars.css');
+@import url("@spectrum-web-components/styles/spectrum-two/scale-large.css");
+@import url("@spectrum-web-components/styles/tokens-v2/large-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/spectrum-two/scale-medium-core-tokens.css
+++ b/tools/theme/src/spectrum-two/scale-medium-core-tokens.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens-v2/medium-vars.css');
+@import url("@spectrum-web-components/styles/tokens-v2/medium-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/spectrum-two/scale-medium.css
+++ b/tools/theme/src/spectrum-two/scale-medium.css
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/spectrum-two/scale-medium.css');
-@import url('@spectrum-web-components/styles/tokens-v2/medium-vars.css');
+@import url("@spectrum-web-components/styles/spectrum-two/scale-medium.css");
+@import url("@spectrum-web-components/styles/tokens-v2/medium-vars.css");
 
 :root,
 :host {

--- a/tools/theme/src/spectrum-two/theme-core-tokens.css
+++ b/tools/theme/src/spectrum-two/theme-core-tokens.css
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens-v2/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens-v2/system-theme-bridge.css');
-@import url('@spectrum-web-components/styles/typography.css');
+@import url("@spectrum-web-components/styles/tokens-v2/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens-v2/system-theme-bridge.css");
+@import url("@spectrum-web-components/styles/typography.css");
 
 :host {
     display: block;

--- a/tools/theme/src/spectrum-two/theme-dark-core-tokens.css
+++ b/tools/theme/src/spectrum-two/theme-dark-core-tokens.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens-v2/dark-vars.css');
+@import url("@spectrum-web-components/styles/tokens-v2/dark-vars.css");
 
 :host,
 :root {

--- a/tools/theme/src/spectrum-two/theme-dark.css
+++ b/tools/theme/src/spectrum-two/theme-dark.css
@@ -10,5 +10,5 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/spectrum-two/theme-dark.css');
-@import url('@spectrum-web-components/styles/tokens-v2/dark-vars.css');
+@import url("@spectrum-web-components/styles/spectrum-two/theme-dark.css");
+@import url("@spectrum-web-components/styles/tokens-v2/dark-vars.css");

--- a/tools/theme/src/spectrum-two/theme-light-core-tokens.css
+++ b/tools/theme/src/spectrum-two/theme-light-core-tokens.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens-v2/light-vars.css');
+@import url("@spectrum-web-components/styles/tokens-v2/light-vars.css");
 
 :host,
 :root {

--- a/tools/theme/src/spectrum-two/theme-light.css
+++ b/tools/theme/src/spectrum-two/theme-light.css
@@ -10,5 +10,5 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/spectrum-two/theme-light.css');
-@import url('@spectrum-web-components/styles/tokens-v2/light-vars.css');
+@import url("@spectrum-web-components/styles/spectrum-two/theme-light.css");
+@import url("@spectrum-web-components/styles/tokens-v2/light-vars.css");

--- a/tools/theme/src/spectrum-two/theme.css
+++ b/tools/theme/src/spectrum-two/theme.css
@@ -10,10 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/spectrum-two/core-global.css');
-@import url('@spectrum-web-components/styles/tokens-v2/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens-v2/system-theme-bridge.css');
-@import url('@spectrum-web-components/styles/typography.css');
+@import url("@spectrum-web-components/styles/spectrum-two/core-global.css");
+@import url("@spectrum-web-components/styles/tokens-v2/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens-v2/system-theme-bridge.css");
+@import url("@spectrum-web-components/styles/typography.css");
 
 :host {
     display: block;

--- a/tools/theme/src/theme-core-tokens.css
+++ b/tools/theme/src/theme-core-tokens.css
@@ -10,10 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/system-theme-bridge.css');
-@import url('@spectrum-web-components/styles/typography.css');
+@import url("@spectrum-web-components/styles/tokens/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/system-theme-bridge.css");
+@import url("@spectrum-web-components/styles/typography.css");
 
 :host {
     display: block;

--- a/tools/theme/src/theme-dark-core-tokens.css
+++ b/tools/theme/src/theme-dark-core-tokens.css
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/dark-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/dark-vars.css');
+@import url("@spectrum-web-components/styles/tokens/dark-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/dark-vars.css");
 
 :host,
 :root {

--- a/tools/theme/src/theme-dark.css
+++ b/tools/theme/src/theme-dark.css
@@ -10,6 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/theme-dark.css');
-@import url('@spectrum-web-components/styles/tokens/dark-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/dark-vars.css');
+@import url("@spectrum-web-components/styles/theme-dark.css");
+@import url("@spectrum-web-components/styles/tokens/dark-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/dark-vars.css");

--- a/tools/theme/src/theme-darkest-core-tokens.css
+++ b/tools/theme/src/theme-darkest-core-tokens.css
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/darkest-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/darkest-vars.css');
+@import url("@spectrum-web-components/styles/tokens/darkest-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/darkest-vars.css");
 
 :host,
 :root {

--- a/tools/theme/src/theme-darkest.css
+++ b/tools/theme/src/theme-darkest.css
@@ -10,6 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/theme-darkest.css');
-@import url('@spectrum-web-components/styles/tokens/darkest-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/darkest-vars.css');
+@import url("@spectrum-web-components/styles/theme-darkest.css");
+@import url("@spectrum-web-components/styles/tokens/darkest-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/darkest-vars.css");

--- a/tools/theme/src/theme-light-core-tokens.css
+++ b/tools/theme/src/theme-light-core-tokens.css
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/light-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/light-vars.css');
+@import url("@spectrum-web-components/styles/tokens/light-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/light-vars.css");
 
 :host,
 :root {

--- a/tools/theme/src/theme-light.css
+++ b/tools/theme/src/theme-light.css
@@ -10,6 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/theme-light.css');
-@import url('@spectrum-web-components/styles/tokens/light-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/light-vars.css');
+@import url("@spectrum-web-components/styles/theme-light.css");
+@import url("@spectrum-web-components/styles/tokens/light-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/light-vars.css");

--- a/tools/theme/src/theme-lightest-core-tokens.css
+++ b/tools/theme/src/theme-lightest-core-tokens.css
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/tokens/light-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/light-vars.css');
+@import url("@spectrum-web-components/styles/tokens/light-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/light-vars.css");
 
 :host,
 :root {

--- a/tools/theme/src/theme-lightest.css
+++ b/tools/theme/src/theme-lightest.css
@@ -10,6 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/theme-lightest.css');
-@import url('@spectrum-web-components/styles/tokens/light-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/light-vars.css');
+@import url("@spectrum-web-components/styles/theme-lightest.css");
+@import url("@spectrum-web-components/styles/tokens/light-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/light-vars.css");

--- a/tools/theme/src/theme.css
+++ b/tools/theme/src/theme.css
@@ -10,11 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/core-global.css');
-@import url('@spectrum-web-components/styles/tokens/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/global-vars.css');
-@import url('@spectrum-web-components/styles/tokens/spectrum/system-theme-bridge.css');
-@import url('@spectrum-web-components/styles/typography.css');
+@import url("@spectrum-web-components/styles/core-global.css");
+@import url("@spectrum-web-components/styles/tokens/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/global-vars.css");
+@import url("@spectrum-web-components/styles/tokens/spectrum/system-theme-bridge.css");
+@import url("@spectrum-web-components/styles/typography.css");
 
 :host {
     display: block;

--- a/tools/theme/src/typography.css
+++ b/tools/theme/src/typography.css
@@ -10,4 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/typography.css');
+@import url("@spectrum-web-components/styles/typography.css");


### PR DESCRIPTION
## Description

Similar to #5463, this cleans up whitespace and formatting logic in the CSS assets for the tools directory.

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [n/a] I have added automated tests to cover my changes.
-   [n/a] I have included a well-written changeset if my change needs to be published.
-   [n/a] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash