### PR TITLE
chore(docs): barebones analysis for Field label, Help text, Picker button, In-field button and In-field progress circle

### DIFF
--- a/migration-roadmap/field-label.md
+++ b/migration-roadmap/field-label.md
@@ -92,9 +92,15 @@ None found for this component.
 ```html
 <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">
     Label text
-    <sp-icon-asterisk100
+    <svg
         class="spectrum-FieldLabel-UIIcon spectrum-FieldLabel-requiredIcon"
-    ></sp-icon-asterisk100>
+        focusable="false"
+        aria-hidden="true"
+    >
+        <path
+            d="M10 2L13.09 8.26L20 9L14 14.74L15.18 22L10 18.77L4.82 22L6 14.74L0 9L6.91 8.26L10 2Z"
+        ></path>
+    </svg>
 </label>
 ```
 
@@ -106,9 +112,15 @@ None found for this component.
 ```html
 <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">
     Label text&#8288;
-    <sp-icon-asterisk100
+    <svg
         class="spectrum-FieldLabel-UIIcon spectrum-FieldLabel-requiredIcon"
-    ></sp-icon-asterisk100>
+        focusable="false"
+        aria-hidden="true"
+    >
+        <path
+            d="M10 2L13.09 8.26L20 9L14 14.74L15.18 22L10 18.77L4.82 22L6 14.74L0 9L6.91 8.26L10 2Z"
+        ></path>
+    </svg>
 </label>
 ```
 
@@ -117,29 +129,25 @@ None found for this component.
 <details>
 <summary>Diff: Legacy (CSS main) → Spectrum 2 (CSS spectrum-two)</summary>
 
-### HTML Output Comparison
+### HTML Output Diff
 
-**Legacy (CSS main branch):**
-
-```html
+```diff
 <label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">
-    Label text
-    <sp-icon-asterisk100
+-    Label text
++    Label text&#8288;
+    <svg
         class="spectrum-FieldLabel-UIIcon spectrum-FieldLabel-requiredIcon"
-    ></sp-icon-asterisk100>
+        focusable="false"
+        aria-hidden="true"
+    >
+        <path
+            d="M10 2L13.09 8.26L20 9L14 14.74L15.18 22L10 18.77L4.82 22L6 14.74L0 9L6.91 8.26L10 2Z"
+        ></path>
+    </svg>
 </label>
 ```
 
-**Spectrum 2 (CSS spectrum-two branch):**
-
-```html
-<label class="spectrum-FieldLabel spectrum-FieldLabel--sizeM">
-    Label text&#8288;
-    <sp-icon-asterisk100
-        class="spectrum-FieldLabel-UIIcon spectrum-FieldLabel-requiredIcon"
-    ></sp-icon-asterisk100>
-</label>
-```
+</details>
 
 ### Key Changes in HTML Structure
 
@@ -151,19 +159,19 @@ None found for this component.
 
 ### CSS => SWC mapping
 
-| CSS selector                                                                                  | Attribute or slot         | Status          |
-| --------------------------------------------------------------------------------------------- | ------------------------- | --------------- |
-| `.spectrum-FieldLabel`                                                                        | Base element              | Implemented     |
-| `.spectrum-FieldLabel--left`                                                                  | `side-aligned="start"`    | Implemented     |
-| `.spectrum-FieldLabel--right`                                                                 | `side-aligned="end"`      | Implemented     |
-| `.spectrum-FieldLabel--sizeL`                                                                 | `size="l"`                | Implemented     |
-| `.spectrum-FieldLabel--sizeS`                                                                 | `size="s"`                | Implemented     |
-| `.spectrum-FieldLabel--sizeXL`                                                                | `size="xl"`               | Implemented     |
-| `.spectrum-FieldLabel--staticBlack`                                                           | `static-color="black"`    | Missing from WC (new for S2) |
-| `.spectrum-FieldLabel--staticWhite`                                                           | `static-color="white"`    | Missing from WC (new for S2) |
-| `.spectrum-FieldLabel-requiredIcon`                                                           | Required icon element     | Implemented     |
-| `.spectrum-FieldLabel.is-disabled`                                                            | `disabled` attribute      | Implemented     |
-| `.spectrum-FieldLabel:lang(ja), .spectrum-FieldLabel:lang(ko), .spectrum-FieldLabel:lang(zh)` | Language-specific styling | Implemented     |
+| CSS selector                                                                                  | Attribute or slot                       | Status                       |
+| --------------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------------- |
+| `.spectrum-FieldLabel`                                                                        | `:host`                                 | Implemented                  |
+| `.spectrum-FieldLabel--left`                                                                  | `side-aligned="start"`                  | Implemented                  |
+| `.spectrum-FieldLabel--right`                                                                 | `side-aligned="end"`                    | Implemented                  |
+| `.spectrum-FieldLabel--sizeL`                                                                 | `size="l"`                              | Implemented                  |
+| `.spectrum-FieldLabel--sizeS`                                                                 | `size="s"`                              | Implemented                  |
+| `.spectrum-FieldLabel--sizeXL`                                                                | `size="xl"`                             | Implemented                  |
+| `.spectrum-FieldLabel--staticBlack`                                                           | `static-color="black"`                  | Missing from WC (new for S2) |
+| `.spectrum-FieldLabel--staticWhite`                                                           | `static-color="white"`                  | Missing from WC (new for S2) |
+| `.spectrum-FieldLabel-requiredIcon`                                                           | Required icon element; `.required-icon` | Implemented                  |
+| `.spectrum-FieldLabel.is-disabled`                                                            | `disabled` attribute                    | Implemented                  |
+| `.spectrum-FieldLabel:lang(ja), .spectrum-FieldLabel:lang(ko), .spectrum-FieldLabel:lang(zh)` | Language-specific styling               | Implemented                  |
 
 ## Summary of changes
 

--- a/migration-roadmap/help-text.md
+++ b/migration-roadmap/help-text.md
@@ -61,6 +61,7 @@ None found for this component.
 <details>
 <summary>Attributes</summary>
 
+- `disabled` (Boolean) - Whether the help text is disabled
 - `icon` (Boolean) - Whether to show the validation icon
 - `variant` (String) - Visual variant: 'neutral' or 'negative'
 
@@ -92,7 +93,16 @@ None found for this component.
 
 ```html
 <div class="spectrum-HelpText spectrum-HelpText--sizeM">
-    <sp-icon-alert class="spectrum-HelpText-validationIcon"></sp-icon-alert>
+    <svg
+        class="spectrum-HelpText-validationIcon"
+        focusable="false"
+        aria-hidden="true"
+        role="img"
+    >
+        <path
+            d="M10 2L13.09 8.26L20 9L14 14.74L15.18 22L10 18.77L4.82 22L6 14.74L0 9L6.91 8.26L10 2Z"
+        ></path>
+    </svg>
     <div class="spectrum-HelpText-text">Help text content</div>
 </div>
 ```
@@ -104,7 +114,16 @@ None found for this component.
 
 ```html
 <div class="spectrum-HelpText spectrum-HelpText--sizeM">
-    <sp-icon-alert class="spectrum-HelpText-validationIcon"></sp-icon-alert>
+    <svg
+        class="spectrum-Icon spectrum-HelpText-validationIcon"
+        focusable="false"
+        aria-hidden="true"
+        role="img"
+    >
+        <path
+            d="M10 2L13.09 8.26L20 9L14 14.74L15.18 22L10 18.77L4.82 22L6 14.74L0 9L6.91 8.26L10 2Z"
+        ></path>
+    </svg>
     <div class="spectrum-HelpText-text">Help text content</div>
 </div>
 ```
@@ -114,59 +133,30 @@ None found for this component.
 <details>
 <summary>Diff: Legacy (CSS main) → Spectrum 2 (CSS spectrum-two)</summary>
 
-### HTML Output Comparison
-
-**Legacy (CSS main branch) - Negative variant:**
-
-```html
-<div
-    class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative"
->
-    <sp-icon-alert class="spectrum-HelpText-validationIcon"></sp-icon-alert>
-    <div class="spectrum-HelpText-text">Help text content</div>
-</div>
-```
-
-**Spectrum 2 (CSS spectrum-two branch) - Negative variant:**
-
-```html
-<div
-    class="spectrum-HelpText spectrum-HelpText--sizeM spectrum-HelpText--negative"
->
-    <sp-icon-alerttriangle
-        class="spectrum-HelpText-validationIcon"
-    ></sp-icon-alerttriangle>
-    <div class="spectrum-HelpText-text">Help text content</div>
-</div>
-```
-
-### Key Changes in HTML Structure
-
-1. **Updated validation icon**: Changed from `sp-icon-alert` to `sp-icon-alerttriangle` for better visual consistency with other form validation elements
-2. **Enhanced text alignment**: Added support for custom text alignment through CSS custom properties (`--mod-helptext-align-text`)
+No significant structural changes.
 
 </details>
 
 ### CSS => SWC mapping
 
-| CSS selector                                                                            | Attribute or slot         | Status          |
-| --------------------------------------------------------------------------------------- | ------------------------- | --------------- |
-| `.spectrum-HelpText`                                                                    | Base element              | Implemented     |
-| `.spectrum-HelpText-text`                                                               | Text slot                 | Implemented     |
-| `.spectrum-HelpText-validationIcon`                                                     | Icon element              | Implemented     |
-| `.spectrum-HelpText.is-disabled`                                                        | `disabled` attribute      | Missing from WC (Implementation gap) |
-| `.spectrum-HelpText--negative`                                                          | `variant="negative"`      | Implemented     |
-| `.spectrum-HelpText--neutral`                                                           | `variant="neutral"`       | Implemented     |
-| `.spectrum-HelpText--sizeL`                                                             | `size="l"`                | Implemented     |
-| `.spectrum-HelpText--sizeS`                                                             | `size="s"`                | Implemented     |
-| `.spectrum-HelpText--sizeXL`                                                            | `size="xl"`               | Implemented     |
-| `.spectrum-HelpText:lang(ja), .spectrum-HelpText:lang(ko), .spectrum-HelpText:lang(zh)` | Language-specific styling | Implemented     |
+| CSS selector                                                                            | Attribute or slot         | Status      |
+| --------------------------------------------------------------------------------------- | ------------------------- | ----------- |
+| `.spectrum-HelpText`                                                                    | `:host`                   | Implemented |
+| `.spectrum-HelpText-text`                                                               | Text slot                 | Implemented |
+| `.spectrum-HelpText-validationIcon`                                                     | Icon element              | Implemented |
+| `.spectrum-HelpText.is-disabled`                                                        | `disabled` attribute      | Implemented |
+| `.spectrum-HelpText--negative`                                                          | `variant="negative"`      | Implemented |
+| `.spectrum-HelpText--neutral`                                                           | `variant="neutral"`       | Implemented |
+| `.spectrum-HelpText--sizeL`                                                             | `size="l"`                | Implemented |
+| `.spectrum-HelpText--sizeS`                                                             | `size="s"`                | Implemented |
+| `.spectrum-HelpText--sizeXL`                                                            | `size="xl"`               | Implemented |
+| `.spectrum-HelpText:lang(ja), .spectrum-HelpText:lang(ko), .spectrum-HelpText:lang(zh)` | Language-specific styling | Implemented |
 
 ## Summary of changes
 
 ### CSS => SWC implementation gaps
 
-- **Disabled state**: The web component lacks a `disabled` attribute, which would be useful for form validation scenarios where help text should be visually de-emphasized when the associated input is disabled.
+No implementation gaps found. All CSS functionality is properly mapped to web component attributes and slots.
 
 ### CSS Spectrum 2 changes
 

--- a/migration-roadmap/infield-button.md
+++ b/migration-roadmap/infield-button.md
@@ -75,16 +75,27 @@ None found for this component.
 <details>
 <summary>Attributes</summary>
 
+- `active` (Boolean) - Whether the infield button is in an active state
 - `block` (String) - Vertical stack position: 'start' or 'end'
+- `disabled` (Boolean) - Disable this control. It will not receive focus or events
+- `download` (String) - Causes the browser to treat the linked URL as a download
+- `href` (String) - The URL that the hyperlink points to
 - `inline` (String) - Horizontal group position: 'start' or 'end'
+- `label` (String) - An accessible label that describes the component. It will be applied to aria-label, but not visually rendered
 - `quiet` (Boolean) - Whether the button is in quiet variant
+- `referrerpolicy` (String) - How much of the referrer to send when following the link
+- `rel` (String) - The relationship of the linked URL as space-separated link types
+- `tabIndex` (Number) - The tab index to apply to this control
+- `target` (String) - Where to display the linked URL, as the name for a browsing context
+- `type` (String) - The default behavior of the button: 'button', 'submit', or 'reset'
 
 </details>
 
 <details>
 <summary>Slots</summary>
 
-- Default slot - Icon content for the button
+- Default slot - Text content for the button
+- Icon slot - Icon content for the button
 
 </details>
 
@@ -111,7 +122,15 @@ None found for this component.
 ```html
 <button class="spectrum-InfieldButton spectrum-InfieldButton--sizeM">
     <div class="spectrum-InfieldButton-fill">
-        <sp-icon-add class="spectrum-InfieldButton-icon"></sp-icon-add>
+        <svg
+            class="spectrum-InfieldButton-icon"
+            focusable="false"
+            aria-hidden="true"
+        >
+            <path
+                d="M10 2C10.55 2 11 2.45 11 3V9H17C17.55 9 18 9.45 18 10C18 10.55 17.55 11 17 11H11V17C11 17.55 10.55 18 10 18C9.45 18 9 17.55 9 17V11H3C2.45 11 2 10.55 2 10C2 9.45 2.45 9 3 9H9V3C9 2.45 9.45 2 10 2Z"
+            ></path>
+        </svg>
     </div>
 </button>
 ```
@@ -122,9 +141,20 @@ None found for this component.
 <summary>Spectrum 2 (CSS spectrum-two branch):</summary>
 
 ```html
-<button class="spectrum-InfieldButton spectrum-InfieldButton--sizeM">
+<button
+    class="spectrum-InfieldButton spectrum-InfieldButton--sizeM"
+    role="presentation"
+>
     <div class="spectrum-InfieldButton-fill">
-        <sp-icon-add class="spectrum-InfieldButton-icon"></sp-icon-add>
+        <svg
+            class="spectrum-InfieldButton-icon"
+            focusable="false"
+            aria-hidden="true"
+        >
+            <path
+                d="M10 2C10.55 2 11 2.45 11 3V9H17C17.55 9 18 9.45 18 10C18 10.55 17.55 11 17 11H11V17C11 17.55 10.55 18 10 18C9.45 18 9 17.55 9 17V11H3C2.45 11 2 10.55 2 10C2 9.45 2.45 9 3 9H9V3C9 2.45 9.45 2 10 2Z"
+            ></path>
+        </svg>
     </div>
 </button>
 ```
@@ -134,279 +164,133 @@ None found for this component.
 <details>
 <summary>Diff: Legacy (CSS main) → Spectrum 2 (CSS spectrum-two)</summary>
 
-### HTML Output Comparison
+### HTML Output Diff
 
-**Legacy (CSS main branch) - Single button:**
+**Single Button Changes:**
 
-```html
+```diff
 <button
     class="spectrum-InfieldButton spectrum-InfieldButton--sizeM"
     aria-haspopup="listbox"
     type="button"
     tabindex="0"
++   role="presentation"
 >
     <div class="spectrum-InfieldButton-fill">
-        <sp-icon-add class="spectrum-InfieldButton-icon"></sp-icon-add>
+        <svg class="spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+            <path d="M10 2C10.55 2 11 2.45 11 3V9H17C17.55 9 18 9.45 18 10C18 10.55 17.55 11 17 11H11V17C11 17.55 10.55 18 10 18C9.45 18 9 17.55 9 17V11H3C2.45 11 2 10.55 2 10C2 9.45 2.45 9 3 9H9V3C9 2.45 9.45 2 10 2Z"></path>
+        </svg>
     </div>
 </button>
 ```
 
-**Legacy (CSS main branch) - Stacked buttons:**
+**Stacked → Inline Layout Changes:**
 
-```html
+```diff
++<div class="spectrum-InfieldButton-inline">
 <button
-    class="spectrum-InfieldButton spectrum-InfieldButton--sizeM spectrum-InfieldButton--top"
+-   class="spectrum-InfieldButton spectrum-InfieldButton--sizeM spectrum-InfieldButton--top"
++   class="spectrum-InfieldButton spectrum-InfieldButton--sizeM"
+    aria-haspopup="listbox"
+    type="button"
+    tabindex="0"
+-   aria-label="add"
++   aria-label="minus"
+>
+    <div class="spectrum-InfieldButton-fill">
+        <svg class="spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+-           <path d="M10 2C10.55 2 11 2.45 11 3V9H17C17.55 9 18 9.45 18 10C18 10.55 17.55 11 17 11H11V17C11 17.55 10.55 18 10 18C9.45 18 9 17.55 9 17V11H3C2.45 11 2 10.55 2 10C2 9.45 2.45 9 3 9H9V3C9 2.45 9.45 2 10 2Z"></path>
++           <path d="M3 10C3 9.45 3.45 9 4 9H16C16.55 9 17 9.45 17 10C17 10.55 16.55 11 16 11H4C3.45 11 3 10.55 3 10Z"></path>
+        </svg>
+    </div>
+</button>
+<button
+-   class="spectrum-InfieldButton spectrum-InfieldButton--sizeM spectrum-InfieldButton--bottom"
++   class="spectrum-InfieldButton spectrum-InfieldButton--sizeM"
     aria-haspopup="listbox"
     type="button"
     tabindex="0"
     aria-label="add"
 >
     <div class="spectrum-InfieldButton-fill">
-        <sp-icon-chevronup75
-            class="spectrum-InfieldButton-icon"
-        ></sp-icon-chevronup75>
+        <svg class="spectrum-InfieldButton-icon" focusable="false" aria-hidden="true">
+            <path d="M10 2C10.55 2 11 2.45 11 3V9H17C17.55 9 18 9.45 18 10C18 10.55 17.55 11 17 11H11V17C11 17.55 10.55 18 10 18C9.45 18 9 17.55 9 17V11H3C2.45 11 2 10.55 2 10C2 9.45 2.45 9 3 9H9V3C9 2.45 9.45 2 10 2Z"></path>
+        </svg>
     </div>
 </button>
-<button
-    class="spectrum-InfieldButton spectrum-InfieldButton--sizeM spectrum-InfieldButton--bottom"
-    aria-haspopup="listbox"
-    type="button"
-    tabindex="0"
-    aria-label="add"
->
-    <div class="spectrum-InfieldButton-fill">
-        <sp-icon-chevrondown75
-            class="spectrum-InfieldButton-icon"
-        ></sp-icon-chevrondown75>
-    </div>
-</button>
-```
-
-**Spectrum 2 (CSS spectrum-two branch) - Single button:**
-
-```html
-<button
-    class="spectrum-InfieldButton spectrum-InfieldButton--sizeM"
-    aria-haspopup="listbox"
-    type="button"
-    tabindex="0"
-    role="presentation"
->
-    <div class="spectrum-InfieldButton-fill">
-        <sp-icon-add100 class="spectrum-InfieldButton-icon"></sp-icon-add100>
-    </div>
-</button>
-```
-
-**Spectrum 2 (CSS spectrum-two branch) - Inline buttons:**
-
-```html
-<div class="spectrum-InfieldButton-inline">
-    <button
-        class="spectrum-InfieldButton spectrum-InfieldButton--sizeM"
-        aria-haspopup="listbox"
-        type="button"
-        tabindex="0"
-        aria-label="minus"
-    >
-        <div class="spectrum-InfieldButton-fill">
-            <sp-icon-dash class="spectrum-InfieldButton-icon"></sp-icon-dash>
-        </div>
-    </button>
-    <button
-        class="spectrum-InfieldButton spectrum-InfieldButton--sizeM"
-        aria-haspopup="listbox"
-        type="button"
-        tabindex="0"
-        aria-label="add"
-    >
-        <div class="spectrum-InfieldButton-fill">
-            <sp-icon-add class="spectrum-InfieldButton-icon"></sp-icon-add>
-        </div>
-    </button>
-</div>
++</div>
 ```
 
 ### Key Changes in HTML Structure
 
 1. **Layout paradigm shift**: Replaced `isStacked` vertical stacking with `isInline` horizontal grouping
-2. **Enhanced iconography**:
+2. **Position styles removed**: The `inline` and `block` position properties from SWC are no longer supported in CSS-only implementations
+3. **Enhanced iconography**:
     - Single button: Uses size-specific icon names (e.g., `Add100` instead of `Add`)
     - Inline buttons: Switched from chevron icons to more intuitive action icons (`Dash`/`Add`)
-3. **Simplified state management**: Removed `isInvalid` and `isFocused` states while preserving `isHovered`/`isActive`
-4. **Improved accessibility**: Added `role="presentation"` for single buttons and proper `aria-label` differentiation for inline buttons
-5. **Container structure**: Inline variant wraps buttons in `spectrum-InfieldButton-inline` container
-
-</details>
-### CSS => SWC mapping
-@@ -15,7 +12,6 @@ export const Template = (
- 		rootClass = "spectrum-InfieldButton",
- 		customClasses = [],
- 		size = "m",
--		position,
- 		isQuiet,
- 		iconName = "Add",
- 		iconSet = "workflow",
-@@ -22,7 +18,6 @@ export const Template = (
- 		isDisabled,
--		isInvalid,
- 		isHovered,
- 		isActive,
--		isFocused,
--		isStacked,
-+		isInline,
- 		tabIndex = 0,
--		onSubtract,
--		onAdd,
- 		onclick,
- 	} = {},
- 	context = {},
-@@ -30,7 +25,6 @@ export const Template = (
- 	let iconSize = size === "s" ? "75" : size === "l" ? "200" : size === "xl" ? "300" : "100";
- 	let iconNameWithSize = `${iconName}${iconSize}`;
--	return isStacked
-+	return isInline
- 		? html`
--			<div class="${rootClass}-inline">
-+			<div class="${rootClass}-inline">
- 			<button
- 				class=${classMap({
- 					[rootClass]: true,
- 					[`${rootClass}--size${size?.toUpperCase()}`]:
- 						typeof size !== "undefined",
--					[`${rootClass}--top`]: typeof position !== "undefined",
- 					[`${rootClass}--quiet`]: isQuiet,
--					"is-invalid": isInvalid,
- 					"is-hover": isHovered,
- 					"is-active": isActive,
--					"is-focus-visible": isFocused,
- 					...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
- 					})}
- 					?disabled=${isDisabled}
- 					aria-haspopup="listbox"
- 					type="button"
- 					tabindex=${tabIndex}
--					aria-label="add"
-+					aria-label="minus"
- 					>
- 					<div class="${rootClass}-fill">
- 						${Icon(
- 							{
- 								size,
--								iconName: "ChevronUp75",
-+								iconName: "Dash",
- 								setName: "ui",
- 								customClasses: [`${rootClass}-icon`],
- 							},
- 							context,
- 						)}
- 					</div>
- 				</button>
- 				<button
- 					class=${classMap({
- 						[rootClass]: true,
- 						[`${rootClass}--size${size?.toUpperCase()}`]:
- 							typeof size !== "undefined",
--						[`${rootClass}--bottom`]: typeof position !== "end",
-+						[`${rootClass}--quiet`]: isQuiet,
- 						"is-hover": isHovered,
- 						"is-active": isActive,
--						"is-focus-visible": isFocused,
- 						...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
- 					})}
- 					?disabled=${isDisabled}
- 					aria-haspopup="listbox"
- 					type="button"
- 					tabindex=${tabIndex}
--					aria-label="add"
-+					aria-label="add"
- 				>
- 					<div class="${rootClass}-fill">
- 						${Icon(
- 							{
- 								size,
--								iconName: "ChevronDown75",
-+								iconName: "Add",
- 								setName: "ui",
- 								customClasses: [`${rootClass}-icon`],
- 							},
- 							context,
- 						)}
- 					</div>
- 				</button>
- 			</div>
- 			`
- 		: html`
- 				<button
- 					class=${classMap({
- 						[rootClass]: true,
- 						[`${rootClass}--size${size?.toUpperCase()}`]:
- 							typeof size !== "undefined",
--						[`${rootClass}--${position}`]: typeof position !== "undefined",
- 						[`${rootClass}--quiet`]: isQuiet,
- 						"is-hover": isHovered,
- 						"is-active": isActive,
--						"is-focus-visible": isFocused,
- 						...customClasses.reduce((a, c) => ({ ...a, [c]: true }), {}),
- 					})}
- 					?disabled=${isDisabled}
- 					aria-haspopup="listbox"
- 					type="button"
- 					tabindex=${tabIndex}
--				>
-+					@click=${onclick}
-+					role="presentation"
-+				>
- 					<div class="${rootClass}-fill">
- 						${when(iconName, () =>
- 							Icon(
- 								{
- 									size,
--									iconName,
-+									iconName: iconNameWithSize,
- 									setName: iconSet,
- 									customClasses: [`${rootClass}-icon`],
- 								},
- 								context,
- 							),
- 						)}
- 					</div>
- 				</button>
- 			`;
-```
+4. **Simplified state management**: Removed `isInvalid` and `isFocused` states while preserving `isHovered`/`isActive`
+5. **Improved accessibility**: Added `role="presentation"` for single buttons and proper `aria-label` differentiation for inline buttons
+6. **Container structure**: Inline variant wraps buttons in `spectrum-InfieldButton-inline` container
+7. **Consistent corner radius**: Position-specific border radius variants have been removed in favor of a consistent corner radius approach
 
 </details>
 
 ### CSS => SWC mapping
 
-| CSS selector                            | Attribute or slot      | Status                       |
-| --------------------------------------- | ---------------------- | ---------------------------- |
-| `.spectrum-InfieldButton`               | Base element           | Implemented                  |
-| `.spectrum-InfieldButton--quiet`        | `quiet` attribute      | Implemented                  |
-| `.spectrum-InfieldButton-fill`          | Fill container         | Implemented                  |
-| `.spectrum-InfieldButton-icon`          | Icon slot              | Implemented                  |
-| `.spectrum-InfieldButton-inline`        | Inline group container | Missing from WC (new for S2) |
-| `.spectrum-InfieldButton--sizeL`        | `size="l"`             | Implemented                  |
-| `.spectrum-InfieldButton--sizeS`        | `size="s"`             | Implemented                  |
-| `.spectrum-InfieldButton--sizeXL`       | `size="xl"`            | Implemented                  |
-| `.spectrum-InfieldButton:disabled`      | `disabled` attribute   | Implemented                  |
-| `.spectrum-InfieldButton:focus-visible` | Focus state            | Implemented                  |
-| `.spectrum-InfieldButton:hover`         | Hover state            | Implemented                  |
-| `.spectrum-InfieldButton:active`        | Active state           | Implemented                  |
+| CSS selector                       | Attribute or slot      | Status                       |
+| ---------------------------------- | ---------------------- | ---------------------------- |
+| `.spectrum-InfieldButton`          | `:host`                | Implemented                  |
+| `.spectrum-InfieldButton--quiet`   | `quiet` attribute      | Implemented                  |
+| `.spectrum-InfieldButton-fill`     | Fill container         | Implemented                  |
+| `.spectrum-InfieldButton-icon`     | Icon slot              | Implemented                  |
+| `.spectrum-InfieldButton-inline`   | Inline group container | Missing from WC (new for S2) |
+| `.spectrum-InfieldButton--sizeL`   | `size="l"`             | Implemented                  |
+| `.spectrum-InfieldButton--sizeS`   | `size="s"`             | Implemented                  |
+| `.spectrum-InfieldButton--sizeXL`  | `size="xl"`            | Implemented                  |
+| `.spectrum-InfieldButton:disabled` | `disabled` attribute   | Implemented                  |
+| `.spectrum-InfieldButton:active`   | `active` attribute     | Implemented                  |
 
 ## Summary of changes
 
 ### CSS => SWC implementation gaps
 
 - **Inline group functionality**: The web component lacks support for `.spectrum-InfieldButton-inline` which enables horizontal button grouping, commonly used for increment/decrement controls in number inputs and similar interfaces.
+- **Required wrapper div**: Spectrum 2 introduces a mandatory `<div class="spectrum-InfieldButton-inline">` wrapper element for inline button layouts. This structural change is essential for proper CSS styling and must be implemented during migration to ensure the component renders correctly in Spectrum 2.
 
 ### CSS Spectrum 2 changes
 
 - **Reduced API complexity**: Eliminated numerous parameters (`position`, `isInvalid`, `isFocused`, `isStacked`, `onSubtract`, `onAdd`) to create a more focused and maintainable component API.
 - **Layout paradigm shift**: Replaced the `isStacked` vertical stacking approach with `isInline` horizontal grouping, better aligning with common use cases for infield buttons.
+- **Position styles removed**: The `inline` and `block` position properties from SWC are no longer supported in CSS-only implementations due to the consistent corner radius approach.
 - **Enhanced iconography**: Switched from chevron-based icons to more intuitive action icons (Dash/Add), providing clearer visual cues for increment/decrement operations.
 - **Streamlined state management**: Removed `isInvalid`/`isFocused` states while preserving essential interaction feedback (`isHovered`/`isActive`).
 - **Flexible template structure**: Inline variant automatically creates paired buttons for common operations, while single variant provides direct click handling for custom actions.
+- **Focus state inheritance**: Infield buttons no longer manage their own focus states, instead inheriting focus styling from their parent components (like textfields or pickers). This creates a more cohesive user experience where the entire input field appears focused rather than individual button elements.
+
+#### Removed modifiers
+
+Due to deprecation of the position variants in the infield button, several spacing and border radius modifiers have been removed:
+
+- `--mod-infield-button-inner-edge-to-fill`
+- `--mod-infield-button-stacked-border-radius-reset`
+- `--mod-infield-button-stacked-bottom-border-block-end-width`
+- `--mod-infield-button-stacked-bottom-border-radius-end-end`
+- `--mod-infield-button-stacked-bottom-border-radius-end-start`
+- `--mod-infield-button-stacked-fill-padding-inline`
+- `--mod-infield-button-stacked-fill-padding-inner`
+
+#### New tokens
+
+These new tokens support the inline variant and stepper (number field) use cases:
+
+- `--spectrum-in-field-button-side-edge-to-fill-small`
+- `--spectrum-in-field-button-side-edge-to-fill-medium`
+- `--spectrum-in-field-button-side-edge-to-fill-large`
+- `--spectrum-in-field-button-side-edge-to-fill-extra-large`
+- `--spectrum-field-edge-to-icon-75`
+- `--spectrum-field-edge-to-icon-100`
+- `--spectrum-field-edge-to-icon-200`
+- `--spectrum-field-edge-to-icon-300`
 
 ## Resources
 

--- a/migration-roadmap/infield-progress-circle.md
+++ b/migration-roadmap/infield-progress-circle.md
@@ -50,107 +50,32 @@ None found for this component.
 
 </details>
 
-## Comparison
-
-### DOM Structure changes
-
-<details>
-<summary>Spectrum Web Components:</summary>
-
-```html
-<slot></slot>
-<div class="track"></div>
-<div class="fills">
-    <div class="fillMask1">
-        <div class="fillSubMask1" style="transform: rotate(0deg);">
-            <div class="fill"></div>
-        </div>
-    </div>
-    <div class="fillMask2">
-        <div class="fillSubMask2" style="transform: rotate(0deg);">
-            <div class="fill"></div>
-        </div>
-    </div>
-</div>
-```
-
-</details>
-
-<details>
-<summary>Legacy (CSS main branch):</summary>
-
-```html
-<!-- No template.js file exists in main branch -->
-```
-
-</details>
-
-<details>
-<summary>Spectrum 2 (CSS spectrum-two branch):</summary>
-
-```html
-<div
-    class="spectrum-InfieldProgressCircle spectrum-InfieldProgressCircle--sizeM"
->
-    <div class="spectrum-ProgressCircle-fill"></div>
-</div>
-```
-
-</details>
-
-<details>
-<summary>Diff: Legacy (CSS main) → Spectrum 2 (CSS spectrum-two)</summary>
-
-```diff
---- a/components/infieldprogresscircle/stories/template.js (main branch)
-+++ b/components/infieldprogresscircle/stories/template.js (spectrum-two branch)
-@@ -1,0 +1,22 @@
-+import { Template as ProgressCircle } from "@spectrum-css/progresscircle/stories/template.js";
-+import { capitalize } from "lodash-es";
-+import "../index.css";
-+
-+export const Template = ({
-+	customClasses = [],
-+	rootClass = "spectrum-InfieldProgressCircle",
-+	size = "m",
-+	staticColor,
-+	...item
-+} = {}, context = {}) => ProgressCircle({
-+	customClasses: [
-+		rootClass,
-+		typeof size !== "undefined" ? `${rootClass}--size${size.toUpperCase()}` : null,
-+		typeof staticColor !== "undefined" ? `${rootClass}--static${capitalize(staticColor)}` : null,
-+		...customClasses
-+	].filter(Boolean),
-+	size,
-+	staticColor,
-+	...item
-+}, context );
-```
-
-</details>
-
 ### CSS => SWC mapping
 
-| CSS selector                                                    | Attribute or slot     | Status             |
-| --------------------------------------------------------------- | --------------------- | ------------------ |
-| `.spectrum-InfieldProgressCircle`                               | Base element          | Implemented        |
-| `.spectrum-InfieldProgressCircle .spectrum-ProgressCircle-fill` | Progress fill element | Implemented        |
-| `.spectrum-InfieldProgressCircle--sizeL`                        | `size="l"`            | Implemented        |
-| `.spectrum-InfieldProgressCircle--sizeS`                        | `size="s"`            | Implemented        |
-| `.spectrum-InfieldProgressCircle--sizeXL`                       | `size="xl"`           | Implemented        |
-| N/A                                                             | `indeterminate`       | Web component only |
-| N/A                                                             | `label`               | Web component only |
+Since the infield progress circle doesn't exist as a separate web component, this mapping shows how it **could** work with the existing `sp-progress-circle` component:
+
+| CSS selector                                                    | ProgressCircle attribute       | Status                       |
+| --------------------------------------------------------------- | ------------------------------ | ---------------------------- |
+| `.spectrum-InfieldProgressCircle`                               | `:host` (with infield classes) | Would need implementation    |
+| `.spectrum-InfieldProgressCircle .spectrum-ProgressCircle-fill` | Progress fill element          | Available via ProgressCircle |
+| `.spectrum-InfieldProgressCircle--sizeL`                        | `size="l"`                     | Available via ProgressCircle |
+| `.spectrum-InfieldProgressCircle--sizeS`                        | `size="s"`                     | Available via ProgressCircle |
+| `.spectrum-InfieldProgressCircle--sizeXL`                       | `size="xl"`                    | Available via ProgressCircle |
+| N/A                                                             | `indeterminate`                | Available via ProgressCircle |
+| N/A                                                             | `label`                        | Available via ProgressCircle |
+| N/A                                                             | `progress`                     | Available via ProgressCircle |
+| N/A                                                             | `static-color`                 | Available via ProgressCircle |
 
 ## Summary of changes
 
 ### CSS => SWC implementation gaps
 
-- **CSS coverage**: All CSS selectors are available in the `spectrum-two` branch, but the web component has not yet been implemented.
+- **Missing infield variant**: The infield progress circle doesn't exist as a separate web component. Implementation would likely involve extending the existing `sp-progress-circle` component with infield-specific styling classes, similar to how it's done in CSS.
+- **Infield-specific styling**: The `.spectrum-InfieldProgressCircle` base class and its size variants would need to be implemented as additional CSS classes that can be applied to the base progress circle component.
 
 ### CSS Spectrum 2 changes
 
-- **New component introduction**: The infield progress circle is entirely new in the `spectrum-two` branch, designed specifically for inline loading states within form fields and input components.
+- **New component introduction**: The infield progress circle is entirely new in the spectrum-two branch, designed specifically for inline loading states within form fields and input components.
 - **Modular architecture**: Built as a wrapper around the base ProgressCircle component with infield-specific styling classes, promoting code reuse and consistency.
 - **Comprehensive sizing**: Introduced S, M, L, and XL size variants to match the sizing scale used throughout the Spectrum design system.
 - **Static color variants**: Added support for static color variants to ensure visibility in various background contexts and high-contrast scenarios.

--- a/migration-roadmap/picker-button.md
+++ b/migration-roadmap/picker-button.md
@@ -72,8 +72,21 @@ None found for this component.
 <details>
 <summary>Attributes</summary>
 
-- `invalid` (Boolean) - Whether the picker button is in an invalid state
+- `active` (Boolean) - Whether the picker button is in an active state
+- `disabled` (Boolean) - Disable this control. It will not receive focus or events
+- `download` (String) - Causes the browser to treat the linked URL as a download
+- `href` (String) - The URL that the hyperlink points to
+- `label` (String) - An accessible label that describes the component. It will be applied to aria-label, but not visually rendered
+- `open` (Boolean) - Whether the picker button is in an open state (for dropdown menus)
 - `position` (String) - Position of the button: 'left' or 'right'
+- `quiet` (Boolean) - Whether the picker button is in quiet variant
+- `referrerpolicy` (String) - How much of the referrer to send when following the link
+- `rel` (String) - The relationship of the linked URL as space-separated link types
+- `rounded` (Boolean) - Whether the picker button has rounded corners (express system)
+- `size` (String) - Size of the picker button: 's', 'm', 'l', 'xl'
+- `tabIndex` (Number) - The tab index to apply to this control
+- `target` (String) - Where to display the linked URL, as the name for a browsing context
+- `type` (String) - The default behavior of the button: 'button', 'submit', or 'reset'
 
 </details>
 
@@ -118,9 +131,15 @@ None found for this component.
         <span class="spectrum-PickerButton-label is-placeholder">
             Label text
         </span>
-        <sp-icon-chevron100
+        <svg
             class="spectrum-PickerButton-icon"
-        ></sp-icon-chevron100>
+            focusable="false"
+            aria-hidden="true"
+        >
+            <path
+                d="M10 2C10.55 2 11 2.45 11 3V9H17C17.55 9 18 9.45 18 10C18 10.55 17.55 11 17 11H11V17C11 17.55 10.55 18 10 18C9.45 18 9 17.55 9 17V11H3C2.45 11 2 10.55 2 10C2 9.45 2.45 9 3 9H9V3C9 2.45 9.45 2 10 2Z"
+            ></path>
+        </svg>
     </div>
 </button>
 ```
@@ -131,11 +150,20 @@ None found for this component.
 <summary>Spectrum 2 (CSS spectrum-two branch):</summary>
 
 ```html
-<button class="spectrum-PickerButton spectrum-PickerButton--sizeM">
+<button
+    class="spectrum-PickerButton spectrum-PickerButton--sizeM"
+    type="button"
+>
     <div class="spectrum-PickerButton-fill">
-        <sp-icon-chevron100
+        <svg
             class="spectrum-PickerButton-icon"
-        ></sp-icon-chevron100>
+            focusable="false"
+            aria-hidden="true"
+        >
+            <path
+                d="M10 2C10.55 2 11 2.45 11 3V9H17C17.55 9 18 9.45 18 10C18 10.55 17.55 11 17 11H11V17C11 17.55 10.55 18 10 18C9.45 18 9 17.55 9 17V11H3C2.45 11 2 10.55 2 10C2 9.45 2.45 9 3 9H9V3C9 2.45 9.45 2 10 2Z"
+            ></path>
+        </svg>
     </div>
 </button>
 ```
@@ -145,51 +173,28 @@ None found for this component.
 <details>
 <summary>Diff: Legacy (CSS main) → Spectrum 2 (CSS spectrum-two)</summary>
 
-### HTML Output Comparison
+### HTML Output Diff
 
-**Legacy (CSS main branch) - With Label:**
+**Legacy (CSS main) → Spectrum 2 (CSS spectrum-two):**
 
-```html
+```diff
 <button
-    class="spectrum-PickerButton spectrum-PickerButton--textuiicon spectrum-PickerButton--right spectrum-PickerButton--sizeM"
+-    class="spectrum-PickerButton spectrum-PickerButton--textuiicon spectrum-PickerButton--right spectrum-PickerButton--sizeM"
++    class="spectrum-PickerButton spectrum-PickerButton--sizeM"
     aria-haspopup="listbox"
++    type="button"
 >
     <div class="spectrum-PickerButton-fill">
-        <span class="spectrum-PickerButton-label is-placeholder">Select</span>
-        <sp-icon-chevron100
+-        <span class="spectrum-PickerButton-label is-placeholder">Select</span>
+        <svg
             class="spectrum-PickerButton-icon"
-        ></sp-icon-chevron100>
-    </div>
-</button>
-```
-
-**Legacy (CSS main branch) - Icon Only:**
-
-```html
-<button
-    class="spectrum-PickerButton spectrum-PickerButton--uiicononly spectrum-PickerButton--right spectrum-PickerButton--sizeM"
-    aria-haspopup="listbox"
->
-    <div class="spectrum-PickerButton-fill">
-        <sp-icon-chevron100
-            class="spectrum-PickerButton-icon"
-        ></sp-icon-chevron100>
-    </div>
-</button>
-```
-
-**Spectrum 2 (CSS spectrum-two branch):**
-
-```html
-<button
-    class="spectrum-PickerButton spectrum-PickerButton--sizeM"
-    aria-haspopup="listbox"
-    type="button"
->
-    <div class="spectrum-PickerButton-fill">
-        <sp-icon-chevron100
-            class="spectrum-PickerButton-icon spectrum-Icon spectrum-UIIcon-ChevronDown100"
-        ></sp-icon-chevron100>
+            focusable="false"
+            aria-hidden="true"
+        >
+            <path
+                d="M10 2C10.55 2 11 2.45 11 3V9H17C17.55 9 18 9.45 18 10C18 10.55 17.55 11 17 11H11V17C11 17.55 10.55 18 10 18C9.45 18 9 17.55 9 17V11H3C2.45 11 2 10.55 2 10C2 9.45 2.45 9 3 9H9V3C9 2.45 9.45 2 10 2Z"
+            ></path>
+        </svg>
     </div>
 </button>
 ```
@@ -208,33 +213,30 @@ None found for this component.
 
 ### CSS => SWC mapping
 
-| CSS selector                                                       | Attribute or slot     | Status          |
-| ------------------------------------------------------------------ | --------------------- | --------------- |
-| `.spectrum-PickerButton`                                           | Base element          | Implemented     |
-| `.spectrum-PickerButton--workflowicon .spectrum-PickerButton-fill` | Workflow icon variant | Missing from WC |
-| `.spectrum-PickerButton--quiet`                                    | `quiet` attribute     | Missing from WC |
-| `.spectrum-PickerButton-fill`                                      | Fill container        | Implemented     |
-| `.spectrum-PickerButton-icon`                                      | Icon slot             | Implemented     |
-| `.spectrum-PickerButton.is-open`                                   | Open state            | Missing from WC |
-| `.spectrum-PickerButton--sizeL`                                    | `size="l"`            | Implemented     |
-| `.spectrum-PickerButton--sizeS`                                    | `size="s"`            | Implemented     |
-| `.spectrum-PickerButton--sizeXL`                                   | `size="xl"`           | Implemented     |
-| `.spectrum-PickerButton:disabled`                                  | `disabled` attribute  | Implemented     |
-| `.spectrum-PickerButton:focus-visible`                             | Focus state           | Implemented     |
-| `.spectrum-PickerButton:hover`                                     | Hover state           | Implemented     |
-| `.spectrum-PickerButton:active`                                    | Active state          | Implemented     |
+| CSS selector                                                       | Attribute or slot             | Status      |
+| ------------------------------------------------------------------ | ----------------------------- | ----------- |
+| `.spectrum-PickerButton`                                           | `:host`                       | Implemented |
+| `.spectrum-PickerButton--workflowicon .spectrum-PickerButton-fill` | Workflow icon via `icon` slot | Implemented |
+| `.spectrum-PickerButton--quiet`                                    | `quiet` attribute             | Implemented |
+| `.spectrum-PickerButton-fill`                                      | Fill container                | Implemented |
+| `.spectrum-PickerButton-icon`                                      | Icon slot                     | Implemented |
+| `.spectrum-PickerButton.is-open`                                   | `open` attribute              | Implemented |
+| `.spectrum-PickerButton--sizeL`                                    | `size="l"`                    | Implemented |
+| `.spectrum-PickerButton--sizeS`                                    | `size="s"`                    | Implemented |
+| `.spectrum-PickerButton--sizeXL`                                   | `size="xl"`                   | Implemented |
+| `.spectrum-PickerButton:disabled`                                  | `disabled` attribute          | Implemented |
+| `.spectrum-PickerButton:active`                                    | `active` attribute            | Implemented |
 
 ## Summary of changes
 
 ### CSS => SWC implementation gaps
 
-- **Quiet variant**: The web component lacks a `quiet` attribute for the subtle button style commonly used in compact interfaces and toolbars.
-- **Open state management**: Missing built-in state management for dropdown open/closed states, requiring manual implementation of `is-open` class handling.
-- **Workflow icon variant**: No support for the `.spectrum-PickerButton--workflowicon` variant, which uses workflow icons instead of UI icons for specific use cases.
+No implementation gaps found. All CSS functionality is properly mapped to web component attributes and slots.
 
 ### CSS Spectrum 2 changes
 
 - **Streamlined API**: Removed complex parameters (`label`, `position`, `isFocused`, `isRounded`) to focus on core functionality and reduce API surface area.
+- **Relationship to infield button**: This component follows the same design patterns as the infield button component in Spectrum 2, both being designed for inline use within form fields. While they were kept as separate components in the CSS implementation, there was discussion about combining them, and this might be worth considering during the web component migration to reduce duplication and maintain consistency.
 - **Icon-focused design**: Shifted from label-based to icon-only design with separate `workflowIconName`/`uiIconName` parameters for better icon management and consistency.
 - **Simplified state handling**: Consolidated state management by removing `isFocused`/`isRounded` while maintaining essential interaction states (`isActive`/`isHovered`/`isDisabled`).
 


### PR DESCRIPTION
## Description

Creates AI-generated migration documentation to analyze component differences to guide SWC migration to S2, with human vetting. The documentation serves as a bridge between the migrated Spectrum 2 CSS work and the corresponding web components, in order to help engineers understand what needs to be implemented, updated, or aligned between the two systems to guide the development of 2nd generation web components.

This batch is for the barebones components: Field label, Help text, Picker button, In-field button and In-field progress circle

## Motivation and context

- **Clear development roadmap**: Provides comprehensive feature gap analysis for building 2nd generation web components
- **Implementation requirements**: Identifies all features and capabilities that need to be implemented to match Spectrum 2 CSS and design specs
- **Breaking change transparency**: Establishes implementation requirements and design changes that may lead to breaking changes and/or API changes for the next major version
- **Adoption planning**: Enables developers and consuming teams to plan for 2nd gen web component adoption and understand migration effort required

## Related issue(s)

`SWC-1218`

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] <strike>I have added automated tests to cover my changes.</strike>
-   [ ] <strike>I have included a well-written changeset if my change needs to be published.</strike>
-   [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] <strike>Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features</strike>
-   [ ] <strike>Automated tests cover all use cases and follow best practices for writing</strike>
-   [ ] <strike>Validated on all supported browsers</strike>
-   [ ] <strike>All VRTs are approved before the author can update Golden Hash</strike>

### Documentation Quality
- [ ] All files follow template structure with proper collapsible sections
- [ ] CSS => SWC mapping tables use correct status values
- [ ] Summary sections are concise and actionable
- [ ] No broken markdown syntax

### Cross-Reference Accuracy
- [ ] CSS selectors match actual `metadata.json` files
- [ ] SWC attributes match actual TypeScript source files
- [ ] DOM structure comparisons match template files
- [ ] Implementation gaps are complete and accurate