### PR TITLE
fix(sp-alert-dialog): Make the divider color transparent for S2 theme

### DIFF
--- a/.changeset/eight-parts-begin.md
+++ b/.changeset/eight-parts-begin.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/alert-dialog': patch
+---
+
+Make the divider color transparent only for spectrum 2 theme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ parameters:
     # 3. Commit this change to the PR branch where the changes exist.
     current_golden_images_hash:
         type: string
-        default: da6da22dec85163edb697d494830b8683d33bb10
+        default: 72eb2eeb8f6997fb8ce21ff5594426c14e174b98
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/alert-dialog/src/alert-dialog-overrides.css
+++ b/packages/alert-dialog/src/alert-dialog-overrides.css
@@ -9,3 +9,10 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+
+/* Override divider background color when used inside alert-dialog */
+.divider {
+    --spectrum-divider-background-color: var(--system-alert-dialog-divider-background-color);
+    --spectrum-divider-background-color-static-white: var(--spectrum-alert-dialog-divider-background-color-static-white);
+    --spectrum-divider-background-color-static-black: var(--spectrum-alert-dialog-divider-background-color-static-black);
+}

--- a/tools/styles/tokens-v2/system-theme-bridge.css
+++ b/tools/styles/tokens-v2/system-theme-bridge.css
@@ -290,6 +290,9 @@
     --system-divider-background-color: var(--spectrum-gray-200);
     --system-divider-background-color-static-white: var(--spectrum-transparent-white-200);
     --system-divider-background-color-static-black: var(--spectrum-transparent-black-200);
+    --system-alert-dialog-divider-background-color: transparent;
+    --system-alert-dialog-divider-background-color-static-white: transparent;
+    --system-alert-dialog-divider-background-color-static-black: transparent;
     --system-drop-zone-border-color: var(--spectrum-gray-200);
     --system-field-group-margin: var(--spectrum-spacing-300);
     --system-field-group-readonly-delimiter: ",";

--- a/tools/styles/tokens/express/system-theme-bridge.css
+++ b/tools/styles/tokens/express/system-theme-bridge.css
@@ -291,6 +291,9 @@
     --system-divider-background-color: var(--spectrum-gray-300);
     --system-divider-background-color-static-white: var(--spectrum-transparent-white-300);
     --system-divider-background-color-static-black: var(--spectrum-transparent-black-300);
+    --system-alert-dialog-divider-background-color: var(--spectrum-gray-300);
+    --system-alert-dialog-divider-background-color-static-white: var(--spectrum-transparent-white-300);
+    --system-alert-dialog-divider-background-color-static-black: var(--spectrum-transparent-black-300);
     --system-drop-zone-border-color: var(--spectrum-gray-300);
     --system-field-group-margin: var(--spectrum-spacing-300);
     --system-field-group-readonly-delimiter: ",";

--- a/tools/styles/tokens/spectrum/system-theme-bridge.css
+++ b/tools/styles/tokens/spectrum/system-theme-bridge.css
@@ -291,6 +291,9 @@
     --system-divider-background-color: var(--spectrum-gray-300);
     --system-divider-background-color-static-white: var(--spectrum-transparent-white-300);
     --system-divider-background-color-static-black: var(--spectrum-transparent-black-300);
+    --system-alert-dialog-divider-background-color: var(--spectrum-gray-300);
+    --system-alert-dialog-divider-background-color-static-white: var(--spectrum-transparent-white-300);
+    --system-alert-dialog-divider-background-color-static-black: var(--spectrum-transparent-black-300);
     --system-drop-zone-border-color: var(--spectrum-gray-300);
     --system-field-group-margin: var(--spectrum-spacing-300);
     --system-field-group-readonly-delimiter: ",";


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

This PR improves the Alert dialog component in spectrum-two theme.
The divider color should be transparent for S2 theme.

## Motivation and context
Fix the regressions found after changing from the express theme to the spectrum-two theme.

## Related issue(s)
SWC-1077 (original)
CCEX-230905

## Screenshots (if appropriate)
Spectrum 1
<img width="536" height="508" alt="Screenshot 2025-09-22 at 14 28 20" src="https://github.com/user-attachments/assets/4ce8bf43-828b-4120-b395-3762ddaddfa4" />

Spectrum 2
<img width="541" height="522" alt="Screenshot 2025-09-22 at 14 28 50" src="https://github.com/user-attachments/assets/311b7da8-2588-4e9f-b88d-e8b105b8f123" />

Express
<img width="539" height="539" alt="Screenshot 2025-09-22 at 14 29 10" src="https://github.com/user-attachments/assets/37401234-eca1-44c9-b1f0-c5603973f40d" />


---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [x] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [x] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Descriptive Test Statement_

    1. Go [alert dialog component](https://swcpreviews.z13.web.core.windows.net/pr-5747/docs/components/alert-dialog/)
    2. Swich to Spectrum 2 theme.
    3. Observe that there is no divider. If you inspect the component, the divider is still there (the DOM is not altered, as the JIRA ticker requires) but its color is transparent.

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [x] Did it pass in Desktop?
-   [x] Did it pass in (emulated) Mobile?
-   [x] Did it pass in (emulated) iPad?
