### PR TITLE
fix(styles): cjk alias mapping fixed

### DIFF
--- a/.changeset/fair-carrots-kiss.md
+++ b/.changeset/fair-carrots-kiss.md
@@ -1,0 +1,7 @@
+---
+'@spectrum-web-components/styles': patch
+---
+
+Bring the CJK font alias token fix from CSS [#3883](https://github.com/adobe/spectrum-css/pull/3883) [`4e3a120`](https://github.com/adobe/spectrum-css/commit/4e3a120339a6e7e6d0d19e3f2f7f608ab96621ed).
+
+The `--spectrum-cjk-font` token was incorrectly mapped to the code font-family stack instead of `--spectrum-cjk-font-family-stack`. Thanks [@byteakp](https://github.com/byteakp)!

--- a/tools/styles/tokens-v2/global-vars.css
+++ b/tools/styles/tokens-v2/global-vars.css
@@ -645,7 +645,7 @@
     --spectrum-font-style: var(--spectrum-default-font-style);
     --spectrum-font-size: var(--spectrum-font-size-100);
     --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-    --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
+    --spectrum-cjk-font: var(--spectrum-cjk-font-family-stack);
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;
     --spectrum-docs-static-white-background-color: rgba(var(--spectrum-docs-static-white-background-color-rgb));
     --spectrum-docs-static-black-background-color-rgb: 181, 209, 211;

--- a/tools/styles/tokens-v2/index.css
+++ b/tools/styles/tokens-v2/index.css
@@ -1474,7 +1474,7 @@
     --spectrum-font-style: var(--spectrum-default-font-style);
     --spectrum-font-size: var(--spectrum-font-size-100);
     --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-    --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
+    --spectrum-cjk-font: var(--spectrum-cjk-font-family-stack);
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;
     --spectrum-docs-static-white-background-color: rgba(var(--spectrum-docs-static-white-background-color-rgb));
     --spectrum-docs-static-black-background-color-rgb: 181, 209, 211;

--- a/tools/styles/tokens-v2/spectrum/custom-vars.css
+++ b/tools/styles/tokens-v2/spectrum/custom-vars.css
@@ -31,7 +31,7 @@
     --spectrum-code-font-family-stack: "Source Code Pro", Monaco, monospace;
 
     --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-    --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
+    --spectrum-cjk-font: var(--spectrum-cjk-font-family-stack);
 
     /* static white / black background color for docs containers */
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;

--- a/tools/styles/tokens/index.css
+++ b/tools/styles/tokens/index.css
@@ -3108,7 +3108,7 @@
     --spectrum-font-style: var(--spectrum-default-font-style);
     --spectrum-font-size: var(--spectrum-font-size-100);
     --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-    --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
+    --spectrum-cjk-font: var(--spectrum-cjk-font-family-stack);
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;
     --spectrum-docs-static-white-background-color: rgba(var(--spectrum-docs-static-white-background-color-rgb));
     --spectrum-docs-static-black-background-color-rgb: 181, 209, 211;

--- a/tools/styles/tokens/spectrum/custom-vars.css
+++ b/tools/styles/tokens/spectrum/custom-vars.css
@@ -31,7 +31,7 @@
     --spectrum-code-font-family-stack: "Source Code Pro", Monaco, monospace;
 
     --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-    --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
+    --spectrum-cjk-font: var(--spectrum-cjk-font-family-stack);
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;
     --spectrum-docs-static-white-background-color: rgba(var(--spectrum-docs-static-white-background-color-rgb));
     --spectrum-docs-static-black-background-color-rgb: 181, 209, 211;

--- a/tools/styles/tokens/spectrum/global-vars.css
+++ b/tools/styles/tokens/spectrum/global-vars.css
@@ -70,7 +70,7 @@
     --spectrum-font-style: var(--spectrum-default-font-style);
     --spectrum-font-size: var(--spectrum-font-size-100);
     --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-    --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
+    --spectrum-cjk-font: var(--spectrum-cjk-font-family-stack);
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;
     --spectrum-docs-static-white-background-color: rgba(var(--spectrum-docs-static-white-background-color-rgb));
     --spectrum-docs-static-black-background-color-rgb: 181, 209, 211;

--- a/tools/styles/tokens/spectrum/index.css
+++ b/tools/styles/tokens/spectrum/index.css
@@ -170,7 +170,7 @@
     --spectrum-font-style: var(--spectrum-default-font-style);
     --spectrum-font-size: var(--spectrum-font-size-100);
     --spectrum-cjk-font-family-stack: adobe-clean-han-japanese, var(--spectrum-cjk-font-family), sans-serif;
-    --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
+    --spectrum-cjk-font: var(--spectrum-cjk-font-family-stack);
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;
     --spectrum-docs-static-white-background-color: rgba(var(--spectrum-docs-static-white-background-color-rgb));
     --spectrum-docs-static-black-background-color-rgb: 181, 209, 211;


### PR DESCRIPTION
## Description

A contributor identified that one of our alias tokens for CJK font was pointing to the code font-family stack instead of the appropriate (and expected) CJK font-family stack.

## Related issue(s)

-  Fix brought over from CSS contribution https://github.com/adobe/spectrum-css/pull/3936

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [n/a] I have added automated tests to cover my changes.
-   [x] I have included a well-written changeset if my change needs to be published.
-   [n/a] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

-   No test cases for this because our library does not appear to use the cjk-font alias variable. Bringing the fix over in case downstream consumers are using it.
