### PR TITLE
fix(progressbar): progress bar animation jitter

### DIFF
--- a/.changeset/smart-yaks-check.md
+++ b/.changeset/smart-yaks-check.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/progress-bar': patch
+---
+
+Smooths the transition animation of indeterminate progress bar by overriding the incoming CSS, and positioning the animating fill element completely off of the progress bar track in both LTR and RTL languages. Before, the fill element was automatically starting on the track which led to a jarring animation loop.

--- a/packages/progress-bar/src/progress-bar.css
+++ b/packages/progress-bar/src/progress-bar.css
@@ -21,3 +21,23 @@ governing permissions and limitations under the License.
 :host([dir="rtl"]) .fill {
     transform-origin: right;
 }
+
+@keyframes indeterminate-loop-ltr {
+    0% {
+        transform: translate(-100%);
+    }
+
+    100% {
+        transform: translate(var(--spectrum-progressbar-size-default));
+    }
+}
+
+@keyframes indeterminate-loop-rtl {
+    0% {
+        transform: translate(100%);
+    }
+
+    100% {
+        transform: translate(calc(var(--spectrum-progressbar-size-default) * -1));
+    }
+}


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

This PR is a copy of #5509 (Netlify wasn't building preview links for that branch)

- first commit: adds magic number positioning to progress bar animation keyframes, to smooth out the looping animation
- second commit: redefines indeterminate animation transforms to position fill off of the track

I am in favor of the second commit, simply redefining the keyframes so that the fill's starting position is off of the track, as opposed to partially on the track.

## Motivation and context

CSS-1241

<!--- Why is this change required? What problem does it solve? -->

A bug was recently reported in Slack that said: 

> The smooth motion followed by the jump to reset is quite jarring. I wonder if it's supposed to smoothly loop? The indeterminate progress bar does not smoothly loop, it has a large jump from the end state to the start state.

**Production storybook**

https://github.com/user-attachments/assets/88df6376-6c58-460f-ae82-5abab7f9c09e


This PR aims to smooth out the transition between the end and the start of the animation loop. 
 **PR preview**

https://github.com/user-attachments/assets/dbb25d33-7a75-4624-8df8-598f060af2d9


## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes CSS-1241

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [x] I have included a well-written changeset if my change needs to be published.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Indeterminate progress bar animation is smooth_

    1. [Go to the indeterminate progress bar story](https://marissahuysentruyt-progressbar-animation--spectrum-wc.netlify.app/storybook/?path=/story/progress-bar--indeterminate)
    2. Upon visual inspection, verify the animation looks smooth now. (see the screen recording above)
    3. Inspect the `.fill` element. The `indeterminate-loop-ltr` animation should start the `.fill` 100% off of the left side of the `.track` (`-100%`), and translate it to the other end of the `.track`.
        a. `--spectrum-progressbar-default-size` is undefined in Chrome, but is defined in Firefox. Chrome, Firefox, and Safari seem to correctly animate the `.fill` regardless. 
    4. Toggle the story from LTR, to RTL. 
    5. Repeat step 3, but verifying the `indeterminate-loop-rtl` animates the `.fill` in the same way, from the right side of the `.track` (`100%`), to the left.
    6. Finally, you can also adjust and slow down the `animation-duration` property in your dev tools. It should be even more apparent at a slower loop speed that the `.fill` starts the animation positioned off of the `.track`, instead of starting on the `.track`.

`animation-duration: 3s;`

https://github.com/user-attachments/assets/84a664c5-e604-4012-bee6-e21feb4ceeaf


### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [x] Did it pass in Desktop?
-   [x] Did it pass in (emulated) Mobile?
-   [x] Did it pass in (emulated) iPad?
