### PR TITLE
Rajdeep/jira 1027

### DIFF
--- a/.changeset/cruel-eels-open.md
+++ b/.changeset/cruel-eels-open.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/menu': minor
+---
+
+**Fixed** MenuItem focus stealing from input elements on mouseover by enhanceing MenuItem's `handleMouseover` method to detect when an input element currently has focus and prevent stealing focus in those cases.

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -28,6 +28,11 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-export.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-folder-open.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-share.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
+import '@spectrum-web-components/search/sp-search.js';
+import '@spectrum-web-components/textfield/sp-textfield.js';
+import '@spectrum-web-components/number-field/sp-number-field.js';
+import '@spectrum-web-components/combobox/sp-combobox.js';
+import '@spectrum-web-components/color-field/sp-color-field.js';
 
 export default {
     component: 'sp-menu',
@@ -482,5 +487,91 @@ export const dynamicRemoval = (): TemplateResult => {
             <sp-menu-item>Save Selection</sp-menu-item>
             <sp-menu-item disabled>Make Work Path</sp-menu-item>
         </sp-menu>
+    `;
+};
+
+export const InputsWithMenu = (): TemplateResult => {
+    return html`
+        <div style="padding: 20px; max-width: 600px;">
+            <h3>Input Focus Demo</h3>
+            <p>
+                Try typing in any input field below, then hover over the menu
+                items. The input should maintain focus and not be interrupted.
+                This demonstrates the fix for focus stealing from all supported input types.
+            </p>
+
+            <div style="display: grid; gap: 16px; grid-template-columns: 1fr 1fr; margin-bottom: 20px;">
+                <!-- Search Input -->
+                <div>
+                    <label for="demo-search">Search:</label>
+                    <sp-search
+                        id="demo-search"
+                        placeholder="Search input..."
+                        style="width: 100%; margin-top: 8px;"
+                    ></sp-search>
+                </div>
+
+                <!-- Textfield Input -->
+                <div>
+                    <label for="demo-textfield">Textfield:</label>
+                    <sp-textfield
+                        id="demo-textfield"
+                        placeholder="Textfield input..."
+                        style="width: 100%; margin-top: 8px;"
+                    ></sp-textfield>
+                </div>
+
+                <!-- Number Field Input -->
+                <div>
+                    <label for="demo-number">Number Field:</label>
+                    <sp-number-field
+                        id="demo-number"
+                        placeholder="Number input..."
+                        style="width: 100%; margin-top: 8px;"
+                    ></sp-number-field>
+                </div>
+
+                <!-- Combobox Input -->
+                <div>
+                    <label for="demo-combobox">Combobox:</label>
+                    <sp-combobox
+                        id="demo-combobox"
+                        placeholder="Combobox input..."
+                        style="width: 100%; margin-top: 8px;"
+                    ></sp-combobox>
+                </div>
+
+                <!-- Color Field Input -->
+                <div>
+                    <label for="demo-color">Color Field:</label>
+                    <sp-color-field
+                        id="demo-color"
+                        placeholder="Color input..."
+                        style="width: 100%; margin-top: 8px;"
+                    ></sp-color-field>
+                </div>
+
+                <!-- Native Input -->
+                <div>
+                    <label for="demo-native">Native Input:</label>
+                    <input
+                        id="demo-native"
+                        placeholder="Native input..."
+                        style="width: 100%; margin-top: 8px; padding: 8px; border: 1px solid #ccc; border-radius: 4px;"
+                    />
+                </div>
+            </div>
+
+            <sp-popover open>
+                <sp-menu>
+                    <sp-menu-item>Search Results</sp-menu-item>
+                    <sp-menu-item>Recent Searches</sp-menu-item>
+                    <sp-menu-item>Saved Searches</sp-menu-item>
+                    <sp-menu-item>Advanced Search</sp-menu-item>
+                    <sp-menu-item>Search Settings</sp-menu-item>
+                    <sp-menu-item>Clear History</sp-menu-item>
+                </sp-menu>
+            </sp-popover>
+        </div>
     `;
 };

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -23,6 +23,12 @@ import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/menu/sp-menu-group.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu.js';
+import '@spectrum-web-components/search/sp-search.js';
+import '@spectrum-web-components/textfield/sp-textfield.js';
+import '@spectrum-web-components/number-field/sp-number-field.js';
+import '@spectrum-web-components/combobox/sp-combobox.js';
+import '@spectrum-web-components/color-field/sp-color-field.js';
+import '@spectrum-web-components/popover/sp-popover.js';
 import { isFirefox, isWebKit } from '@spectrum-web-components/shared';
 import { sendKeys } from '@web/test-runner-commands';
 import { spy } from 'sinon';
@@ -837,5 +843,143 @@ describe('Menu', () => {
 
         // Test that the component can be disconnected without errors
         el.remove();
+    });
+
+    it('does not steal focus from input elements on mouseover', async () => {
+        const el = await fixture<Menu>(html`
+            <div>
+                <sp-search
+                    id="test-search"
+                    placeholder="Search input..."
+                ></sp-search>
+                <sp-textfield
+                    id="test-textfield"
+                    placeholder="Textfield input..."
+                ></sp-textfield>
+                <sp-number-field
+                    id="test-number"
+                    placeholder="Number input..."
+                ></sp-number-field>
+                <sp-combobox
+                    id="test-combobox"
+                    placeholder="Combobox input..."
+                ></sp-combobox>
+                <sp-color-field
+                    id="test-color"
+                    placeholder="Color input..."
+                ></sp-color-field>
+                <input id="test-native" placeholder="Native input..." />
+
+                <sp-popover open>
+                    <sp-menu>
+                        <sp-menu-item id="menu-item-1">
+                            Menu Item 1
+                        </sp-menu-item>
+                        <sp-menu-item id="menu-item-2">
+                            Menu Item 2
+                        </sp-menu-item>
+                        <sp-menu-item id="menu-item-3">
+                            Menu Item 3
+                        </sp-menu-item>
+                    </sp-menu>
+                </sp-popover>
+            </div>
+        `);
+
+        await elementUpdated(el);
+
+        const searchInput = el.querySelector('#test-search') as HTMLElement;
+        const textfieldInput = el.querySelector(
+            '#test-textfield'
+        ) as HTMLElement;
+        const numberInput = el.querySelector('#test-number') as HTMLElement;
+        const comboboxInput = el.querySelector('#test-combobox') as HTMLElement;
+        const colorInput = el.querySelector('#test-color') as HTMLElement;
+        const nativeInput = el.querySelector(
+            '#test-native'
+        ) as HTMLInputElement;
+
+        const menuItem1 = el.querySelector('#menu-item-1') as MenuItem;
+        const menuItem2 = el.querySelector('#menu-item-2') as MenuItem;
+        const menuItem3 = el.querySelector('#menu-item-3') as MenuItem;
+
+        // Test with sp-search
+        searchInput.focus();
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(searchInput);
+
+        await sendMouseTo(menuItem1);
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(
+            searchInput,
+            'sp-search should retain focus'
+        );
+
+        await sendMouseTo(menuItem2);
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(
+            searchInput,
+            'sp-search should retain focus'
+        );
+
+        // Test with sp-textfield
+        textfieldInput.focus();
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(textfieldInput);
+
+        await sendMouseTo(menuItem1);
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(
+            textfieldInput,
+            'sp-textfield should retain focus'
+        );
+
+        // Test with sp-number-field
+        numberInput.focus();
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(numberInput);
+
+        await sendMouseTo(menuItem2);
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(
+            numberInput,
+            'sp-number-field should retain focus'
+        );
+
+        // Test with sp-combobox
+        comboboxInput.focus();
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(comboboxInput);
+
+        await sendMouseTo(menuItem3);
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(
+            comboboxInput,
+            'sp-combobox should retain focus'
+        );
+
+        // Test with sp-color-field
+        colorInput.focus();
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(colorInput);
+
+        await sendMouseTo(menuItem1);
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(
+            colorInput,
+            'sp-color-field should retain focus'
+        );
+
+        // Test with native input
+        nativeInput.focus();
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(nativeInput);
+
+        await sendMouseTo(menuItem2);
+        await elementUpdated(el);
+        expect(document.activeElement).to.equal(
+            nativeInput,
+            'native input should retain focus'
+        );
     });
 });


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

### Solution

-  Added `isInputElement()` method that detects all input types
- Uses `getRootNode().activeElement` for reliable focus detection across shadow boundaries
- Handles both document and shadow root contexts
- Avoids expensive DOM queries and property enumeration
- Uses ARIA roles (`textbox`, `searchbox`, `combobox`, `spinbutton`, `slider`) for generic detection
- Regex pattern matching for Spectrum Web Components (`/^(SP-SEARCH|SP-TEXTFIELD|SP-NUMBER-FIELD|SP-COMBOBOX|SP-COLOR-FIELD)$/`)

### No Breaking Changes
- Existing menu functionality preserved
- Menu items still receive focus when appropriate
- No API changes
- Backward compatible

<!--- Describe your changes in detail -->


## Technical Details

### Before
```typescript
handleMouseover(event: MouseEvent): void {
    const target = event.target as HTMLElement;
    if (target === this) {
        this.focus(); // Always stole focus
        this.focused = false;
    }
}
```

### After
```typescript
handleMouseover(event: MouseEvent): void {
    const target = event.target as HTMLElement;
    if (target === this) {
        const rootNode = this.getRootNode() as Document | ShadowRoot;
        const activeElement = rootNode.activeElement as HTMLElement;
        
        // Only focus if no input element is currently active
        if (!activeElement || !this.isInputElement(activeElement)) {
            this.focus();
        }
        this.focused = false;
    }
}
```

## Motivation and context

MenuItem was stealing focus from input elements (searchboxes, textfields, etc.) when users hovered over menu items while typing. This created a poor user experience where:

- Users typing in search boxes would lose focus when hovering over menu items
- Input was interrupted mid-typing, forcing users to click back into the input
- This affected all Spectrum Web Components input types (`sp-search`, `sp-textfield`, `sp-number-field`, `sp-combobox`, `sp-color-field`)
- Native HTML inputs (`input`, `textarea`, `select`) were also affected
- Contenteditable elements experienced the same issue

<!--- Why is this change required? What problem does it solve? -->

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes SWC-1027

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Descriptive Test Statement_

    1. Go [here](url)
    2. Do this action
    3. Expect this result

-   [ ] _Descriptive Test Statement_
    1. Go [here](url)
    2. Do this action
    3. Expect this result

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
