### PR TITLE
feat(combobox): selected value property

### DIFF
--- a/1st-gen/packages/combobox/src/Combobox.ts
+++ b/1st-gen/packages/combobox/src/Combobox.ts
@@ -103,6 +103,13 @@ export class Combobox extends Textfield {
     @query('#input')
     private input!: HTMLInputElement;
 
+    /**
+     * The value of the currently selected option.
+     * This differs from `value` which contains the `itemText` displayed in the input.
+     */
+    @property({ type: String, attribute: 'selected-value', reflect: true })
+    public selectedValue = '';
+
     private itemValue = '';
 
     /**
@@ -164,6 +171,8 @@ export class Combobox extends Textfield {
         } else if (event.code === 'Escape') {
             if (!this.open) {
                 this.value = '';
+                this.selectedValue = '';
+                this.itemValue = '';
             }
             this.open = false;
         } else if (event.code === 'Enter') {
@@ -303,6 +312,8 @@ export class Combobox extends Textfield {
             (item) => item.value === target?.value
         );
         this.value = selected?.itemText || '';
+        this.selectedValue = selected?.value || '';
+        this.itemValue = selected?.value || '';
         event.preventDefault();
         this.open = false;
         this._returnItems();
@@ -339,10 +350,11 @@ export class Combobox extends Textfield {
         }
         if (changed.has('value')) {
             this.filterAvailableOptions();
-            this.itemValue =
-                this.availableOptions.find(
-                    (option) => option.itemText === this.value
-                )?.value ?? '';
+            const foundOption = this.availableOptions.find(
+                (option) => option.itemText === this.value
+            );
+            this.itemValue = foundOption?.value ?? '';
+            this.selectedValue = foundOption?.value ?? '';
         }
         return super.shouldUpdate(changed);
     }

--- a/1st-gen/packages/combobox/stories/combobox.stories.ts
+++ b/1st-gen/packages/combobox/stories/combobox.stories.ts
@@ -284,3 +284,86 @@ controlled.parameters = {
     // Disables Chromatic's snapshotting on a global level
     chromatic: { disableSnapshot: true },
 };
+
+class SelectedValueDemo extends LitElement {
+    // Options with duplicate itemText to demonstrate the need for selectedValue
+    static duplicateOptions: ComboboxOption[] = [
+        { value: 'city-nyc', itemText: 'New York' },
+        { value: 'state-ny', itemText: 'New York' },
+        { value: 'city-la', itemText: 'Los Angeles' },
+        { value: 'state-la', itemText: 'Los Angeles' },
+        { value: 'city-chi', itemText: 'Chicago' },
+        { value: 'state-il', itemText: 'Illinois' },
+    ];
+
+    @state()
+    private selectedItemText = '';
+
+    @state()
+    private selectedValue = '';
+
+    @query('#combobox-selected-value')
+    private combobox!: Combobox;
+
+    override render(): TemplateResult {
+        return html`
+            <sp-field-label for="combobox-selected-value">
+                Select a location (some have duplicate names)
+            </sp-field-label>
+            <sp-combobox
+                id="combobox-selected-value"
+                .options=${SelectedValueDemo.duplicateOptions}
+                @change=${this.onChange}
+            ></sp-combobox>
+            <div
+                style="margin-top: 16px; padding: 12px; background: var(--spectrum-global-color-gray-100); border-radius: 4px;"
+            >
+                <p style="margin: 0 0 8px 0; font-weight: bold;">
+                    Selected values:
+                </p>
+                <p style="margin: 4px 0;">
+                    <strong>itemText (value property):</strong>
+                    <code
+                        style="margin-left: 8px; padding: 2px 6px; background: white; border-radius: 2px;"
+                    >
+                        ${this.selectedItemText || '(none)'}
+                    </code>
+                </p>
+                <p style="margin: 4px 0;">
+                    <strong>selectedValue (option value):</strong>
+                    <code
+                        style="margin-left: 8px; padding: 2px 6px; background: white; border-radius: 2px;"
+                    >
+                        ${this.selectedValue || '(none)'}
+                    </code>
+                </p>
+                <p
+                    style="margin: 8px 0 0 0; font-size: 12px; color: var(--spectrum-global-color-gray-700);"
+                >
+                    Notice how both "New York" options have the same itemText
+                    but different values. The selectedValue property allows you
+                    to distinguish between them.
+                </p>
+            </div>
+        `;
+    }
+
+    private onChange(): void {
+        this.selectedItemText = this.combobox.value;
+        this.selectedValue = this.combobox.selectedValue;
+    }
+}
+defineElement('selected-value-demo', SelectedValueDemo);
+
+export const selectedValue = (): TemplateResult => {
+    return html`
+        <selected-value-demo></selected-value-demo>
+    `;
+};
+selectedValue.swc_vrt = {
+    skip: true,
+};
+
+selectedValue.parameters = {
+    chromatic: { disableSnapshot: true },
+};


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

This PR adds a new public `selectedValue` property to the `sp-combobox` component that exposes the selected option's `value` property, distinct from the `value` property which contains the `itemText` displayed in the input field.

**Changes made:**
- Added `selectedValue` as a public `@property` with `reflect: true` attribute
- Updated `handleMenuChange` to set `selectedValue` when an option is selected from the menu
- Updated `shouldUpdate` to sync `selectedValue` when `value` changes programmatically
- Clear `selectedValue` when the value is cleared via Escape key
- Added a demonstration story (`selectedValue`) showing how to use the property with duplicate `itemText` values

**Technical details:**
- The component already tracked the selected option's value internally in `itemValue`, but it was private
- `selectedValue` is now publicly accessible and reflects to the DOM as the `selected-value` attribute
- Both `value` (itemText) and `selectedValue` (option value) are kept in sync when selections change

## Motivation and context

Previously, the `sp-combobox` component only exposed the `itemText` of the selected option through its `value` property. This created a problem when multiple options had duplicate `itemText` values but different `value` properties. Consumers could not reliably determine which option was actually selected.

**Problem scenario:**
```typescript
const options = [
  { value: 'city-nyc', itemText: 'New York' },
  { value: 'state-ny', itemText: 'New York' },
];
// After selecting "New York", combobox.value = "New York"
// But which one? city-nyc or state-ny? No way to tell!
```

**Solution:**
By exposing `selectedValue`, consumers can now access both:
- `combobox.value` - the display text (`itemText`)
- `combobox.selectedValue` - the unique option identifier (`value`)

This allows proper handling of duplicate `itemText` scenarios and provides a reliable way to identify the selected option.

## Related issue(s)

- Related to internal discussion about accessing option values in change events

## Screenshots (if appropriate)

A demonstration story has been added that shows the `selectedValue` property in action with duplicate `itemText` values. The story displays both `value` and `selectedValue` in real-time as selections are made.

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] **Test selectedValue property with options array**

    1. Navigate to the Combobox storybook: `1st-gen/packages/combobox/stories/combobox.stories.ts`
    2. Open the "Selected Value" story
    3. Select an option from the dropdown (e.g., "New York")
    4. Verify that `combobox.value` shows the `itemText` ("New York")
    5. Verify that `combobox.selectedValue` shows the option's `value` (e.g., "city-nyc" or "state-ny")
    6. Select a different option with the same `itemText` (e.g., the other "New York")
    7. Verify that `selectedValue` changes to reflect the different option's `value`
    8. Verify that `value` remains the same (since `itemText` is the same)

-   [ ] **Test selectedValue with slotted menu items**

    1. Navigate to the "Light DOM" story in combobox stories
    2. Open browser DevTools console
    3. Select an option from a combobox using slotted menu items
    4. Access the combobox element and check `combobox.selectedValue`
    5. Verify that `selectedValue` matches the selected menu item's `value` attribute

-   [ ] **Test selectedValue synchronization**

    1. Create a combobox with options array
    2. Programmatically set `combobox.value = "Some itemText"`
    3. Verify that `selectedValue` is automatically updated to match the option with that `itemText`
    4. If multiple options have the same `itemText`, verify that `selectedValue` matches the first matching option

-   [ ] **Test selectedValue clearing**

    1. Select an option in a combobox
    2. Verify both `value` and `selectedValue` are set
    3. Press Escape key to clear the input
    4. Verify that both `value` and `selectedValue` are cleared (empty string)

-   [ ] **Test backward compatibility**

    1. Verify that existing combobox usage continues to work without changes
    2. Verify that `combobox.value` still returns `itemText` as before
    3. Verify that change events still fire correctly
    4. Test with existing stories that use combobox to ensure no regressions

-   [ ] **Test selectedValue attribute reflection**

    1. Select an option in a combobox
    2. Inspect the DOM element
    3. Verify that the `selected-value` attribute is present on the combobox element
    4. Verify that the attribute value matches the selected option's `value`

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?

