### PR TITLE
fix(overlay-testing-helpers): resolve race condition that lead to flaky test results

### DIFF
--- a/packages/overlay/test/overlay-testing-helpers.ts
+++ b/packages/overlay/test/overlay-testing-helpers.ts
@@ -10,12 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {
-    oneEvent,
-    waitUntil,
-} from '@open-wc/testing';
+import { oneEvent, waitUntil } from '@open-wc/testing';
 import { Overlay } from '../src/Overlay';
-
 
 // make sure overlay state is about to change, and wait until overlay state changes to 'opened'
 export const overlayOpened = async (
@@ -23,11 +19,18 @@ export const overlayOpened = async (
     timeout: number = 100,
     messagePrefix?: string
 ): Promise<unknown> => {
-    return await waitUntil(
-        () => overlay?.state === 'opened' || (overlay && oneEvent(overlay, 'sp-opened')),
-        `${messagePrefix ? `${messagePrefix}: ` : ''}open timeout (still ${overlay?.state})`,
-        { timeout: timeout }
-    );
+    if (overlay?.state === 'opened') {
+        return Promise.resolve();
+    }
+
+    return await Promise.race([
+        waitUntil(
+            () => overlay?.state === 'opened',
+            `${messagePrefix ? `${messagePrefix}: ` : ''}open timeout (still ${overlay?.state})`,
+            { timeout: timeout }
+        ),
+        oneEvent(overlay, 'sp-opened'),
+    ]);
 };
 
 export const overlayClosed = async (
@@ -35,9 +38,16 @@ export const overlayClosed = async (
     timeout: number = 100,
     messagePrefix?: string
 ): Promise<unknown> => {
-    return await waitUntil(
-        () => overlay?.state === 'closed' || oneEvent(overlay, 'sp-closed'),
-        `${messagePrefix ? `${messagePrefix}: ` : ''}closed timeout (still ${overlay?.state})`,
-        { timeout: timeout }
-    );
+    if (overlay?.state === 'closed') {
+        return Promise.resolve();
+    }
+
+    return await Promise.race([
+        waitUntil(
+            () => overlay?.state === 'closed',
+            `${messagePrefix ? `${messagePrefix}: ` : ''}closed timeout (still ${overlay?.state})`,
+            { timeout: timeout }
+        ),
+        oneEvent(overlay, 'sp-closed'),
+    ]);
 };

--- a/packages/overlay/test/overlay-trigger-extended.test.ts
+++ b/packages/overlay/test/overlay-trigger-extended.test.ts
@@ -245,9 +245,6 @@ describe('Overlay Trigger - extended', () => {
         // Focus the textfield by clicking it (simulates user interaction)
         await sendMouseTo(textfield, 'click');
 
-        // Give the click event time to process
-        await aTimeout(50);
-
         if (document.activeElement !== textfield) {
             textfield.focus();
         }
@@ -312,9 +309,6 @@ describe('Overlay Trigger - extended', () => {
 
         // Try clicking the textfield again after the overlay is closed
         await sendMouseTo(textfield, 'click');
-
-        // Give the click event time to process
-        await aTimeout(50);
 
         // If click didn't focus, focus directly (common in test environments)
         if (document.activeElement !== textfield) {

--- a/packages/overlay/test/overlay-trigger-extended.test.ts
+++ b/packages/overlay/test/overlay-trigger-extended.test.ts
@@ -243,9 +243,19 @@ describe('Overlay Trigger - extended', () => {
         expect(textfield.tabIndex, 'textfield is focusable').to.be.equal(0);
 
         // Focus the textfield by clicking it (simulates user interaction)
+        await sendMouseTo(textfield, 'click');
+
+        // Give the click event time to process
+        await aTimeout(50);
+
+        if (document.activeElement !== textfield) {
+            textfield.focus();
+        }
+
         await waitUntil(
-            async () => await sendMouseTo(textfield, 'click'),
-            `Trying to click textfield`
+            () => document.activeElement === textfield,
+            `textfield focused`,
+            { timeout: 500 }
         );
 
         expect(document.activeElement, `textfield focused`).to.equal(textfield);
@@ -278,10 +288,10 @@ describe('Overlay Trigger - extended', () => {
         await overlayOpened(overlayTrigger.clickOverlayElement, 400);
 
         // Attempt to click the textfield while the overlay is open
-        await waitUntil(
-            async () => await sendMouseTo(textfield, 'click'),
-            `textfield clicked again`
-        );
+        await sendMouseTo(textfield, 'click');
+
+        // Give the click action time to process
+        await aTimeout(100);
 
         // Verify that the textfield cannot be focused (is occluded by the overlay)
         expect(
@@ -301,9 +311,20 @@ describe('Overlay Trigger - extended', () => {
         );
 
         // Try clicking the textfield again after the overlay is closed
+        await sendMouseTo(textfield, 'click');
+
+        // Give the click event time to process
+        await aTimeout(50);
+
+        // If click didn't focus, focus directly (common in test environments)
+        if (document.activeElement !== textfield) {
+            textfield.focus();
+        }
+
         await waitUntil(
-            async () => await sendMouseTo(textfield, 'click'),
-            `textfield clicked again`
+            () => document.activeElement === textfield,
+            `textfield focused after overlay closed`,
+            { timeout: 500 }
         );
 
         // Verify that the textfield can now be focused (no longer occluded)

--- a/packages/overlay/test/overlay-trigger-extended.test.ts
+++ b/packages/overlay/test/overlay-trigger-extended.test.ts
@@ -245,10 +245,6 @@ describe('Overlay Trigger - extended', () => {
         // Focus the textfield by clicking it (simulates user interaction)
         await sendMouseTo(textfield, 'click');
 
-        if (document.activeElement !== textfield) {
-            textfield.focus();
-        }
-
         await waitUntil(
             () => document.activeElement === textfield,
             `textfield focused`,
@@ -309,11 +305,6 @@ describe('Overlay Trigger - extended', () => {
 
         // Try clicking the textfield again after the overlay is closed
         await sendMouseTo(textfield, 'click');
-
-        // If click didn't focus, focus directly (common in test environments)
-        if (document.activeElement !== textfield) {
-            textfield.focus();
-        }
 
         await waitUntil(
             () => document.activeElement === textfield,


### PR DESCRIPTION
## Description

`SWC-1016`

`oneEvent(overlay, 'sp-opened')` returned a promise which is always truthy, meaning `(overlay && oneEvent(overlay, 'sp-opened'))` evaluates to a truthy promise and `waitUntil` returns immediately and never waits.

Now, we return early if the overlay's in the desired state, wait for the state change or event to occur and properly await the overlay transition.

## Motivation and context

This was causing test failures in CI for unrelated changes.

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [x] I have included updated documentation if my change required it.