### PR TITLE
docs: fix markdown table syntax in fonts guide

### DIFF
--- a/2nd-gen/packages/swc/.storybook/guides/customization/fonts.mdx
+++ b/2nd-gen/packages/swc/.storybook/guides/customization/fonts.mdx
@@ -214,13 +214,13 @@ Add this before switching locales. The event is dispatched by both `preview-head
 
 #### CJK Troubleshooting
 
-| What you might look for                                 | What you'll find                            | Why                                                                        |
-| ------------------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------- | --- |
-| `<style>` element with CJK `@font-face` rules           | Not present                                 | CJK fonts registered via CSS Font Loading API, not DOM injection           |
-| `[data-swc-typekit-dynamic]` elements with `@font-face` | Not present                                 | MutationObserver only stamps `.tk-*` helper `<style>` elements             |
-| `<link rel="stylesheet">` to CJK kit CSS                | Not present                                 | CSS URLs return 412; CJK kits are JS-only delivery                         |
-| CJK `@font-face` in DevTools Sources/Network            | Present under the JS script, not a CSS file | Delivered via `Typekit.load()` JS execution                                |
-| CJK font-family name present in "Rendered Fonts"        | Numerical font id, not the font-family name | Dyinamic subsetting streams specific glyphs in addition to the font-family |     |
+| What you might look for                                 | What you'll find                            | Why                                                                       |
+| ------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------- |
+| `<style>` element with CJK `@font-face` rules           | Not present                                 | CJK fonts registered via CSS Font Loading API, not DOM injection          |
+| `[data-swc-typekit-dynamic]` elements with `@font-face` | Not present                                 | MutationObserver only stamps `.tk-*` helper `<style>` elements            |
+| `<link rel="stylesheet">` to CJK kit CSS                | Not present                                 | CSS URLs return 412; CJK kits are JS-only delivery                        |
+| CJK `@font-face` in DevTools Sources/Network            | Present under the JS script, not a CSS file | Delivered via `Typekit.load()` JS execution                               |
+| CJK font-family name present in "Rendered Fonts"        | Numerical font id, not the font-family name | Dynamic subsetting streams specific glyphs in addition to the font-family |
 
 ## Adding a new locale
 


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

Corrects the CJK Troubleshooting markdown table in `2nd-gen/packages/swc/.storybook/guides/customization/fonts.mdx`. The table had invalid syntax (extra column separator and misaligned rows), so it did not render as a proper 3-column table. Also fixes the typo "Dyinamic" → "Dynamic" in the last row.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

The CJK Troubleshooting table in the Fonts guide was not rendering correctly due to markdown table syntax errors. This fix ensures the reference table displays correctly in Storybook and on GitHub.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- fixes [Issue Number]

## Screenshots (if appropriate)

🚫 Before

<img width="735" height="292" alt="Screenshot 2026-03-09 at 12 05 01 PM" src="https://github.com/user-attachments/assets/687827c7-c537-475d-802d-777fb73a5b9a" />

✅ After

<img width="720" height="491" alt="Screenshot 2026-03-09 at 12 02 35 PM" src="https://github.com/user-attachments/assets/0b00a373-cc0a-4aa4-b220-31016419adbf" />

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

- [ ] Open the [Fonts guide](https://github.com/adobe/spectrum-web-components/blob/main/2nd-gen/packages/swc/.storybook/guides/customization/fonts.mdx) in 2nd-gen Storybook (Customization → Fonts) and confirm the "CJK Troubleshooting" table renders as a proper 3-column table with no broken rows or extra columns.

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?
