### PR TITLE
chore(tooling): add changesets cli patch to allow yarn npm publish

### DIFF
--- a/patches/@changesets+cli+2.29.7.patch
+++ b/patches/@changesets+cli+2.29.7.patch
@@ -1,0 +1,58 @@
+diff --git a/node_modules/@changesets/cli/dist/changesets-cli.cjs.js b/node_modules/@changesets/cli/dist/changesets-cli.cjs.js
+index 53fc925..4cf6c1b 100644
+--- a/node_modules/@changesets/cli/dist/changesets-cli.cjs.js
++++ b/node_modules/@changesets/cli/dist/changesets-cli.cjs.js
+@@ -634,7 +634,13 @@ async function getPublishTool(cwd) {
+   const pm = await packageManagerDetector.detect({
+     cwd
+   });
+-  if (!pm || pm.name !== "pnpm") return {
++  if (!pm) return {
++    name: "npm"
++  };
++  if (pm.name === "yarn") return {
++    name: "yarn"
++  };
++  if (pm.name !== "pnpm") return {
+     name: "npm"
+   };
+   try {
+@@ -771,6 +777,9 @@ async function internalPublish(packageJson, opts, twoFactorState) {
+   } = publishTool.name === "pnpm" ? await spawn__default["default"]("pnpm", ["publish", "--json", ...publishFlags], {
+     env: Object.assign({}, process.env, envOverride),
+     cwd: opts.cwd
++  }) : publishTool.name === "yarn" ? await spawn__default["default"]("yarn", ["npm", "publish", ...publishFlags], {
++    env: Object.assign({}, process.env, envOverride),
++    cwd: opts.cwd
+   }) : await spawn__default["default"](publishTool.name, ["publish", opts.publishDir, "--json", ...publishFlags], {
+     env: Object.assign({}, process.env, envOverride)
+   });
+diff --git a/node_modules/@changesets/cli/dist/changesets-cli.esm.js b/node_modules/@changesets/cli/dist/changesets-cli.esm.js
+index 6c363c0..df8d412 100644
+--- a/node_modules/@changesets/cli/dist/changesets-cli.esm.js
++++ b/node_modules/@changesets/cli/dist/changesets-cli.esm.js
+@@ -596,7 +596,13 @@ async function getPublishTool(cwd) {
+   const pm = await detect({
+     cwd
+   });
+-  if (!pm || pm.name !== "pnpm") return {
++  if (!pm) return {
++    name: "npm"
++  };
++  if (pm.name === "yarn") return {
++    name: "yarn"
++  };
++  if (pm.name !== "pnpm") return {
+     name: "npm"
+   };
+   try {
+@@ -733,6 +739,9 @@ async function internalPublish(packageJson, opts, twoFactorState) {
+   } = publishTool.name === "pnpm" ? await spawn$1("pnpm", ["publish", "--json", ...publishFlags], {
+     env: Object.assign({}, process.env, envOverride),
+     cwd: opts.cwd
++  }) : publishTool.name === "yarn" ? await spawn$1("yarn", ["npm", "publish", ...publishFlags], {
++    env: Object.assign({}, process.env, envOverride),
++    cwd: opts.cwd
+   }) : await spawn$1(publishTool.name, ["publish", opts.publishDir, "--json", ...publishFlags], {
+     env: Object.assign({}, process.env, envOverride)
+   });


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description


Adds a patch for `@changesets/cli` v2.29.7 that enables proper yarn support when publishing packages. The patch modifies two key functions:

1. **`getPublishTool`** - Now detects and returns yarn as the publish tool when yarn is the package manager
2. **`internalPublish`** - Uses `yarn npm publish` command instead of `npm publish` when yarn is detected

This ensures that `workspace:*` protocol references in package.json dependencies are properly replaced with actual version numbers during publishing.

## Motivation and context

Without this patch, `changeset publish` fails to properly replace `workspace:*` references when publishing packages in a yarn workspace. This is because changesets defaults to using `npm publish` even in yarn workspaces, and npm doesn't understand yarn's workspace protocol.

The `yarn npm publish` command properly resolves `workspace:*` to the actual published version numbers before publishing to the registry.

## Related issue(s)

- Related to upstream [changesets/changesets#1449](https://github.com/changesets/changesets/pull/1449) - Similar fix pending merge
- Related to upstream [changesets/changesets#1411](https://github.com/changesets/changesets/issues/1411) - Original issue report
- Related to upstream [changesets/changesets#674](https://github.com/changesets/changesets/pull/674) - Comprehensive rework (stalled)

This patch is a temporary solution until the upstream fix is merged and released.
