### PR TITLE
docs(color-area): reorganize README to follow documentation standards

### DIFF
--- a/packages/color-area/README.md
+++ b/packages/color-area/README.md
@@ -1,6 +1,6 @@
-## Description
+## Overview
 
-An `<sp-color-area>` allows users to visually select two properties of a color simultaneously. It's commonly used together with a color slider or color wheel.
+An `<sp-color-area>` allows users to visually select two properties of a color simultaneously. It's commonly used together with a color slider or color wheel to create comprehensive color selection interfaces.
 
 ### Usage
 
@@ -8,23 +8,61 @@ An `<sp-color-area>` allows users to visually select two properties of a color s
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/color-area?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/color-area)
 [![Try it on Stackblitz](https://img.shields.io/badge/Try%20it%20on-Stackblitz-blue?style=for-the-badge)](https://stackblitz.com/edit/vitejs-vite-nqupkmym)
 
-```
+```bash
 yarn add @spectrum-web-components/color-area
 ```
 
 Import the side effectful registration of `<sp-color-area>` via:
 
-```
+```javascript
 import '@spectrum-web-components/color-area/sp-color-area.js';
 ```
 
 When looking to leverage the `ColorArea` base class as a type and/or for extension purposes, do so via:
 
-```
+```javascript
 import { ColorArea } from '@spectrum-web-components/color-area';
 ```
 
-## Color Formatting
+### Anatomy
+
+The color area consists of several key parts:
+
+- A two-dimensional color selection area with visual gradients
+- A draggable handle that indicates the current color position
+- Accessible labels for the X and Y axes
+
+```html
+<sp-color-area></sp-color-area>
+```
+
+### Options
+
+#### Custom Sizing
+
+An `<sp-color-area>`'s height and width can be customized appropriately for its context.
+
+```html
+<sp-color-area
+    style="
+        width: 72px; 
+        height: 72px"
+></sp-color-area>
+```
+
+### States
+
+#### Disabled
+
+An `<sp-color-area>` in a disabled state shows that an input exists, but is not available in that circumstance. This can be used to maintain layout continuity and communicate that the area may become available later.
+
+```html
+<sp-color-area disabled></sp-color-area>
+```
+
+### Behaviors
+
+#### Color Formatting
 
 When using the color elements, use `el.color` to access the `color` property, which should manage itself in the colour format supplied. For example, If you supply a color in `rgb()` format, `el.color` should return the color in `rgb()` format, as well. In ColorArea, colours are formatted as hex values.
 
@@ -36,35 +74,11 @@ The current color formats supported are as follows:
 - RGB, RGBA
 - Named color strings (see [full list](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color))
 
-## Standard
+### Accessibility
 
-```html
-<sp-color-area></sp-color-area>
-```
+The `<sp-color-area>` is rendered with appropriate ARIA attributes to ensure accessibility for screen readers and keyboard navigation.
 
-## Variants
-
-### Disabled
-
-An `<sp-color-area>` in a disabled state shows that an input exists, but is not available in that circumstance. This can be used to maintain layout continuity and communicate that the area may become available later.
-
-```html
-<sp-color-area disabled></sp-color-area>
-```
-
-### Sized
-
-An `<sp-color-area>`’s height and width can be customized appropriately for its context.
-
-```html
-<sp-color-area
-    style="
-        width: 72px; 
-        height: 72px"
-></sp-color-area>
-```
-
-## Labels
+#### Accessible Labels
 
 An `<sp-color-area>` renders accessible labels for each axis: _"saturation"_ and _"luminosity"_.
 Specify `label-x` and `label-y` attributes to override these defaults.
@@ -75,3 +89,15 @@ Specify `label-x` and `label-y` attributes to override these defaults.
     label-y="Color brightness"
 ></sp-color-area>
 ```
+
+#### Keyboard Navigation
+
+The color area supports keyboard interaction for precise color selection:
+
+- Use arrow keys to adjust the color position
+- Hold <kbd>Shift</kbd> while using arrow keys for fine adjustments
+- The component maintains focus management for accessibility
+
+#### Screen Reader Support
+
+The component provides meaningful labels and descriptions for assistive technologies, ensuring users can understand the current color selection and how to interact with the control.


### PR DESCRIPTION
# docs(color-area): reorganize README to follow documentation standards

## Overview

This PR reorganizes the color-area README.md to follow the established documentation standards structure, improving accessibility and consistency with other components.

## Changes Made

### Structure Reorganization
- **Overview**: Replaced "Description" with "Overview" section and expanded component description
- **Usage**: Updated import code blocks with proper language syntax highlighting (`bash`, `javascript`)
- **Anatomy**: Added new section describing the component's key parts and basic usage
- **Options**: Reorganized sizing information under "Custom Sizing" subsection
- **States**: Moved disabled state information to dedicated "States" section
- **Behaviors**: Added new section containing color formatting information
- **Accessibility**: Expanded accessibility section with comprehensive guidance

### Content Improvements
- Enhanced component description to mention comprehensive color selection interfaces
- Added proper code syntax highlighting for better readability
- Reorganized existing content without removing any information
- Added keyboard navigation documentation using `<kbd>` tags
- Included screen reader support information
- Improved section hierarchy and organization

### Accessibility Enhancements
- Added detailed keyboard navigation instructions
- Included proper semantic markup with `<kbd>` tags
- Enhanced screen reader support documentation
- Maintained all existing accessibility features while improving documentation clarity

## Testing
- [x] Verified all existing content is preserved
- [x] Confirmed proper markdown syntax and formatting
- [x] Checked consistency with documentation standards
- [x] Reviewed accessibility improvements

## Related Documentation
- Follows structure outlined in [Adding a Component Documentation Standards](https://opensource.adobe.com/spectrum-web-components/guides/adding-component/#documentation-standards)
- Maintains consistency with accordion, button, meter, progress bar, progress circle, and tooltip README files
- Implements accessibility best practices as demonstrated in other component documentation

This reorganization makes the color-area documentation more accessible, easier to navigate, and consistent with the established documentation standards across the Spectrum Web Components library.
