### PR TITLE
fix(build): add missing alert-banner export

### DIFF
--- a/.changeset/core-alert-banner-export-fix.md
+++ b/.changeset/core-alert-banner-export-fix.md
@@ -1,0 +1,7 @@
+---
+'@spectrum-web-components/alert-banner': patch
+'@spectrum-web-components/core': patch
+'@adobe/swc': patch
+---
+
+**Fixed** missing export for `alert-banner` from `@spectrum-web-components/core`, which could cause build failures in certain environments.

--- a/2nd-gen/packages/core/package.json
+++ b/2nd-gen/packages/core/package.json
@@ -15,6 +15,10 @@
     },
     "type": "module",
     "exports": {
+        "./components/alert-banner": {
+            "types": "./dist/components/alert-banner/index.d.ts",
+            "import": "./dist/components/alert-banner/index.js"
+        },
         "./components/asset": {
             "types": "./dist/components/asset/index.d.ts",
             "import": "./dist/components/asset/index.js"
@@ -91,6 +95,9 @@
     },
     "typesVersions": {
         "*": {
+            "components/alert-banner": [
+                "dist/components/alert-banner/index.d.ts"
+            ],
             "components/asset": [
                 "dist/components/asset/index.d.ts"
             ],


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

Restored the missing `alert-banner` export from `@spectrum-web-components/core` by adding it to the package exports map (and typesVersions) so consumer builds can resolve `@spectrum-web-components/core/components/alert-banner`.

## Motivation and context

Some build environments fail module resolution when a subpath isn’t listed in package.json exports. Because alert-banner wasn’t exported from @spectrum-web-components/core, downstream builds could error even though the source existed.


## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
-   [x] I have added automated tests to cover my changes.
-   [x] I have included a well-written changeset if my change needs to be published.
-   [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

-   [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
-   [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
-   [ ] Automated tests cover all use cases and follow best practices for writing
-   [ ] Validated on all supported browsers
-   [ ] All VRTs are approved before the author can update Golden Hash
