### PR TITLE
fix(azure-deploy): add missing check out step

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -117,6 +117,11 @@ jobs:
         runs-on: ubuntu-latest
         name: Clean up PR deployment
         steps:
+            - name: Check out code
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 0
+
             - name: Generate PR hash
               id: pr_hash
               run: |


### PR DESCRIPTION
ix(ci): standardize checkout action version in preview-docs workflow

## Description

Updated the `close_pull_request_job` to use `actions/checkout@v5` for consistency with GitHub Actions best practices.

## Motivation and context

The cleanup job needed the checkout action to access the custom AzCopy setup action (`./.github/actions/setup-azcopy`). Using the latest stable version (v5) ensures consistency and includes the latest security and performance improvements.

## Related issue(s)

- N/A (workflow maintenance)

---

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/) (N/A for CI changes)
-   [x] I have added automated tests to cover my changes. (N/A for workflow changes - verified by workflow execution)
-   [ ] I have included a well-written changeset if my change needs to be published. (N/A for CI-only changes)
-   [x] I have included updated documentation if my change required it. (N/A - internal workflow change)

---

## Reviewer's checklist

-   [ ] Validated the workflow executes successfully on PR close events

### Manual review test cases

-   [ ] Verify cleanup job executes successfully
    1. Create a test PR that triggers documentation preview
    2. Close or merge the PR
    3. Expect the cleanup job to run and successfully remove Azure Blob Storage artifacts