### PR TITLE
fix(web-dev-server): fixes new tab on save

### DIFF
--- a/projects/documentation/web-dev-server.config.js
+++ b/projects/documentation/web-dev-server.config.js
@@ -18,7 +18,7 @@ const alias = fromRollup(rollupAlias);
 const json = fromRollup(rollupJson);
 
 export default {
-    open: true,
+    open: false,
     watch: true,
     nodeResolve: {
         exportConditions: ['browser', 'development'],


### PR DESCRIPTION
## Description

`SWC-947`

Fixes the issue in the docs application where saving a file would open a new browser tab.

## Motivation and context

Opening a new browser tab on save is a bad developer experience.

### Device review

-   [x] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
