### PR TITLE
fix(storybook-icon): fix contrast by adopting static color background tokens

### DIFF
--- a/1st-gen/packages/button/README.md
+++ b/1st-gen/packages/button/README.md
@@ -251,7 +251,7 @@ The `treatment` attribute accepts `fill` and `outline` as values, and defaults t
 
 ```html demo
 <sp-button-group
-  style="background: var(--spectrum-seafoam-600); padding: 0.5em; min-width: max-content"
+  style="background: var(--spectrum-docs-static-black-background-color); padding: 0.5em; min-width: max-content"
 >
   <sp-button treatment="outline" static-color="black">Label only</sp-button>
   <sp-button treatment="outline" static-color="black">
@@ -275,7 +275,7 @@ The `treatment` attribute accepts `fill` and `outline` as values, and defaults t
 
 ```html demo
 <sp-button-group
-  style="background: var(--spectrum-seafoam-600); padding: 0.5em; min-width: max-content"
+  style="background: var(--spectrum-docs-static-white-background-color); padding: 0.5em; min-width: max-content"
 >
   <sp-button treatment="outline" static-color="white">Label only</sp-button>
   <sp-button treatment="outline" static-color="white">
@@ -442,6 +442,8 @@ A screen reader user will not encounter href buttons when navigating by buttons 
 #### Use static black or static white to contrast with backgrounds and images
 
 To ensure maximum contrast with the background, use static black for light backgrounds and images, and static white for dark backgrounds and images. Avoid placing static components on top of busy images with a lot of variance in contrast.
+
+> **Contrast requirement**: When using `treatment="outline"` with `static-color`, the button's text, icons, and border must maintain a minimum **3:1** contrast ratio against the background per [WCAG 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast). Choose background colors carefully to meet this threshold. For example, `--spectrum-seafoam-600` provides only **2.5:1** contrast with white, which fails the requirement.
 
 <sp-tabs selected="black" auto label="Static variants for contrast">
 <sp-tab value="black">Static black on light background</sp-tab>


### PR DESCRIPTION
## Description

Replaced `var(--spectrum-seafoam-600)` background color in the button README's "Outline, black" and "Outline, white" treatment examples with the semantic tokens `--spectrum-docs-static-black-background-color` and `--spectrum-docs-static-white-background-color`, respectively. Added a contrast requirement callout in the Accessibility section warning authors to maintain a minimum 3:1 contrast ratio when using `treatment="outline"` with `static-color`.

## Motivation and context

The Help icon in the "Outline, white" treatment tab had a contrast ratio of only 2.5:1 (white #FFFFFF on `--spectrum-seafoam-600` #0FB5AE), failing the WCAG 1.4.11 Non-text Contrast (Level AA) requirement of 3:1. The same token was used for the "Outline, black" tab. Both backgrounds have been replaced with purpose-built semantic tokens that provide sufficient contrast across all themes (~13:1 for black, ~5.2:1 for white).

## Related issue(s)

- fixes SWC-1114

## Screenshots (if appropriate)

<img width="324" height="70" alt="Screenshot 2026-03-11 at 9 40 15 AM" src="https://github.com/user-attachments/assets/98bc5921-3c67-457c-8205-1d1d4923f842" />

<img width="329" height="74" alt="Screenshot 2026-03-11 at 9 50 55 AM" src="https://github.com/user-attachments/assets/a9159b82-e74c-453a-a2f1-04eedb88a2e3" />

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link

### Manual review test cases

- [ ] _Outline, black tab background provides sufficient contrast_
  1. Go to the [button component docs](http://localhost:4000/components/button/) (or deployed preview)
  2. Scroll to **Options > Treatment** and click the **Outline, black** tab
  3. Expect a light teal background (rgb(181, 209, 211)) with black button text, borders, and icons clearly visible (~13:1 contrast)

- [ ] _Outline, white tab background provides sufficient contrast_
  1. Go to the [button component docs](http://localhost:4000/components/button/) (or deployed preview)
  2. Scroll to **Options > Treatment** and click the **Outline, white** tab
  3. Expect a dark teal background (rgb(15, 121, 125)) with white button text, borders, and icons clearly visible (~5.2:1 contrast)

- [ ] _Accessibility guidance is present_
  1. Go to the [button component docs](http://localhost:4000/components/button/) (or deployed preview)
  2. Scroll to **Accessibility > Use static black or static white to contrast with backgrounds and images**
  3. Expect a blockquote warning about the 3:1 minimum contrast ratio for `treatment="outline"` with `static-color`

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [x] **Keyboard** — No interactive changes; this is a documentation-only fix. The buttons in the examples remain standard `<sp-button>` elements with no keyboard behavior changes.

- [x] **Screen reader** — No interactive changes; this is a documentation-only fix affecting only the background color of demo containers.