### PR TITLE
fix(close-button): add a default slot containing visually hidden text for close button

### DIFF
--- a/.changeset/odd-times-give.md
+++ b/.changeset/odd-times-give.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/close-button': minor
+---
+
+Added visually hidden default slot rendering to sp-close-button so text content is accessible to screen readers while remaining invisible to sighted users.

--- a/1st-gen/packages/button/src/CloseButton.ts
+++ b/1st-gen/packages/button/src/CloseButton.ts
@@ -75,6 +75,13 @@ export class CloseButton extends SizedMixin(StyledButton, {
     public staticColor?: 'black' | 'white';
 
     protected override get buttonContent(): TemplateResult[] {
-        return [crossIcon[this.size]()];
+        return [
+            crossIcon[this.size](),
+            html`
+                <span id="label" class="visually-hidden">
+                    <slot @slotchange=${this.manageTextObservedSlot}></slot>
+                </span>
+            `,
+        ];
     }
 }

--- a/1st-gen/packages/button/test/close-button.test.ts
+++ b/1st-gen/packages/button/test/close-button.test.ts
@@ -12,8 +12,8 @@
 
 import '@spectrum-web-components/button/sp-close-button.js';
 import { CloseButton } from '@spectrum-web-components/button';
-import { expect, fixture, html } from '@open-wc/testing';
-import { testForLitDevWarnings } from '../../../test/testing-helpers';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
 describe('Close Button', () => {
     testForLitDevWarnings(
@@ -38,6 +38,36 @@ describe('Close Button', () => {
                 <sp-close-button size=${size} label="Close"></sp-close-button>
             `);
 
+            await expect(el).to.be.accessible();
+        });
+    });
+
+    describe('accessibility', () => {
+        it('should have accessible name with label attribute', async () => {
+            const el = await fixture<CloseButton>(html`
+                <sp-close-button label="Close"></sp-close-button>
+            `);
+
+            await elementUpdated(el);
+            expect(el.getAttribute('aria-label')).to.equal('Close');
+            await expect(el).to.be.accessible();
+        });
+
+        it('should have accessible name with default slot content', async () => {
+            const el = await fixture<CloseButton>(html`
+                <sp-close-button>Close</sp-close-button>
+            `);
+
+            await elementUpdated(el);
+            await expect(el).to.be.accessible();
+        });
+
+        it('should have accessible name when disabled', async () => {
+            const el = await fixture<CloseButton>(html`
+                <sp-close-button disabled>Close</sp-close-button>
+            `);
+
+            await elementUpdated(el);
             await expect(el).to.be.accessible();
         });
     });

--- a/1st-gen/packages/close-button/src/close-button-overrides.css
+++ b/1st-gen/packages/close-button/src/close-button-overrides.css
@@ -28,3 +28,16 @@
     --spectrum-closebutton-static-background-color-down: var(--system-close-button-static-black-static-background-color-down);
     --spectrum-closebutton-static-background-color-focus: var(--system-close-button-static-black-static-background-color-focus);
 }
+
+.visually-hidden {
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: 0 -1px -1px 0;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    white-space: nowrap;
+}


### PR DESCRIPTION
fix(close-button): add accessible name support for default slot

## Description

Added visually hidden default slot rendering to `sp-close-button` so text content is accessible to screen readers while remaining invisible to sighted users.

**Changes:**
- Render default slot with `.visually-hidden` styling in `CloseButton.ts`
- Add `.visually-hidden` CSS class to `close-button-overrides.css`
- Add accessibility tests to verify screen reader support

## Motivation and context

`<sp-close-button>Close</sp-close-button>` had no accessible name for screen readers because the default slot wasn't being rendered. This caused WCAG 4.1.2 (Name, Role, Value - Level A) violations when using slot content instead of the `label` attribute.

The `label` attribute already worked correctly (via `aria-label`), but the documented default slot pattern was inaccessible.

## Related issue(s)

-   fixes `SWC-1150`

---

## Author's checklist

-   [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [x] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

-   [ ] **Verify accessible name with default slot**
    1. Go to [close-button documentation](https://opensource.adobe.com/spectrum-web-components/components/close-button/)
    2. Enable a screen reader (NVDA, JAWS, VoiceOver, etc.)
    3. Navigate to `<sp-close-button>Close</sp-close-button>` examples
    4. Expect screen reader announces "Close" as the button's accessible name

-   [ ] **Verify disabled state accessibility**
    1. Navigate to disabled close button: `<sp-close-button disabled>Disabled</sp-close-button>`
    2. Expect screen reader announces the label "Disabled" along with its disabled state when the element is programmatically focused or inspected

-   [ ] **Verify label attribute still works**
    1. Navigate to `<sp-close-button label="Close"></sp-close-button>`
    2. Expect screen reader announces "Close" via aria-label (existing behavior)

### Device review

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?