### PR TITLE
docs: update link to main branch from barebones

### DIFF
--- a/2nd-gen/packages/swc/.storybook/guides/welcome.mdx
+++ b/2nd-gen/packages/swc/.storybook/guides/welcome.mdx
@@ -26,7 +26,7 @@ SWC is currently in transition from its first generation (1st-gen) to its second
 
 2nd-gen SWC is currently in active development, with the first pre-releases expected in early 2026.
 
-For more information on 2nd-gen plans and status, see the [CONTRIBUTOR-DOCS](https://github.com/adobe/spectrum-web-components/tree/barebones/CONTRIBUTOR-DOCS/README.md) in the [SWC repository](https://github.com/adobe/spectrum-web-components).
+For more information on 2nd-gen plans and status, see the [CONTRIBUTOR-DOCS](https://github.com/adobe/spectrum-web-components/tree/main/CONTRIBUTOR-DOCS/README.md) in the [SWC repository](https://github.com/adobe/spectrum-web-components).
 
 ## About these Guides
 


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

Updated the CONTRIBUTOR-DOCS link in the 2nd-gen welcome guide to point to the `main` branch instead of the `barebones` branch. The link was previously pointing to our now-merged and deleted `barebones` branch.

https://github.com/user-attachments/assets/646c5fe8-2367-43cd-acff-8ddec671ebcf

## Motivation and context

The welcome guide for 2nd-gen SWC contained a broken link that pointed to the `barebones` branch. Since the CONTRIBUTOR-DOCS are maintained on the `main` branch now, this link needed to be updated to ensure contributors can access the correct documentation.

## Related issue(s)

-   fixes SWC-1358

## Screenshots (if appropriate)

N/A - Documentation link fix only

---

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] ~~I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)~~
-   [ ] ~~I have added automated tests to cover my changes.~~
-   [ ] ~~I have included a well-written changeset if my change needs to be published.~~
**Note:** This is a minor documentation fix that updates a single link reference. No changeset is required as it doesn't affect published packages.
-   [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

-   [ ] Verify the CONTRIBUTOR-DOCS link is accessible

    1. Navigate to the 2nd-gen Storybook welcome guide. Because this is a second-gen issue, you may have to run this locally to test.
    2. Click on the CONTRIBUTOR-DOCS link

<img width="699" height="105" alt="Screenshot 2025-11-11 at 2 50 29 PM" src="https://github.com/user-attachments/assets/e58cf569-7758-4348-95b6-679b282565b0" />

    3. Expect to land on the main branch CONTRIBUTOR-DOCS README at https://github.com/adobe/spectrum-web-components/tree/main/CONTRIBUTOR-DOCS/README.md. The link shouldn't 404 like it does on main.


### Device review

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?