### PR TITLE
docs(textfield): document autocomplete in textfield

### DIFF
--- a/1st-gen/packages/textfield/README.md
+++ b/1st-gen/packages/textfield/README.md
@@ -8,13 +8,13 @@
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/textfield?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/textfield)
 [![Try it on Stackblitz](https://img.shields.io/badge/Try%20it%20on-Stackblitz-blue?style=for-the-badge)](https://stackblitz.com/edit/vitejs-vite-wb3tywmy)
 
-```
+```zsh
 yarn add @spectrum-web-components/textfield
 ```
 
 Import the side effectful registration of `<sp-textfield>` via:
 
-```
+```js
 import '@spectrum-web-components/textfield/sp-textfield.js';
 ```
 
@@ -166,9 +166,14 @@ user affordances like mobile keyboards and obscured characters:
     id="tel-1"
     type="tel"
     placeholder="Enter your phone number"
+    autocomplete="tel"
 ></sp-textfield>
 <sp-field-label for="password-1">Password</sp-field-label>
-<sp-textfield id="password-1" type="password"></sp-textfield>
+<sp-textfield
+    id="password-1"
+    type="password"
+    autocomplete="current-password"
+></sp-textfield>
 ```
 
 If the `type` attribute is not specified, or if it does not match any of these values, the default type adopted is "text."
@@ -179,7 +184,12 @@ The quiet style works best when a clear layout (vertical stack, table, grid) ass
 
 ```html
 <sp-field-label for="name-3">Name (quietly)</sp-field-label>
-<sp-textfield id="name-3" placeholder="Enter your name" quiet></sp-textfield>
+<sp-textfield
+    id="name-3"
+    placeholder="Enter your name"
+    quiet
+    autocomplete="name"
+></sp-textfield>
 ```
 
 ### States
@@ -193,10 +203,16 @@ Use the `required` attribute to indicate a textfield value is required. Dictate 
     placeholder="Enter your name"
     valid
     value="My Name"
+    autocomplete="name"
 ></sp-textfield>
 <br />
 <sp-field-label for="name-2" required>Name</sp-field-label>
-<sp-textfield id="name-2" invalid placeholder="Enter your name"></sp-textfield>
+<sp-textfield
+    id="name-2"
+    invalid
+    autocomplete="name"
+    placeholder="Enter your name"
+></sp-textfield>
 ```
 
 ### Accessibility
@@ -220,6 +236,36 @@ Learn more about [using help text](https://spectrum.adobe.com/page/text-field/#U
 Write error messaging in a human-centered way by guiding a user and showing them a solution — don’t simply state what’s wrong and then leave them guessing as to how to resolve it. Ambiguous error messages can be frustrating and even shame-inducing for users. Also, keep in mind that something that a system may deem an error may not actually be perceived as an error to a user.
 
 Learn more about [writing error messages](https://spectrum.adobe.com/page/text-field/#Write-error-text-that-shows-a-solution).
+
+#### Autocomplete
+
+Use the `autocomplete` attribute to help users complete forms faster and with fewer errors, especially on mobile devices. Auto-complete is required only for common input fields that collect an individual’s personal data.
+
+```html
+<sp-field-label for="email-1">Email</sp-field-label>
+<sp-textfield id="email-1" type="email" autocomplete="email"></sp-textfield>
+
+<sp-field-label for="phone-1">Phone</sp-field-label>
+<sp-textfield id="phone-1" type="tel" autocomplete="tel"></sp-textfield>
+
+<sp-field-label for="name-1">Full Name</sp-field-label>
+<sp-textfield id="name-1" type="text" autocomplete="name"></sp-textfield>
+```
+
+**Common autocomplete values include**:
+
+| Input type        | Autocomplete token                                                       |
+| ----------------- | ------------------------------------------------------------------------ |
+| `type="text"`     | `name` - Full name                                                       |
+| `type="text"`     | `given-name` - First name                                                |
+| `type="text"`     | `family-name` - Last name                                                |
+| `type="email"`    | `email` - Email address                                                  |
+| `type="tel"`      | `tel` - Telephone number                                                 |
+| `type="url"`      | `url` - Website URL                                                      |
+| `type="password"` | `current-password` - Current password for login                          |
+| `type="password"` | `new-password` - New password when creating account or changing password |
+
+See the [MDN autocomplete reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for the complete list of values.
 
 #### Do not us a placeholder as a replacement for a label or help-text
 

--- a/1st-gen/packages/textfield/src/Textfield.ts
+++ b/1st-gen/packages/textfield/src/Textfield.ts
@@ -194,6 +194,10 @@ export class TextfieldBase extends ManageHelpText(
 
     /**
      * What form of assistance should be provided when attempting to supply a value to the form control
+     *
+     * Note: combobox overrides `autocomplete` intentionally with `aria-autocomplete` values, which is
+     * why those values (although invalid for native `autocomplete`) are included here to support the
+     * combobox accessibility pattern.
      */
     @property({ type: String, reflect: true })
     public autocomplete?:

--- a/1st-gen/packages/textfield/stories/textfield.stories.ts
+++ b/1st-gen/packages/textfield/stories/textfield.stories.ts
@@ -140,17 +140,29 @@ export const readonly = (): TemplateResult => html`
 export const types = (): TemplateResult => html`
     <sp-textfield label="Default" placeholder="default (text)"></sp-textfield>
     <sp-textfield label="Text" type="text" placeholder="text"></sp-textfield>
-    <sp-textfield label="URL" type="url" placeholder="url"></sp-textfield>
-    <sp-textfield label="Tel" type="tel" placeholder="tel"></sp-textfield>
+    <sp-textfield
+        label="URL"
+        type="url"
+        placeholder="url"
+        autocomplete="url"
+    ></sp-textfield>
+    <sp-textfield
+        label="Tel"
+        type="tel"
+        placeholder="tel"
+        autocomplete="tel"
+    ></sp-textfield>
     <sp-textfield
         label="E-Mail"
         type="email"
         placeholder="email"
+        autocomplete="email"
     ></sp-textfield>
     <sp-textfield
         label="Password"
         type="password"
         placeholder="password"
+        autocomplete="current-password"
     ></sp-textfield>
 `;
 


### PR DESCRIPTION
## Description

This PR fixes the `autocomplete` usage in examples in Textfield documentation. Some documentation was also added regarding the autocomplete attribute (for WCAG 2.1 Level AA compliance (Success Criterion 1.3.5: Identify Input Purpose)).

**Changes:**
**Documentation Updates**: Added appropriate `autocomplete` attributes to Textfield stories and README examples that collect personal data (name, email, telephone, password fields).

**Impact on other components**: No breaking changes. All extended components (Combobox, Search, NumberField, ColorField) continue to work correctly:
- Combobox intentionally overrides with ARIA values for `aria-autocomplete` (see the JSDoc in `Textfield.ts`)
- Search, ColorField inherit the fix automatically
- NumberField continues to set `autocomplete="off"` as expected

📝 **Note**: I didn't update every instance of `sp-textfield` throughout other stories (i.e. the textfields in the Form dialog wrapper story) since most are not actually in a form, and our Storybook is not saving any data. The ticket is about the textfield docs examples, so that's all I focused on. I did however leave some [additional validation steps](#additional-validation) if reviewers wanted to verify the autocomplete dropdowns were working when data _is_ saved. 

## Motivation and context

The `autocomplete` attribute helps users complete forms faster and with fewer errors, especially on mobile devices. This is particularly important for users with limited language, cognitive, and learning abilities, as well as those with limited manipulation abilities.

## Related issue(s)

- SWC-1176

## Screenshots (if appropriate)

N/A - Type definition change and documentation updates only.

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes. _(Existing tests verify autocomplete passthrough)_
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it. _(README and stories updated)_

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] **Verify autocomplete appears on internal input elements**
    1. Open Storybook and navigate to Textfield → [Types story](https://swcpreviews.z13.web.core.windows.net/pr-6002/docs/first-gen-storybook/?path=/story/textfield--types)
    2. Open browser DevTools and inspect the shadow DOM of each textfield
    3. Expect to see `autocomplete="tel"`, `autocomplete="email"`, `autocomplete="current-password"`, and `autocomplete="url"` on the internal `<input>` elements
    4. Open the docs site and [navigate to Textfield](https://swcpreviews.z13.web.core.windows.net/pr-6002/docs/first-gen-docs/components/textfield/)
    5. Find the [Quiet](https://swcpreviews.z13.web.core.windows.net/pr-6002/docs/first-gen-docs/components/textfield/#quiet) and [Types](https://swcpreviews.z13.web.core.windows.net/pr-6002/docs/first-gen-docs/components/textfield/#types) sections.
    6. When inspecting the textfields in the browser, verify the `type` and `autocomplete` attributes declared on the parent `sp-textfield` are passed to the child `input` element. 

- [ ] **Verify child components still work correctly**
    1. Open Storybook and [navigate to Combobox](https://swcpreviews.z13.web.core.windows.net/pr-6002/docs/first-gen-storybook/?path=/story/combobox--default) stories
    2. Verify combobox functionality works (filtering, selection, keyboard navigation)
        a. For testing filtering, add `autocomplete="list"` on `sp-combobox`
    4. Inspect shadow DOM and verify `aria-autocomplete="list"` or `aria-autocomplete="none"` is present
    8. Verify HTML `autocomplete="off"` is present on the input
    9. You may choose to repeat similar steps for Search, NumberField, and ColorField components

- [ ] **Verify no other regressions**
    1. `yarn build` returns noTypeScript errors in textfield, combobox, search, number-field, or color-field packages
    2. No VRT diffs were generated

#### Additional validation
- [ ] **Verify browser autocomplete suggestions appear**
    1. Pull down the branch, build and run 1st-gen locally
    2. In your editor, find the `dialog/dialog-wrapper.stories.ts` file
    3. In the `form` story, replace lines 221-247 with the following (basically replace the div with a form, and add some address-specific autocomplete values)


```ts
                <form action="javascript:void(0);" onsubmit="alert('Form submitted! Refresh the page and try filling out the fields again.')>
                    <sp-field-label side-aligned="end" for="street">
                        Street:
                    </sp-field-label>
                    <sp-textfield id="street" autofocus autocomplete="street-address"></sp-textfield>
                    <sp-field-label side-aligned="end" for="city">
                        City:
                    </sp-field-label>
                    <sp-textfield id="city" autocomplete="address-level2"></sp-textfield>
                    <sp-field-label side-aligned="end" for="state">
                        State:
                    </sp-field-label>
                    <sp-textfield id="state" autocomplete="address-level1"></sp-textfield>
                    <sp-field-label side-aligned="end" for="zip">
                        Zip:
                    </sp-field-label>
                    <sp-textfield id="zip" autocomplete="postal-code"></sp-textfield>
                    <sp-field-label side-aligned="end" for="instructions">
                        Special instructions:
                    </sp-field-label>
                    <sp-textfield id="instructions" multiline>
                        <sp-help-text slot="help-text">
                            For example, gate code or other information to help
                            the driver find you
                        </sp-help-text>
                    </sp-textfield>
                </form>
```


  iv. Open Storybook and navigate to Dialog wrapper → Form story
  v. Fill in the form (use dummy info) and click verify address.
  vi. Refresh the browser.
  vii. Expect browser to show autocomplete suggestions based on previously entered addresses

<img width="543" height="467" alt="Screenshot 2026-02-03 at 4 54 13 PM" src="https://github.com/user-attachments/assets/73c8ed70-efb6-449c-9741-8fcaeb83c4bd" />

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?
