### PR TITLE
fix(field-input-purpose): replace email address with proper placeholder

### DIFF
--- a/1st-gen/packages/field-label/README.md
+++ b/1st-gen/packages/field-label/README.md
@@ -29,8 +29,8 @@ import { FieldLabel } from '@spectrum-web-components/field-label';
 Field labels can be associated with form elements by using the `for` attribute, which should reference the `id` of the related input element.
 
 ```html demo
-<sp-field-label for="email">Email address</sp-field-label>
-<sp-textfield id="email" placeholder="user@adobe.com"></sp-textfield>
+<sp-field-label for="product-name">Product name</sp-field-label>
+<sp-textfield id="product-name" placeholder="Enter product name"></sp-textfield>
 ```
 
 Field labels can also be used to label a group of related inputs:


### PR DESCRIPTION
## Description

Updated the field-label documentation's Anatomy section example to use "Product name" instead of "Email address" to avoid using personal data fields in examples.

## Motivation and context

The Email address field example violated WCAG 2.2 criterion 1.3.5 (Identify Input Purpose - Level AA) by using a personal data field without an autocomplete attribute. Rather than adding autocomplete to documentation examples, we changed to a non-personal data field ("Product name") which doesn't require autocomplete attributes.

This improves accessibility compliance in our documentation and provides a more universally applicable example.

## Related issue(s)

`SWC-1167`

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

### Manual review test cases

- [ ] Verify documentation renders correctly
    1. Navigate to [https://opensource.adobe.com/spectrum-web-components/components/field-label/#anatomy](https://opensource.adobe.com/spectrum-web-components/components/field-label/#anatomy)
    2. Verify the Anatomy section shows "Product name" field instead of "Email address"
    3. Confirm the example displays correctly with placeholder "Enter product name"