### PR TITLE
chore: fix storybook dev mode warning

### DIFF
--- a/1st-gen/packages/action-menu/src/ActionMenu.ts
+++ b/1st-gen/packages/action-menu/src/ActionMenu.ts
@@ -148,19 +148,21 @@ export class ActionMenu extends ObserveSlotPresence(
     }
 
     protected override warnNoLabel(): void {
-        window.__swc.warn(
-            this,
-            `<${this.localName}> needs one of the following to be accessible:`,
-            'https://opensource.adobe.com/spectrum-web-components/components/action-menu/#accessibility',
-            {
-                type: 'accessibility',
-                issues: [
-                    `an <sp-field-label> element with a \`for\` attribute referencing the \`id\` of the \`<${this.localName}>\`, or`,
-                    'value supplied to the "label" attribute, which will be displayed visually as placeholder text',
-                    'text content supplied in a <span> with slot="label", or, text content supplied in a <span> with slot="label-only"',
-                    'which will also be displayed visually as placeholder text.',
-                ],
-            }
-        );
+        if (window.__swc?.DEBUG) {
+            window.__swc.warn(
+                this,
+                `<${this.localName}> needs one of the following to be accessible:`,
+                'https://opensource.adobe.com/spectrum-web-components/components/action-menu/#accessibility',
+                {
+                    type: 'accessibility',
+                    issues: [
+                        `an <sp-field-label> element with a \`for\` attribute referencing the \`id\` of the \`<${this.localName}>\`, or`,
+                        'value supplied to the "label" attribute, which will be displayed visually as placeholder text',
+                        'text content supplied in a <span> with slot="label", or, text content supplied in a <span> with slot="label-only"',
+                        'which will also be displayed visually as placeholder text.',
+                    ],
+                }
+            );
+        }
     }
 }

--- a/1st-gen/packages/overlay/src/slottable-request-directive.ts
+++ b/1st-gen/packages/overlay/src/slottable-request-directive.ts
@@ -74,7 +74,7 @@ export class SlottableRequestDirective extends AsyncDirective {
             { signal }
         );
 
-        if (window.__swc.DEBUG) {
+        if (window.__swc?.DEBUG) {
             window.__swc.warn(
                 undefined,
                 `⚠️  WARNING ⚠️ : The Overlay Trigger Directive is experimental and there is no guarantees behind its usage in an application!! Its API and presence within the library could be changed at anytime. See "sp-overlay" or "Overlay.open()" for a stable API for overlaying content on your application.`,

--- a/1st-gen/packages/overlay/src/slottable-request-event.ts
+++ b/1st-gen/packages/overlay/src/slottable-request-event.ts
@@ -23,7 +23,7 @@ export class SlottableRequestEvent extends Event {
         this.name = name;
         this.data = data;
         this.slotName = key !== undefined ? `${name}.${key}` : name;
-        if (window.__swc.DEBUG) {
+        if (window.__swc?.DEBUG) {
             window.__swc.warn(
                 undefined,
                 `⚠️  WARNING ⚠️ : \`slottable-request\` events are experimental and there is no guarantees behind usage of them in an application!! Their shape and presence within the library could be changed at anytime.

--- a/1st-gen/packages/picker/src/Picker.ts
+++ b/1st-gen/packages/picker/src/Picker.ts
@@ -556,19 +556,21 @@ export class PickerBase extends SizedMixin(SpectrumElement, {
     }
 
     protected warnNoLabel(): void {
-        window.__swc.warn(
-            this,
-            `<${this.localName}> needs one of the following to be accessible:`,
-            'https://opensource.adobe.com/spectrum-web-components/components/picker/#accessibility',
-            {
-                type: 'accessibility',
-                issues: [
-                    `an <sp-field-label> element with a \`for\` attribute referencing the \`id\` of the \`<${this.localName}>\`, or`,
-                    'value supplied to the "label" attribute, which will be displayed visually as placeholder text, or',
-                    'text content supplied in a <span> with slot="label", which will also be displayed visually as placeholder text.',
-                ],
-            }
-        );
+        if (window.__swc?.DEBUG) {
+            window.__swc.warn(
+                this,
+                `<${this.localName}> needs one of the following to be accessible:`,
+                'https://opensource.adobe.com/spectrum-web-components/components/picker/#accessibility',
+                {
+                    type: 'accessibility',
+                    issues: [
+                        `an <sp-field-label> element with a \`for\` attribute referencing the \`id\` of the \`<${this.localName}>\`, or`,
+                        'value supplied to the "label" attribute, which will be displayed visually as placeholder text, or',
+                        'text content supplied in a <span> with slot="label", which will also be displayed visually as placeholder text.',
+                    ],
+                }
+            );
+        }
     }
 
     protected renderOverlay(menu: TemplateResult): TemplateResult {
@@ -1000,7 +1002,7 @@ export class Picker extends PickerBase {
         );
         if (!this.value || nextItem !== this.selectedItem) {
             // updates picker text but does not fire change event until action is completed
-            if (!!nextItem) this.setValueFromItem(nextItem as MenuItem);
+            if (nextItem) this.setValueFromItem(nextItem as MenuItem);
         }
     };
 }

--- a/1st-gen/packages/slider/src/Slider.ts
+++ b/1st-gen/packages/slider/src/Slider.ts
@@ -31,7 +31,7 @@ import {
 
 import sliderStyles from './slider.css.js';
 import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
-import { StyleInfo } from 'lit/directives/style-map.js';
+import type { StyleInfo } from '@spectrum-web-components/base/src/directives.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import type { NumberField } from '@spectrum-web-components/number-field';
 import { HandleController, HandleValueDictionary } from './HandleController.js';
@@ -232,7 +232,7 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
         this.handleController.hostConnected();
 
         // Deprecation warning for default slot when content is provided
-        if (window.__swc.DEBUG && this.textContent?.trim()) {
+        if (window.__swc?.DEBUG && this.textContent?.trim()) {
             window.__swc.warn(
                 this,
                 `The default slot for text label in <${this.localName}> has been deprecated and will be removed in a future release. Use the "label" property instead.`,

--- a/1st-gen/storybook/preview.js
+++ b/1st-gen/storybook/preview.js
@@ -16,6 +16,25 @@ import { Locales } from '@spectrum-web-components/story-decorator/src/locales.js
 import DocumentationTemplate from './DocumentationTemplate.mdx';
 import '@spectrum-web-components/story-decorator/sp-story-decorator.js';
 
+/**
+ * Ensure that window.__swc is defined in the storybook runtime.
+ *
+ * This prevents debug-only calls like `window.__swc.warn(...)` from throwing
+ * when the debug flag is inlined to `true` by the dev build configuration.
+ */
+if (typeof window !== 'undefined') {
+    window.__swc = window.__swc || {};
+    if (typeof window.__swc.DEBUG === 'undefined') {
+        window.__swc.DEBUG = true;
+    }
+    if (typeof window.__swc.warn !== 'function') {
+        window.__swc.warn = (...args) => {
+            // Forward warnings to the console for visibility in storybook.
+            console.warn('[SWC]', ...args);
+        };
+    }
+}
+
 // const cem = await import('./custom-elements.json', {
 //     assert: { type: 'json' },
 // });


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

Define a safe `window.__swc` shim in Storybook (`storybook/preview.js`) so debug warnings (`window.__swc.warn`) cannot crash the Storybook runtime.

## Motivation and context

- When running `storybook:build` for 1st‑gen and serving the static Storybook docs, opening components that use overlays and `SlottableRequestEvent` would throw `TypeError: Cannot read properties of undefined (reading 'warn')`.
- This happened because the dev build inlines `window.__swc?.DEBUG` to true, causing `window.__swc.warn(...)` to be called even when `window.__swc` is not defined in the Storybook runtime.
- The change introduces a Storybook‑only shim so debug warnings remain visible (via `console.warn`) without breaking stories, and allows us to keep the experimental warning in `SlottableRequestEvent`.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

-   fixes [Issue Number]

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [x] Storybook build and static docs load without overlay errors
1. Go [here](https://swcpreviews.z13.web.core.windows.net/pr-5896/docs/first-gen-storybook/?path=/story/overlay-directive--default)
2. Navigate to stories that use sp-action-menu, sp-menu, and sp-picker or sp-overlay-trigger.
3. Open and interact with overlays (menus, pickers) and verify there is no Cannot read properties of undefined (reading 'warn') error in the console.
- [x] Debug warning is emitted but does not crash
1. Go [here](https://swcpreviews.z13.web.core.windows.net/pr-5896/docs/first-gen-storybook/?path=/story/overlay-directive--default)
2. Open the browser devtools console.
3. Confirm that a warning about experimental slottable-request events appears, prefixed with [SWC], and that the story continues to function normally.

<img width="512" height="143" alt="Screenshot 2025-11-18 at 3 26 40 PM" src="https://github.com/user-attachments/assets/ef614e59-5d88-444e-8c16-08689e5d7d31" />


### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
