### PR TITLE
fix(overlay): scroll jitter due to layout thrashing in safari and safari

### DIFF
--- a/.changeset/happy-cycles-check.md
+++ b/.changeset/happy-cycles-check.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/overlay': major
+---
+
+**Fixed** : Overlays (like pickers and action menus) were incorrectly closing when scrolling occurred within components. The fix ensures the `handleScroll` method in `OverlayStack` only responds to document/body scrolling events and ignores component-level scrolling events, which was the original intention.

--- a/packages/overlay/src/OverlayStack.ts
+++ b/packages/overlay/src/OverlayStack.ts
@@ -40,6 +40,15 @@ class OverlayStack {
     }
 
     private handleScroll = (event: Event): void => {
+        // Only handle document/body level scrolls
+        // Skip any component scrolls
+        if (
+            event.target !== document &&
+            event.target !== document.documentElement &&
+            event.target !== document.body
+        ) {
+            return;
+        }
         // Update positions of all open overlays
         this.stack.forEach((overlay) => {
             if (overlay.open) {


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

This PR addresses an issue where overlays (particularly pickers and action menus) were incorrectly closing when scrolling occurred within a component, rather than only closing on document/body scrolling.

## Problem
Previously, the `handleScroll` method in the OverlayStack class would trigger for all scroll events, including those that occurred within components. This caused overlays to close unexpectedly when users scrolled within menus, lists, or other scrollable content inside components.

## Solution
The fix is straightforward - we now check the scroll event target at the beginning of the handleScroll method to determine if it's a document-level scroll or a component-level scroll:

```ts
if (event.target !== document && 
    event.target !== document.documentElement && 
    event.target !== document.body) {
    return;
}
```
This ensures the method only handles document/body scrolls and ignores component-specific scrolling, which was the original intention.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes [5473](https://github.com/adobe/spectrum-web-components/issues/5473)

## Screenshots (if appropriate)


---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [x] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [x] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [x] Automated tests cover all use cases and follow best practices for writing
-   [x] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [x] Chrome

https://github.com/user-attachments/assets/a4520446-ecf0-4351-bfde-c4bcb1f251b1


-   [x] Safari

https://github.com/user-attachments/assets/f1a1c243-5f01-4ca2-ba4a-1b802d9c6732


-   [x] Firefox

https://github.com/user-attachments/assets/3e777b90-4899-4c7d-a19f-ef49b6432de1


### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [x] Did it pass in Desktop?
-   [x] Did it pass in (emulated) Mobile?
-   [x] Did it pass in (emulated) iPad?
