### PR TITLE
docs(tray): improve a11y of tray docs examples

### DIFF
--- a/1st-gen/packages/tray/README.md
+++ b/1st-gen/packages/tray/README.md
@@ -25,11 +25,7 @@ import { Tray } from '@spectrum-web-components/tray';
 
 ### Anatomy
 
-A tray has a single default `slot`.
-
-<sp-tabs selected="dialog" auto label="Using tray's slot">
-<sp-tab value="dialog">Dialog</sp-tab>
-<sp-tab-panel value="dialog">
+A tray has a single default `slot`. Expected content typically includes dialogs and their content, plain text, forms and/or form elements, and some native HTML elements. Always ensure that your tray's content is accessible according to WCAG standards.
 
 ```html
 <overlay-trigger type="modal">
@@ -42,30 +38,6 @@ A tray has a single default `slot`.
     </sp-tray>
 </overlay-trigger>
 ```
-
-</sp-tab-panel>
-<sp-tab value="menu">Menu</sp-tab>
-<sp-tab-panel value="menu">
-
-```html
-<overlay-trigger type="modal">
-    <sp-button slot="trigger" variant="secondary">Toggle menu</sp-button>
-    <sp-tray slot="click-content">
-        <sp-menu style="width: 100%">
-            <sp-menu-item selected>Deselect</sp-menu-item>
-            <sp-menu-item>Select Inverse</sp-menu-item>
-            <sp-menu-item focused>Feather...</sp-menu-item>
-            <sp-menu-item>Select and Mask...</sp-menu-item>
-            <sp-menu-divider></sp-menu-divider>
-            <sp-menu-item>Save Selection</sp-menu-item>
-            <sp-menu-item disabled>Make Work Path</sp-menu-item>
-        </sp-menu>
-    </sp-tray>
-</overlay-trigger>
-```
-
-</sp-tab-panel>
-</sp-tabs>
 
 ### Accessibility
 
@@ -87,20 +59,35 @@ This dismiss helper pattern is also implemented in the [`<sp-picker>`](https://o
 <sp-tab value="auto">Content has no buttons</sp-tab>
 <sp-tab-panel value="auto">
 
-This example shows the default behavior where the tray automatically detects that the menu content lacks dismiss buttons and renders visually hidden helpers. Screen readers will announce them as "Dismiss, button" and these helpers are keyboard accessible.
+This example shows the default behavior where the tray automatically detects that the content lacks dismiss buttons and renders visually hidden helpers. Screen readers will announce them as "Dismiss, button" and these helpers are keyboard accessible.
 
 ```html
 <overlay-trigger type="modal">
     <sp-button slot="trigger" variant="secondary">
-        Toggle menu content
+        Toggle tray content
     </sp-button>
     <sp-tray slot="click-content">
-        <sp-menu style="width: 100%">
-            <sp-menu-item>Deselect</sp-menu-item>
-            <sp-menu-item>Select Inverse</sp-menu-item>
-            <sp-menu-item>Feather...</sp-menu-item>
-            <sp-menu-item>Select and Mask...</sp-menu-item>
-        </sp-menu>
+        <div style="display: flex; flex-direction: column; margin: 16px;">
+            <p style="margin-block-start: 0;">
+                Custom content that doesn't have dismiss functionality, so the
+                tray detects it needs the visually-hidden dismiss buttons.
+            </p>
+            <label>
+                What's your favorite Super Mario character?
+                <select
+                    name="favorite-characters"
+                    style="margin-block-start: 8px;"
+                >
+                    <option value="">
+                        Choose your favorite Super Mario character.
+                    </option>
+                    <option value="mario">Mario</option>
+                    <option value="luigi">Luigi</option>
+                    <option value="toad">Toad</option>
+                    <option value="bowser">Bowser</option>
+                </select>
+            </label>
+        </div>
     </sp-tray>
 </overlay-trigger>
 ```
@@ -137,7 +124,7 @@ Set `has-keyboard-dismiss` (or `has-keyboard-dismiss="true"`) to prevent the tra
         Toggle without helpers
     </sp-button>
     <sp-tray slot="click-content" has-keyboard-dismiss>
-        <p>
+        <p style="margin: 16px;">
             Custom content that should have custom dismiss functionality, even
             though the tray didn't detect buttons in this slot.
         </p>


### PR DESCRIPTION
## Description

This PR removes the menu examples found on the tray documentation page. The menu examples are partial and unrealistically used within the tray, so removing them resolves the accessibility concerns regarding `aria-current`/`aria-checked`. 

## Motivation and context

Screen readers were not announcing the selected state for menu items with `role="menuitem"`, causing confusion for users relying on assistive technology. But because our examples were not realistic examples, (menus are usually children of popovers instead), removing the menu examples from the tray docs is most accurate.

## Related issue(s)

- Fixes SWC-1108

---

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] **Tray docs no longer have menu examples**
    1. Go to [sp-tray documentation](https://swcpreviews.z13.web.core.windows.net/pr-5888/docs/components/tray/).
    2. Navigate to the 'Anatomy' section.
    3. Verify the tabs are no longer present, and only the dialog example remains.
    5. The new documentation is technically and grammatically accurate and follows [Spectrum content standards](https://spectrum.adobe.com/page/grammar-and-mechanics/).
    6. Navigate to the 'Accessibility' section.
    7. Validate the behavior of the tray in the "Content has no buttons" tab remains unchanged (i.e. the visually hidden dismiss buttons are still keyboard navigable and get announced properly by a screen reader). 
        i. Verify the accessibility of the `select` element. It is implicitly associated to the `label` as a child of the label, and all options have `value` attributes.


- [ ] ~~**Screen reader announces selected state for menuitem**~~
    1. ~~Go to [sp-tray documentation](https://swcpreviews.z13.web.core.windows.net/pr-5888/docs/components/tray/)~~
    2. ~~Navigate to the 'Anatomy' section, 'Dialog' tab, and select the 'Menu' tab~~
    3. ~~Activate the "Toggle menu" button and navigate to a selected menu item using a screen reader (NVDA, JAWS, or VoiceOver)~~
        i. ~~In the bug ticket, they are specifically using NVDA on a Windows machine, so I was using AssitivLabs during development. ~~
    5. ~~Expect the screen reader to announce the selected/current state (e.g., "Deselect, current, 1 of 6")~~

- [ ] ~~**aria-current attribute is correctly applied**~~
    1. ~~Inspect a selected `sp-menu-item` with `role="menuitem"` in browser DevTools~~
    2. ~~Verify it has `aria-current="true"` attribute~~
    3. ~~Inspect a non-selected `sp-menu-item` with `role="menuitem"`~~
    4. ~~Verify it does NOT have an `aria-current` attribute (not set to "false")~~
    5. ~~Manually remove the `selected` attribute from the first item.~~
    9. ~~Verify the corresponding `aria-current` attribute is removed.~~

- [ ] ~~**Other menu item roles are unaffected**~~
    1. ~~Test menu items with `role="menuitemradio"` and `role="menuitemcheckbox"`~~
    2. ~~Verify they still use `aria-checked` (not `aria-current`)~~
    3. ~~Test menu items with `role="option"` in a listbox context~~
    4. ~~Verify they still use `aria-selected` (not `aria-current`)~~

- [ ] ~~New unit tests pass in CI.~~
    1. ~~"sets aria-current to true if the item has selected property"~~
    2. ~~"removes aria-current if the item is deselected"~~
    3. "updates aria-current when the selected item changes"~~

- [ ] ~~[New documentation for menu item](https://swcpreviews.z13.web.core.windows.net/pr-5888/docs/components/menu-item/#accessibility) is technically and grammatically accurate and follows [Spectrum content standards](https://spectrum.adobe.com/page/grammar-and-mechanics/).~~

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

