### PR TITLE
chore: import/no-extraneous-dependencies off for stories and test files

### DIFF
--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -85,8 +85,8 @@
     "overrides": [
         {
             "files": [
-                "**/test/**/*.test.{js,ts,jsx,tsx}",
-                "**/stories/**/*.{js,ts,jsx,tsx}"
+                "{packages,tools}/*/test/*.test.ts",
+                "{packages,tools}/*/stories/*.ts"
             ],
             "rules": {
                 "import/no-extraneous-dependencies": "off"

--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -85,15 +85,6 @@
     "overrides": [
         {
             "files": [
-                "{packages,tools}/*/test/*.test.ts",
-                "{packages,tools}/*/stories/*.ts"
-            ],
-            "rules": {
-                "import/no-extraneous-dependencies": "off"
-            }
-        },
-        {
-            "files": [
                 "*.test.ts",
                 "*.stories.ts",
                 "**/benchmark/*.ts",
@@ -102,7 +93,8 @@
             "rules": {
                 "@spectrum-web-components/document-active-element": ["off"],
                 "lit-a11y/no-autofocus": ["off"],
-                "lit-a11y/tabindex-no-positive": ["off"]
+                "lit-a11y/tabindex-no-positive": ["off"],
+                "import/no-extraneous-dependencies": "off"
             }
         },
         {

--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -85,6 +85,15 @@
     "overrides": [
         {
             "files": [
+                "**/test/**/*.test.{js,ts,jsx,tsx}",
+                "**/stories/**/*.{js,ts,jsx,tsx}"
+            ],
+            "rules": {
+                "import/no-extraneous-dependencies": "off"
+            }
+        },
+        {
+            "files": [
                 "*.test.ts",
                 "*.stories.ts",
                 "**/benchmark/*.ts",


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

This PR modifies the ESLint configuration to disable the `import/no-extraneous-dependencies` rule for test and storybook files, allowing these files to import development dependencies without triggering linting errors.

## Changes
- Updated `.eslintrc.json` to turn off `import/no-extraneous-dependencies` rule for:
  - Test files (`**/test/**/*.test.{js,ts,jsx,tsx}`)
  - Storybook files (`**/stories/**/*.{js,ts,jsx,tsx}`)
- Simplified the file patterns in the override configuration
- Maintained the rule for all other source files

## Impact

This change:
- Reduces noise in the linting output for test and storybook files
- Allows test and storybook files to freely import development dependencies
- Maintains strict dependency checking for the main source code


<!--- Describe your changes in detail -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-  N/A

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] Create a test commit in your local branch or in this branch

    1. Update any file in your code and try to add any test or storybook file to your commit
    2. Try to push this commit
    3. Commit passes without any errors stating missing dependencies


### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
