### PR TITLE
fix(tooltip,textfield,sidenav): update deprecated css [CSS-1223]

### DIFF
--- a/.changeset/word-break-updates.md
+++ b/.changeset/word-break-updates.md
@@ -1,0 +1,7 @@
+---
+'@spectrum-web-components/textfield': patch
+'@spectrum-web-components/sidenav': patch
+'@spectrum-web-components/tooltip': patch
+---
+
+Replace deprecated `word-break: break-word` with `overflow-wrap: break-word` to align with modern CSS standards and improve cross-browser compatibility. This property was deprecated in Chrome 44 (July 2015) in favor of the standardized `overflow-wrap` property.

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -130,7 +130,7 @@ governing permissions and limitations under the License.
 #item-link {
     padding-inline: var(--mod-sidenav-inline-padding, var(--spectrum-sidenav-inline-padding));
     box-sizing: border-box;
-    word-break: break-word;
+    overflow-wrap: break-word;
     hyphens: auto;
     cursor: pointer;
     transition:

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -56,8 +56,7 @@ textarea {
 
 #sizer {
     block-size: auto;
-    /* stylelint-disable-next-line declaration-property-value-keyword-no-deprecated */
-    word-break: break-word;
+    overflow-wrap: break-word;
     opacity: 0;
     white-space: pre-line;
 }

--- a/packages/tooltip/src/spectrum-tooltip.css
+++ b/packages/tooltip/src/spectrum-tooltip.css
@@ -92,7 +92,7 @@ governing permissions and limitations under the License.
     font-size: var(--mod-tooltip-font-size, var(--spectrum-tooltip-font-size));
     font-weight: var(--mod-tooltip-font-weight, var(--spectrum-tooltip-font-weight));
     line-height: var(--mod-tooltip-line-height, var(--spectrum-tooltip-line-height));
-    word-break: break-word;
+    overflow-wrap: break-word;
     -webkit-font-smoothing: antialiased;
     cursor: default;
     -webkit-user-select: none;


### PR DESCRIPTION
## Description

Replace deprecated `word-break: break-word` with `overflow-wrap: break-word` to align with modern CSS standards and improve cross-browser compatibility. This property was deprecated in Chrome 44 (July 2015) in favor of the standardized `overflow-wrap` property.

## Motivation and context

I've been seeing a lot of stylelint warnings about this property-value pairing and after doing a little research, found a non-deprecated alternative to accomplish the same results.

## Related issue(s)

-   fixes [CSS-1223]

---

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [x] I have added automated tests to cover my changes.
-   [x] I have included a well-written changeset if my change needs to be published.
-   [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

-   [x] _Tooltip_: Expect to see no line-wrap regressions or changes to VRTs [@cdransf]
-   [x] Text field: Expect to see no line-wrap regressions or changes to VRTs [@cdransf]
-   [x] Side nav: Expect to see no line-wrap regressions or changes to VRTs [@cdransf]

### Device review

-   [x] Did it pass in Desktop?
-   [x] Did it pass in (emulated) Mobile?
-   [x] Did it pass in (emulated) iPad?
