### PR TITLE
docs(tabs): update a11y docs

### DIFF
--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -128,7 +128,7 @@ Tabs are created from the following parts:
 
 #### Variants
 
-An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, and `quiet`, or with content like icons, etc.
+An `<sp-tabs>` element will display horizontally by default. It can be modified with attributes like `compact`, and `quiet`, or with content like icons, etc.
 
 <sp-tabs selected="compact" auto label="Horizontal Tabs variants">
 <sp-tab value="compact">Compact</sp-tab>
@@ -146,25 +146,6 @@ Compact tabs should never be used without the quiet variation. Please use Quiet 
     <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
     <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
     <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
-</sp-tabs>
-```
-
-</sp-tab-panel>
-<sp-tab value="disabled">Disabled</sp-tab>
-<sp-tab-panel value="disabled">
-
-When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
-
-```html demo
-<sp-tabs selected="2" disabled>
-    <sp-tab label="Tab 1" value="1"></sp-tab>
-    <sp-tab label="Tab 2" value="2"></sp-tab>
-    <sp-tab label="Tab 3" value="3"></sp-tab>
-    <sp-tab label="Tab 4" value="4"></sp-tab>
-    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
-    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
 </sp-tabs>
 ```
 
@@ -252,25 +233,6 @@ Compact tabs should never be used without the quiet variation. Please use Quiet 
 ```
 
 </sp-tab-panel>
-<sp-tab value="disabled">Disabled</sp-tab>
-<sp-tab-panel value="disabled">
-
-When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
-
-```html demo
-<sp-tabs selected="2" disabled direction="vertical">
-    <sp-tab label="Tab 1" value="1"></sp-tab>
-    <sp-tab label="Tab 2" value="2"></sp-tab>
-    <sp-tab label="Tab 3" value="3"></sp-tab>
-    <sp-tab label="Tab 4" value="4"></sp-tab>
-    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
-    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
-</sp-tabs>
-```
-
-</sp-tab-panel>
 <sp-tab value="icons">Icons</sp-tab>
 <sp-tab-panel value="icons">
 
@@ -334,7 +296,7 @@ When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` chi
 
 ### States
 
-When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+When an `<sp-tabs>` element is given the `disabled` attribute, its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
 
 ```html demo
 <sp-tabs selected="2" disabled>

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -1,4 +1,4 @@
-## Description
+## Overview
 
 The `<sp-tabs>` displays a list of `<sp-tab>` element children as `role="tablist"`. An `<sp-tab>` element is associated with a sibling `<sp-tab-panel>` element via their `value` attribute. When an `<sp-tab>` element is `selected`, the associated `<sp-tab-panel>` will also be selected, showing that panel and hiding the others.
 
@@ -348,6 +348,7 @@ When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` chi
     <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
 </sp-tabs>
 ```
+
 ### Accessibility
 
 When an `<sp-tabs>` has a `selected` value, the `<sp-tab>` child of that `value` will be given `[tabindex="0"]` and will receive initial focus when tabbing into the `<sp-tabs>` element. When no `selected` value is present, the first `<sp-tab>` child will be treated in this way. When focus is currently within the `<sp-tabs>` element, the left and right arrows will move that focus back and forth through the available `<sp-tab>` children.

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -30,44 +30,28 @@ import { Tabs, Tab, TabPanel } from '@spectrum-web-components/tabs';
 
 ### Anatomy
 
+Tabs are created from the following parts:
+
 - **Tabs:** The container component (`<sp-tabs>`) that manages the tab list and handles selection logic.
 - **Tab item:** An individual tab (`<sp-tab>`) that users can select to view different content panels.
 - **Tab view:** The content panel (`<sp-tab-panel>`) associated with a tab, shown when its corresponding tab is selected.
 - **Divider:** A visual separator between tab items, used in some variants for clarity.
 - **Selection indicator:** A visual highlight (such as an underline or bar) that shows which tab is currently selected.
 
-### Options
+```html
+<sp-tabs selected="1" size="m">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```
 
-<sp-table>
-    <sp-table-head>
-        <sp-table-head-cell>Property</sp-table-head-cell>
-        <sp-table-head-cell>Values</sp-table-head-cell>
-        <sp-table-head-cell>Default value</sp-table-head-cell>
-    </sp-table-head>
-    <sp-table-body>
-        <sp-table-row>
-            <sp-table-cell>label</sp-table-cell>
-            <sp-table-cell>text / nothing</sp-table-cell>
-            <sp-table-cell>–</sp-table-cell>
-        </sp-table-row>
-        <sp-table-row>
-            <sp-table-cell>icon</sp-table-cell>
-            <sp-table-cell>icon / nothing</sp-table-cell>
-            <sp-table-cell>nothing</sp-table-cell>
-        </sp-table-row>
-        <sp-table-row>
-            <sp-table-cell>is selected</sp-table-cell>
-            <sp-table-cell>yes / no</sp-table-cell>
-            <sp-table-cell>no</sp-table-cell>
-        </sp-table-row>
-        <sp-table-row>
-            <sp-table-cell>is disabled</sp-table-cell>
-            <sp-table-cell>yes / no</sp-table-cell>
-            <sp-table-cell>no</sp-table-cell>
-        </sp-table-row>
-    </sp-table-body>
-</sp-table>
-<br/>
+### Options
 
 #### Sizes
 
@@ -144,7 +128,7 @@ import { Tabs, Tab, TabPanel } from '@spectrum-web-components/tabs';
 
 #### Variants
 
-An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, `disabled`, and `quiet`, or with content like icons, etc.
+An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, and `quiet`, or with content like icons, etc.
 
 <sp-tabs selected="compact" auto label="Horizontal Tabs variants">
 <sp-tab value="compact">Compact</sp-tab>
@@ -348,6 +332,22 @@ When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` chi
 </sp-tab-panel>
 </sp-tabs>
 
+### States
+
+When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+
+```html demo
+<sp-tabs selected="2" disabled>
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
+</sp-tabs>
+```
 ### Accessibility
 
 When an `<sp-tabs>` has a `selected` value, the `<sp-tab>` child of that `value` will be given `[tabindex="0"]` and will receive initial focus when tabbing into the `<sp-tabs>` element. When no `selected` value is present, the first `<sp-tab>` child will be treated in this way. When focus is currently within the `<sp-tabs>` element, the left and right arrows will move that focus back and forth through the available `<sp-tab>` children.

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -2,19 +2,21 @@
 
 The `<sp-tabs>` displays a list of `<sp-tab>` element children as `role="tablist"`. An `<sp-tab>` element is associated with a sibling `<sp-tab-panel>` element via their `value` attribute. When an `<sp-tab>` element is `selected`, the associated `<sp-tab-panel>` will also be selected, showing that panel and hiding the others.
 
+[View the design documentation for this component.](https://spectrum.adobe.com/page/tabs/)
+
 ### Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/tabs?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/tabs)
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/tabs?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/tabs)
 [![Try it on Stackblitz](https://img.shields.io/badge/Try%20it%20on-Stackblitz-blue?style=for-the-badge)](https://stackblitz.com/edit/vitejs-vite-3smxuwr2)
 
-```
+```zsh
 yarn add @spectrum-web-components/tabs
 ```
 
 Import the side effectful registration of `<sp-tabs>`, `<sp-tab>` or `<sp-tab-panel>` via:
 
-```
+```ts
 import '@spectrum-web-components/tabs/sp-tabs.js';
 import '@spectrum-web-components/tabs/sp-tab.js';
 import '@spectrum-web-components/tabs/sp-tab-panel.js';
@@ -22,15 +24,52 @@ import '@spectrum-web-components/tabs/sp-tab-panel.js';
 
 When looking to leverage the `Tabs`, `Tab`, or `TabPanel` base class as a type and/or for extension purposes, do so via:
 
-```
-import {
-    Tabs,
-    Tab,
-    TabPanel
-} from '@spectrum-web-components/tabs';
+```ts
+import { Tabs, Tab, TabPanel } from '@spectrum-web-components/tabs';
 ```
 
-## Sizes
+### Anatomy
+
+- **Tabs:** The container component (`<sp-tabs>`) that manages the tab list and handles selection logic.
+- **Tab item:** An individual tab (`<sp-tab>`) that users can select to view different content panels.
+- **Tab view:** The content panel (`<sp-tab-panel>`) associated with a tab, shown when its corresponding tab is selected.
+- **Divider:** A visual separator between tab items, used in some variants for clarity.
+- **Selection indicator:** A visual highlight (such as an underline or bar) that shows which tab is currently selected.
+
+### Options
+
+<sp-table>
+    <sp-table-head>
+        <sp-table-head-cell>Property</sp-table-head-cell>
+        <sp-table-head-cell>Values</sp-table-head-cell>
+        <sp-table-head-cell>Default value</sp-table-head-cell>
+    </sp-table-head>
+    <sp-table-body>
+        <sp-table-row>
+            <sp-table-cell>label</sp-table-cell>
+            <sp-table-cell>text / nothing</sp-table-cell>
+            <sp-table-cell>–</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>icon</sp-table-cell>
+            <sp-table-cell>icon / nothing</sp-table-cell>
+            <sp-table-cell>nothing</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>is selected</sp-table-cell>
+            <sp-table-cell>yes / no</sp-table-cell>
+            <sp-table-cell>no</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>is disabled</sp-table-cell>
+            <sp-table-cell>yes / no</sp-table-cell>
+            <sp-table-cell>no</sp-table-cell>
+        </sp-table-row>
+    </sp-table-body>
+</sp-table>
+<br/>
+
+#### Sizes
 
 <sp-tabs selected="m" auto label="Size Attribute Options">
 <sp-tab value="s">Small</sp-tab>
@@ -103,7 +142,7 @@ import {
 </sp-tab-panel>
 </sp-tabs>
 
-## Horizontal Tabs
+#### Variants
 
 An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, `disabled`, and `quiet`, or with content like icons, etc.
 
@@ -207,8 +246,6 @@ When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` chi
 </sp-tab-panel>
 </sp-tabs>
 
-## Vertical Tabs
-
 An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, `disabled`, and `quiet`, or with content like icons, etc.
 
 <sp-tabs selected="compact" auto label="Horizontal Tabs variants">
@@ -311,6 +348,14 @@ When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` chi
 </sp-tab-panel>
 </sp-tabs>
 
-## Accessibility
+### Accessibility
 
 When an `<sp-tabs>` has a `selected` value, the `<sp-tab>` child of that `value` will be given `[tabindex="0"]` and will receive initial focus when tabbing into the `<sp-tabs>` element. When no `selected` value is present, the first `<sp-tab>` child will be treated in this way. When focus is currently within the `<sp-tabs>` element, the left and right arrows will move that focus back and forth through the available `<sp-tab>` children.
+
+#### Include a label
+
+Tab items should have a label for accessibility. If a label isn’t present, it must include an icon and becomes an icon-only tab item.
+
+#### Use icons only when necessary
+
+Icons should only be used in a tab item when absolutely necessary: when adding essential value and having a strong association with the label. If the tab item does not have a visible label, it must still have a tooltip to disclose the label.

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -128,7 +128,7 @@ Tabs are created from the following parts:
 
 #### Variants
 
-An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, and `quiet`, or with content like icons, etc.
+An `<sp-tabs>` element will display horizontally by default. It can be modified with attributes like `compact`, and `quiet`, or with content like icons, etc.
 
 <sp-tabs selected="compact" auto label="Horizontal Tabs variants">
 <sp-tab value="compact">Compact</sp-tab>
@@ -150,25 +150,7 @@ Compact tabs should never be used without the quiet variation. Please use Quiet 
 ```
 
 </sp-tab-panel>
-<sp-tab value="disabled">Disabled</sp-tab>
-<sp-tab-panel value="disabled">
 
-When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
-
-```html demo
-<sp-tabs selected="2" disabled>
-    <sp-tab label="Tab 1" value="1"></sp-tab>
-    <sp-tab label="Tab 2" value="2"></sp-tab>
-    <sp-tab label="Tab 3" value="3"></sp-tab>
-    <sp-tab label="Tab 4" value="4"></sp-tab>
-    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
-    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
-</sp-tabs>
-```
-
-</sp-tab-panel>
 <sp-tab value="icons">Icons</sp-tab>
 <sp-tab-panel value="icons">
 
@@ -252,25 +234,6 @@ Compact tabs should never be used without the quiet variation. Please use Quiet 
 ```
 
 </sp-tab-panel>
-<sp-tab value="disabled">Disabled</sp-tab>
-<sp-tab-panel value="disabled">
-
-When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
-
-```html demo
-<sp-tabs selected="2" disabled direction="vertical">
-    <sp-tab label="Tab 1" value="1"></sp-tab>
-    <sp-tab label="Tab 2" value="2"></sp-tab>
-    <sp-tab label="Tab 3" value="3"></sp-tab>
-    <sp-tab label="Tab 4" value="4"></sp-tab>
-    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
-    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
-</sp-tabs>
-```
-
-</sp-tab-panel>
 <sp-tab value="icons">Icons</sp-tab>
 <sp-tab-panel value="icons">
 
@@ -334,7 +297,7 @@ When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` chi
 
 ### States
 
-When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+When an `<sp-tabs>` element is given the `disabled` attribute, its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
 
 ```html demo
 <sp-tabs selected="2" disabled>

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -211,7 +211,7 @@ Compact tabs should never be used without the quiet variation. Please use Quiet 
 </sp-tab-panel>
 </sp-tabs>
 
-An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, `disabled`, and `quiet`, or with content like icons, etc.
+An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, `disabled`, and `quiet`, or with content like icons, etc. Vertical tabs should be used when horizontal space is more generous and when the list of sections is greater than can be presented to the user in a horizontal format. Vertical tabs are enabled by setting the `direction` attribute to `vertical` on `sp-tabs`.
 
 <sp-tabs selected="compact" auto label="Horizontal Tabs variants">
 <sp-tab value="compact">Compact</sp-tab>

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -128,7 +128,7 @@ Tabs are created from the following parts:
 
 #### Variants
 
-An `<sp-tabs>` element will display horizontally by default. It can be modified with attributes like `compact`, and `quiet`, or with content like icons, etc.
+An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, and `quiet`, or with content like icons, etc.
 
 <sp-tabs selected="compact" auto label="Horizontal Tabs variants">
 <sp-tab value="compact">Compact</sp-tab>
@@ -150,7 +150,25 @@ Compact tabs should never be used without the quiet variation. Please use Quiet 
 ```
 
 </sp-tab-panel>
+<sp-tab value="disabled">Disabled</sp-tab>
+<sp-tab-panel value="disabled">
 
+When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+
+```html demo
+<sp-tabs selected="2" disabled>
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
 <sp-tab value="icons">Icons</sp-tab>
 <sp-tab-panel value="icons">
 
@@ -234,6 +252,25 @@ Compact tabs should never be used without the quiet variation. Please use Quiet 
 ```
 
 </sp-tab-panel>
+<sp-tab value="disabled">Disabled</sp-tab>
+<sp-tab-panel value="disabled">
+
+When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+
+```html demo
+<sp-tabs selected="2" disabled direction="vertical">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
 <sp-tab value="icons">Icons</sp-tab>
 <sp-tab-panel value="icons">
 
@@ -297,7 +334,7 @@ Compact tabs should never be used without the quiet variation. Please use Quiet 
 
 ### States
 
-When an `<sp-tabs>` element is given the `disabled` attribute, its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
 
 ```html demo
 <sp-tabs selected="2" disabled>


### PR DESCRIPTION
## Description

Improving the accessibility documentation of components.

## Related issue(s)

`SWC-412`

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Device review

-   [x] Did it pass in Desktop?
-   [x] Did it pass in (emulated) Mobile?
-   [x] Did it pass in (emulated) iPad?
