### PR TITLE
chore: add second linting commit hash to blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # Local setup: git config blame.ignoreRevsFile .git-blame-ignore-revs
 # Mass formatting/linting commit to hide in blame.
 5c83d1c53c1c40be5176dc99e84bf62105fd5254
+# Mass formatting/linting commit to hide in blame.
+e8bc6d9bd30350f1b610d49ca7725288d1ebcfb6


### PR DESCRIPTION
## Description

Add `.git-blame-ignore-revs` with the repository-wide formatting/linting baseline commit:
- `e8bc6d9bd30350f1b610d49ca7725288d1ebcfb6` (https://github.com/adobe/spectrum-web-components/pull/6033)

This allows Git blame to skip mechanical formatting changes and keep line attribution focused on behavioral edits.

Please run `git config blame.ignoreRevsFile .git-blame-ignore-revs` locally to use it.

See docs: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view

## Motivation and context

A large formatting commit makes blame history noisy.  
Ignoring that revision improves code archaeology and review clarity.

## Screenshots (if appropriate)

N/A (non-visual change)

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

### Manual review test cases

- [ ] _Blame ignores formatting baseline revision_
  1. Open any file touched by https://github.com/adobe/spectrum-web-components/pull/6033 (it's prretty much all of them)
  2. View blame in GitHub.
  3. Confirm lines are attributed to prior functional commits, not the formatting baseline.
