### PR TITLE
feat(combobox, slider, picker-button, number-field): optional haptic feedback for accessibilityeedback on webkit api

### DIFF
--- a/1st-gen/packages/combobox/src/Combobox.ts
+++ b/1st-gen/packages/combobox/src/Combobox.ts
@@ -95,8 +95,21 @@ export class Combobox extends Textfield {
   @property({ type: String, attribute: 'pending-label' })
   public pendingLabel = 'Pending';
 
+  /**
+   * When true, enables haptic feedback on supported platforms (e.g. iOS 18+ Safari)
+   * for accessibility. Uses the native `<input type="checkbox" switch>` haptic
+   * by toggling a hidden control on selection and when the list opens.
+   *
+   * @see https://webkit.org/blog/15865/webkit-features-in-safari-18-0/
+   */
+  @property({ type: Boolean, attribute: 'haptic-feedback', reflect: true })
+  public hapticFeedback = false;
+
   @query('slot:not([name])')
   private optionSlot!: HTMLSlotElement;
+
+  @query('#haptic-trigger')
+  private hapticTriggerEl?: HTMLInputElement;
 
   @state()
   overlayOpen = false;
@@ -306,6 +319,7 @@ export class Combobox extends Textfield {
       (item) => item.value === target?.value
     );
     this.value = selected?.itemText || '';
+    this.triggerHapticFeedback();
     event.preventDefault();
     this.open = false;
     this._returnItems();
@@ -321,12 +335,36 @@ export class Combobox extends Textfield {
     // Do stuff here?
   }
 
+  /**
+   * Triggers haptic feedback when enabled. Uses Vibration API on Android when
+   * available; on iOS (no vibrate), programmatically clicks the hidden switch's
+   * label so the native switch haptic fires (Safari 18+).
+   *
+   * @see https://codepen.io/jh3y/pen/PwGPaZQ
+   */
+  private triggerHapticFeedback(): void {
+    if (!this.hapticFeedback) {
+      return;
+    }
+    if ('vibrate' in navigator) {
+      navigator.vibrate(16);
+      return;
+    }
+    const label = this.shadowRoot?.getElementById('haptic-label');
+    if (label) {
+      label.click();
+    }
+  }
+
   public toggleOpen(): void {
     if (this.readonly || this.pending) {
       this.open = false;
       return;
     }
     this.open = !this.open;
+    if (this.open) {
+      this.triggerHapticFeedback();
+    }
     this.inputElement.focus();
   }
 
@@ -524,6 +562,23 @@ export class Combobox extends Textfield {
         </sp-popover>
       </sp-overlay>
       ${this.renderVisuallyHiddenLabels()}
+      ${this.hapticFeedback
+        ? html`
+            <label
+              id="haptic-label"
+              for="haptic-trigger"
+              class="visually-hidden"
+              aria-hidden="true"
+            ></label>
+            <input
+              type="checkbox"
+              id="haptic-trigger"
+              class="visually-hidden"
+              aria-hidden="true"
+              tabindex="-1"
+            />
+          `
+        : nothing}
       <slot
         aria-hidden="true"
         name="tooltip"
@@ -567,6 +622,9 @@ export class Combobox extends Textfield {
   }
 
   protected override updated(changed: PropertyValues<this>): void {
+    if (this.hapticFeedback && this.hapticTriggerEl) {
+      this.hapticTriggerEl.setAttribute('switch', '');
+    }
     if (changed.has('open') && !this.pending) {
       this.manageListOverlay();
     }

--- a/1st-gen/packages/combobox/stories/args.ts
+++ b/1st-gen/packages/combobox/stories/args.ts
@@ -84,4 +84,17 @@ export const argTypes = {
       type: 'boolean',
     },
   },
+  hapticFeedback: {
+    name: 'hapticFeedback',
+    type: { name: 'boolean', required: false },
+    description:
+      'Enables haptic feedback on supported platforms (e.g. iOS 18+ Safari) for accessibility.',
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
+    control: {
+      type: 'boolean',
+    },
+  },
 };

--- a/1st-gen/packages/combobox/stories/combobox.stories.ts
+++ b/1st-gen/packages/combobox/stories/combobox.stories.ts
@@ -73,6 +73,119 @@ readonly.args = {
   value: 'Solomon Islands',
 };
 
+export const webHaptics = (args: StoryArgs): TemplateResult => html`
+  <div class="web-haptics-story">
+    <div class="web-haptics-story__instructions">
+      <h3>Web Haptics (accessibility)</h3>
+      <p>
+        Test haptic feedback on
+        <strong>iOS 18+ Safari</strong>
+        (iPhone/iPad). Haptics fire when you open the list and when you select
+        an option.
+      </p>
+      <ul>
+        <li>
+          <strong>With haptics:</strong>
+          tap the first combobox — you should feel a tap when the list opens and
+          again when you pick an option.
+        </li>
+        <li>
+          <strong>Without haptics:</strong>
+          second combobox has haptics disabled for comparison.
+        </li>
+      </ul>
+      <p>
+        Uses the native
+        <code>&lt;input type="checkbox" switch&gt;</code>
+        haptic in Safari 18.
+        <a
+          href="https://webkit.org/blog/15865/webkit-features-in-safari-18-0/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          WebKit blog
+        </a>
+        .
+      </p>
+    </div>
+    <div class="web-haptics-story__demos">
+      <div class="web-haptics-story__demo">
+        <sp-field-label for="combobox-haptic-on">
+          With haptic feedback
+        </sp-field-label>
+        <sp-combobox
+          id="combobox-haptic-on"
+          .options=${fruits}
+          .value=${args.value ?? ''}
+          ?haptic-feedback=${true}
+        ></sp-combobox>
+      </div>
+      <div class="web-haptics-story__demo">
+        <sp-field-label for="combobox-haptic-off">
+          Without haptic feedback
+        </sp-field-label>
+        <sp-combobox
+          id="combobox-haptic-off"
+          .options=${fruits}
+          .value=${args.value ?? ''}
+        ></sp-combobox>
+      </div>
+    </div>
+  </div>
+  <style>
+    .web-haptics-story {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      max-inline-size: 32rem;
+    }
+    .web-haptics-story__instructions {
+      padding: 1rem;
+      background: var(--spectrum-gray-100, #f5f5f5);
+      border-radius: 0.5rem;
+    }
+    .web-haptics-story__instructions h3 {
+      margin: 0 0 0.5rem 0;
+      font-size: 1.125rem;
+    }
+    .web-haptics-story__instructions p,
+    .web-haptics-story__instructions ul {
+      margin: 0.5rem 0 0 0;
+      font-size: 0.875rem;
+    }
+    .web-haptics-story__instructions code {
+      font-size: 0.8125rem;
+      padding: 0.125rem 0.25rem;
+      background: var(--spectrum-gray-200, #e5e5e5);
+      border-radius: 0.25rem;
+    }
+    .web-haptics-story__instructions a {
+      color: var(--spectrum-blue-600, #0d66d0);
+    }
+    .web-haptics-story__demos {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .web-haptics-story__demo {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+  </style>
+`;
+webHaptics.args = {
+  value: '',
+};
+webHaptics.parameters = {
+  docs: {
+    description: {
+      story:
+        'Side-by-side comboboxes to test native haptic feedback on iOS 18+ Safari. Enable haptics for accessibility when users benefit from tactile confirmation (e.g. open list, selection).',
+    },
+  },
+};
+
 export const hasDisabledItems = (args: StoryArgs): TemplateResult => {
   // let's create a new array from countries and set the disabled property to true if the value is in args.disabledItems
   const countriesWithDisabledItems = countries.map((country) => ({

--- a/1st-gen/packages/combobox/stories/index.ts
+++ b/1st-gen/packages/combobox/stories/index.ts
@@ -30,6 +30,7 @@ export type StoryArgs = {
   value?: string;
   disabledItems?: string[];
   autocomplete?: 'list' | 'none';
+  hapticFeedback?: boolean;
   size?: ElementSize;
   onChange?: (val: string) => void;
   onInput?: (val: string) => void;

--- a/1st-gen/packages/number-field/src/NumberField.ts
+++ b/1st-gen/packages/number-field/src/NumberField.ts
@@ -157,6 +157,16 @@ export class NumberField extends TextfieldBase {
   @property({ type: Number, reflect: true, attribute: 'step-modifier' })
   public stepModifier = 10;
 
+  /**
+   * When true, triggers haptic feedback on value commit (stepper release, input
+   * change, keyboard step). Same pattern as combobox/slider/picker-button.
+   */
+  @property({ type: Boolean, attribute: 'haptic-feedback', reflect: true })
+  public hapticFeedback = false;
+
+  @query('#haptic-trigger')
+  private hapticTriggerEl?: HTMLInputElement;
+
   @property({ type: Number })
   public override set value(rawValue: number) {
     const value = this.validateInput(rawValue);
@@ -193,8 +203,23 @@ export class NumberField extends TextfieldBase {
     }
 
     this.lastCommitedValue = this.value;
+    this.triggerHapticFeedback();
 
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+  }
+
+  public triggerHapticFeedback(): void {
+    if (!this.hapticFeedback) {
+      return;
+    }
+    if ('vibrate' in navigator) {
+      navigator.vibrate(16);
+      return;
+    }
+    const label = this.shadowRoot?.getElementById('haptic-label');
+    if (label) {
+      label.click();
+    }
   }
 
   /**
@@ -728,6 +753,24 @@ export class NumberField extends TextfieldBase {
     this.autocomplete = 'off';
     return html`
       ${super.renderField()}
+      ${this.hapticFeedback
+        ? html`
+            <label
+              id="haptic-label"
+              for="haptic-trigger"
+              class="visually-hidden"
+              aria-hidden="true"
+            ></label>
+            <input
+              style="display: none;"
+              type="checkbox"
+              id="haptic-trigger"
+              class="visually-hidden"
+              aria-hidden="true"
+              tabindex="-1"
+            />
+          `
+        : nothing}
       ${this.hideStepper
         ? nothing
         : html`
@@ -826,6 +869,9 @@ export class NumberField extends TextfieldBase {
   }
 
   protected override updated(changes: PropertyValues<this>): void {
+    if (this.hapticFeedback && this.hapticTriggerEl) {
+      this.hapticTriggerEl.setAttribute('switch', '');
+    }
     if (!this.inputElement || !this.isConnected) {
       // Prevent race conditions if inputElement is removed from DOM while a queued update is still running.
       return;

--- a/1st-gen/packages/number-field/stories/number-field.stories.ts
+++ b/1st-gen/packages/number-field/stories/number-field.stories.ts
@@ -216,6 +216,91 @@ Default.args = {
   value: 100,
 };
 
+const webHapticsStyles = `
+  .web-haptics-story { display: flex; flex-direction: column; gap: 1.5rem; max-inline-size: 32rem; }
+  .web-haptics-story__instructions { padding: 1rem; background: var(--spectrum-gray-100, #f5f5f5); border-radius: 0.5rem; }
+  .web-haptics-story__instructions h3 { margin: 0 0 0.5rem 0; font-size: 1.125rem; }
+  .web-haptics-story__instructions p, .web-haptics-story__instructions ul { margin: 0.5rem 0 0 0; font-size: 0.875rem; }
+  .web-haptics-story__instructions code { font-size: 0.8125rem; padding: 0.125rem 0.25rem; background: var(--spectrum-gray-200, #e5e5e5); border-radius: 0.25rem; }
+  .web-haptics-story__instructions a { color: var(--spectrum-blue-600, #0d66d0); }
+  .web-haptics-story__demos { display: flex; flex-direction: column; gap: 1rem; }
+  .web-haptics-story__demo { display: flex; flex-direction: column; gap: 0.25rem; }
+`;
+
+export const WebHaptics = (): TemplateResult => html`
+  <div class="web-haptics-story">
+    <div class="web-haptics-story__instructions">
+      <h3>Web Haptics (accessibility)</h3>
+      <p>
+        Test on
+        <strong>iOS 18+ Safari</strong>
+        or Android. Haptic fires when you
+        <strong>commit a value</strong>
+        (stepper release, input change, or keyboard step) — same pattern as
+        combobox/slider.
+      </p>
+      <ul>
+        <li>
+          <strong>With haptics:</strong>
+          use the stepper or type and blur; feel a tap on commit.
+        </li>
+        <li>
+          <strong>Without haptics:</strong>
+          second field for comparison.
+        </li>
+      </ul>
+      <p>
+        <a
+          href="https://webkit.org/blog/15865/webkit-features-in-safari-18-0/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          WebKit blog
+        </a>
+        .
+      </p>
+    </div>
+    <div class="web-haptics-story__demos">
+      <div class="web-haptics-story__demo">
+        <sp-field-label for="number-haptic-on">
+          With haptic feedback
+        </sp-field-label>
+        <sp-number-field
+          id="number-haptic-on"
+          label="Quantity"
+          value="50"
+          min="0"
+          max="100"
+          haptic-feedback
+        ></sp-number-field>
+      </div>
+      <div class="web-haptics-story__demo">
+        <sp-field-label for="number-haptic-off">
+          Without haptic feedback
+        </sp-field-label>
+        <sp-number-field
+          id="number-haptic-off"
+          label="Quantity"
+          value="50"
+          min="0"
+          max="100"
+        ></sp-number-field>
+      </div>
+    </div>
+  </div>
+  <style>
+    ${webHapticsStyles}
+  </style>
+`;
+WebHaptics.parameters = {
+  docs: {
+    description: {
+      story:
+        'Side-by-side number fields to test haptic feedback on value commit (stepper release, input change, keyboard step).',
+    },
+  },
+};
+
 export const quiet = (args: StoryArgs = {}): TemplateResult => Default(args);
 
 quiet.args = {

--- a/1st-gen/packages/picker-button/src/PickerButton.ts
+++ b/1st-gen/packages/picker-button/src/PickerButton.ts
@@ -13,10 +13,15 @@ import {
   CSSResultArray,
   DefaultElementSize,
   html,
+  nothing,
+  PropertyValues,
   SizedMixin,
   TemplateResult,
 } from '@spectrum-web-components/base';
-import { property } from '@spectrum-web-components/base/src/decorators.js';
+import {
+  property,
+  query,
+} from '@spectrum-web-components/base/src/decorators.js';
 import { classMap } from '@spectrum-web-components/base/src/directives.js';
 import { ButtonBase } from '@spectrum-web-components/button/src/ButtonBase.js';
 import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
@@ -49,8 +54,52 @@ export class PickerButton extends SizedMixin(
   @property({ reflect: true })
   position: 'left' | 'right' = 'right';
 
+  /**
+   * When true, triggers haptic feedback on click (release). Same pattern as
+   * combobox/slider: Vibration API on Android; native switch haptic on iOS 18+.
+   */
+  @property({ type: Boolean, attribute: 'haptic-feedback', reflect: true })
+  public hapticFeedback = false;
+
+  @query('#haptic-trigger')
+  private hapticTriggerEl?: HTMLInputElement;
+
   protected get hasText(): boolean {
     return this.slotContentIsPresent;
+  }
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    this.addEventListener('click', this.handleClickHaptic);
+  }
+
+  public override disconnectedCallback(): void {
+    this.removeEventListener('click', this.handleClickHaptic);
+    super.disconnectedCallback();
+  }
+
+  private handleClickHaptic = (): void => {
+    this.triggerHapticFeedback();
+  };
+
+  public triggerHapticFeedback(): void {
+    if (!this.hapticFeedback) {
+      return;
+    }
+    if ('vibrate' in navigator) {
+      navigator.vibrate(16);
+      return;
+    }
+    const label = this.shadowRoot?.getElementById('haptic-label');
+    if (label) {
+      label.click();
+    }
+  }
+
+  protected override updated(_changed: PropertyValues): void {
+    if (this.hapticFeedback && this.hapticTriggerEl) {
+      this.hapticTriggerEl.setAttribute('switch', '');
+    }
   }
 
   protected override render(): TemplateResult {
@@ -60,6 +109,24 @@ export class PickerButton extends SizedMixin(
       textuiicon: this.hasText,
     };
     return html`
+      ${this.hapticFeedback
+        ? html`
+            <label
+              id="haptic-label"
+              for="haptic-trigger"
+              class="visually-hidden"
+              aria-hidden="true"
+            ></label>
+            <input
+              style="display: none;"
+              type="checkbox"
+              id="haptic-trigger"
+              class="visually-hidden"
+              aria-hidden="true"
+              tabindex="-1"
+            />
+          `
+        : nothing}
       <div class=${classMap(rootClasses)}>
         <div class="spectrum-PickerButton-fill">
           <span

--- a/1st-gen/packages/picker-button/stories/picker-button.stories.ts
+++ b/1st-gen/packages/picker-button/stories/picker-button.stories.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { TemplateResult } from '@spectrum-web-components/base';
+import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/picker-button/sp-picker-button.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-add.js';
@@ -60,4 +60,75 @@ export const roundedLabel = (args: StoryArgs): TemplateResult => Template(args);
 roundedLabel.args = {
   label: true,
   rounded: true,
+};
+
+const webHapticsStyles = `
+  .web-haptics-story { display: flex; flex-direction: column; gap: 1.5rem; max-inline-size: 32rem; }
+  .web-haptics-story__instructions { padding: 1rem; background: var(--spectrum-gray-100, #f5f5f5); border-radius: 0.5rem; }
+  .web-haptics-story__instructions h3 { margin: 0 0 0.5rem 0; font-size: 1.125rem; }
+  .web-haptics-story__instructions p, .web-haptics-story__instructions ul { margin: 0.5rem 0 0 0; font-size: 0.875rem; }
+  .web-haptics-story__instructions code { font-size: 0.8125rem; padding: 0.125rem 0.25rem; background: var(--spectrum-gray-200, #e5e5e5); border-radius: 0.25rem; }
+  .web-haptics-story__instructions a { color: var(--spectrum-blue-600, #0d66d0); }
+  .web-haptics-story__demos { display: flex; flex-direction: column; gap: 1rem; }
+  .web-haptics-story__demo { display: flex; flex-direction: column; gap: 0.25rem; }
+`;
+
+export const WebHaptics = (): TemplateResult => html`
+  <div class="web-haptics-story">
+    <div class="web-haptics-story__instructions">
+      <h3>Web Haptics (accessibility)</h3>
+      <p>
+        Test on
+        <strong>iOS 18+ Safari</strong>
+        or Android. Haptic fires on
+        <strong>release</strong>
+        (click) — same pattern as combobox/slider.
+      </p>
+      <ul>
+        <li>
+          <strong>With haptics:</strong>
+          tap the first button; feel a tap when you release.
+        </li>
+        <li>
+          <strong>Without haptics:</strong>
+          second button for comparison.
+        </li>
+      </ul>
+      <p>
+        <a
+          href="https://webkit.org/blog/15865/webkit-features-in-safari-18-0/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          WebKit blog
+        </a>
+        .
+      </p>
+    </div>
+    <div class="web-haptics-story__demos">
+      <div class="web-haptics-story__demo">
+        <span style="font-size: 14px; font-weight: 600;">
+          With haptic feedback
+        </span>
+        <sp-picker-button haptic-feedback></sp-picker-button>
+      </div>
+      <div class="web-haptics-story__demo">
+        <span style="font-size: 14px; font-weight: 600;">
+          Without haptic feedback
+        </span>
+        <sp-picker-button></sp-picker-button>
+      </div>
+    </div>
+  </div>
+  <style>
+    ${webHapticsStyles}
+  </style>
+`;
+WebHaptics.parameters = {
+  docs: {
+    description: {
+      story:
+        'Side-by-side picker buttons to test haptic feedback on click (release). Enable haptics for accessibility when users benefit from tactile confirmation.',
+    },
+  },
 };

--- a/1st-gen/packages/slider/src/HandleController.ts
+++ b/1st-gen/packages/slider/src/HandleController.ts
@@ -381,6 +381,8 @@ export class HandleController {
     this.cancelDrag(model);
     this.requestUpdate();
     this.host.track.releasePointerCapture(event.pointerId);
+    // Haptic on pointerup: reliable on iOS/touch (often not on pointerdown)
+    this.host.triggerHapticFeedback?.();
     this.dispatchChangeEvent(input, model.handle);
   }
 
@@ -416,6 +418,7 @@ export class HandleController {
     const input = event.target as InputWithModel;
     input.model.handle.value = input.valueAsNumber;
 
+    this.host.triggerHapticFeedback?.();
     this.requestUpdate();
     this.dispatchChangeEvent(input, input.model.handle);
   };

--- a/1st-gen/packages/slider/src/Slider.ts
+++ b/1st-gen/packages/slider/src/Slider.ts
@@ -165,8 +165,20 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
   @property({ type: Boolean, reflect: true })
   public override disabled = false;
 
+  /**
+   * When true, enables haptic feedback on click (release) interaction
+   * (Vibration API on Android; native switch haptic on iOS 18+ Safari).
+   *
+   * @see https://webkit.org/blog/15865/webkit-features-in-safari-18-0/
+   */
+  @property({ type: Boolean, attribute: 'haptic-feedback', reflect: true })
+  public hapticFeedback = false;
+
   @property({ type: Number, reflect: true, attribute: 'fill-start' })
   public fillStart?: number | boolean;
+
+  @query('#haptic-trigger')
+  private hapticTriggerEl?: HTMLInputElement;
 
   /**
    * Applies `quiet` to the underlying `sp-number-field` when `editable === true`.
@@ -204,9 +216,44 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
     }
   }
 
+  /**
+   * Triggers haptic feedback when enabled (e.g. on handle press).
+   * Uses Vibration API on Android; on iOS, clicks the hidden switch label.
+   */
+  public triggerHapticFeedback(): void {
+    if (!this.hapticFeedback) {
+      return;
+    }
+    if ('vibrate' in navigator) {
+      navigator.vibrate(16);
+      return;
+    }
+    const label = this.shadowRoot?.getElementById('haptic-label');
+    if (label) {
+      label.click();
+    }
+  }
+
   protected override render(): TemplateResult {
     return html`
       ${this.renderLabel()} ${this.renderTrack()}
+      ${this.hapticFeedback
+        ? html`
+            <label
+              id="haptic-label"
+              for="haptic-trigger"
+              class="visually-hidden"
+              aria-hidden="true"
+            ></label>
+            <input
+              type="checkbox"
+              id="haptic-trigger"
+              class="visually-hidden"
+              aria-hidden="true"
+              tabindex="-1"
+            />
+          `
+        : nothing}
       ${this.editable
         ? html`
             <sp-number-field
@@ -552,6 +599,12 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
     }
     await this.handleController.handleUpdatesComplete();
     return complete;
+  }
+
+  protected override updated(_changed: PropertyValues): void {
+    if (this.hapticFeedback && this.hapticTriggerEl) {
+      this.hapticTriggerEl.setAttribute('switch', '');
+    }
   }
 
   protected override willUpdate(changed: PropertyValues): void {

--- a/1st-gen/packages/slider/stories/slider.stories.ts
+++ b/1st-gen/packages/slider/stories/slider.stories.ts
@@ -80,6 +80,7 @@ export interface StoryArgs {
   variant?: string;
   tickStep?: number;
   labelVisibility?: string;
+  hapticFeedback?: boolean;
   onInput?: (val: string) => void;
   onChange?: (val: string) => void;
   min?: number;
@@ -141,6 +142,30 @@ export const Default = (args: StoryArgs = {}): TemplateResult => {
     </div>
   `;
 };
+
+export const WebHaptics = (args: StoryArgs = {}): TemplateResult => {
+  return html`
+    <div style="width: 500px; margin-inline: 20px;">
+      <p style="font-size: 14px; margin-bottom: 12px;">
+        Haptic feedback fires when you commit a value (release after drag, or
+        change via keyboard), same as combobox on selection (iOS 18+ Safari or
+        Android Vibration API).
+      </p>
+      <sp-slider
+        label="Volume"
+        max="100"
+        min="0"
+        value="50"
+        step="1"
+        ?haptic-feedback=${args.hapticFeedback ?? true}
+        @input=${handleEvent(args)}
+        @change=${handleEvent(args)}
+        ...=${spreadProps(args)}
+      ></sp-slider>
+    </div>
+  `;
+};
+WebHaptics.args = { hapticFeedback: true };
 
 export const Filled = (args: StoryArgs = {}): TemplateResult => {
   return html`


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

Adds optional **haptic feedback** to four 1st-gen components (Combobox, Slider, Picker Button, Number Field) for better accessibility on supported mobile devices.

- **New property:** `hapticFeedback` (boolean, default `false`), attribute `haptic-feedback`.
- **Behavior when enabled:**  
  - Uses **Vibration API** (`navigator.vibrate(16)`) when available.  
  - On iOS 18+, falls back to a visually hidden native switch control triggered via programmatic `label.click()` to leverage system haptics when Vibration API is not supported.
- **Trigger points:**
  - **Combobox:** list open; option selected.
  - **Slider:** pointer up; value commit (single and multi-handle).
  - **Picker Button:** click/release.
  - **Number Field:** value commit (stepper buttons, input change, keyboard step).
- **Number Field (mobile):** The haptic switch is fully hidden on mobile: `opacity: 0`, `appearance: none`, and `pointer-events: none` are applied only to the native switch input (`#haptic-trigger`), so the label remains programmatically clickable for haptics without showing the control.
- **Storybook:** New “Web Haptics” stories for each component with instructions and demos (with/without haptic feedback).

## Motivation and context

Haptic feedback improves usability and accessibility on touch devices by confirming interactions (e.g., list open, selection, value change) without relying solely on visual or auditory feedback. This change keeps haptics opt-in so existing apps are unchanged and authors can enable it where it adds value.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- fixes [Issue Number] _(or N/A if no issue yet)_

## Screenshots (if appropriate)

N/A — behavior is haptic and/or visible only when `haptic-feedback` is set and tested on a supporting device/emulator.

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published. _(Note: 1st-gen is in changeset ignore; add a changeset only if your release process publishes these packages.)_
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

- [ ] **Combobox — haptic feedback**
  1. Open Storybook → Combobox → “Web Haptics” (or story with `haptic-feedback`).
  2. On a device/emulator that supports vibration or iOS 18+ haptics, open the combobox and select an option.
  3. Expect a short haptic pulse when the list opens and when an option is selected (no visible UI change beyond existing behavior).

- [ ] **Slider — haptic feedback**
  1. Open Storybook → Slider → “Web Haptics” (or story with `haptic-feedback`).
  2. Drag a handle and release; on multi-handle, move a handle and commit.
  3. Expect haptic feedback on pointer up / value commit.

- [ ] **Picker Button — haptic feedback**
  1. Open Storybook → Picker Button → “Web Haptics” (or story with `haptic-feedback`).
  2. Click the picker button.
  3. Expect haptic feedback on click/release.

- [ ] **Number Field — haptic feedback and hidden switch**
  1. Open Storybook → Number Field → “Web Haptics” (or story with `haptic-feedback`).
  2. Change value via stepper, typing, or arrow keys; commit value.
  3. Expect haptic feedback on value commit. On mobile viewport, confirm the native switch is not visible (no extra control shown).

- [ ] **Number Field — default (no haptics)**
  1. Use Number Field without `haptic-feedback` (default).
  2. Confirm behavior and layout are unchanged; no hidden switch or haptics.

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

<!---
    Manual accessibility testing is required because automated tools cannot catch all issues (e.g. focus order, screen reader announcements, keyboard flow).
    You must document your keyboard and screen reader testing steps below. Reviewers will use this checklist during review.
    See: [Accessibility testing guide](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTOR-DOCS/01_contributor-guides/09_accessibility-testing.md)
-->

**Required:** Complete each applicable item and document your testing steps (replace the placeholders with your component-specific instructions).

- [ ] **Keyboard** (required — document steps below) — _What to test for:_ Focus order is logical; <kbd>Tab</kbd> reaches the component and all interactive descendants; <kbd>Enter</kbd>/<kbd>Space</kbd> activate where appropriate; arrow keys work for tabs, menus, sliders, etc.; no focus traps; <kbd>Escape</kbd> dismisses when applicable; focus indicator is visible.
  1. Go to each component’s Storybook story (Combobox, Slider, Picker Button, Number Field).
  2. Tab to the component, use keyboard to open/change value/select; ensure no new focusable elements are exposed (hidden switch is not in tab order).
  3. Expect same keyboard behavior as before; haptics (when enabled) fire on the same commit/selection events.

- [ ] **Screen reader** (required — document steps below) — _What to test for:_ Role and name are announced correctly; state changes (e.g. expanded, selected) are announced; labels and relationships are clear; no unnecessary or duplicate announcements.
  1. Go to each component’s Storybook story with `haptic-feedback` enabled.
  2. Use screen reader to operate the component (open list, select, change value).
  3. Expect no new or duplicate announcements from the haptic implementation; the hidden switch (when used) should not be announced or focused.
