### PR TITLE
chore(netlify): remove netlify.toml now that Azure is used for deployments

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,0 @@
-[build]
-  command = "yarn docs:build"
-  publish = "projects/documentation/dist"
-
-[[headers]]
-  for = "/storybook/*.json"
-    [headers.values]
-    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
## Description

We no longer deploy to Netlify, so we don't need a `netlify.toml`.

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [x] I have included updated documentation if my change required it.