### PR TITLE
test(number-field): ensure element updates after input events

### DIFF
--- a/.changeset/seven-yaks-open.md
+++ b/.changeset/seven-yaks-open.md
@@ -1,5 +1,0 @@
----
-'@spectrum-web-components/number-field': patch
----
-
-Fix flaky stepper UI pointer interaction test by ensuring element updates complete before assertions

--- a/.changeset/seven-yaks-open.md
+++ b/.changeset/seven-yaks-open.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/number-field': patch
+---
+
+Fix flaky stepper UI pointer interaction test by ensuring element updates complete before assertions

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -836,21 +836,8 @@ describe('NumberField', () => {
             const buttonUp = el.shadowRoot.querySelector(
                 '.step-up'
             ) as HTMLElement;
-            const buttonUpRect = buttonUp.getBoundingClientRect();
-            const buttonUpPosition: [number, number] = [
-                buttonUpRect.x + buttonUpRect.width / 2,
-                buttonUpRect.y + buttonUpRect.height / 2,
-            ];
-
             // Click the step-up button
-            await sendMouse({
-                steps: [
-                    {
-                        type: 'click',
-                        position: buttonUpPosition,
-                    },
-                ],
-            });
+            await sendMouseTo(buttonUp, 'click);
 
             await elementUpdated(el);
 
@@ -868,21 +855,8 @@ describe('NumberField', () => {
             const buttonDown = el.shadowRoot.querySelector(
                 '.step-down'
             ) as HTMLElement;
-            const buttonDownRect = buttonDown.getBoundingClientRect();
-            const buttonDownPosition: [number, number] = [
-                buttonDownRect.x + buttonDownRect.width / 2,
-                buttonDownRect.y + buttonDownRect.height / 2,
-            ];
-
             // Click the step-down button
-            await sendMouse({
-                steps: [
-                    {
-                        type: 'click',
-                        position: buttonDownPosition,
-                    },
-                ],
-            });
+            await sendMouseTo(buttonDown, 'click);
 
             await elementUpdated(el);
 

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -828,6 +828,7 @@ describe('NumberField', () => {
             ],
         });
         await oneEvent(el, 'input');
+        await elementUpdated(el);
         let value = 50 + inputSpy.callCount;
         expect(el.formattedValue).to.equal(String(value));
         expect(el.valueAsString).to.equal(String(value));
@@ -841,6 +842,7 @@ describe('NumberField', () => {
                 },
             ],
         });
+        await elementUpdated(el);
         value = value - inputSpy.callCount;
         expect(el.formattedValue).to.equal(String(value));
         expect(el.valueAsString).to.equal(String(value));
@@ -854,12 +856,14 @@ describe('NumberField', () => {
                 },
             ],
         });
+        await elementUpdated(el);
         value = value - inputSpy.callCount;
         expect(el.formattedValue).to.equal(String(value));
         expect(el.valueAsString).to.equal(String(value));
         expect(el.value).to.equal(value);
         inputSpy.resetHistory();
         await oneEvent(el, 'input');
+        await elementUpdated(el);
         value = value - inputSpy.callCount;
         expect(el.formattedValue).to.equal(String(value));
         expect(el.valueAsString).to.equal(String(value));
@@ -872,6 +876,7 @@ describe('NumberField', () => {
                 },
             ],
         });
+        await elementUpdated(el);
         let framesToWait = FRAMES_PER_CHANGE;
         while (framesToWait) {
             // input is only processed onces per FRAMES_PER_CHANGE number of frames

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -55,7 +55,10 @@ import {
 } from '../../../test/testing-helpers.js';
 
 // Helper function to set up input and change spies
-function setupEventSpies(element: NumberField) {
+function setupEventSpies(element: NumberField): {
+    inputSpy: SinonSpy;
+    changeSpy: SinonSpy;
+} {
     const inputSpy = spy();
     const changeSpy = spy();
     element.addEventListener('input', () => inputSpy());

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -837,7 +837,7 @@ describe('NumberField', () => {
                 '.step-up'
             ) as HTMLElement;
             // Click the step-up button
-            await sendMouseTo(buttonUp, 'click);
+            await sendMouseTo(buttonUp, 'click');
 
             await elementUpdated(el);
 
@@ -856,7 +856,7 @@ describe('NumberField', () => {
                 '.step-down'
             ) as HTMLElement;
             // Click the step-down button
-            await sendMouseTo(buttonDown, 'click);
+            await sendMouseTo(buttonDown, 'click');
 
             await elementUpdated(el);
 
@@ -985,7 +985,7 @@ describe('NumberField', () => {
                 ],
             });
 
-            // Wait for the direction to change
+            // input is only processed onces per FRAMES_PER_CHANGE number of frames so wait for the direction to change
             let framesToWait = FRAMES_PER_CHANGE * 2;
             while (framesToWait) {
                 framesToWait -= 1;


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->
**Overview**
This PR addresses test flakiness in the number-field component's stepper UI pointer interaction test by adding proper element update awaits.
**Changes Made**

- Test Stability Improvements
- Added await elementUpdated(el) after mouse move operations to ensure DOM updates complete
- Added await elementUpdated(el) after input events to ensure value changes are reflected
- Added await elementUpdated(el) after frame waiting loops to ensure all pending updates complete

**Specific Fixes**
After moving to step-down button: Added await to ensure the element processes the pointer movement
After moving outside the buttons: Added await to ensure continuous input processing completes
After input events: Added await to ensure value updates are applied to the DOM
After frame waiting: Added await to ensure any remaining updates from the frame loop are completed

**Testing**
[x] Verified test runs consistently without flakiness
[x] Confirmed all element updates complete before assertions
[x] Maintained existing test behavior and expectations

**Technical Details**
The test was experiencing race conditions where assertions were being made before the element had fully processed pointer interactions. The number field's stepper UI processes continuous input events during pointer hold operations, which requires proper synchronization between test actions and element updates.
By adding elementUpdated() awaits at key points, we ensure:

- DOM updates complete after pointer movements
- Value changes propagate through the component
- Frame-based input processing completes before assertions

This change improves test reliability without altering the component's behavior or the test's intent.
## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This number-filed was flaky and needed refactoring.
## Related issue(s)
SWC-893
<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes [Issue Number]

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [x] I have added automated tests to cover my changes.
-   [x] I have included a well-written changeset if my change needs to be published.
-   [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash



### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [x] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
