### PR TITLE
fix(link): added delegateFocus for Safari tab index issue in shadow root

### DIFF
--- a/.changeset/free-candles-scream.md
+++ b/.changeset/free-candles-scream.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/link': patch
+---
+
+** Fixed ** : Safari keyboard navigation compatibility for sp-link component by implementing an approach with shadow DOM delegatesFocus and explicit tabindex.

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -10,7 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import { CSSResultArray, TemplateResult } from '@spectrum-web-components/base';
+import {
+    CSSResultArray,
+    LitElement,
+    TemplateResult,
+} from '@spectrum-web-components/base';
 import {
     property,
     query,
@@ -23,8 +27,6 @@ import linkStyles from './link.css.js';
 /**
  * @element sp-link
  *
- * Updated to follow IBM's approach for better Safari keyboard navigation compatibility.
- * Uses shadow DOM with delegatesFocus and explicit tabindex on the anchor element.
  */
 export class Link extends LikeAnchor(Focusable) {
     public static override get styles(): CSSResultArray {
@@ -61,7 +63,7 @@ export class Link extends LikeAnchor(Focusable) {
      * This enables delegatesFocus for Safari compatibility
      */
     static override shadowRootOptions = {
-        mode: 'open' as const,
+        ...LitElement.shadowRootOptions,
         delegatesFocus: true,
     };
 }

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -22,6 +22,9 @@ import linkStyles from './link.css.js';
 
 /**
  * @element sp-link
+ *
+ * Updated to follow IBM's approach for better Safari keyboard navigation compatibility.
+ * Uses shadow DOM with delegatesFocus and explicit tabindex on the anchor element.
  */
 export class Link extends LikeAnchor(Focusable) {
     public static override get styles(): CSSResultArray {
@@ -48,6 +51,17 @@ export class Link extends LikeAnchor(Focusable) {
     }
 
     protected override render(): TemplateResult {
-        return this.renderAnchor({ id: 'anchor' });
+        return this.renderAnchor({
+            id: 'anchor',
+            tabindex: 0,
+        });
     }
+    /**
+     * Static property to configure shadow root options
+     * This enables delegatesFocus for Safari compatibility
+     */
+    static override shadowRootOptions = {
+        mode: 'open' as const,
+        delegatesFocus: true,
+    };
 }

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -12,7 +12,7 @@
 
 import {
     CSSResultArray,
-    LitElement,
+    SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import {
@@ -63,7 +63,7 @@ export class Link extends LikeAnchor(Focusable) {
      * This enables delegatesFocus for Safari compatibility
      */
     static override shadowRootOptions = {
-        ...LitElement.shadowRootOptions,
+        ...SpectrumElement.shadowRootOptions,
         delegatesFocus: true,
     };
 }

--- a/packages/link/test/link.test.ts
+++ b/packages/link/test/link.test.ts
@@ -15,6 +15,7 @@ import { Link } from '@spectrum-web-components/link';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 import { spy } from 'sinon';
+import { isWebKit } from '@spectrum-web-components/shared';
 
 describe('Link', () => {
     testForLitDevWarnings(
@@ -75,5 +76,35 @@ describe('Link', () => {
         await expect(el).to.be.accessible();
         el.click();
         expect(clickSpy.callCount).to.equal(0);
+    });
+
+    it('has proper Safari keyboard navigation support when running in WebKit', async () => {
+        const el = await fixture<Link>(html`
+            <sp-link href="test_url">WebKit Test Link</sp-link>
+        `);
+
+        await elementUpdated(el);
+
+        // Always verify basic configuration
+        expect(el.shadowRoot).to.not.be.null;
+        expect(el.shadowRoot?.delegatesFocus).to.be.true;
+
+        const anchor = el.shadowRoot?.querySelector(
+            '#anchor'
+        ) as HTMLAnchorElement;
+        expect(anchor.getAttribute('tabindex')).to.eq('0');
+
+        // WebKit-specific enhanced tests
+        if (isWebKit()) {
+            // Verify that the anchor element is properly focusable in Safari
+            expect(anchor.tabIndex).to.be.greaterThan(-1);
+
+            // Verify that the link maintains proper ARIA attributes in Safari
+            expect(anchor.hasAttribute('href')).to.be.true;
+            expect(anchor.getAttribute('role')).to.not.equal('button');
+        }
+
+        // Common verification for all browsers
+        await expect(el).to.be.accessible();
     });
 });


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->
SWC Link components `<sp-link>` were not keyboard navigable on Safari/WebKit browsers, particularly when using external keyboards on iOS devices. Users could not Tab through links or use Enter/Space to activate them, making the component inaccessible in Safari.
## Motivation and context

## Root Cause

1. The original implementation had several issues that prevented proper keyboard navigation in Safari:
2. **Shadow DOM Focus Management**: Safari has stricter requirements for custom elements and shadow DOM focus delegation
3. **Missing Explicit Tabindex**: The anchor element inside shadow DOM didn't have explicit `tabindex="0"`, which Safari requires for keyboard navigation
4. **Focus Delegation Issues**: Safari doesn't always properly delegate focus from custom elements to internal shadow DOM elements
5. **iOS WebView Limitations**: iOS Safari has additional restrictions on keyboard navigation with custom elements

## Key Changes
1. Added `delegatesFocus: true` to shadow root configuration
```ts
   static override shadowRootOptions = {
       mode: 'open' as const,
       delegatesFocus: true,
   };
```   
2. Set explicit `tabindex="0"` on anchor element
```ts
   return this.renderAnchor({ 
       id: 'anchor',
       tabindex: 0,
   });
```   
## Breaking Changes
**None**. This is a non-breaking enhancement that improves Safari compatibility while maintaining all existing APIs, styling, and behavior.
<!--- Why is this change required? What problem does it solve? -->

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes https://github.com/adobe/spectrum-web-components/issues/5581

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [x] I have added automated tests to cover my changes.
-   [x] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [x] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [x] Safari Test

    1. Go [here](https://swcpreviews.z13.web.core.windows.net/pr-5580/docs/storybook/?path=/story/link--default)
    2. Open Safari
    3. Press Tab and see the link is highlighted
    4. Press <strike>Space or </strike>Enter, link action fires

-   [x] Chrome Test

    1. Go [here](https://swcpreviews.z13.web.core.windows.net/pr-5580/docs/storybook/?path=/story/link--default)
    2. Open Chrome
    3. Press Tab and see the link is highlighted
    4. Press <strike>Space or </strike>Enter, link action fires

-   [x] Firefox Test

    1. Go [here](https://swcpreviews.z13.web.core.windows.net/pr-5580/docs/storybook/?path=/story/link--default)
    2. Open Firefox
    3. Press Tab and see the link is highlighted
    4. Press <strike>Space or </strike>Enter, link action fires


### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [x] Did it pass in Desktop?
-   [x] Did it pass in (emulated) Mobile?
-   [x] Did it pass in (emulated) iPad?
