### PR TITLE
fix(dialog): revert close event logic

### DIFF
--- a/packages/dialog/src/DialogBase.ts
+++ b/packages/dialog/src/DialogBase.ts
@@ -24,7 +24,6 @@ import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 
 // Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
-import '@spectrum-web-components/dialog/sp-dialog.js';
 import modalWrapperStyles from '@spectrum-web-components/modal/src/modal-wrapper.css.js';
 import modalStyles from '@spectrum-web-components/modal/src/modal.css.js';
 import { Dialog } from './Dialog.js';
@@ -122,7 +121,7 @@ export class DialogBase extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public close(): void {
         this.open = false;
     }
-
+    // Dispatch close event immediately when closing is initiated
     private dispatchClosed(): void {
         this.dispatchEvent(
             new Event('close', {
@@ -155,41 +154,18 @@ export class DialogBase extends FocusVisiblePolyfillMixin(SpectrumElement) {
         this.handleTransitionEvent(event);
     }
 
-    private get hasTransitionDuration(): boolean {
-        const modal = this.shadowRoot.querySelector('.modal') as HTMLElement;
-
-        const modalTransitionDurations =
-            window.getComputedStyle(modal).transitionDuration;
-        for (const duration of modalTransitionDurations.split(','))
-            if (parseFloat(duration) > 0) return true;
-
-        const underlay = this.shadowRoot.querySelector(
-            'sp-underlay'
-        ) as HTMLElement;
-
-        if (underlay) {
-            const underlayTransitionDurations =
-                window.getComputedStyle(underlay).transitionDuration;
-            for (const duration of underlayTransitionDurations.split(','))
-                if (parseFloat(duration) > 0) return true;
-        }
-
-        return false;
-    }
-
     protected override update(changes: PropertyValues<this>): void {
         if (changes.has('open') && changes.get('open') !== undefined) {
-            const hasTransitionDuration = this.hasTransitionDuration;
             this.animating = true;
             this.transitionPromise = new Promise((res) => {
                 this.resolveTransitionPromise = () => {
                     this.animating = false;
-                    if (!this.open && hasTransitionDuration)
-                        this.dispatchClosed();
                     res();
                 };
             });
-            if (!this.open && !hasTransitionDuration) this.dispatchClosed();
+            if (!this.open) {
+                this.dispatchClosed();
+            }
         }
         super.update(changes);
     }


### PR DESCRIPTION
## Description
This PR reverts the breaking change introduced in `SWC 1.0.3` [PR #4937](https://github.com/adobe/spectrum-web-components/pull/4937) that moved the close event dispatch from immediate to post-animation completion. The change was causing issues for applications that rely on immediate close event handling, such as route changes and state cleanup.

## Problem
The previous change in [PR #4937](https://github.com/adobe/spectrum-web-components/pull/4937) moved the close event to fire after animations complete, which:

- Breaks applications expecting immediate event handling
- Prevents route changes from happening when users click close
- Delays state cleanup and navigation preparation

## Solution
Revert the close event timing to dispatch immediately when `dialog.close()` is called, while maintaining proper animation coordination through the existing `sp-closed` event from the overlay system.

## Changes Made
- DialogBase.ts:
  - Modified `close()` method to dispatch close event immediately
  - Removed post-animation close event dispatch from update() method
  - Cleaned up unused methods `(dispatchClosed, hasTransitionDuration)`

## Breaking Change
This is a breaking change that reverts the previous breaking change from SWC 1.0.3. Applications that were updated to work with the delayed close event timing will need to be updated to handle immediate close events again.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

 - Reverts changes from PR #4937
 - Fixes issues with Quick Actions dialogs and other applications requiring immediate close event handling

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Descriptive Test Statement_

    1. Go [here](url)
    2. Do this action
    3. Expect this result

-   [ ] _Descriptive Test Statement_
    1. Go [here](url)
    2. Do this action
    3. Expect this result

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
