### PR TITLE
docs(color-wheel): enhance README 

### DIFF
--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -43,11 +43,8 @@ You can provide a custom gradient to replace the default color wheel appearance 
 
 ```html
 <sp-color-wheel>
-    <div slot="gradient" class="custom-gradient">
-        <!-- Custom SVG or gradient implementation -->
-    </div>
+        <svg slot="gradient" class="custom-gradient" ...>...</svg>
 </sp-color-wheel>
-```
 
 ### Options
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -132,6 +132,8 @@ The color wheel supports a wide variety of color formats for setting and getting
     </sp-table-body>
 </sp-table>
 
+---
+
 #### Step Size
 
 The `step` attribute controls the increment of hue adjustment when using keyboard navigation. It defines how many degrees the hue changes with each arrow key press:

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -2,7 +2,7 @@
 
 An `<sp-color-wheel>` allows users to visually select the hue of a color on a circular track. It's commonly used together with other color components to create comprehensive color selection interfaces.
 
-### Usage
+## Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/color-wheel?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/color-wheel)
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/color-wheel?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/color-wheel)
@@ -24,7 +24,7 @@ When looking to leverage the `ColorWheel` base class as a type and/or for extens
 import { ColorWheel } from '@spectrum-web-components/color-wheel';
 ```
 
-### Anatomy
+## Anatomy
 
 The color wheel consists of several key parts:
 
@@ -37,7 +37,7 @@ The color wheel consists of several key parts:
 <sp-color-wheel></sp-color-wheel>
 ```
 
-#### Custom Gradient
+## Custom Gradient
 
 You can provide a custom gradient to replace the default color wheel appearance using the `gradient` slot:
 
@@ -49,13 +49,13 @@ You can provide a custom gradient to replace the default color wheel appearance 
 </sp-color-wheel>
 ```
 
-### Options
+## Options
 
-#### Properties
+### Properties
 
 The color wheel supports several properties for configuration:
 
-##### Value (Hue)
+#### Value (Hue)
 
 Control the hue value directly (0-360 degrees):
 
@@ -63,7 +63,7 @@ Control the hue value directly (0-360 degrees):
 <sp-color-wheel value="180"></sp-color-wheel>
 ```
 
-##### Color Values
+#### Color Values
 
 The color wheel supports a wide variety of color formats for setting and getting color values:
 
@@ -132,7 +132,7 @@ The color wheel supports a wide variety of color formats for setting and getting
     </sp-table-body>
 </sp-table>
 
-##### Step Size
+#### Step Size
 
 The `step` attribute controls the increment of hue adjustment when using keyboard navigation. It defines how many degrees the hue changes with each arrow key press:
 
@@ -156,7 +156,7 @@ The step size affects keyboard navigation:
     - **step="10"**: Balanced control, good for general use
     - **step="45"**: Quick selection between major hues, ideal for simple color pickers
 
-##### Label
+#### Label
 
 Provide a custom aria-label for accessibility:
 
@@ -164,7 +164,7 @@ Provide a custom aria-label for accessibility:
 <sp-color-wheel label="Select color hue"></sp-color-wheel>
 ```
 
-##### Direction
+#### Direction
 
 The color wheel supports both left-to-right and right-to-left layouts:
 
@@ -172,7 +172,7 @@ The color wheel supports both left-to-right and right-to-left layouts:
 <sp-color-wheel dir="rtl"></sp-color-wheel>
 ```
 
-#### Custom Sizing
+### Custom Sizing
 
 An `<sp-color-wheel>`'s size can be customized appropriately for its context. By default, the size is size-2400 (192 px on desktop, 240 px on mobile).
 
@@ -180,9 +180,9 @@ An `<sp-color-wheel>`'s size can be customized appropriately for its context. By
 <sp-color-wheel style="width: 300px; height: 300px;"></sp-color-wheel>
 ```
 
-### States
+## States
 
-#### Disabled
+### Disabled
 
 A color wheel in a disabled state shows that an input exists, but is not available in that circumstance. This can be used to maintain layout continuity and communicate that the wheel may become available later.
 
@@ -190,7 +190,7 @@ A color wheel in a disabled state shows that an input exists, but is not availab
 <sp-color-wheel disabled></sp-color-wheel>
 ```
 
-#### Focused
+### Focused
 
 The color wheel manages its focused state automatically, providing visual feedback during keyboard navigation:
 
@@ -199,9 +199,9 @@ const colorWheel = document.querySelector('sp-color-wheel');
 console.log(colorWheel.focused); // true or false
 ```
 
-### Behaviors
+## Behaviors
 
-#### Color Formatting
+### Color Formatting
 
 When using the color elements, use `el.color` to access the `color` property, which should manage itself in the color format supplied. If you supply a color in `rgb()` format, `el.color` should return the color in `rgb()` format, as well.
 
@@ -216,7 +216,7 @@ The current color formats supported are as follows:
 **Please note for the following formats: HSV, HSVA, HSL, HSLA**
 When using the HSL or HSV formats, and a color's value (in HSV) is set to 0, or its luminosity (in HSL) is set to 0 or 1, the hue and saturation values may not be preserved by the element's `color` property. This is detailed in the [colorjs documentation](https://colorjs.io/docs/). Separately, the element's `value` property is directly managed by the hue as represented in the interface.
 
-#### Pointer Interactions
+### Pointer Interactions
 
 The color wheel supports both mouse and touch interactions:
 
@@ -224,15 +224,15 @@ The color wheel supports both mouse and touch interactions:
 - **Drag**: Continuously adjust hue while dragging around the wheel
 - **Touch**: Full touch support for mobile devices
 
-#### Focus Management
+### Focus Management
 
 The color wheel automatically manages focus for keyboard accessibility, ensuring proper focus indication and keyboard operability.
 
-### Accessibility
+## Accessibility
 
 The `<sp-color-wheel>` is rendered with appropriate ARIA attributes to ensure accessibility for screen readers and keyboard navigation.
 
-#### Keyboard Navigation
+### Keyboard Navigation
 
 The color wheel supports comprehensive keyboard interaction:
 
@@ -257,7 +257,7 @@ The color wheel supports comprehensive keyboard interaction:
     </sp-table-body>
 </sp-table>
 
-#### ARIA Attributes
+### ARIA Attributes
 
 The component provides comprehensive ARIA support:
 
@@ -266,7 +266,7 @@ The component provides comprehensive ARIA support:
 - **Value Text**: Announces the current hue value in degrees with proper internationalization
 - **Orientation**: Implicitly circular, supporting both LTR and RTL layouts
 
-#### Screen Reader Support
+### Screen Reader Support
 
 The component provides meaningful announcements for assistive technologies:
 
@@ -274,7 +274,7 @@ The component provides meaningful announcements for assistive technologies:
 - Internationalized number formatting based on user's locale
 - Clear indication of the control's purpose through proper labeling
 
-#### Mobile Accessibility
+### Mobile Accessibility
 
 The color wheel is fully accessible on mobile devices with:
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -2,7 +2,7 @@
 
 An `<sp-color-wheel>` allows users to visually select the hue of a color on a circular track. It's commonly used together with other color components to create comprehensive color selection interfaces.
 
-## Usage
+### Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/color-wheel?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/color-wheel)
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/color-wheel?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/color-wheel)
@@ -24,7 +24,7 @@ When looking to leverage the `ColorWheel` base class as a type and/or for extens
 import { ColorWheel } from '@spectrum-web-components/color-wheel';
 ```
 
-## Anatomy
+### Anatomy
 
 The color wheel consists of several key parts:
 
@@ -37,7 +37,19 @@ The color wheel consists of several key parts:
 <sp-color-wheel></sp-color-wheel>
 ```
 
-## Custom Gradient
+
+
+```suggestion
+
+#### Label
+
+Provide a custom aria-label for accessibility:
+
+```html
+<sp-color-wheel label="Select color hue"></sp-color-wheel>
+```
+
+#### Custom Gradient
 
 **⚠️ Deprecated Feature**
 
@@ -51,21 +63,18 @@ If you previously relied on custom gradients for the color wheel, you should:
 
 **Note**: Even if you find the `gradient` slot in the component's source code, this feature is non-functional and should not be used in new implementations.
 
-## Options
-
-### Properties
+### Options
 
 The color wheel supports several properties for configuration:
 
 #### Value (Hue)
 
-Control the hue value directly (0-360 degrees):
+Use the `value` property to control the hue value directly (0-360 degrees):
 
 ```html
 <sp-color-wheel value="180"></sp-color-wheel>
 ```
 
-#### Color Values
 
 The color wheel supports a wide variety of color formats for setting and getting color values:
 
@@ -175,7 +184,7 @@ The color wheel supports both left-to-right and right-to-left layouts:
 <sp-color-wheel dir="rtl"></sp-color-wheel>
 ```
 
-### Custom Sizing
+#### Custom Sizing
 
 An `<sp-color-wheel>`'s size can be customized appropriately for its context. By default, the size is size-2400 (192 px on desktop, 240 px on mobile).
 
@@ -193,7 +202,7 @@ A color wheel in a disabled state shows that an input exists, but is not availab
 <sp-color-wheel disabled></sp-color-wheel>
 ```
 
-### Focused
+#### Focused
 
 The color wheel manages its focused state automatically, providing visual feedback during keyboard navigation:
 
@@ -201,9 +210,9 @@ The color wheel manages its focused state automatically, providing visual feedba
 <sp-color-wheel focused></sp-color-wheel>
 ```
 
-## Behaviors
+#### Behaviors
 
-### Color Formatting
+#### Color Formatting
 
 When using the color elements, use `el.color` to access the `color` property, which should manage itself in the color format supplied. If you supply a color in `rgb()` format, `el.color` should return the color in `rgb()` format, as well.
 
@@ -218,7 +227,7 @@ The current color formats supported are as follows:
 **Please note for the following formats: HSV, HSVA, HSL, HSLA**
 When using the HSL or HSV formats, and a color's value (in HSV) is set to 0, or its luminosity (in HSL) is set to 0 or 1, the hue and saturation values may not be preserved by the element's `color` property. This is detailed in the [colorjs documentation](https://colorjs.io/docs/). Separately, the element's `value` property is directly managed by the hue as represented in the interface.
 
-### Pointer Interactions
+#### Pointer Interactions
 
 The color wheel supports both mouse and touch interactions:
 
@@ -226,15 +235,15 @@ The color wheel supports both mouse and touch interactions:
 - **Drag**: Continuously adjust hue while dragging around the wheel
 - **Touch**: Full touch support for mobile devices
 
-### Focus Management
+#### Focus Management
 
 The color wheel automatically manages focus for keyboard accessibility, ensuring proper focus indication and keyboard operability.
 
-## Accessibility
+### Accessibility
 
 The `<sp-color-wheel>` is rendered with appropriate ARIA attributes to ensure accessibility for screen readers and keyboard navigation.
 
-### Keyboard Navigation
+#### Keyboard Navigation
 
 The color wheel supports comprehensive keyboard interaction:
 
@@ -259,7 +268,7 @@ The color wheel supports comprehensive keyboard interaction:
     </sp-table-body>
 </sp-table>
 
-### ARIA Attributes
+#### ARIA Attributes
 
 The component provides comprehensive ARIA support:
 
@@ -268,7 +277,7 @@ The component provides comprehensive ARIA support:
 - **Value Text**: Announces the current hue value in degrees with proper internationalization
 - **Orientation**: Implicitly circular, supporting both LTR and RTL layouts
 
-### Screen Reader Support
+#### Screen Reader Support
 
 The component provides meaningful announcements for assistive technologies:
 
@@ -276,7 +285,7 @@ The component provides meaningful announcements for assistive technologies:
 - Internationalized number formatting based on user's locale
 - Clear indication of the control's purpose through proper labeling
 
-### Mobile Accessibility
+#### Mobile Accessibility
 
 The color wheel is fully accessible on mobile devices with:
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -131,8 +131,7 @@ The color wheel supports a wide variety of color formats for setting and getting
         </sp-table-row>
     </sp-table-body>
 </sp-table>
-
----
+</br>
 
 #### Step Size
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -199,6 +199,7 @@ The color wheel manages its focused state automatically, providing visual feedba
 
 ```html
 <sp-color-wheel focused></sp-color-wheel>
+```
 
 ## Behaviors
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -39,15 +39,17 @@ The color wheel consists of several key parts:
 
 ## Custom Gradient
 
-You can provide a custom gradient to replace the default color wheel appearance using the `gradient` slot:
+**⚠️ Deprecated Feature**
 
-```html
-<sp-color-wheel>
-    <div slot="gradient" class="custom-gradient">
-        <!-- Custom SVG or gradient implementation -->
-    </div>
-</sp-color-wheel>
-```
+The custom gradient functionality has been deprecated and is no longer supported. While the `gradient` slot may still be present in the component's code, it is broken and will not work as intended.
+
+If you previously relied on custom gradients for the color wheel, you should:
+
+- Use the default color wheel appearance
+- Consider alternative approaches for custom styling
+- Remove any existing custom gradient implementations
+
+**Note**: Even if you find the `gradient` slot in the component's source code, this feature is non-functional and should not be used in new implementations.
 
 ## Options
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -41,54 +41,205 @@ The color wheel consists of several key parts:
 
 You can provide a custom gradient to replace the default color wheel appearance using the `gradient` slot:
 
-```html
+````html
+<!-- Example 1: Enhanced color wheel with custom CSS gradient -->
 <sp-color-wheel>
-    <div slot="gradient" class="custom-gradient">
-        <!-- Custom SVG or gradient implementation -->
+    <div slot="gradient" class="enhanced-wheel"></div>
+</sp-color-wheel>
+
+<style>
+    .enhanced-wheel {
+        width: 100%;
+        height: 100%;
+        border-radius: 50%;
+        background: conic-gradient(
+            from 0deg,
+            hsl(0, 100%, 50%),
+            hsl(30, 100%, 50%),
+            hsl(60, 100%, 50%),
+            hsl(90, 100%, 50%),
+            hsl(120, 100%, 50%),
+            hsl(150, 100%, 50%),
+            hsl(180, 100%, 50%),
+            hsl(210, 100%, 50%),
+            hsl(240, 100%, 50%),
+            hsl(270, 100%, 50%),
+            hsl(300, 100%, 50%),
+            hsl(330, 100%, 50%),
+            hsl(360, 100%, 50%)
+        );
+        /* Add inner circle for ring effect */
+        mask: radial-gradient(circle, transparent 35%, black 35%);
+        -webkit-mask: radial-gradient(circle, transparent 35%, black 35%);
+    }
+</style>
+
+<!-- Example 2: Pastel color wheel using SVG -->
+<sp-color-wheel>
+    <svg
+        slot="gradient"
+        viewBox="0 0 200 200"
+        style="width: 100%; height: 100%;"
+    >
+        <defs>
+            <linearGradient id="pastel-blend">
+                <stop offset="0%" style="stop-color:white;stop-opacity:0.5" />
+                <stop offset="100%" style="stop-color:white;stop-opacity:0" />
+            </linearGradient>
+        </defs>
+        <!-- Create pastel wheel with multiple path segments -->
+        <g transform="translate(100,100)">
+            <path
+                d="M 0,-80 A 80,80 0 0,1 69.3,-40 L 34.6,-20 A 40,40 0 0,0 0,-40 Z"
+                fill="hsl(0, 70%, 70%)"
+            />
+            <path
+                d="M 69.3,-40 A 80,80 0 0,1 69.3,40 L 34.6,20 A 40,40 0 0,0 34.6,-20 Z"
+                fill="hsl(60, 70%, 70%)"
+            />
+            <path
+                d="M 69.3,40 A 80,80 0 0,1 0,80 L 0,40 A 40,40 0 0,0 34.6,20 Z"
+                fill="hsl(120, 70%, 70%)"
+            />
+            <path
+                d="M 0,80 A 80,80 0 0,1 -69.3,40 L -34.6,20 A 40,40 0 0,0 0,40 Z"
+                fill="hsl(180, 70%, 70%)"
+            />
+            <path
+                d="M -69.3,40 A 80,80 0 0,1 -69.3,-40 L -34.6,-20 A 40,40 0 0,0 -34.6,20 Z"
+                fill="hsl(240, 70%, 70%)"
+            />
+            <path
+                d="M -69.3,-40 A 80,80 0 0,1 0,-80 L 0,-40 A 40,40 0 0,0 -34.6,-20 Z"
+                fill="hsl(300, 70%, 70%)"
+            />
+            <!-- Apply gradient overlay for smooth blending -->
+            <circle r="80" fill="url(#pastel-blend)" />
+        </g>
+    </svg>
+</sp-color-wheel>
+
+<!-- Example 3: High contrast wheel with markers -->
+<sp-color-wheel>
+    <div slot="gradient" class="high-contrast-wheel">
+        <div class="marker" style="--angle: 0deg;">R</div>
+        <div class="marker" style="--angle: 120deg;">G</div>
+        <div class="marker" style="--angle: 240deg;">B</div>
     </div>
 </sp-color-wheel>
-```
 
-### Options
+<style>
+    .high-contrast-wheel {
+        width: 100%;
+        height: 100%;
+        position: relative;
+        border-radius: 50%;
+        background: conic-gradient(
+            from 0deg,
+            #ff0000,
+            #ffff00,
+            #00ff00,
+            #00ffff,
+            #0000ff,
+            #ff00ff,
+            #ff0000
+        );
+        mask: radial-gradient(circle, transparent 40%, black 40%);
+        -webkit-mask: radial-gradient(circle, transparent 40%, black 40%);
+    }
 
-#### Properties
+    .high-contrast-wheel .marker {
+        position: absolute;
+        top: 10%;
+        left: 50%;
+        transform: translate(-50%, -50%) rotate(var(--angle)) translateY(-90px);
+        font-weight: bold;
+        color: white;
+        text-shadow: 0 0 3px black;
+    }
+</style>
 
-The color wheel supports several properties for configuration:
-
-##### Value (Hue)
-
-Control the hue value directly (0-360 degrees):
-
+### Options #### Properties The color wheel supports several properties for
+configuration: ##### Value (Hue) Control the hue value directly (0-360 degrees):
 ```html
 <sp-color-wheel value="180"></sp-color-wheel>
-```
+````
 
 ##### Color Values
 
-Set and get color values using various formats:
+The color wheel supports a wide variety of color formats for setting and getting color values:
 
 ```html
-<!-- Hex formats -->
-<sp-color-wheel color="#ff0000"></sp-color-wheel>
+<!-- Hex3 format (3-digit) -->
 <sp-color-wheel color="#f00"></sp-color-wheel>
+<sp-color-wheel color="#0a5"></sp-color-wheel>
+
+<!-- Hex4 format (3-digit + alpha) -->
+<sp-color-wheel color="#f00f"></sp-color-wheel>
+<sp-color-wheel color="#0a58"></sp-color-wheel>
+
+<!-- Hex6 format (6-digit) -->
+<sp-color-wheel color="#ff0000"></sp-color-wheel>
+<sp-color-wheel color="#00aa55"></sp-color-wheel>
+
+<!-- Hex8 format (6-digit + alpha) -->
+<sp-color-wheel color="#ff0000ff"></sp-color-wheel>
+<sp-color-wheel color="#00aa5580"></sp-color-wheel>
 
 <!-- RGB format -->
 <sp-color-wheel color="rgb(255, 0, 0)"></sp-color-wheel>
+<sp-color-wheel color="rgb(0, 170, 85)"></sp-color-wheel>
+
+<!-- RGBA format -->
+<sp-color-wheel color="rgba(255, 0, 0, 1)"></sp-color-wheel>
+<sp-color-wheel color="rgba(0, 170, 85, 0.5)"></sp-color-wheel>
 
 <!-- HSL format -->
 <sp-color-wheel color="hsl(0, 100%, 50%)"></sp-color-wheel>
+<sp-color-wheel color="hsl(150, 100%, 33%)"></sp-color-wheel>
 
-<!-- Named colors -->
+<!-- HSLA format -->
+<sp-color-wheel color="hsla(0, 100%, 50%, 1)"></sp-color-wheel>
+<sp-color-wheel color="hsla(150, 100%, 33%, 0.5)"></sp-color-wheel>
+
+<!-- HSV format -->
+<sp-color-wheel color="hsv(0, 100%, 100%)"></sp-color-wheel>
+<sp-color-wheel color="hsv(150, 100%, 67%)"></sp-color-wheel>
+
+<!-- HSVA format -->
+<sp-color-wheel color="hsva(0, 100%, 100%, 1)"></sp-color-wheel>
+<sp-color-wheel color="hsva(150, 100%, 67%, 0.5)"></sp-color-wheel>
+
+<!-- Named color strings -->
 <sp-color-wheel color="red"></sp-color-wheel>
+<sp-color-wheel color="rebeccapurple"></sp-color-wheel>
+<sp-color-wheel color="darkseagreen"></sp-color-wheel>
+<sp-color-wheel color="cornflowerblue"></sp-color-wheel>
 ```
 
 ##### Step Size
 
-Customize the precision of keyboard navigation (default: 1):
+The `step` attribute controls the increment of hue adjustment when using keyboard navigation. It defines how many degrees the hue changes with each arrow key press:
 
 ```html
+<!-- Fine control: 1 degree per key press (default) -->
+<sp-color-wheel step="1"></sp-color-wheel>
+
+<!-- Medium control: 10 degrees per key press -->
 <sp-color-wheel step="10"></sp-color-wheel>
+
+<!-- Coarse control: 45 degrees per key press (8 stops around the wheel) -->
+<sp-color-wheel step="45"></sp-color-wheel>
 ```
+
+The step size affects keyboard navigation:
+
+- Regular arrow keys move by the step value
+- <kbd>Shift</kbd> + arrow keys move by 10× the step value
+- Choose your step size based on your use case:
+    - **step="1"**: Precise color selection, best for professional design tools
+    - **step="10"**: Balanced control, good for general use
+    - **step="45"**: Quick selection between major hues, ideal for simple color pickers
 
 ##### Label
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -2,7 +2,7 @@
 
 An `<sp-color-wheel>` allows users to visually select the hue of a color on a circular track. It's commonly used together with other color components to create comprehensive color selection interfaces.
 
-### Usage
+## Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/color-wheel?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/color-wheel)
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/color-wheel?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/color-wheel)
@@ -24,7 +24,7 @@ When looking to leverage the `ColorWheel` base class as a type and/or for extens
 import { ColorWheel } from '@spectrum-web-components/color-wheel';
 ```
 
-### Anatomy
+## Anatomy
 
 The color wheel consists of several key parts:
 
@@ -37,19 +37,7 @@ The color wheel consists of several key parts:
 <sp-color-wheel></sp-color-wheel>
 ```
 
-
-
-```suggestion
-
-#### Label
-
-Provide a custom aria-label for accessibility:
-
-```html
-<sp-color-wheel label="Select color hue"></sp-color-wheel>
-```
-
-#### Custom Gradient
+## Custom Gradient
 
 **⚠️ Deprecated Feature**
 
@@ -63,20 +51,31 @@ If you previously relied on custom gradients for the color wheel, you should:
 
 **Note**: Even if you find the `gradient` slot in the component's source code, this feature is non-functional and should not be used in new implementations.
 
-### Options
+## Options
+
+### Properties
 
 The color wheel supports several properties for configuration:
 
 #### Value (Hue)
 
-Use the `value` property to control the hue value directly (0-360 degrees):
+The `value` property controls the hue angle of the color wheel (0-360 degrees). This represents the position of the handle on the circular track and determines the hue component of the displayed color.
 
 ```html
 <sp-color-wheel value="180"></sp-color-wheel>
 ```
 
+#### Color Values
 
 The color wheel supports a wide variety of color formats for setting and getting color values:
+
+```html
+<div style="display: flex; gap: 16px;">
+    <sp-color-wheel color="#7277b5"></sp-color-wheel>
+    <sp-color-wheel color="hsl(96, 84.00%, 49.00%)"></sp-color-wheel>
+    <sp-color-wheel color="red"></sp-color-wheel>
+</div>
+```
 
 <sp-table>
     <sp-table-head>
@@ -149,14 +148,17 @@ The color wheel supports a wide variety of color formats for setting and getting
 The `step` attribute controls the increment of hue adjustment when using keyboard navigation. It defines how many degrees the hue changes with each arrow key press:
 
 ```html
-<!-- Fine control: 1 degree per key press (default) -->
-<sp-color-wheel step="1"></sp-color-wheel>
-
-<!-- Medium control: 10 degrees per key press -->
-<sp-color-wheel step="10"></sp-color-wheel>
-
-<!-- Coarse control: 45 degrees per key press (8 stops around the wheel) -->
-<sp-color-wheel step="45"></sp-color-wheel>
+<div style="display: flex; gap: 16px;">
+    <sp-color-wheel step="1" label="Fine Control (1° per key)"></sp-color-wheel>
+    <sp-color-wheel
+        step="10"
+        label="Medium Control (10° per key)"
+    ></sp-color-wheel>
+    <sp-color-wheel
+        step="45"
+        label="Coarse Control (45° per key)"
+    ></sp-color-wheel>
+</div>
 ```
 
 The step size affects keyboard navigation:
@@ -184,13 +186,58 @@ The color wheel supports both left-to-right and right-to-left layouts:
 <sp-color-wheel dir="rtl"></sp-color-wheel>
 ```
 
-#### Custom Sizing
+#### Tab Index
 
-An `<sp-color-wheel>`'s size can be customized appropriately for its context. By default, the size is size-2400 (192 px on desktop, 240 px on mobile).
+The `tabIndex` property controls the tab order of the color wheel within the page. This follows the standard HTML `tabindex` attribute behavior:
+
+```html
+<div style="display: flex; gap: 16px;">
+    <div style="text-align: center;">
+        <div style="font-weight: bold; margin-bottom: 8px;">
+            Default Tab Order
+        </div>
+        <sp-color-wheel></sp-color-wheel>
+    </div>
+    <div style="text-align: center;">
+        <div style="font-weight: bold; margin-bottom: 8px;">
+            Skip in Tab Order
+        </div>
+        <sp-color-wheel tabindex="-1"></sp-color-wheel>
+    </div>
+    <div style="text-align: center;">
+        <div style="font-weight: bold; margin-bottom: 8px;">
+            Custom Tab Order
+        </div>
+        <sp-color-wheel tabindex="5"></sp-color-wheel>
+    </div>
+</div>
+```
+
+**Note**: See the general documentation about the [HTML tabindex property](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) for detailed information about tab order behavior.
+
+### Custom Sizing
+
+An `<sp-color-wheel>`'s size can be customized appropriately for its context. By default, the size is 192 px.
+
+#### Using Inline Styles
+
+You can set custom dimensions using inline styles. For a perfect circle, ensure width and height are the same:
 
 ```html
 <sp-color-wheel style="width: 300px; height: 300px;"></sp-color-wheel>
 ```
+
+#### Using Mod Tokens
+
+The component exposes CSS custom properties for consistent theming. Both `--mod-colorwheel-width` and `--mod-colorwheel-height` should be set to the same value to maintain a perfect circle:
+
+```html
+<sp-color-wheel
+    style="--mod-colorwheel-width: 250px; --mod-colorwheel-height: 250px;"
+></sp-color-wheel>
+```
+
+**Note**: The CSS internally reuses the width value for both dimensions, but both mod tokens are exposed for flexibility in custom implementations.
 
 ## States
 
@@ -202,7 +249,7 @@ A color wheel in a disabled state shows that an input exists, but is not availab
 <sp-color-wheel disabled></sp-color-wheel>
 ```
 
-#### Focused
+### Focused
 
 The color wheel manages its focused state automatically, providing visual feedback during keyboard navigation:
 
@@ -210,24 +257,16 @@ The color wheel manages its focused state automatically, providing visual feedba
 <sp-color-wheel focused></sp-color-wheel>
 ```
 
-#### Behaviors
+## Behaviors
 
-#### Color Formatting
+### Color Formatting
 
 When using the color elements, use `el.color` to access the `color` property, which should manage itself in the color format supplied. If you supply a color in `rgb()` format, `el.color` should return the color in `rgb()` format, as well.
-
-The current color formats supported are as follows:
-
-- Hex3, Hex4, Hex6, Hex8
-- HSV, HSVA
-- HSL, HSLA
-- RGB, RGBA
-- Named color strings (see [full list](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color))
 
 **Please note for the following formats: HSV, HSVA, HSL, HSLA**
 When using the HSL or HSV formats, and a color's value (in HSV) is set to 0, or its luminosity (in HSL) is set to 0 or 1, the hue and saturation values may not be preserved by the element's `color` property. This is detailed in the [colorjs documentation](https://colorjs.io/docs/). Separately, the element's `value` property is directly managed by the hue as represented in the interface.
 
-#### Pointer Interactions
+### Pointer Interactions
 
 The color wheel supports both mouse and touch interactions:
 
@@ -235,15 +274,15 @@ The color wheel supports both mouse and touch interactions:
 - **Drag**: Continuously adjust hue while dragging around the wheel
 - **Touch**: Full touch support for mobile devices
 
-#### Focus Management
+### Focus Management
 
 The color wheel automatically manages focus for keyboard accessibility, ensuring proper focus indication and keyboard operability.
 
-### Accessibility
+## Accessibility
 
 The `<sp-color-wheel>` is rendered with appropriate ARIA attributes to ensure accessibility for screen readers and keyboard navigation.
 
-#### Keyboard Navigation
+### Keyboard Navigation
 
 The color wheel supports comprehensive keyboard interaction:
 
@@ -268,7 +307,7 @@ The color wheel supports comprehensive keyboard interaction:
     </sp-table-body>
 </sp-table>
 
-#### ARIA Attributes
+### ARIA Attributes
 
 The component provides comprehensive ARIA support:
 
@@ -277,7 +316,7 @@ The component provides comprehensive ARIA support:
 - **Value Text**: Announces the current hue value in degrees with proper internationalization
 - **Orientation**: Implicitly circular, supporting both LTR and RTL layouts
 
-#### Screen Reader Support
+### Screen Reader Support
 
 The component provides meaningful announcements for assistive technologies:
 
@@ -285,10 +324,9 @@ The component provides meaningful announcements for assistive technologies:
 - Internationalized number formatting based on user's locale
 - Clear indication of the control's purpose through proper labeling
 
-#### Mobile Accessibility
+### Mobile Accessibility
 
 The color wheel is fully accessible on mobile devices with:
 
 - Touch-friendly interaction areas
 - Proper focus management for mobile screen readers
-- Responsive sizing that maintains usability on smaller screens

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -2,7 +2,7 @@
 
 An `<sp-color-wheel>` allows users to visually select the hue of a color on a circular track. It's commonly used together with other color components to create comprehensive color selection interfaces.
 
-## Usage
+### Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/color-wheel?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/color-wheel)
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/color-wheel?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/color-wheel)
@@ -24,7 +24,7 @@ When looking to leverage the `ColorWheel` base class as a type and/or for extens
 import { ColorWheel } from '@spectrum-web-components/color-wheel';
 ```
 
-## Anatomy
+### Anatomy
 
 The color wheel consists of several key parts:
 
@@ -37,7 +37,7 @@ The color wheel consists of several key parts:
 <sp-color-wheel></sp-color-wheel>
 ```
 
-## Custom Gradient
+### Custom Gradient
 
 **⚠️ Deprecated Feature**
 
@@ -51,13 +51,13 @@ If you previously relied on custom gradients for the color wheel, you should:
 
 **Note**: Even if you find the `gradient` slot in the component's source code, this feature is non-functional and should not be used in new implementations.
 
-## Options
+### Options
 
-### Properties
+#### Properties
 
 The color wheel supports several properties for configuration:
 
-#### Value (Hue)
+##### Value (Hue)
 
 The `value` property controls the hue angle of the color wheel (0-360 degrees). This represents the position of the handle on the circular track and determines the hue component of the displayed color.
 
@@ -65,7 +65,7 @@ The `value` property controls the hue angle of the color wheel (0-360 degrees). 
 <sp-color-wheel value="180"></sp-color-wheel>
 ```
 
-#### Color Values
+##### Color Values
 
 The color wheel supports a wide variety of color formats for setting and getting color values:
 
@@ -143,7 +143,7 @@ The color wheel supports a wide variety of color formats for setting and getting
 </sp-table>
 </br>
 
-#### Step Size
+##### Step Size
 
 The `step` attribute controls the increment of hue adjustment when using keyboard navigation. It defines how many degrees the hue changes with each arrow key press:
 
@@ -170,7 +170,7 @@ The step size affects keyboard navigation:
     - **step="10"**: Balanced control, good for general use
     - **step="45"**: Quick selection between major hues, ideal for simple color pickers
 
-#### Label
+##### Label
 
 Provide a custom aria-label for accessibility:
 
@@ -178,7 +178,7 @@ Provide a custom aria-label for accessibility:
 <sp-color-wheel label="Select color hue"></sp-color-wheel>
 ```
 
-#### Direction
+##### Direction
 
 The color wheel supports both left-to-right and right-to-left layouts:
 
@@ -186,7 +186,7 @@ The color wheel supports both left-to-right and right-to-left layouts:
 <sp-color-wheel dir="rtl"></sp-color-wheel>
 ```
 
-#### Tab Index
+##### Tab Index
 
 The `tabIndex` property controls the tab order of the color wheel within the page. This follows the standard HTML `tabindex` attribute behavior:
 
@@ -215,11 +215,11 @@ The `tabIndex` property controls the tab order of the color wheel within the pag
 
 **Note**: See the general documentation about the [HTML tabindex property](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) for detailed information about tab order behavior.
 
-### Custom Sizing
+#### Custom Sizing
 
 An `<sp-color-wheel>`'s size can be customized appropriately for its context. By default, the size is 192 px.
 
-#### Using Inline Styles
+##### Using Inline Styles
 
 You can set custom dimensions using inline styles. For a perfect circle, ensure width and height are the same:
 
@@ -227,7 +227,7 @@ You can set custom dimensions using inline styles. For a perfect circle, ensure 
 <sp-color-wheel style="width: 300px; height: 300px;"></sp-color-wheel>
 ```
 
-#### Using Mod Tokens
+##### Using Mod Tokens
 
 The component exposes CSS custom properties for consistent theming. Both `--mod-colorwheel-width` and `--mod-colorwheel-height` should be set to the same value to maintain a perfect circle:
 
@@ -239,9 +239,9 @@ The component exposes CSS custom properties for consistent theming. Both `--mod-
 
 **Note**: The CSS internally reuses the width value for both dimensions, but both mod tokens are exposed for flexibility in custom implementations.
 
-## States
+### States
 
-### Disabled
+#### Disabled
 
 A color wheel in a disabled state shows that an input exists, but is not available in that circumstance. This can be used to maintain layout continuity and communicate that the wheel may become available later.
 
@@ -249,7 +249,7 @@ A color wheel in a disabled state shows that an input exists, but is not availab
 <sp-color-wheel disabled></sp-color-wheel>
 ```
 
-### Focused
+#### Focused
 
 The color wheel manages its focused state automatically, providing visual feedback during keyboard navigation:
 
@@ -257,16 +257,16 @@ The color wheel manages its focused state automatically, providing visual feedba
 <sp-color-wheel focused></sp-color-wheel>
 ```
 
-## Behaviors
+### Behaviors
 
-### Color Formatting
+#### Color Formatting
 
 When using the color elements, use `el.color` to access the `color` property, which should manage itself in the color format supplied. If you supply a color in `rgb()` format, `el.color` should return the color in `rgb()` format, as well.
 
 **Please note for the following formats: HSV, HSVA, HSL, HSLA**
 When using the HSL or HSV formats, and a color's value (in HSV) is set to 0, or its luminosity (in HSL) is set to 0 or 1, the hue and saturation values may not be preserved by the element's `color` property. This is detailed in the [colorjs documentation](https://colorjs.io/docs/). Separately, the element's `value` property is directly managed by the hue as represented in the interface.
 
-### Pointer Interactions
+#### Pointer Interactions
 
 The color wheel supports both mouse and touch interactions:
 
@@ -274,15 +274,15 @@ The color wheel supports both mouse and touch interactions:
 - **Drag**: Continuously adjust hue while dragging around the wheel
 - **Touch**: Full touch support for mobile devices
 
-### Focus Management
+#### Focus Management
 
 The color wheel automatically manages focus for keyboard accessibility, ensuring proper focus indication and keyboard operability.
 
-## Accessibility
+### Accessibility
 
 The `<sp-color-wheel>` is rendered with appropriate ARIA attributes to ensure accessibility for screen readers and keyboard navigation.
 
-### Keyboard Navigation
+#### Keyboard Navigation
 
 The color wheel supports comprehensive keyboard interaction:
 
@@ -307,7 +307,7 @@ The color wheel supports comprehensive keyboard interaction:
     </sp-table-body>
 </sp-table>
 
-### ARIA Attributes
+#### ARIA Attributes
 
 The component provides comprehensive ARIA support:
 
@@ -316,7 +316,7 @@ The component provides comprehensive ARIA support:
 - **Value Text**: Announces the current hue value in degrees with proper internationalization
 - **Orientation**: Implicitly circular, supporting both LTR and RTL layouts
 
-### Screen Reader Support
+#### Screen Reader Support
 
 The component provides meaningful announcements for assistive technologies:
 
@@ -324,7 +324,7 @@ The component provides meaningful announcements for assistive technologies:
 - Internationalized number formatting based on user's locale
 - Clear indication of the control's purpose through proper labeling
 
-### Mobile Accessibility
+#### Mobile Accessibility
 
 The color wheel is fully accessible on mobile devices with:
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -41,205 +41,54 @@ The color wheel consists of several key parts:
 
 You can provide a custom gradient to replace the default color wheel appearance using the `gradient` slot:
 
-````html
-<!-- Example 1: Enhanced color wheel with custom CSS gradient -->
+```html
 <sp-color-wheel>
-    <div slot="gradient" class="enhanced-wheel"></div>
-</sp-color-wheel>
-
-<style>
-    .enhanced-wheel {
-        width: 100%;
-        height: 100%;
-        border-radius: 50%;
-        background: conic-gradient(
-            from 0deg,
-            hsl(0, 100%, 50%),
-            hsl(30, 100%, 50%),
-            hsl(60, 100%, 50%),
-            hsl(90, 100%, 50%),
-            hsl(120, 100%, 50%),
-            hsl(150, 100%, 50%),
-            hsl(180, 100%, 50%),
-            hsl(210, 100%, 50%),
-            hsl(240, 100%, 50%),
-            hsl(270, 100%, 50%),
-            hsl(300, 100%, 50%),
-            hsl(330, 100%, 50%),
-            hsl(360, 100%, 50%)
-        );
-        /* Add inner circle for ring effect */
-        mask: radial-gradient(circle, transparent 35%, black 35%);
-        -webkit-mask: radial-gradient(circle, transparent 35%, black 35%);
-    }
-</style>
-
-<!-- Example 2: Pastel color wheel using SVG -->
-<sp-color-wheel>
-    <svg
-        slot="gradient"
-        viewBox="0 0 200 200"
-        style="width: 100%; height: 100%;"
-    >
-        <defs>
-            <linearGradient id="pastel-blend">
-                <stop offset="0%" style="stop-color:white;stop-opacity:0.5" />
-                <stop offset="100%" style="stop-color:white;stop-opacity:0" />
-            </linearGradient>
-        </defs>
-        <!-- Create pastel wheel with multiple path segments -->
-        <g transform="translate(100,100)">
-            <path
-                d="M 0,-80 A 80,80 0 0,1 69.3,-40 L 34.6,-20 A 40,40 0 0,0 0,-40 Z"
-                fill="hsl(0, 70%, 70%)"
-            />
-            <path
-                d="M 69.3,-40 A 80,80 0 0,1 69.3,40 L 34.6,20 A 40,40 0 0,0 34.6,-20 Z"
-                fill="hsl(60, 70%, 70%)"
-            />
-            <path
-                d="M 69.3,40 A 80,80 0 0,1 0,80 L 0,40 A 40,40 0 0,0 34.6,20 Z"
-                fill="hsl(120, 70%, 70%)"
-            />
-            <path
-                d="M 0,80 A 80,80 0 0,1 -69.3,40 L -34.6,20 A 40,40 0 0,0 0,40 Z"
-                fill="hsl(180, 70%, 70%)"
-            />
-            <path
-                d="M -69.3,40 A 80,80 0 0,1 -69.3,-40 L -34.6,-20 A 40,40 0 0,0 -34.6,20 Z"
-                fill="hsl(240, 70%, 70%)"
-            />
-            <path
-                d="M -69.3,-40 A 80,80 0 0,1 0,-80 L 0,-40 A 40,40 0 0,0 -34.6,-20 Z"
-                fill="hsl(300, 70%, 70%)"
-            />
-            <!-- Apply gradient overlay for smooth blending -->
-            <circle r="80" fill="url(#pastel-blend)" />
-        </g>
-    </svg>
-</sp-color-wheel>
-
-<!-- Example 3: High contrast wheel with markers -->
-<sp-color-wheel>
-    <div slot="gradient" class="high-contrast-wheel">
-        <div class="marker" style="--angle: 0deg;">R</div>
-        <div class="marker" style="--angle: 120deg;">G</div>
-        <div class="marker" style="--angle: 240deg;">B</div>
+    <div slot="gradient" class="custom-gradient">
+        <!-- Custom SVG or gradient implementation -->
     </div>
 </sp-color-wheel>
+```
 
-<style>
-    .high-contrast-wheel {
-        width: 100%;
-        height: 100%;
-        position: relative;
-        border-radius: 50%;
-        background: conic-gradient(
-            from 0deg,
-            #ff0000,
-            #ffff00,
-            #00ff00,
-            #00ffff,
-            #0000ff,
-            #ff00ff,
-            #ff0000
-        );
-        mask: radial-gradient(circle, transparent 40%, black 40%);
-        -webkit-mask: radial-gradient(circle, transparent 40%, black 40%);
-    }
+### Options
 
-    .high-contrast-wheel .marker {
-        position: absolute;
-        top: 10%;
-        left: 50%;
-        transform: translate(-50%, -50%) rotate(var(--angle)) translateY(-90px);
-        font-weight: bold;
-        color: white;
-        text-shadow: 0 0 3px black;
-    }
-</style>
+#### Properties
 
-### Options #### Properties The color wheel supports several properties for
-configuration: ##### Value (Hue) Control the hue value directly (0-360 degrees):
+The color wheel supports several properties for configuration:
+
+##### Value (Hue)
+
+Control the hue value directly (0-360 degrees):
+
 ```html
 <sp-color-wheel value="180"></sp-color-wheel>
-````
+```
 
 ##### Color Values
 
-The color wheel supports a wide variety of color formats for setting and getting color values:
+Set and get color values using various formats:
 
 ```html
-<!-- Hex3 format (3-digit) -->
-<sp-color-wheel color="#f00"></sp-color-wheel>
-<sp-color-wheel color="#0a5"></sp-color-wheel>
-
-<!-- Hex4 format (3-digit + alpha) -->
-<sp-color-wheel color="#f00f"></sp-color-wheel>
-<sp-color-wheel color="#0a58"></sp-color-wheel>
-
-<!-- Hex6 format (6-digit) -->
+<!-- Hex formats -->
 <sp-color-wheel color="#ff0000"></sp-color-wheel>
-<sp-color-wheel color="#00aa55"></sp-color-wheel>
-
-<!-- Hex8 format (6-digit + alpha) -->
-<sp-color-wheel color="#ff0000ff"></sp-color-wheel>
-<sp-color-wheel color="#00aa5580"></sp-color-wheel>
+<sp-color-wheel color="#f00"></sp-color-wheel>
 
 <!-- RGB format -->
 <sp-color-wheel color="rgb(255, 0, 0)"></sp-color-wheel>
-<sp-color-wheel color="rgb(0, 170, 85)"></sp-color-wheel>
-
-<!-- RGBA format -->
-<sp-color-wheel color="rgba(255, 0, 0, 1)"></sp-color-wheel>
-<sp-color-wheel color="rgba(0, 170, 85, 0.5)"></sp-color-wheel>
 
 <!-- HSL format -->
 <sp-color-wheel color="hsl(0, 100%, 50%)"></sp-color-wheel>
-<sp-color-wheel color="hsl(150, 100%, 33%)"></sp-color-wheel>
 
-<!-- HSLA format -->
-<sp-color-wheel color="hsla(0, 100%, 50%, 1)"></sp-color-wheel>
-<sp-color-wheel color="hsla(150, 100%, 33%, 0.5)"></sp-color-wheel>
-
-<!-- HSV format -->
-<sp-color-wheel color="hsv(0, 100%, 100%)"></sp-color-wheel>
-<sp-color-wheel color="hsv(150, 100%, 67%)"></sp-color-wheel>
-
-<!-- HSVA format -->
-<sp-color-wheel color="hsva(0, 100%, 100%, 1)"></sp-color-wheel>
-<sp-color-wheel color="hsva(150, 100%, 67%, 0.5)"></sp-color-wheel>
-
-<!-- Named color strings -->
+<!-- Named colors -->
 <sp-color-wheel color="red"></sp-color-wheel>
-<sp-color-wheel color="rebeccapurple"></sp-color-wheel>
-<sp-color-wheel color="darkseagreen"></sp-color-wheel>
-<sp-color-wheel color="cornflowerblue"></sp-color-wheel>
 ```
 
 ##### Step Size
 
-The `step` attribute controls the increment of hue adjustment when using keyboard navigation. It defines how many degrees the hue changes with each arrow key press:
+Customize the precision of keyboard navigation (default: 1):
 
 ```html
-<!-- Fine control: 1 degree per key press (default) -->
-<sp-color-wheel step="1"></sp-color-wheel>
-
-<!-- Medium control: 10 degrees per key press -->
 <sp-color-wheel step="10"></sp-color-wheel>
-
-<!-- Coarse control: 45 degrees per key press (8 stops around the wheel) -->
-<sp-color-wheel step="45"></sp-color-wheel>
 ```
-
-The step size affects keyboard navigation:
-
-- Regular arrow keys move by the step value
-- <kbd>Shift</kbd> + arrow keys move by 10× the step value
-- Choose your step size based on your use case:
-    - **step="1"**: Precise color selection, best for professional design tools
-    - **step="10"**: Balanced control, good for general use
-    - **step="45"**: Quick selection between major hues, ideal for simple color pickers
 
 ##### Label
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -67,53 +67,70 @@ Control the hue value directly (0-360 degrees):
 
 The color wheel supports a wide variety of color formats for setting and getting color values:
 
-```html
-<!-- Hex3 format (3-digit) -->
-<sp-color-wheel color="#f00"></sp-color-wheel>
-<sp-color-wheel color="#0a5"></sp-color-wheel>
-
-<!-- Hex4 format (3-digit + alpha) -->
-<sp-color-wheel color="#f00f"></sp-color-wheel>
-<sp-color-wheel color="#0a58"></sp-color-wheel>
-
-<!-- Hex6 format (6-digit) -->
-<sp-color-wheel color="#ff0000"></sp-color-wheel>
-<sp-color-wheel color="#00aa55"></sp-color-wheel>
-
-<!-- Hex8 format (6-digit + alpha) -->
-<sp-color-wheel color="#ff0000ff"></sp-color-wheel>
-<sp-color-wheel color="#00aa5580"></sp-color-wheel>
-
-<!-- RGB format -->
-<sp-color-wheel color="rgb(255, 0, 0)"></sp-color-wheel>
-<sp-color-wheel color="rgb(0, 170, 85)"></sp-color-wheel>
-
-<!-- RGBA format -->
-<sp-color-wheel color="rgba(255, 0, 0, 1)"></sp-color-wheel>
-<sp-color-wheel color="rgba(0, 170, 85, 0.5)"></sp-color-wheel>
-
-<!-- HSL format -->
-<sp-color-wheel color="hsl(0, 100%, 50%)"></sp-color-wheel>
-<sp-color-wheel color="hsl(150, 100%, 33%)"></sp-color-wheel>
-
-<!-- HSLA format -->
-<sp-color-wheel color="hsla(0, 100%, 50%, 1)"></sp-color-wheel>
-<sp-color-wheel color="hsla(150, 100%, 33%, 0.5)"></sp-color-wheel>
-
-<!-- HSV format -->
-<sp-color-wheel color="hsv(0, 100%, 100%)"></sp-color-wheel>
-<sp-color-wheel color="hsv(150, 100%, 67%)"></sp-color-wheel>
-
-<!-- HSVA format -->
-<sp-color-wheel color="hsva(0, 100%, 100%, 1)"></sp-color-wheel>
-<sp-color-wheel color="hsva(150, 100%, 67%, 0.5)"></sp-color-wheel>
-
-<!-- Named color strings -->
-<sp-color-wheel color="red"></sp-color-wheel>
-<sp-color-wheel color="rebeccapurple"></sp-color-wheel>
-<sp-color-wheel color="darkseagreen"></sp-color-wheel>
-<sp-color-wheel color="cornflowerblue"></sp-color-wheel>
-```
+<sp-table>
+    <sp-table-head>
+        <sp-table-head-cell>Format</sp-table-head-cell>
+        <sp-table-head-cell>Example Values</sp-table-head-cell>
+        <sp-table-head-cell>Description</sp-table-head-cell>
+    </sp-table-head>
+    <sp-table-body>
+        <sp-table-row>
+            <sp-table-cell>Hex3</sp-table-cell>
+            <sp-table-cell><code>#f00</code>, <code>#0a5</code></sp-table-cell>
+            <sp-table-cell>3-digit hexadecimal</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>Hex4</sp-table-cell>
+            <sp-table-cell><code>#f00f</code>, <code>#0a58</code></sp-table-cell>
+            <sp-table-cell>3-digit hexadecimal + alpha</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>Hex6</sp-table-cell>
+            <sp-table-cell><code>#ff0000</code>, <code>#00aa55</code></sp-table-cell>
+            <sp-table-cell>6-digit hexadecimal</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>Hex8</sp-table-cell>
+            <sp-table-cell><code>#ff0000ff</code>, <code>#00aa5580</code></sp-table-cell>
+            <sp-table-cell>6-digit hexadecimal + alpha</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>RGB</sp-table-cell>
+            <sp-table-cell><code>rgb(255, 0, 0)</code>, <code>rgb(0, 170, 85)</code></sp-table-cell>
+            <sp-table-cell>Red, Green, Blue values (0-255)</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>RGBA</sp-table-cell>
+            <sp-table-cell><code>rgba(255, 0, 0, 1)</code>, <code>rgba(0, 170, 85, 0.5)</code></sp-table-cell>
+            <sp-table-cell>RGB + Alpha channel (0-1)</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>HSL</sp-table-cell>
+            <sp-table-cell><code>hsl(0, 100%, 50%)</code>, <code>hsl(150, 100%, 33%)</code></sp-table-cell>
+            <sp-table-cell>Hue (0-360°), Saturation, Lightness</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>HSLA</sp-table-cell>
+            <sp-table-cell><code>hsla(0, 100%, 50%, 1)</code>, <code>hsla(150, 100%, 33%, 0.5)</code></sp-table-cell>
+            <sp-table-cell>HSL + Alpha channel (0-1)</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>HSV</sp-table-cell>
+            <sp-table-cell><code>hsv(0, 100%, 100%)</code>, <code>hsv(150, 100%, 67%)</code></sp-table-cell>
+            <sp-table-cell>Hue (0-360°), Saturation, Value</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>HSVA</sp-table-cell>
+            <sp-table-cell><code>hsva(0, 100%, 100%, 1)</code>, <code>hsva(150, 100%, 67%, 0.5)</code></sp-table-cell>
+            <sp-table-cell>HSV + Alpha channel (0-1)</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell>Named Colors</sp-table-cell>
+            <sp-table-cell><code>red</code>, <code>rebeccapurple</code>, <code>darkseagreen</code></sp-table-cell>
+            <sp-table-cell>CSS color keywords (<a href="https://developer.mozilla.org/en-US/docs/Web/CSS/named-color">full list</a>)</sp-table-cell>
+        </sp-table-row>
+    </sp-table-body>
+</sp-table>
 
 ##### Step Size
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -65,30 +65,79 @@ Control the hue value directly (0-360 degrees):
 
 ##### Color Values
 
-Set and get color values using various formats:
+The color wheel supports a wide variety of color formats for setting and getting color values:
 
 ```html
-<!-- Hex formats -->
-<sp-color-wheel color="#ff0000"></sp-color-wheel>
+<!-- Hex3 format (3-digit) -->
 <sp-color-wheel color="#f00"></sp-color-wheel>
+<sp-color-wheel color="#0a5"></sp-color-wheel>
+
+<!-- Hex4 format (3-digit + alpha) -->
+<sp-color-wheel color="#f00f"></sp-color-wheel>
+<sp-color-wheel color="#0a58"></sp-color-wheel>
+
+<!-- Hex6 format (6-digit) -->
+<sp-color-wheel color="#ff0000"></sp-color-wheel>
+<sp-color-wheel color="#00aa55"></sp-color-wheel>
+
+<!-- Hex8 format (6-digit + alpha) -->
+<sp-color-wheel color="#ff0000ff"></sp-color-wheel>
+<sp-color-wheel color="#00aa5580"></sp-color-wheel>
 
 <!-- RGB format -->
 <sp-color-wheel color="rgb(255, 0, 0)"></sp-color-wheel>
+<sp-color-wheel color="rgb(0, 170, 85)"></sp-color-wheel>
+
+<!-- RGBA format -->
+<sp-color-wheel color="rgba(255, 0, 0, 1)"></sp-color-wheel>
+<sp-color-wheel color="rgba(0, 170, 85, 0.5)"></sp-color-wheel>
 
 <!-- HSL format -->
 <sp-color-wheel color="hsl(0, 100%, 50%)"></sp-color-wheel>
+<sp-color-wheel color="hsl(150, 100%, 33%)"></sp-color-wheel>
 
-<!-- Named colors -->
+<!-- HSLA format -->
+<sp-color-wheel color="hsla(0, 100%, 50%, 1)"></sp-color-wheel>
+<sp-color-wheel color="hsla(150, 100%, 33%, 0.5)"></sp-color-wheel>
+
+<!-- HSV format -->
+<sp-color-wheel color="hsv(0, 100%, 100%)"></sp-color-wheel>
+<sp-color-wheel color="hsv(150, 100%, 67%)"></sp-color-wheel>
+
+<!-- HSVA format -->
+<sp-color-wheel color="hsva(0, 100%, 100%, 1)"></sp-color-wheel>
+<sp-color-wheel color="hsva(150, 100%, 67%, 0.5)"></sp-color-wheel>
+
+<!-- Named color strings -->
 <sp-color-wheel color="red"></sp-color-wheel>
+<sp-color-wheel color="rebeccapurple"></sp-color-wheel>
+<sp-color-wheel color="darkseagreen"></sp-color-wheel>
+<sp-color-wheel color="cornflowerblue"></sp-color-wheel>
 ```
 
 ##### Step Size
 
-Customize the precision of keyboard navigation (default: 1):
+The `step` attribute controls the increment of hue adjustment when using keyboard navigation. It defines how many degrees the hue changes with each arrow key press:
 
 ```html
+<!-- Fine control: 1 degree per key press (default) -->
+<sp-color-wheel step="1"></sp-color-wheel>
+
+<!-- Medium control: 10 degrees per key press -->
 <sp-color-wheel step="10"></sp-color-wheel>
+
+<!-- Coarse control: 45 degrees per key press (8 stops around the wheel) -->
+<sp-color-wheel step="45"></sp-color-wheel>
 ```
+
+The step size affects keyboard navigation:
+
+- Regular arrow keys move by the step value
+- <kbd>Shift</kbd> + arrow keys move by 10× the step value
+- Choose your step size based on your use case:
+    - **step="1"**: Precise color selection, best for professional design tools
+    - **step="10"**: Balanced control, good for general use
+    - **step="45"**: Quick selection between major hues, ideal for simple color pickers
 
 ##### Label
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -43,8 +43,11 @@ You can provide a custom gradient to replace the default color wheel appearance 
 
 ```html
 <sp-color-wheel>
-        <svg slot="gradient" class="custom-gradient" ...>...</svg>
+    <div slot="gradient" class="custom-gradient">
+        <!-- Custom SVG or gradient implementation -->
+    </div>
 </sp-color-wheel>
+```
 
 ### Options
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -197,10 +197,8 @@ A color wheel in a disabled state shows that an input exists, but is not availab
 
 The color wheel manages its focused state automatically, providing visual feedback during keyboard navigation:
 
-```javascript
-const colorWheel = document.querySelector('sp-color-wheel');
-console.log(colorWheel.focused); // true or false
-```
+```html
+<sp-color-wheel focused></sp-color-wheel>
 
 ## Behaviors
 

--- a/packages/color-wheel/README.md
+++ b/packages/color-wheel/README.md
@@ -1,6 +1,6 @@
-## Description
+## Overview
 
-An `<sp-color-wheel>` lets users visually change an individual channel of a color on a circular track.
+An `<sp-color-wheel>` allows users to visually select the hue of a color on a circular track. It's commonly used together with other color components to create comprehensive color selection interfaces.
 
 ### Usage
 
@@ -8,23 +8,134 @@ An `<sp-color-wheel>` lets users visually change an individual channel of a colo
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/color-wheel?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/color-wheel)
 [![Try it on Stackblitz](https://img.shields.io/badge/Try%20it%20on-Stackblitz-blue?style=for-the-badge)](https://stackblitz.com/edit/vitejs-vite-cqyqwmbq)
 
-```
+```bash
 yarn add @spectrum-web-components/color-wheel
 ```
 
 Import the side effectful registration of `<sp-color-wheel>` via:
 
-```
+```javascript
 import '@spectrum-web-components/color-wheel/sp-color-wheel.js';
 ```
 
 When looking to leverage the `ColorWheel` base class as a type and/or for extension purposes, do so via:
 
-```
+```javascript
 import { ColorWheel } from '@spectrum-web-components/color-wheel';
 ```
 
-## Color Formatting
+### Anatomy
+
+The color wheel consists of several key parts:
+
+- A circular track displaying the full spectrum of hues
+- A draggable handle that indicates the current hue selection
+- Accessible labels for screen readers
+- Optional custom gradient slot for advanced styling
+
+```html
+<sp-color-wheel></sp-color-wheel>
+```
+
+#### Custom Gradient
+
+You can provide a custom gradient to replace the default color wheel appearance using the `gradient` slot:
+
+```html
+<sp-color-wheel>
+    <div slot="gradient" class="custom-gradient">
+        <!-- Custom SVG or gradient implementation -->
+    </div>
+</sp-color-wheel>
+```
+
+### Options
+
+#### Properties
+
+The color wheel supports several properties for configuration:
+
+##### Value (Hue)
+
+Control the hue value directly (0-360 degrees):
+
+```html
+<sp-color-wheel value="180"></sp-color-wheel>
+```
+
+##### Color Values
+
+Set and get color values using various formats:
+
+```html
+<!-- Hex formats -->
+<sp-color-wheel color="#ff0000"></sp-color-wheel>
+<sp-color-wheel color="#f00"></sp-color-wheel>
+
+<!-- RGB format -->
+<sp-color-wheel color="rgb(255, 0, 0)"></sp-color-wheel>
+
+<!-- HSL format -->
+<sp-color-wheel color="hsl(0, 100%, 50%)"></sp-color-wheel>
+
+<!-- Named colors -->
+<sp-color-wheel color="red"></sp-color-wheel>
+```
+
+##### Step Size
+
+Customize the precision of keyboard navigation (default: 1):
+
+```html
+<sp-color-wheel step="10"></sp-color-wheel>
+```
+
+##### Label
+
+Provide a custom aria-label for accessibility:
+
+```html
+<sp-color-wheel label="Select color hue"></sp-color-wheel>
+```
+
+##### Direction
+
+The color wheel supports both left-to-right and right-to-left layouts:
+
+```html
+<sp-color-wheel dir="rtl"></sp-color-wheel>
+```
+
+#### Custom Sizing
+
+An `<sp-color-wheel>`'s size can be customized appropriately for its context. By default, the size is size-2400 (192 px on desktop, 240 px on mobile).
+
+```html
+<sp-color-wheel style="width: 300px; height: 300px;"></sp-color-wheel>
+```
+
+### States
+
+#### Disabled
+
+A color wheel in a disabled state shows that an input exists, but is not available in that circumstance. This can be used to maintain layout continuity and communicate that the wheel may become available later.
+
+```html
+<sp-color-wheel disabled></sp-color-wheel>
+```
+
+#### Focused
+
+The color wheel manages its focused state automatically, providing visual feedback during keyboard navigation:
+
+```javascript
+const colorWheel = document.querySelector('sp-color-wheel');
+console.log(colorWheel.focused); // true or false
+```
+
+### Behaviors
+
+#### Color Formatting
 
 When using the color elements, use `el.color` to access the `color` property, which should manage itself in the color format supplied. If you supply a color in `rgb()` format, `el.color` should return the color in `rgb()` format, as well.
 
@@ -34,31 +145,73 @@ The current color formats supported are as follows:
 - HSV, HSVA
 - HSL, HSLA
 - RGB, RGBA
-- Strings (eg "red", "blue")
+- Named color strings (see [full list](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color))
 
 **Please note for the following formats: HSV, HSVA, HSL, HSLA**
-When using the HSL or HSV formats, and a color's value (in HSV) is set to 0, or its luminosity (in HSL) is set to 0 or 1, the hue and saturation values may not be preserved by the element's `color` property. This is detailed in the [colorjs documentation](https://colorjs.io/docs/). Seperately, the element's `value` property is directly managed by the hue as represented in the interface.
+When using the HSL or HSV formats, and a color's value (in HSV) is set to 0, or its luminosity (in HSL) is set to 0 or 1, the hue and saturation values may not be preserved by the element's `color` property. This is detailed in the [colorjs documentation](https://colorjs.io/docs/). Separately, the element's `value` property is directly managed by the hue as represented in the interface.
 
-## Example
+#### Pointer Interactions
 
-```html
-<sp-color-wheel></sp-color-wheel>
-```
+The color wheel supports both mouse and touch interactions:
 
-### Disabled
+- **Click**: Jump to a specific hue on the wheel
+- **Drag**: Continuously adjust hue while dragging around the wheel
+- **Touch**: Full touch support for mobile devices
 
-A color wheel in a disabled state shows that an input exists, but is not available in that circumstance. This can be used to maintain layout continuity and communicate that the wheel may become available later.
+#### Focus Management
 
-```html
-<sp-color-wheel disabled></sp-color-wheel>
-```
+The color wheel automatically manages focus for keyboard accessibility, ensuring proper focus indication and keyboard operability.
 
-## Variants
+### Accessibility
 
-### Sized
+The `<sp-color-wheel>` is rendered with appropriate ARIA attributes to ensure accessibility for screen readers and keyboard navigation.
 
-An `<sp-color-wheel>`’s size can be customized appropriately for its context. By default, the size is size-2400 (192 px on desktop, 240 px on mobile).
+#### Keyboard Navigation
 
-```html
-<sp-color-wheel style="width: 300px; height: 300px;"></sp-color-wheel>
-```
+The color wheel supports comprehensive keyboard interaction:
+
+<sp-table>
+    <sp-table-head>
+        <sp-table-head-cell>Key</sp-table-head-cell>
+        <sp-table-head-cell>Action</sp-table-head-cell>
+    </sp-table-head>
+    <sp-table-body>
+        <sp-table-row>
+            <sp-table-cell><kbd>Arrow Left</kbd>/<kbd>Arrow Right</kbd></sp-table-cell>
+            <sp-table-cell>Decrease/Increase hue by step value (respects RTL)</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell><kbd>Arrow Up</kbd>/<kbd>Arrow Down</kbd></sp-table-cell>
+            <sp-table-cell>Increase/Decrease hue by step value</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row>
+            <sp-table-cell><kbd>Shift</kbd> + Arrow Keys</sp-table-cell>
+            <sp-table-cell>Adjust hue by larger increments (10× step)</sp-table-cell>
+        </sp-table-row>
+    </sp-table-body>
+</sp-table>
+
+#### ARIA Attributes
+
+The component provides comprehensive ARIA support:
+
+- **Role**: Uses native `input[type="range"]` with implicit "slider" role
+- **Label**: Customizable via the `label` property (defaults to "hue")
+- **Value Text**: Announces the current hue value in degrees with proper internationalization
+- **Orientation**: Implicitly circular, supporting both LTR and RTL layouts
+
+#### Screen Reader Support
+
+The component provides meaningful announcements for assistive technologies:
+
+- Current hue value announced in degrees (e.g., "180 degrees")
+- Internationalized number formatting based on user's locale
+- Clear indication of the control's purpose through proper labeling
+
+#### Mobile Accessibility
+
+The color wheel is fully accessible on mobile devices with:
+
+- Touch-friendly interaction areas
+- Proper focus management for mobile screen readers
+- Responsive sizing that maintains usability on smaller screens


### PR DESCRIPTION
### **Overview**
This PR reorganizes the color-wheel README.md to follow the established documentation standards structure, improving accessibility and consistency with other components.

**### Changes Made**
**Structure Reorganization**

- Overview: Replaced "Description" with "Overview" section and expanded component description

- Usage: Updated import code blocks with proper language syntax highlighting (bash, javascript)

- Anatomy: Added new section describing the component's key parts, basic usage, and custom gradient slot

- Options: Created comprehensive properties documentation including:

  - Value (Hue) control
  - Color format examples
  - Step size configuration
  - Label customization
  - Direction support
  - Custom sizing (moved from Variants section)

- States: Reorganized disabled state and added focused state documentation

- Behaviors: Moved color formatting information and added:

  - Pointer interactions
  - Focus management

- Accessibility: Added comprehensive new section with:

  - Keyboard navigation table
  - ARIA attributes documentation
  - Screen reader support details
  - Mobile accessibility information

**Content Improvements**

- Enhanced component description to mention use with other color components
- Added documentation for previously undocumented properties (value, step, label, dir)
- Provided more comprehensive color format examples
- Fixed typo: "Seperately" → "Separately"
- Added link to MDN for named colors reference
- Included custom gradient slot documentation

**Accessibility Enhancements**

- Added detailed keyboard navigation instructions with <kbd> tags
- Documented ARIA implementation details
- Included screen reader announcement patterns
- Added mobile-specific accessibility considerations
- Used semantic table markup for keyboard navigation guide

**Testing**

- [] Verified all existing content is preserved
- [] Confirmed proper markdown syntax and formatting
- [] Checked consistency with documentation standards
- [] Reviewed accessibility improvements against WCAG guidelines

**Related Documentation**

- Follows structure outlined in Adding a Component Documentation Standards
- Maintains consistency with accordion, button, meter, progress bar, progress circle, and tooltip README files
- References PR #5600 (color-area documentation reorganization) as a model
- This reorganization makes the color-wheel documentation more accessible, easier to navigate, and consistent with the established documentation standards across the Spectrum Web Components library.