### PR TITLE
test(picker): enable webkit tab navigation tests

### DIFF
--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -1085,11 +1085,9 @@ export function runPickerTests(): void {
             el.insertAdjacentElement('afterend', input);
 
             el.focus();
-            if (!isWebKit()) {
-                await sendTabKey();
-                expect(document.activeElement).to.equal(input);
-                await sendShiftTabKey();
-            }
+            await sendTabKey();
+            expect(document.activeElement).to.equal(input);
+            await sendShiftTabKey();
             expect(document.activeElement).to.equal(el);
             const opened = oneEvent(el, 'sp-opened');
             await sendKeys({ press: 'Enter' });
@@ -1124,11 +1122,9 @@ export function runPickerTests(): void {
             el.insertAdjacentElement('afterend', input);
 
             el.focus();
-            if (!isWebKit()) {
-                await sendTabKey();
-                expect(document.activeElement).to.equal(input);
-                await sendKeys({ press: 'Shift+Tab' });
-            }
+            await sendTabKey();
+            expect(document.activeElement).to.equal(input);
+            await sendKeys({ press: 'Shift+Tab' });
             expect(document.activeElement).to.equal(el);
             const opened = oneEvent(el, 'sp-opened');
             await sendKeys({ down: 'Enter' });


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->
Removes `!isWebKit()` conditionals from two picker tests that were skipping tab key navigation validation in Safari/WebKit browsers. These conditionals were likely added because Safari's default tab behavior only focused form controls, not all interactive elements.

Changes:
- Removed `if (!isWebKit())` wrapper from "closes when focusing away from the menu" test (line ~1088)
- Removed `if (!isWebKit())` wrapper from similar tab navigation validation (line ~1125)
- Tab navigation validation now runs on all browsers including WebKit

## Motivation and context

This addresses a reported accessibility issue where the Picker component could not be tabbed into in Safari within Storybook.

**Investigation findings:**
- On macOS 26.0.1 (Tahoe)/Safari, tab navigation to the Picker works by default without requiring accessibility settings changes
- On older macOS versions, tab navigation works when Safari's "Press Tab to highlight each item on a webpage" setting is enabled
- Playwright's 1.53.1 (using WebKit 18.5) appears to support proper tab navigation to all focusable elements by default
- The test skips were masking that this behavior already works correctly
- Since Safari/WebKit now properly supports tab navigation by default, these test workarounds are no longer necessary. Removing them improves test coverage and ensures consistent behavior validation across all browsers.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- fixes SWC-1081
- resolves #5568

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [x] I have added automated tests to cover my changes.
-   [ ] <strike>I have included a well-written changeset if my change needs to be published.</strike>
-   [ ] <strike>I have included updated documentation if my change required it.</strike>

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] Verify picker tests pass locally:
    1. Run `yarn test:focus picker`
    2. Confirm all tests pass on Chromium, Firefox, and WebKit
    3. Expect no test failures, particularly in the "closes when focusing away from the menu" tests

-   [x] Confirm that bug cannot be replicated with appropriate settings on:
    1. Turn on keyboard accessibility settings:
        - System settings → Accessibility → Keyboard → Full Keyboard Access (on)
        - Safari settings → Advanced → Press Tab to highlight each item on a webpage (on)
    2. Navigate to the [Picker Default story](https://opensource.adobe.com/spectrum-web-components/storybook/index.html?path=/story/picker--default) in Storybook
    3. From page load, begin tabbing until you reach the Storybook canvas (try to avoid using the mouse - clicking into the canvas may cause Safari to skip the Picker in tab order).
    4. Confirm that you are able to keyboard focus on the picker and its menu.

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [x] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
