### PR TITLE
fix(swc): export TypeScript type declarations for CSS files

### DIFF
--- a/2nd-gen/packages/swc/package.json
+++ b/2nd-gen/packages/swc/package.json
@@ -24,6 +24,7 @@
       "import": "./dist/components/*/index.js"
     },
     "./*.css": {
+      "types": "./dist/*.css.d.ts",
       "default": "./dist/*.css"
     },
     "./components/*": {

--- a/2nd-gen/packages/swc/vite.config.ts
+++ b/2nd-gen/packages/swc/vite.config.ts
@@ -51,6 +51,7 @@ function processStylesheets(): Plugin {
           to: dest,
         });
         await writeFile(dest, result.css);
+        await writeFile(`${dest}.d.ts`, 'export {};\n');
       }
     },
   };


### PR DESCRIPTION
## Description

Adds TypeScript type declarations for the `./*.css` package exports in `@adobe/spectrum-wc`, resolving `TS2307: Cannot find module '@adobe/spectrum-wc/swc.css' or its corresponding type declarations` errors for consumers.

**Changes:**

- `package.json`: Added `"types": "./dist/*.css.d.ts"` to the `./*.css` export entry so TypeScript can resolve CSS imports via the package exports map.
- `vite.config.ts`: Updated the `processStylesheets` Vite plugin to emit a `.css.d.ts` declaration file (`export {};`) alongside each processed CSS file during build.

The declaration files use `export {};` — the correct minimal TypeScript module declaration for global stylesheet imports used as side effects (e.g. `import '@adobe/spectrum-wc/swc.css'`).

## Motivation and context

Consumers of `@adobe/spectrum-wc` who import global stylesheets in TypeScript projects were getting a hard build error:

```
TS2307: Cannot find module '@adobe/spectrum-wc/swc.css' or its corresponding type declarations.
```

This happened because the package exports map had a `./*.css` entry with only a `default` field and no `types` field, so TypeScript could not resolve the module.

## Related issue(s)

- fixes [Issue Number]

## Screenshots (if appropriate)

---

## Author's checklist

- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Import `@adobe/spectrum-wc/swc.css` in a TypeScript project and confirm no `TS2307` error is thrown.
  1. Add `import '@adobe/spectrum-wc/swc.css'` to a `.ts` file in a consumer project
  2. Run `tsc --noEmit`
  3. Expect no TypeScript errors related to the CSS import

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

N/A — this is a build/type declaration fix with no runtime or UI changes.

Made with [Cursor](https://cursor.com)