### PR TITLE
chore: enable size controls for 2nd-gen components

### DIFF
--- a/2nd-gen/packages/swc/cem.config.js
+++ b/2nd-gen/packages/swc/cem.config.js
@@ -11,7 +11,11 @@
  */
 
 export default {
-    globs: ['components/**/*.ts', '../core/components/**/*.ts'],
+    globs: [
+        'components/**/*.ts',
+        '../core/components/**/*.ts',
+        '../core/shared/**/*.ts',
+    ],
     exclude: ['**/*.stories.ts', '**/*.test.ts', '**/*.spec.ts'],
     outdir: '.storybook',
     litelement: true,

--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -37,16 +37,11 @@ argTypes.fixed = {
     options: [undefined, ...Badge.FIXED_VALUES],
 };
 
-/*
- * @todo This is properly configuring the Select, but the control doesn't
- * seem to work; need to investigate.
- */
-
-// argTypes.size = {
-//     ...argTypes.size,
-//     control: { type: 'select' },
-//     options: Badge.VALID_SIZES,
-// };
+argTypes.size = {
+    ...argTypes.size,
+    control: { type: 'select' },
+    options: Badge.VALID_SIZES,
+};
 
 args['default-slot'] = 'Badge';
 

--- a/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
+++ b/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
@@ -24,16 +24,11 @@ import '@adobe/swc/divider';
 
 const { events, args, argTypes, template } = getStorybookHelpers('swc-divider');
 
-/*
- * @todo This is properly configuring the Select, but the control doesn't
- * seem to work; need to investigate.
- */
-
-// argTypes.size = {
-//     ...argTypes.size,
-//     control: { type: 'select' },
-//     options: Divider.VALID_SIZES,
-// };
+argTypes.size = {
+    ...argTypes.size,
+    control: { type: 'select' },
+    options: Divider.VALID_SIZES,
+};
 
 argTypes['static-color'] = {
     ...argTypes['static-color'],

--- a/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
@@ -35,15 +35,11 @@ const { events, args, argTypes, template } = getStorybookHelpers(
 //     control: { type: 'range', min: 0, max: 100, step: 1 },
 // };
 
-/*
- * @todo This is properly configuring the Select, but the control doesn't
- * seem to work; need to investigate.
- */
-// argTypes.size = {
-//     ...argTypes.size,
-//     control: { type: 'select' },
-//     options: ProgressCircle.VALID_SIZES,
-// };
+argTypes.size = {
+    ...argTypes.size,
+    control: { type: 'select' },
+    options: ProgressCircle.VALID_SIZES,
+};
 
 argTypes['static-color'] = {
     ...argTypes['static-color'],

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -30,23 +30,11 @@ argTypes.variant = {
     options: StatusLight.VARIANTS,
 };
 
-/*
- * @todo This is properly configuring the Select, but the control doesn't
- * seem to work; need to investigate.
- *
- * We may have to explicitly bind the args to the component (particularly
- * helpful for the size property) so the Storybook controls work as expected.
- * 
- * i.e. render: (args) =>
-        html`<swc-status-light .size=${args.size} variant=${args.variant}
-            >${args['default-slot']}</swc-status-light
-        >`,
- */
-// argTypes.size = {
-//     ...argTypes.size,
-//     control: { type: 'select' },
-//     options: StatusLight.VALID_SIZES,
-// };
+argTypes.size = {
+    ...argTypes.size,
+    control: { type: 'select' },
+    options: StatusLight.VALID_SIZES,
+};
 
 args['default-slot'] = 'Status light';
 args.size = 'm';


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

The `size` property from `SizedMixin` wasn't being recognized by storybook-helpers because the CEM was missing the shared base modules. Added `../core/shared/**/*.ts` to `cem.config.js` globs and enabled size controls in all affected component stories 👍 

<!--- Describe your changes in detail -->

## Motivation and context

Without this we don't get the fancy select dropdown picker (just a textfield input 🤷 ).

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate)

<img width="1043" height="596" alt="Screenshot 2025-12-12 at 14 09 37" src="https://github.com/user-attachments/assets/a981f014-86dd-436d-bee3-54c7984f75d3" />

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Verify it works_

    1. Go to the deployed [2nd-gen Storybook](https://swcpreviews.z13.web.core.windows.net/pr-5933/docs/second-gen-storybook/?path=/docs/components-badge--docs)
    2. Select a size from the select picker
    3. The component preview reacts to it!
