### PR TITLE
fix(picker): add picker attribute to nested popover and styles to constrain to picker width

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ parameters:
     # 3. Commit this change to the PR branch where the changes exist.
     current_golden_images_hash:
         type: string
-        default: b603e40ceec985d714ea7660266908aa5476ced1
+        default: 9b2f918bdfb7a5d90ac435f9cb103a9d35c263c9
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -719,7 +719,6 @@ export class PickerBase extends SizedMixin(SpectrumElement, {
                     id="popover"
                     role="presentation"
                     style=${styleMap(this.containerStyles)}
-                    picker
                 >
                     ${accessibleMenu}
                 </sp-tray>
@@ -733,7 +732,6 @@ export class PickerBase extends SizedMixin(SpectrumElement, {
                 role="presentation"
                 style=${styleMap(this.containerStyles)}
                 placement=${this.placement}
-                picker
             >
                 ${accessibleMenu}
             </sp-popover>

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -719,6 +719,7 @@ export class PickerBase extends SizedMixin(SpectrumElement, {
                     id="popover"
                     role="presentation"
                     style=${styleMap(this.containerStyles)}
+                    picker
                 >
                     ${accessibleMenu}
                 </sp-tray>
@@ -732,6 +733,7 @@ export class PickerBase extends SizedMixin(SpectrumElement, {
                 role="presentation"
                 style=${styleMap(this.containerStyles)}
                 placement=${this.placement}
+                picker
             >
                 ${accessibleMenu}
             </sp-popover>

--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -14,6 +14,8 @@
 @import url("./picker-overrides.css");
 
 :host {
+    --mod-popover-inline-size: var(--mod-picker-inline-size, var(--spectrum-picker-inline-size));
+
     display: inline-flex;
     vertical-align: top;
 

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -431,6 +431,7 @@ export const iconValue = (args: StoryArgs): TemplateResult => {
             label="Pick an action"
             icons="only"
             value="2"
+            style="--mod-picker-inline-size: 100px;"
         >
             <sp-menu-item value="1">
                 <sp-icon-edit slot="icon"></sp-icon-edit>
@@ -459,6 +460,7 @@ export const iconsOnly = (args: StoryArgs): TemplateResult => {
             @change=${handleChange(args)}
             label="Pick an action"
             value="3"
+            style="--mod-picker-inline-size: 100px;"
         >
             <sp-menu-item value="1">
                 <sp-icon-edit slot="icon" label="Edit"></sp-icon-edit>

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -430,7 +430,6 @@ export const iconValue = (args: StoryArgs): TemplateResult => {
             @change=${handleChange(args)}
             label="Pick an action"
             icons="only"
-            style="width: 100px"
             value="2"
         >
             <sp-menu-item value="1">
@@ -459,7 +458,6 @@ export const iconsOnly = (args: StoryArgs): TemplateResult => {
             id="picker-quiet"
             @change=${handleChange(args)}
             label="Pick an action"
-            style="width: 100px"
             value="3"
         >
             <sp-menu-item value="1">

--- a/packages/popover/src/popover.css
+++ b/packages/popover/src/popover.css
@@ -17,6 +17,7 @@
     min-width: min-content;
     max-height: 100%;
     max-width: 100%;
+    inline-size: var(--mod-popover-inline-size);
     clip-path: none;
 }
 
@@ -77,8 +78,4 @@
 
 :host([tip][placement]) #tip {
     height: auto;
-}
-
-:host([picker]) {
-    inline-size: var(--mod-picker-inline-size, var(--spectrum-picker-inline-size));
 }

--- a/packages/popover/src/popover.css
+++ b/packages/popover/src/popover.css
@@ -78,3 +78,7 @@
 :host([tip][placement]) #tip {
     height: auto;
 }
+
+:host([picker]) {
+    inline-size: var(--mod-picker-inline-size, var(--spectrum-picker-inline-size));
+}


### PR DESCRIPTION
## Description

This PR adds styles to the `popover.css` to enforce a fixed width when the popover is used within the picker component. This aligns with the design documentation and the picker component styles.

## Motivation and context

Without this change the rendered picker options will grow in width without wrapping for longer labeld.

## Related issue(s)

-   fixes SWC-562

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [x] I have included updated documentation if my change required it.

---

### Manual review test cases

1. Navigate to the [picker docs](https://swcpreviews.z13.web.core.windows.net/pr-5767/docs/components/picker/)
2. Open the picker
3. Edit one of the options in the inspector, changing the label text to something much longer than the default.
4. See that the label wraps rather than causing the dropdown to grow horizontally.

### Device review

-   [x] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [x] Did it pass in (emulated) iPad?
