### PR TITLE
chore(ci): fix preview release error on immutable installs

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
     release:
         runs-on: ubuntu-latest
+        env:
+            YARN_ENABLE_IMMUTABLE_INSTALLS: false
         # Run the job if manually triggered or if the commit message includes a commit type of fix or feat or breaking change
         if: contains(github.event.head_commit.message, 'fix:') || contains(github.event.head_commit.message, 'fix(') || contains(github.event.head_commit.message, 'feat:') || contains(github.event.head_commit.message, 'feat(') || contains(github.event.head_commit.message, '!:')
         steps:


### PR DESCRIPTION
## Description

Snapshot builds on main are failing on the default behavior for yarn which does not allow for lockfile updates in CI. The lock file needs to be updated during the release CI so this update allows for those changes without failing the workflow.

## Related issue(s)

- Failing build: https://github.com/adobe/spectrum-web-components/actions/runs/16674003610/job/47196380337

<img width="1198" height="617" alt="Screenshot 2025-08-01 at 11 51 23 AM" src="https://github.com/user-attachments/assets/c3fd705f-96d9-4903-8d6f-28b4b4d9f67d" />

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash
