### PR TITLE
docs: migration analysis skill improvements

### DIFF
--- a/.cursor/skills/component-migration-analysis/references/migration-analysis-prompt.md
+++ b/.cursor/skills/component-migration-analysis/references/migration-analysis-prompt.md
@@ -261,13 +261,13 @@ The key question: "Was this intentionally removed as part of Spectrum 2?" If yes
 CSS and SWC often use different names for the same concept. When mapping:
 
 1. **Look for functional equivalence**, not just naming similarity:
-    - CSS `hasClearButton` / `isRemovable` → SWC `deletable`
-    - CSS `is-invalid` state → SWC `invalid` attribute
-    - CSS `-clearButton` subcomponent → SWC `deletable` attribute triggers its render
+   - CSS `hasClearButton` / `isRemovable` → SWC `deletable`
+   - CSS `is-invalid` state → SWC `invalid` attribute
+   - CSS `-clearButton` subcomponent → SWC `deletable` attribute triggers its render
 
 2. **Document name differences** in the mapping table:
-    - If a CSS selector maps to a differently-named SWC feature, note the relationship
-    - Example: `.spectrum-Tag-clearButton` | `deletable` (renders clear button) | Implemented
+   - If a CSS selector maps to a differently-named SWC feature, note the relationship
+   - Example: `.spectrum-Tag-clearButton` | `deletable` (renders clear button) | Implemented
 
 3. **Do not mark as "Missing"** if the feature exists under a different name. A feature is only "Missing from WC" if no equivalent functionality exists.
 


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

Improves the `migration-analysis-prompt.md` used for generating component migration documentation. Changes address recurring issues identified during human review of AI-generated docs, including branch confusion, missing diffs, verbose summaries, and incorrect status classifications.

## Motivation and context

- During review of generated migration docs (link, tag, taggroup, tooltip), several patterns of errors were identified:
TagGroup incorrectly stated "no changes in Spectrum 2" due to branch verification failures
- Diff sections were often prose descriptions instead of actual unified diffs
- Summary sections included structure descriptions instead of focusing on changes
- Features removed in Spectrum 2 were marked "Missing from CSS" instead of "Deprecated"
- These changes make the prompt more explicit about requirements to reduce errors and improve output quality.

## Related issue(s)

- Related to ongoing 2nd-gen component analysis work

-   fixes [Issue Number]

## Summary of changes

Commits are separated for easier review:

1. Branch verification protocol - Requires proof of correct branch (git output, quoted imports, distinguishing features)
2. Mandatory diff generation - Adds git diff command and makes diff section required
3. HTML diff format - Provides realistic example showing actual structural changes
4. Summary writing guidelines - Constrains summaries to change-focused bullets only
5. CSS selector categorization - Requires organizing selectors by type (base, variants, states, etc.)
6. Name equivalence mapping - Guides recognition of same concepts with different names
7. --mod change tracking - Notes --mod changes as signals for new/deprecated features
8. Deprecation detection criteria - Expands when to use "Deprecated" vs "Missing from CSS"
9. Documentation goal statement - Frames output for engineers estimating migration work
10. Quality gates checklist - Self-check before completion

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [ ] I have added automated tests to cover my changes.
-   [ ] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

-   [ ] _Descriptive Test Statement_

    1. Go [here](url)
    2. Do this action
    3. Expect this result

-   [ ] _Descriptive Test Statement_
    1. Go [here](url)
    2. Do this action
    3. Expect this result

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in (emulated) Mobile?
-   [ ] Did it pass in (emulated) iPad?
