### PR TITLE
chore: disable flaky number field test in webkit

### DIFF
--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -53,6 +53,7 @@ import {
     sendMouseTo,
     testForLitDevWarnings,
 } from '../../../test/testing-helpers.js';
+import { isWebKit } from '@spectrum-web-components/shared';
 
 describe('NumberField', () => {
     before(async () => {
@@ -1743,6 +1744,10 @@ describe('NumberField', () => {
     });
     describe('accessibility model', () => {
         it('increment and decrement buttons cannot receive keyboard focus', async () => {
+            // TODO: remove this once the infield-button is no longer a role='button'
+            if (isWebKit()) {
+                return;
+            }
             await fixture<HTMLDivElement>(html`
                 <div>
                     ${Default({
@@ -1760,20 +1765,23 @@ describe('NumberField', () => {
                 children: NamedNode[];
             };
 
+            const increase = findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) => node.name === 'Increase Enter a number'
+            );
+            const decrease = findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) => node.name === 'Decrease Enter a number'
+            );
+
             expect(
-                findAccessibilityNode<NamedNode>(
-                    snapshot,
-                    (node) => node.name === 'Increase Enter a number'
-                ),
-                '`name` is the label text'
+                increase,
+                'increase button is hidden from accessibility tree'
             ).to.be.null;
 
             expect(
-                findAccessibilityNode<NamedNode>(
-                    snapshot,
-                    (node) => node.name === 'Decrease Enter a number'
-                ),
-                '`name` is the label text'
+                decrease,
+                'decrease button is hidden from accessibility tree'
             ).to.be.null;
         });
     });


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

Test failure identified during `yarn test:focus no-memory-ci` run
Test fails on Webkit with AssertionError: name is the label text: expected { Object (role, name) } to be null

After a deeper investigation with @nikkimk, the fix for this test to pass the way its set up would require work to the component which is out of scope for this task and has been flagged with a TODO so we know why this test is getting skipped in WebKit

> NOTE: other VRT and tests WILL fail and be resolved in future tasks, this is going in to the WTR feature branch which will have passing tests before merge to main.

## Motivation and context

The accessibility model test "increment and decrement buttons cannot receive keyboard focus" should pass

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes [SWC-1006]

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [x] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Should pass locally_

    1. Checkout branch
    2. Run `yarn test:focus number-field`
    3. Expect passing tests

-   [ ] _Passes in CI_


### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
