### PR TITLE
chore: migrate linting from circleci to github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,20 +143,6 @@ commands:
                   key: v2-golden-images-{{ .Branch }}-<< parameters.regression_system >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-{{ epoch }}
 
 jobs:
-    commitlint:
-        executor: node
-
-        steps:
-            - downstream
-            - run:
-                  name: Define environment variable with lastest commit's message
-                  command: |
-                      echo 'export COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")' >> $BASH_ENV
-                      source $BASH_ENV
-            - run:
-                  name: Lint commit message
-                  command: echo "$COMMIT_MESSAGE" | yarn commitlint --config commitlint.config.cjs
-
     test-chromium:
         executor: node
 
@@ -208,18 +194,6 @@ jobs:
                       yarn test:start --files $TEST --config web-test-runner.config.ci-webkit.js --group unit-ci
             - store_test_results:
                   path: /root/project/results/
-
-    lint:
-        executor: node
-
-        steps:
-            - downstream
-            - run:
-                  name: Lint
-                  command: yarn lint
-            - run:
-                  name: Are there changes?
-                  command: git diff-files --exit-code
 
     preview-docs:
         executor: node
@@ -372,17 +346,12 @@ jobs:
                   regression_dir: << parameters.dir >>
 
 workflows:
-    version: 2
-    commitlint:
-        jobs:
-            - commitlint
     build:
         jobs:
             - test-chromium
             - test-chromium-memory
             - test-firefox
             - test-webkit
-            - lint
             - hcm-visual:
                   filters:
                       branches:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,98 @@
 {
-    "root": true,
+    "env": {
+        "browser": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:prettier/recommended",
+        "plugin:lit-a11y/recommended",
+        "plugin:require-extensions/recommended"
+    ],
+    "overrides": [
+        {
+            "extends": ["plugin:jsonc/recommended-with-jsonc"],
+            "files": ["*.json"],
+            "parser": "jsonc-eslint-parser",
+            "rules": {
+                "jsonc/sort-keys": [
+                    "warn",
+                    {
+                        "hasProperties": ["type"],
+                        "order": [
+                            "$schema",
+                            "name",
+                            "version",
+                            "private",
+                            "description",
+                            "license",
+                            "author",
+                            "maintainers",
+                            "contributors",
+                            "homepage",
+                            "repository",
+                            "bugs",
+                            "type",
+                            "exports",
+                            "main",
+                            "module",
+                            "browser",
+                            "man",
+                            "preferGlobal",
+                            "bin",
+                            "files",
+                            "directories",
+                            "scripts",
+                            "config",
+                            "sideEffects",
+                            "types",
+                            "typings",
+                            "workspaces",
+                            "resolutions",
+                            "dependencies",
+                            "bundleDependencies",
+                            "bundledDependencies",
+                            "peerDependencies",
+                            "peerDependenciesMeta",
+                            "optionalDependencies",
+                            "devDependencies",
+                            "keywords",
+                            "engines",
+                            "engineStrict",
+                            "os",
+                            "cpu",
+                            "publishConfig"
+                        ],
+                        "pathPattern": ".*" // Hits the all properties
+                    },
+                    {
+                        "order": { "type": "asc" },
+                        "pathPattern": ".*"
+                    }
+                ],
+                "notice/notice": "off"
+            }
+        },
+        {
+            "files": ["scripts/*"],
+            "rules": {
+                "no-console": ["off"]
+            }
+        },
+        {
+            "files": ["react/**/*.ts"],
+            "rules": {
+                "@typescript-eslint/no-explicit-any": "off"
+            }
+        }
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": 2020,
+        "sourceType": "module"
+    },
     "plugins": [
         "@typescript-eslint",
         "notice",
@@ -7,25 +100,13 @@
         "import",
         "require-extensions"
     ],
-    "env": {
-        "browser": true,
-        "node": true,
-        "es6": true
-    },
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 2020,
-        "sourceType": "module"
-    },
+    "root": true,
     "rules": {
-        "curly": ["error", "all"],
-        "no-debugger": 2,
-        "no-console": [
+        "@spectrum-web-components/prevent-argument-names": [
             "error",
-            {
-                "allow": ["warn", "error"]
-            }
+            ["e", "ev", "evt", "err"]
         ],
+        "curly": ["error", "all"],
         "import/extensions": [
             "error",
             "ignorePackages",
@@ -34,26 +115,6 @@
             }
         ],
         "import/prefer-default-export": "off",
-        "@spectrum-web-components/prevent-argument-names": [
-            "error",
-            ["e", "ev", "evt", "err"]
-        ],
-        "notice/notice": [
-            "error",
-            {
-                "mustMatch": "Copyright [0-9]{0,4} Adobe. All rights reserved.",
-                "templateFile": "config/license.js"
-            }
-        ],
-        "sort-imports": [
-            "error",
-            {
-                "ignoreCase": true,
-                "ignoreDeclarationSort": true,
-                "ignoreMemberSort": false,
-                "allowSeparatedGroups": false
-            }
-        ],
         "lit-a11y/click-events-have-key-events": [
             "error",
             {
@@ -68,27 +129,29 @@
                     "sp-underlay"
                 ]
             }
+        ],
+        "no-console": [
+            "error",
+            {
+                "allow": ["warn", "error"]
+            }
+        ],
+        "no-debugger": 2,
+        "notice/notice": [
+            "error",
+            {
+                "mustMatch": "Copyright [0-9]{0,4} Adobe. All rights reserved.",
+                "templateFile": "config/license.js"
+            }
+        ],
+        "sort-imports": [
+            "error",
+            {
+                "allowSeparatedGroups": false,
+                "ignoreCase": true,
+                "ignoreDeclarationSort": true,
+                "ignoreMemberSort": false
+            }
         ]
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:prettier/recommended",
-        "plugin:lit-a11y/recommended",
-        "plugin:require-extensions/recommended"
-    ],
-    "overrides": [
-        {
-            "files": ["scripts/*"],
-            "rules": {
-                "no-console": ["off"]
-            }
-        },
-        {
-            "files": ["react/**/*.ts"],
-            "rules": {
-                "@typescript-eslint/no-explicit-any": "off"
-            }
-        }
-    ]
+    }
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,122 @@
+name: Lint
+#
+# This workflow lints the library and reports back suggested fixes
+#
+
+on:
+    push:
+        branches:
+            - main
+
+    pull_request:
+        branches:
+            - main
+
+        types:
+            - opened
+            - synchronize
+            - reopened
+            - auto_merge_enabled
+
+permissions:
+    contents: read
+    pull-requests: write
+
+concurrency:
+    group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+    cancel-in-progress: true
+
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    # -------------------------------------------------------------
+    # Returns all changed pull request files.
+    # --------------------------------------------------------------
+    changed_files:
+        runs-on: ubuntu-latest
+        name: Capture changed-files
+        outputs:
+            styles_added_files: ${{ steps.changed-files.outputs.styles_added_files }}
+            styles_modified_files: ${{ steps.changed-files.outputs.styles_modified_files }}
+            eslint_added_files: ${{ steps.changed-files.outputs.eslint_added_files }}
+            eslint_modified_files: ${{ steps.changed-files.outputs.eslint_modified_files }}
+        permissions:
+            pull-requests: read
+
+        steps:
+            - name: Get changed files
+              id: changed-files
+              uses: step-security/changed-files@v46
+              with:
+                  files_yaml: |
+                      styles:
+                        - '*.css'
+                        - '**/*.css'
+                      eslint:
+                        - '*.{js,json,ts}'
+                        - '**/*.{js,json,ts}'
+                        - '!*.d.ts'
+                        - '!**/*.d.ts'
+
+    # --- Lint pre-compiled assets for consistency --- #
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        needs: [changed_files]
+        timeout-minutes: 5
+        steps:
+            # install but don't build - we're linting pre-compiled assets
+            - name: Check out code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Use Node LTS version
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: yarn
+
+            - name: Enable Corepack
+              run: corepack enable
+
+            ## --- YARN CACHE --- ##
+            - name: Check for cached dependencies
+              continue-on-error: true
+              id: cache-dependencies
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      .cache/yarn
+                      node_modules
+                  key: ubuntu-latest-node20-${{ hashFiles('yarn.lock') }}
+
+            ## --- INSTALL --- ##
+            # If statement isn't needed here b/c yarn will leverage the cache if it exists
+            - name: Install dependencies
+              shell: bash
+              run: yarn install --immutable
+
+            - name: Lint styles
+              if: ${{ needs.changed_files.outputs.styles_added_files != '' || needs.changed_files.outputs.styles_modified_files != '' }}
+              uses: reviewdog/action-stylelint@v1.30.2
+              with:
+                  fail_level: error
+                  filter_mode: diff_context
+                  level: error
+                  reporter: github-pr-review
+                  stylelint_input: '${{ needs.changed_files.outputs.styles_added_files }} ${{ needs.changed_files.outputs.styles_modified_files }}'
+                  stylelint_config: '${{ github.workspace }}/.stylelintrc.json'
+                  packages: 'stylelint-header stylelint-config-standard'
+
+            - name: ESLint
+              uses: reviewdog/action-eslint@v1.33.2
+              if: ${{ needs.changed_files.outputs.eslint_added_files != '' || needs.changed_files.outputs.eslint_modified_files != '' }}
+              with:
+                  fail_level: error
+                  level: error
+                  reporter: github-pr-review
+                  filter_mode: diff_context
+                  eslint_flags: '${{ needs.changed_files.outputs.eslint_added_files }} ${{ needs.changed_files.outputs.eslint_modified_files }}'

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build-storybook.log
 tach-results.*
 .gitconfig
 .netlify/plugins
+.env
 
 # documentation
 documentation/components/searchIndex.json

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,11 +6,6 @@
     },
     "overrides": [
         {
-            "files": [
-                "!packages/**/src/spectrum-*.css",
-                "!tools/**/src/spectrum-*.css",
-                "!tools/styles/**/*.css"
-            ],
             "extends": ["stylelint-config-standard"],
             "rules": {
                 "header/header": ["config/license.js", {}],

--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
+    "private": true,
     "name": "@adobe/spectrum-web-components",
     "version": "0.0.9",
-    "private": true,
-    "description": "",
-    "type": "module",
-    "engines": {
-        "node": ">=20",
-        "yarn": ">=4.6.0"
+    "description": "Spectrum Web Components are a set of reusable, accessible, and customizable web components following the design language of Adobe Spectrum.",
+    "license": "Apache-2.0",
+    "author": "Adobe",
+    "homepage": "https://opensource.adobe.com/spectrum-web-components/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/adobe/spectrum-web-components.git"
     },
+    "bugs": {
+        "url": "https://github.com/adobe/spectrum-web-components/issues"
+    },
+    "type": "module",
     "scripts": {
         "analyze": "lit-analyzer \"{packages,tools}/*/src/**/!(*.css).ts\"",
         "build": "wireit",
@@ -79,6 +85,13 @@
         "vrt:preview": "yarn wds --config test/visual/wds-vrt.config.js",
         "vrt:quick-link": "yarn netlify deploy --alias=vrt --dir=projects/vrt-quick-link"
     },
+    "workspaces": [
+        "linters/*",
+        "packages/*",
+        "projects/*",
+        "tools/*",
+        "react/*"
+    ],
     "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.5",
@@ -144,6 +157,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-formatter-pretty": "^5.0.0",
         "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jsonc": "^2.20.1",
         "eslint-plugin-lit-a11y": "^2.2.2",
         "eslint-plugin-notice": "^0.9.10",
         "eslint-plugin-prettier": "^5.1.3",
@@ -157,6 +171,7 @@
         "gh-pages": "^6.0.0",
         "gunzip-maybe": "^1.4.2",
         "husky": "^9.0.10",
+        "jsonc-eslint-parser": "^2.4.0",
         "latest-version": "^9.0.0",
         "lightningcss": "1.19.0",
         "lint-staged": "^15.5.1",
@@ -189,12 +204,29 @@
         "wireit": "^0.14.3",
         "yargs": "^17.2.1"
     },
+    "keywords": [
+        "design-system",
+        "spectrum",
+        "adobe",
+        "adobe-spectrum",
+        "web components",
+        "web-components",
+        "lit-element",
+        "lit-html"
+    ],
+    "engines": {
+        "node": ">=20",
+        "yarn": ">=4.6.0"
+    },
     "wireit": {
-        "build:css:watch": {
-            "command": "node ./scripts/watch-css.js",
-            "service": true
+        "build": {
+            "dependencies": [
+                "build:ts",
+                "build:types"
+            ]
         },
         "build:css": {
+            "clean": "if-file-deleted",
             "command": "node ./scripts/build-css.js",
             "files": [
                 "packages/**/*.css",
@@ -205,14 +237,14 @@
             "output": [
                 "packages/**/*.css.ts",
                 "tools/**/*.css.ts"
-            ],
-            "clean": "if-file-deleted"
+            ]
         },
-        "build:ts:watch": {
-            "command": "node ./scripts/watch-ts.js",
+        "build:css:watch": {
+            "command": "node ./scripts/watch-css.js",
             "service": true
         },
         "build:ts": {
+            "clean": "if-file-deleted",
             "command": "node ./scripts/build-ts.js",
             "dependencies": [
                 "process-icons",
@@ -259,10 +291,14 @@
                 "!test/visual/src/index.html",
                 "!test/visual/wds-vrt.config.js",
                 "!tools/base/src/version.js"
-            ],
-            "clean": "if-file-deleted"
+            ]
+        },
+        "build:ts:watch": {
+            "command": "node ./scripts/watch-ts.js",
+            "service": true
         },
         "build:types": {
+            "clean": "if-file-deleted",
             "command": "tsc --build tsconfig-all.json --pretty",
             "dependencies": [
                 "process-icons",
@@ -283,19 +319,12 @@
                 "tools/**/tsconfig.tsbuildinfo",
                 "!**/local.d.ts",
                 "!tools/base/src/version.d.ts"
-            ],
-            "clean": "if-file-deleted"
+            ]
         },
         "build:watch": {
             "dependencies": [
                 "build:css:watch",
                 "build:ts:watch"
-            ]
-        },
-        "build": {
-            "dependencies": [
-                "build:ts",
-                "build:types"
             ]
         },
         "icons": {
@@ -308,6 +337,7 @@
             ]
         },
         "icons:ui": {
+            "clean": "if-file-deleted",
             "command": "yarn workspace @spectrum-web-components/icons-ui build",
             "files": [
                 "packages/icons-ui/bin/build.js",
@@ -324,10 +354,10 @@
                 "!packages/icons-ui/src/index.ts",
                 "!packages/icons-ui/src/custom-tag.ts",
                 "!packages/icons-workflow/src/DefaultIcon.ts"
-            ],
-            "clean": "if-file-deleted"
+            ]
         },
         "icons:workflow": {
+            "clean": "if-file-deleted",
             "command": "yarn workspace @spectrum-web-components/icons-workflow build",
             "files": [
                 "!packages/icons-workflow/bin/build.js",
@@ -343,8 +373,7 @@
                 "!packages/icons-workflow/src/custom-tag.ts",
                 "!packages/icons-workflow/src/DefaultIcon.ts",
                 "!packages/icons-workflow/bin/icons-mapping.json"
-            ],
-            "clean": "if-file-deleted"
+            ]
         },
         "prestorybook": {
             "command": "cem analyze --outdir storybook/",
@@ -365,13 +394,14 @@
         },
         "storybook": {
             "command": "storybook dev -p 8080 -c storybook",
-            "service": true,
             "dependencies": [
                 "build:watch",
                 "prestorybook"
-            ]
+            ],
+            "service": true
         },
         "test:create": {
+            "clean": "if-file-deleted",
             "command": "node test/visual/create.js",
             "files": [
                 "packages/*/stories/*.stories.ts",
@@ -380,36 +410,8 @@
             "output": [
                 "packages/*/test/*.test-vrt.ts",
                 "tools/*/test/*.test-vrt.ts"
-            ],
-            "clean": "if-file-deleted"
+            ]
         }
     },
-    "workspaces": [
-        "linters/*",
-        "packages/*",
-        "projects/*",
-        "tools/*",
-        "react/*"
-    ],
-    "packageManager": "yarn@4.9.1",
-    "license": "Apache-2.0",
-    "author": "Adobe",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/adobe/spectrum-web-components.git"
-    },
-    "bugs": {
-        "url": "https://github.com/adobe/spectrum-web-components/issues"
-    },
-    "keywords": [
-        "design-system",
-        "spectrum",
-        "adobe",
-        "adobe-spectrum",
-        "web components",
-        "web-components",
-        "lit-element",
-        "lit-html"
-    ],
-    "homepage": "https://opensource.adobe.com/spectrum-web-components/"
+    "packageManager": "yarn@4.9.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,6 +270,7 @@ __metadata:
     eslint-config-prettier: "npm:^9.1.0"
     eslint-formatter-pretty: "npm:^5.0.0"
     eslint-plugin-import: "npm:^2.26.0"
+    eslint-plugin-jsonc: "npm:^2.20.1"
     eslint-plugin-lit-a11y: "npm:^2.2.2"
     eslint-plugin-notice: "npm:^0.9.10"
     eslint-plugin-prettier: "npm:^5.1.3"
@@ -283,6 +284,7 @@ __metadata:
     gh-pages: "npm:^6.0.0"
     gunzip-maybe: "npm:^1.4.2"
     husky: "npm:^9.0.10"
+    jsonc-eslint-parser: "npm:^2.4.0"
     latest-version: "npm:^9.0.0"
     lightningcss: "npm:1.19.0"
     lint-staged: "npm:^15.5.1"
@@ -3906,6 +3908,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint-community/eslint-utils@npm:^4.5.1":
+  version: 4.7.0
+  resolution: "@eslint-community/eslint-utils@npm:4.7.0"
+  dependencies:
+    eslint-visitor-keys: "npm:^3.4.3"
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+  checksum: 10c0/c0f4f2bd73b7b7a9de74b716a664873d08ab71ab439e51befe77d61915af41a81ecec93b408778b3a7856185244c34c2c8ee28912072ec14def84ba2dec70adf
+  languageName: node
+  linkType: hard
+
 "@eslint-community/regexpp@npm:^4.10.0, @eslint-community/regexpp@npm:^4.6.1":
   version: 4.10.0
   resolution: "@eslint-community/regexpp@npm:4.10.0"
@@ -5786,6 +5799,13 @@ __metadata:
   version: 0.1.1
   resolution: "@pkgr/core@npm:0.1.1"
   checksum: 10c0/3f7536bc7f57320ab2cf96f8973664bef624710c403357429fbf680a5c3b4843c1dbd389bb43daa6b1f6f1f007bb082f5abcb76bb2b5dc9f421647743b71d3d8
+  languageName: node
+  linkType: hard
+
+"@pkgr/core@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "@pkgr/core@npm:0.2.4"
+  checksum: 10c0/2528a443bbbef5d4686614e1d73f834f19ccbc975f62b2a64974a6b97bcdf677b9c5e8948e04808ac4f0d853e2f422adfaae2a06e9e9f4f5cf8af76f1adf8dc1
   languageName: node
   linkType: hard
 
@@ -16423,6 +16443,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-compat-utils@npm:^0.6.4":
+  version: 0.6.5
+  resolution: "eslint-compat-utils@npm:0.6.5"
+  dependencies:
+    semver: "npm:^7.5.4"
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 10c0/f3519e1460ec82c6967c4b0132801924bf5c17328999014f444ec12f075b151e992d1ebf378cb8eb0b2e00b3d04e0eaac80897209121fd115f857598b4588393
+  languageName: node
+  linkType: hard
+
 "eslint-config-airbnb-base@npm:^15.0.0":
   version: 15.0.0
   resolution: "eslint-config-airbnb-base@npm:15.0.0"
@@ -16473,6 +16504,21 @@ __metadata:
     is-core-module: "npm:^2.13.0"
     resolve: "npm:^1.22.4"
   checksum: 10c0/0ea8a24a72328a51fd95aa8f660dcca74c1429806737cf10261ab90cfcaaf62fd1eff664b76a44270868e0a932711a81b250053942595bcd00a93b1c1575dd61
+  languageName: node
+  linkType: hard
+
+"eslint-json-compat-utils@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "eslint-json-compat-utils@npm:0.2.1"
+  dependencies:
+    esquery: "npm:^1.6.0"
+  peerDependencies:
+    eslint: "*"
+    jsonc-eslint-parser: ^2.4.0
+  peerDependenciesMeta:
+    "@eslint/json":
+      optional: true
+  checksum: 10c0/2eb584916150454da891547042d417b31ed4df9b7a8c47561c3cda08d0d9e66c698259cf3dbb4ecc139a6620c793aeba40109f572e47f4fe7b3185b9c1d388d7
   languageName: node
   linkType: hard
 
@@ -16531,6 +16577,24 @@ __metadata:
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
   checksum: 10c0/5f35dfbf4e8e67f741f396987de9504ad125c49f4144508a93282b4ea0127e052bde65ab6def1f31b6ace6d5d430be698333f75bdd7dca3bc14226c92a083196
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-jsonc@npm:^2.20.1":
+  version: 2.20.1
+  resolution: "eslint-plugin-jsonc@npm:2.20.1"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.5.1"
+    eslint-compat-utils: "npm:^0.6.4"
+    eslint-json-compat-utils: "npm:^0.2.1"
+    espree: "npm:^9.6.1 || ^10.3.0"
+    graphemer: "npm:^1.4.0"
+    jsonc-eslint-parser: "npm:^2.4.0"
+    natural-compare: "npm:^1.4.0"
+    synckit: "npm:^0.6.2 || ^0.7.3 || ^0.11.5"
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 10c0/a75923263436a92c2d7232677cabdac06c966ca9fccfe7edea190dc762c28538f1df22d4deb81f8ba11df742f3bdfbfde3b059d8174d8814fa1667d01eb1163e
   languageName: node
   linkType: hard
 
@@ -16705,10 +16769,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
+"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
   checksum: 10c0/92708e882c0a5ffd88c23c0b404ac1628cf20104a108c745f240a13c332a11aac54f49a22d5762efbffc18ecbc9a580d1b7ad034bf5f3cc3307e5cbff2ec9820
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "eslint-visitor-keys@npm:4.2.0"
+  checksum: 10c0/2ed81c663b147ca6f578312919483eb040295bbab759e5a371953456c636c5b49a559883e2677112453728d66293c0a4c90ab11cab3428cf02a0236d2e738269
   languageName: node
   linkType: hard
 
@@ -16769,7 +16840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:^9.6.0, espree@npm:^9.6.1":
+"espree@npm:^9.0.0, espree@npm:^9.6.0, espree@npm:^9.6.1":
   version: 9.6.1
   resolution: "espree@npm:9.6.1"
   dependencies:
@@ -16777,6 +16848,17 @@ __metadata:
     acorn-jsx: "npm:^5.3.2"
     eslint-visitor-keys: "npm:^3.4.1"
   checksum: 10c0/1a2e9b4699b715347f62330bcc76aee224390c28bb02b31a3752e9d07549c473f5f986720483c6469cf3cfb3c9d05df612ffc69eb1ee94b54b739e67de9bb460
+  languageName: node
+  linkType: hard
+
+"espree@npm:^9.6.1 || ^10.3.0":
+  version: 10.3.0
+  resolution: "espree@npm:10.3.0"
+  dependencies:
+    acorn: "npm:^8.14.0"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^4.2.0"
+  checksum: 10c0/272beeaca70d0a1a047d61baff64db04664a33d7cfb5d144f84bc8a5c6194c6c8ebe9cc594093ca53add88baa23e59b01e69e8a0160ab32eac570482e165c462
   languageName: node
   linkType: hard
 
@@ -16796,6 +16878,15 @@ __metadata:
   dependencies:
     estraverse: "npm:^5.1.0"
   checksum: 10c0/a084bd049d954cc88ac69df30534043fb2aee5555b56246493f42f27d1e168f00d9e5d4192e46f10290d312dc30dc7d58994d61a609c579c1219d636996f9213
+  languageName: node
+  linkType: hard
+
+"esquery@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "esquery@npm:1.6.0"
+  dependencies:
+    estraverse: "npm:^5.1.0"
+  checksum: 10c0/cb9065ec605f9da7a76ca6dadb0619dfb611e37a81e318732977d90fab50a256b95fee2d925fba7c2f3f0523aa16f91587246693bc09bc34d5a59575fe6e93d2
   languageName: node
   linkType: hard
 
@@ -21474,6 +21565,18 @@ __metadata:
   bin:
     json5: lib/cli.js
   checksum: 10c0/5a04eed94810fa55c5ea138b2f7a5c12b97c3750bc63d11e511dcecbfef758003861522a070c2272764ee0f4e3e323862f386945aeb5b85b87ee43f084ba586c
+  languageName: node
+  linkType: hard
+
+"jsonc-eslint-parser@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "jsonc-eslint-parser@npm:2.4.0"
+  dependencies:
+    acorn: "npm:^8.5.0"
+    eslint-visitor-keys: "npm:^3.0.0"
+    espree: "npm:^9.0.0"
+    semver: "npm:^7.3.5"
+  checksum: 10c0/1bef9f4f12122824e1d13ef651b7a8d16cbf6995bfd08fabb81df34ff0cf57f5c1c822dd5ee7aece0575fb1351538c8c5ce86f9b94d8f41bcd3bbe2773b62db3
   languageName: node
   linkType: hard
 
@@ -31532,6 +31635,15 @@ __metadata:
   version: 2.0.17
   resolution: "synchronous-promise@npm:2.0.17"
   checksum: 10c0/1babe643d8417789ef6e5a2f3d4b8abcda2de236acd09bbe2c98f6be82c0a2c92ed21a6e4f934845fa8de18b1435a9cba1e8c3d945032e8a532f076224c024b1
+  languageName: node
+  linkType: hard
+
+"synckit@npm:^0.6.2 || ^0.7.3 || ^0.11.5":
+  version: 0.11.8
+  resolution: "synckit@npm:0.11.8"
+  dependencies:
+    "@pkgr/core": "npm:^0.2.4"
+  checksum: 10c0/a1de5131ee527512afcaafceb2399b2f3e63678e56b831e1cb2dc7019c972a8b654703a3b94ef4166868f87eb984ea252b467c9d9e486b018ec2e6a55c24dfd8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This migrates linting from CircleCI to GitHub Actions.

## Motivation and context

The current linting in CI is more-or-less boolean (did it pass or not) but requires pulling down the branch locally and linting to fix things. This update moves our linting work into a GitHub Action that uses ReviewDog to lint and report back to the pull request what the linter identified.

---

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [x] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [x] Automated tests cover all use cases and follow best practices for writing
-   [x] Validated on all supported browsers
-   [x] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

-   [x] _Expect linting to report back to the pull request with the specific errors_: https://github.com/adobe/spectrum-web-components/pull/5507#discussion_r2116138725 🎉 