### PR TITLE
chore: checkout before fetching changed files to have a baseline to run against

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,9 @@ jobs:
             pull-requests: read
 
         steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
             - name: Get changed files
               id: changed-files
               uses: step-security/changed-files@v46


### PR DESCRIPTION
## Description

Identified a bug in this [run](https://github.com/adobe/spectrum-web-components/actions/runs/15588961722/job/43902673269) requiring the checkout action to be run before the changed files can be identified.

This is only an issue when run from a push event and not from a pull request.

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.