### PR TITLE
fix(menu): ipad menu item click

### DIFF
--- a/packages/picker/src/InteractionController.ts
+++ b/packages/picker/src/InteractionController.ts
@@ -179,15 +179,6 @@ export class InteractionController implements ReactiveController {
 
     hostConnected(): void {
         this.init();
-        this.host.addEventListener('sp-opened', () => {
-            /**
-             * set shouldSupportDragAndSelect to false for mobile
-             * to prevent click event being captured behind the menu-tray
-             * we do this here because the menu gets reinitialized on overlay open
-             */
-            this.host.optionsMenu.shouldSupportDragAndSelect =
-                !this.host.isMobile.matches;
-        });
         this.host.addEventListener('sp-closed', () => {
             if (
                 !this.open &&

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -49,6 +49,7 @@ import type { SlottableRequestEvent } from '@spectrum-web-components/overlay/src
 import { DependencyManagerController } from '@spectrum-web-components/reactive-controllers/src/DependencyManger.js';
 import {
     IS_MOBILE,
+    IS_TOUCH_DEVICE,
     MatchMediaController,
 } from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
 import type { Tooltip } from '@spectrum-web-components/tooltip';
@@ -84,6 +85,7 @@ export class PickerBase extends SizedMixin(SpectrumElement, {
     };
 
     public isMobile = new MatchMediaController(this, IS_MOBILE);
+    public isTouchDevice = new MatchMediaController(this, IS_TOUCH_DEVICE);
 
     public strategy!: DesktopController | MobileController;
 
@@ -772,6 +774,7 @@ export class PickerBase extends SizedMixin(SpectrumElement, {
                 role=${this.listRole}
                 .selects=${this.selects}
                 .selected=${this.value ? [this.value] : []}
+                .shouldSupportDragAndSelect=${!this.isTouchDevice.matches}
                 size=${this.size}
                 @sp-menu-item-keydown=${this.handleEscape}
                 @sp-menu-item-added-or-updated=${this.shouldManageSelection}

--- a/tools/reactive-controllers/src/MatchMedia.ts
+++ b/tools/reactive-controllers/src/MatchMedia.ts
@@ -14,6 +14,7 @@ import type { ReactiveController, ReactiveElement } from 'lit';
 export const DARK_MODE = '(prefers-color-scheme: dark)';
 export const IS_MOBILE =
     '(max-width: 743px) and (hover: none) and (pointer: coarse)';
+export const IS_TOUCH_DEVICE = '(hover: none) and (pointer: coarse)';
 
 export class MatchMediaController implements ReactiveController {
     key = Symbol('match-media-key');


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

### Issue

Menu items (`<sp-menu-item>`) in `<sp-action-menu>` were not registering click events on iPad devices, while the same items wrapped in `<sp-menu-group>` worked correctly. This issue was reported in [GitHub Issue #5706](https://github.com/adobe/spectrum-web-components/issues/5706).

### Symptoms

- **On iPad (and other tablets):**
    - Direct menu items inside `<sp-action-menu>` don't fire click events
    - `pointerdown` and `pointerup` events fire correctly
    - Works fine when menu items are wrapped in `<sp-menu-group>`
- **On desktop and mobile phones:**
    - Everything works as expected

## Root cause

The issue stemmed from an incorrect device detection strategy that didn't properly account for tablet devices with touch input.

### Technical details

1. **Device detection query**

    ```typescript
    // Old IS_MOBILE definition
    const IS_MOBILE =
        '(max-width: 743px) and (hover: none) and (pointer: coarse)';
    ```

    This query only matched devices with:
    - Screen width ≤ 743px AND
    - Touch input (hover: none, pointer: coarse)

    **iPad devices don't match** because their screen width is typically 768px-1024px.

2. **The shouldSupportDragAndSelect flag**

    In `packages/picker/src/InteractionController.ts`, the code set:

    ```typescript
    this.host.optionsMenu.shouldSupportDragAndSelect =
        !this.host.isMobile.matches;
    ```

    Since iPad didn't match `IS_MOBILE`, `shouldSupportDragAndSelect` was set to `true`.

3. **Event handling conflict**

    In `packages/menu/src/Menu.ts`:

    ```typescript
    private handlePointerup(event: Event): void {
        this.handleTouchEnd();

        if (!this.shouldSupportDragAndSelect) {
            return; // Selection handled by click event
        }
        this.pointerUpTarget = event.target;
        this.handlePointerBasedSelection(event);
    }

    private handleClick(event: Event): void {
        if (this.pointerUpTarget === event.target) {
            this.pointerUpTarget = null;
            return; // EARLY RETURN - Click is ignored!
        }
        this.handlePointerBasedSelection(event);
    }
    ```

    When `shouldSupportDragAndSelect = true`:
    - `handlePointerup` processes the selection and sets `pointerUpTarget`
    - `handleClick` sees that `pointerUpTarget === event.target` and returns early
    - **The click event is never processed!**

4. **Why menu-group worked**

    When menu items are wrapped in `<sp-menu-group>`, the additional DOM wrapper causes the `event.target` in the click handler to sometimes differ from the `pointerUpTarget` set in the pointerup handler, allowing the click to proceed.

### Solution

We introduced a new `IS_TOUCH_DEVICE` media query that detects any device with touch input, regardless of screen size:

```typescript
export const IS_TOUCH_DEVICE = '(hover: none) and (pointer: coarse)';
```

This query matches:

- Mobile phones (screen width ≤ 743px)
- Tablets like iPad (screen width 744px-1366px)
- Any other device with touch input

The `PickerBase` class now includes an `isTouchDevice` property:

```typescript
public isTouchDevice = new MatchMediaController(this, IS_TOUCH_DEVICE);
```

The menu's `shouldSupportDragAndSelect` property is set directly in the template when the menu is rendered:

```typescript
protected get renderMenu(): TemplateResult {
    const menu = html`
        <sp-menu
            ...
            .shouldSupportDragAndSelect=${!this.isTouchDevice.matches}
            ...
        >
            <slot></slot>
        </sp-menu>
    `;
    ...
}
```

This ensures that on **all touch devices** (including iPads), the menu uses click events instead of the drag-and-select pattern, preventing the event handling conflict.



<!--- Describe your changes in detail -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes https://github.com/adobe/spectrum-web-components/issues/5706

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] iPad Menu Item click test

    1. Go https://swcpreviews.z13.web.core.windows.net/pr-5829/docs/storybook/?path=/story/action-menu--menu-item-alerts
    2. Open this in iPad mini or any iPad
    3. Click any menu Item
    4. You will see an alert
    

-   [ ] _Descriptive Test Statement_
    1. Go [here](url)
    2. Do this action
    3. Expect this result

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
