### PR TITLE
fix(progressbar): progress bar animation jitter

### DIFF
--- a/.changeset/smart-yaks-check.md
+++ b/.changeset/smart-yaks-check.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/progress-bar': patch
+---
+
+Smooths the transition animation of indeterminate progress bar by overriding the incoming CSS, and positioning the animating fill element completely off of the progress bar track in both LTR and RTL languages. Before, the fill element was automatically starting on the track which led to a jarring animation loop.

--- a/packages/progress-bar/src/progress-bar.css
+++ b/packages/progress-bar/src/progress-bar.css
@@ -24,28 +24,20 @@ governing permissions and limitations under the License.
 
 @keyframes indeterminate-loop-ltr {
     0% {
-        /* Magic number: positions the fill fully off the track */
-        left: -25%;
-        transform: translate(calc(var(--mod-progressbar-fill-size-indeterminate, var(--spectrum-progressbar-fill-size-indeterminate)) * -1));
+        transform: translate(-100%);
     }
 
     100% {
-        /* repositions the fill to its original position */
-        left: 0;
-        transform: translate(var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default)));
+        transform: translate(var(--spectrum-progressbar-size-default));
     }
 }
 
 @keyframes indeterminate-loop-rtl {
     0% {
-        /* Magic number:positions the fill fully off the track */
-        right: -25%;
-        transform: translate(var(--mod-progressbar-size-default, var(--spectrum-progressbar-fill-size-indeterminate)));
+        transform: translate(100%);
     }
 
     100% {
-        /* repositions the fill to its original position */
-        right: 0;
-        transform: translate(calc(var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default)) * -1));
+        transform: translate(calc(var(--spectrum-progressbar-size-default) * -1));
     }
 }

--- a/packages/progress-bar/src/progress-bar.css
+++ b/packages/progress-bar/src/progress-bar.css
@@ -21,3 +21,31 @@ governing permissions and limitations under the License.
 :host([dir="rtl"]) .fill {
     transform-origin: right;
 }
+
+@keyframes indeterminate-loop-ltr {
+    0% {
+        /* Magic number: positions the fill fully off the track */
+        left: -25%;
+        transform: translate(calc(var(--mod-progressbar-fill-size-indeterminate, var(--spectrum-progressbar-fill-size-indeterminate)) * -1));
+    }
+
+    100% {
+        /* repositions the fill to its original position */
+        left: 0;
+        transform: translate(var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default)));
+    }
+}
+
+@keyframes indeterminate-loop-rtl {
+    0% {
+        /* Magic number:positions the fill fully off the track */
+        right: -25%;
+        transform: translate(var(--mod-progressbar-size-default, var(--spectrum-progressbar-fill-size-indeterminate)));
+    }
+
+    100% {
+        /* repositions the fill to its original position */
+        right: 0;
+        transform: translate(calc(var(--mod-progressbar-size-default, var(--spectrum-progressbar-size-default)) * -1));
+    }
+}


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

- first commit: adds magic number positioning to progress bar animation keyframes, to smooth out the looping animation
- second commit: redefines indeterminate animation transforms to position fill off of the track

I am in favor of the second commit, simply redefining the keyframes so that the fill's starting position is off of the track, as opposed to partially on the track.

## Motivation and context

CSS-1241

<!--- Why is this change required? What problem does it solve? -->

A bug was recently reported in Slack that said: 

> The smooth motion followed by the jump to reset is quite jarring. I wonder if it's supposed to smoothly loop? The indeterminate progress bar does not smoothly loop, it has a large jump from the end state to the start state.

This PR aims to smooth out the transition between the end and the start of the animation loop. 

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes CSS-1241

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [x] I have included a well-written changeset if my change needs to be published.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Descriptive Test Statement_

    1. Go [here](url)
    2. Do this action
    3. Expect this result

-   [ ] _Descriptive Test Statement_
    1. Go [here](url)
    2. Do this action
    3. Expect this result

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
