### PR TITLE
fix(switch): down state styles take precedence over hover

### DIFF
--- a/.changeset/grumpy-forks-bathe.md
+++ b/.changeset/grumpy-forks-bathe.md
@@ -1,0 +1,9 @@
+---
+'@spectrum-web-components/switch': patch
+---
+
+### Fix down state colors for switch
+
+Because the `postcss-hover-media-feature` plugin converts hover styles into a media query for devices that support hover, the hover styles were overriding any active/down state styles. We needed to target the active/down states of the switch with additional active state selectors, in order to ensure that the active state takes precedence over the hover state, maintaining the correct visual behavior of the switch component across different interaction states.
+
+This fix should address hover + active state discrepancies in S1 and S2 foundations.

--- a/packages/switch/src/switch.css
+++ b/packages/switch/src/switch.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2025 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -15,4 +15,28 @@ governing permissions and limitations under the License.
 
 :host([disabled]) {
     pointer-events: none;
+}
+
+/* the handle's border in the down/active state remains the same if a user moves their cursor 
+while still activating/pressing the switch. Read-only switches should not have this behavior. */
+:host(:hover:active) #input + #switch:before,
+:host([emphasized]:hover:active) #input + #switch:before {
+    border-color: var(--highcontrast-switch-handle-border-color-down, var(--mod-switch-handle-border-color-down, var(--spectrum-switch-handle-border-color-down)));
+}
+
+:host(:active[checked]) #input:enabled + #switch:before {
+    border-color: var(--highcontrast-switch-handle-border-color-selelcted-down, var(--mod-switch-handle-border-color-selected-down, var(--spectrum-switch-handle-border-color-selected-down)));
+}
+
+:host(:active[checked]) #input:enabled + #switch {
+    background-color: var(--highcontrast-switch-background-color-selected-down, var(--mod-switch-background-color-selected-down, var(--spectrum-switch-background-color-selected-down)));
+}
+
+/* Ensure read-only switches don't show interaction styles */
+:host([readonly]) #input + #switch:before {
+    border-color: var(--highcontrast-switch-handle-border-color-default, var(--mod-switch-handle-border-color-default, var(--spectrum-switch-handle-border-color-default))) !important;
+}
+
+:host([readonly][checked]) #input + #switch:before {
+    border-color: var(--highcontrast-switch-handle-border-color-selected-default, var(--mod-switch-handle-border-color-selected-default, var(--spectrum-switch-handle-border-color-selected-default))) !important;
 }


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->
This work builds off of the `spectrum-two` fix for this in https://github.com/adobe/spectrum-css/pull/3767, but addressing the same bug in the S1 context for SWC components. The switch in either context should now respond appropriately to the active state, with the active styles taking precedence over any hover styles. When a user now activates the active/down state, a visual difference can be noted, and that visual difference is no longer dependent on mouse movement (where it was incorrect before).

**New behavior**

https://github.com/user-attachments/assets/f1b8306c-6001-4d54-a733-5b160bd7f620


## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

It was brought up in a Slack bug report that the switch may have some specificity issues between the hover and active states. The original message noted how to reproduce what they were seeing: 

> Note the default color of the switch
Hover on the switch, note the color change
Click and hold on the switch, note there is no color change
While holding the mouse down, move the mouse off the switch -- note the color is now darker than default or hover
Release the mouse with your cursor outside of the switch and the color goes back to default

**Production (old behavior)**

https://github.com/user-attachments/assets/031071d8-bdee-4814-88b9-70b75456abbf


## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- CSS-1240 (clones 👇 1199)
-  CSS-1199 (archived)

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have included a well-written changeset if my change needs to be published.

---

## Reviewer's checklist

-   [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [x] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [n/a] Automated tests cover all use cases and follow best practices for writing
-   [x] Validated on all supported browsers
-   [x] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

#### S1
-   [x] _Unchecked switch down state styles_

    1. Go to [the switch default story](https://marissahuysentruyt-css-1240-switch-down-state-s1--spectrum-wc.netlify.app/storybook/?path=/story/switch--default)
    2. Using the steps noted in the "Motivation and context" section above, you should be able to visually see the active/down state styles get triggered on click, as opposed to not seeing the down state styles until after you have clicked AND dragged off of the switch.
    3. Inspect `sp-switch` and toggle `:active` and `:hover` states in your browser tools.
    4. Verify that the border-color for the `#switch::before` element renders `--spectrum-switch-handle-border-color-down` [@cdransf]

-   [x] _Checked switch down state styles_
    1. Go to [the checked switch story](https://marissahuysentruyt-css-1240-switch-down-state-s1--spectrum-wc.netlify.app/storybook/?path=/story/switch--checked)
    2. Once again, using the steps noted in the "Motivation and context" section above, you should be able to visually see the active/down state styles get triggered on click, as opposed to not seeing the down state styles until after you have clicked AND dragged off of the switch.
    3. Inspect `sp-switch` and toggle `:active` and `:hover` states in your browser tools.
    4. Verify that the border-color for the `#switch::before` element renders `--spectrum-switch-handle-border-color-selected-down`. [@cdransf]

#### Additional validation
- [x] Test the same steps as outlined in the "Motivation and context" section on the 2 emphasized stories. Results should be the same, just with emphasized styles. [@cdransf]
- [x] Test the read-only and disabled switches. When going through the steps outlined, nothing should occur (this was the behavior as it was before these changes). [@cdransf]

#### S2 foundations & Express
- [x] Repeat the test scenarios above in the S2 foundations and Express context. [@cdransf]

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [x] Did it pass in Desktop?
-   [x] Did it pass in (emulated) Mobile?
-   [x] Did it pass in (emulated) iPad?
