### PR TITLE
fix(typography): unintended typography element margins

### DIFF
--- a/tools/styles/fonts.css
+++ b/tools/styles/fonts.css
@@ -73,8 +73,6 @@
     --spectrum-heading-cjk-font-family: var(--spectrum-cjk-font-family-stack);
     --spectrum-heading-cjk-letter-spacing: var(--spectrum-cjk-letter-spacing);
     --spectrum-heading-font-color: var(--spectrum-heading-color);
-    --spectrum-heading-margin-start: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-top-multiplier));
-    --spectrum-heading-margin-end: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-bottom-multiplier));
     font-family: var(--mod-heading-sans-serif-font-family, var(--spectrum-heading-sans-serif-font-family));
     font-style: var(--mod-heading-sans-serif-font-style, var(--spectrum-heading-sans-serif-font-style));
     font-weight: var(--mod-heading-sans-serif-font-weight, var(--spectrum-heading-sans-serif-font-weight));
@@ -502,8 +500,6 @@
     --spectrum-detail-sans-serif-font-family: var(--spectrum-sans-font-family-stack);
     --spectrum-detail-serif-font-family: var(--spectrum-serif-font-family-stack);
     --spectrum-detail-cjk-font-family: var(--spectrum-cjk-font-family-stack);
-    --spectrum-detail-margin-start: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-top-multiplier));
-    --spectrum-detail-margin-end: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-bottom-multiplier));
     --spectrum-detail-font-color: var(--spectrum-detail-color);
     font-family: var(--mod-detail-sans-serif-font-family, var(--spectrum-detail-sans-serif-font-family));
     font-style: var(--mod-detail-sans-serif-font-style, var(--spectrum-detail-sans-serif-font-style));

--- a/tools/styles/src/spectrum-detail.css
+++ b/tools/styles/src/spectrum-detail.css
@@ -42,8 +42,6 @@
     --spectrum-detail-sans-serif-font-family: var(--spectrum-sans-font-family-stack);
     --spectrum-detail-serif-font-family: var(--spectrum-serif-font-family-stack);
     --spectrum-detail-cjk-font-family: var(--spectrum-cjk-font-family-stack);
-    --spectrum-detail-margin-start: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-top-multiplier));
-    --spectrum-detail-margin-end: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-bottom-multiplier));
     --spectrum-detail-font-color: var(--spectrum-detail-color);
     font-family: var(--mod-detail-sans-serif-font-family, var(--spectrum-detail-sans-serif-font-family));
     font-style: var(--mod-detail-sans-serif-font-style, var(--spectrum-detail-sans-serif-font-style));

--- a/tools/styles/src/spectrum-heading.css
+++ b/tools/styles/src/spectrum-heading.css
@@ -68,8 +68,6 @@
     --spectrum-heading-cjk-font-family: var(--spectrum-cjk-font-family-stack);
     --spectrum-heading-cjk-letter-spacing: var(--spectrum-cjk-letter-spacing);
     --spectrum-heading-font-color: var(--spectrum-heading-color);
-    --spectrum-heading-margin-start: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-top-multiplier));
-    --spectrum-heading-margin-end: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-bottom-multiplier));
     font-family: var(--mod-heading-sans-serif-font-family, var(--spectrum-heading-sans-serif-font-family));
     font-style: var(--mod-heading-sans-serif-font-style, var(--spectrum-heading-sans-serif-font-style));
     font-weight: var(--mod-heading-sans-serif-font-weight, var(--spectrum-heading-sans-serif-font-weight));

--- a/tools/styles/typography.css
+++ b/tools/styles/typography.css
@@ -73,8 +73,6 @@
     --spectrum-heading-cjk-font-family: var(--spectrum-cjk-font-family-stack);
     --spectrum-heading-cjk-letter-spacing: var(--spectrum-cjk-letter-spacing);
     --spectrum-heading-font-color: var(--spectrum-heading-color);
-    --spectrum-heading-margin-start: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-top-multiplier));
-    --spectrum-heading-margin-end: calc(var(--mod-heading-font-size, var(--spectrum-heading-font-size)) * var(--spectrum-heading-margin-bottom-multiplier));
     font-family: var(--mod-heading-sans-serif-font-family, var(--spectrum-heading-sans-serif-font-family));
     font-style: var(--mod-heading-sans-serif-font-style, var(--spectrum-heading-sans-serif-font-style));
     font-weight: var(--mod-heading-sans-serif-font-weight, var(--spectrum-heading-sans-serif-font-weight));
@@ -502,8 +500,6 @@
     --spectrum-detail-sans-serif-font-family: var(--spectrum-sans-font-family-stack);
     --spectrum-detail-serif-font-family: var(--spectrum-serif-font-family-stack);
     --spectrum-detail-cjk-font-family: var(--spectrum-cjk-font-family-stack);
-    --spectrum-detail-margin-start: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-top-multiplier));
-    --spectrum-detail-margin-end: calc(var(--mod-detail-font-size, var(--spectrum-detail-font-size)) * var(--spectrum-detail-margin-bottom-multiplier));
     --spectrum-detail-font-color: var(--spectrum-detail-color);
     font-family: var(--mod-detail-sans-serif-font-family, var(--spectrum-detail-sans-serif-font-family));
     font-style: var(--mod-detail-sans-serif-font-style, var(--spectrum-detail-sans-serif-font-style));


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

Removes  `--spectrum-detail-margin-start` and `--spectrum-detail-margin-end` definitions from `.spectrum-Detail` and `.spectrum-Heading` ensuring margin custom properties are scoped only to .spectrum-Typography .spectrum-Heading and .spectrum-Typography .spectrum-Detail. 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

We recently made a change in the Typography CSS that unintentionally scoped margin custom properties more broadly than intended. Typography margin custom properties should only be scoped to .spectrum-Typography

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes [CSS-1248](https://jira.corp.adobe.com/browse/CSS-1248)

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash


