### PR TITLE
fix(menu): iPad scrolling issue in picker dropdown

### DIFF
--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -618,6 +618,50 @@ export function runPickerTests(): void {
             expect(el.open, 'open?').to.be.false;
             expect(el.value).to.equal(thirdItem.value);
         });
+        it('does not select items when scrolling on iPad', async () => {
+            // Simulate iPad touch scrolling behavior
+            const el = await pickerFixture();
+            await elementUpdated(el);
+
+            // Open the picker
+            el.open = true;
+            await elementUpdated(el);
+
+            // Store initial value
+            const initialValue = el.value;
+            const touchStartEvent = new Event('touchstart', {
+                bubbles: true,
+                composed: true,
+            });
+
+            // Simulate touch move (scrolling gesture)
+            const touchMoveEvent = new Event('touchmove', {
+                bubbles: true,
+                composed: true,
+            });
+
+            // Simulate touch end on fourth item (after scrolling)
+            const touchEndEvent = new Event('touchend', {
+                bubbles: true,
+                composed: true,
+            });
+
+            // Dispatch touch events in sequence
+            el.optionsMenu.dispatchEvent(touchStartEvent);
+            await nextFrame();
+
+            el.optionsMenu.dispatchEvent(touchMoveEvent);
+            await nextFrame();
+
+            el.optionsMenu.dispatchEvent(touchEndEvent);
+            await nextFrame();
+
+            // The value should not have changed because we were scrolling, not selecting
+            expect(el.value).to.equal(
+                initialValue,
+                'Value should not change during scroll gesture'
+            );
+        });
         it('opens/closes multiple times', async () => {
             expect(el.open, 'open?').to.be.false;
             const boundingRect = el.button.getBoundingClientRect();


### PR DESCRIPTION
## Summary

Fixes an issue where scrolling through menu items in a picker dropdown on iPad would accidentally select the first touched item and close the picker. This was caused by touch events being interpreted as selection events during scroll gestures.

## Problem

When users attempted to scroll through menu items in a picker dropdown on iPad, the item they first touched when starting to scroll would be selected instead of allowing the scroll gesture to complete. This made the picker unusable on iPad devices.

## Solution

- Added touch event handling to distinguish between scroll gestures and selection gestures:
- Touch tracking: Added properties to track touch start position, time, and scroll state
- Scroll detection: Implemented logic to detect when a touch gesture is a scroll (vertical movement > threshold within time limit)
- Selection prevention: Modified handlePointerBasedSelection to prevent selection when scrolling is detected
- Memory leak prevention: Properly bound and cleaned up touch event listeners in disconnectedCallback

## Technical details

- Added `touchStartY`, `touchStartTime`, `isScrolling` properties for scroll detection
- Implemented `handleTouchStart`, `handleTouchMove`, `handleTouchEnd` methods
- Used `passive: true` for touch event listeners to improve scrolling performance
- Added scroll `threshold (10px)` and time `threshold (300ms)` for scroll detection
- Modified `handlePointerBasedSelection` to check `isScrolling` state before processing selection

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes https://github.com/adobe/spectrum-web-components/issues/5606

## Screenshots (if appropriate)

Fix


https://github.com/user-attachments/assets/191dc536-cef1-4a4d-b4b5-fa87c3b1a87d



---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Descriptive Test Statement_

    1. Go [here](url)
    2. Do this action
    3. Expect this result

-   [ ] _Descriptive Test Statement_
    1. Go [here](url)
    2. Do this action
    3. Expect this result

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
