### PR TITLE
fix(docs-alert-banner): fix action variant text color

### DIFF
--- a/1st-gen/packages/alert-banner/README.md
+++ b/1st-gen/packages/alert-banner/README.md
@@ -38,7 +38,12 @@ An optional action using `slot="action"`:
 ```html
 <sp-alert-banner open>
   Your trial has expired
-  <sp-button treatment="outline" variant="secondary" slot="action">
+  <sp-button
+    treatment="outline"
+    static-color="white"
+    variant="secondary"
+    slot="action"
+  >
     Buy now
   </sp-button>
 </sp-alert-banner>


### PR DESCRIPTION
## Description

Added `static-color="white"` to the `<sp-button>` in the alert-banner README's "Action" anatomy example. Without this attribute, the button text color adapts to the current `sp-theme`, producing insufficient contrast against the alert banner's colored background. The "Info" variant example and the stories template already had this attribute; only the "Action" anatomy example was missing it.

## Motivation and context

The action button inside the neutral alert-banner (background #6D6D6D) rendered with dark text (#222222) in light themes, producing a contrast ratio of only 3.1:1 — failing the WCAG 1.4.3 Contrast (Minimum) requirement of 4.5:1. Adding `static-color="white"` forces white text (#FFFFFF), which yields 5.2:1 contrast against the neutral background, passing the requirement. This matches the pattern already used by the info variant example in the same README, the stories template, and the toast component's action button examples.

## Related issue(s)

- fixes SWC-1118

## Screenshots (if appropriate)

**Before**

<img width="1000" height="176" alt="Screenshot 2026-03-11 at 11 23 43 AM" src="https://github.com/user-attachments/assets/6599268a-791c-4a65-bdce-1d1dd4f682e1" />

**After**

<img width="962" height="135" alt="Screenshot 2026-03-11 at 11 31 28 AM" src="https://github.com/user-attachments/assets/a3e28fcf-22b2-491c-950e-9ca0fac9b493" />

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link

### Manual review test cases

- [ ] _Action button text has accessible contrast on neutral alert banner_
  1. Go to the [alert-banner docs](http://localhost:4000/components/alert-banner/) and scroll to **Anatomy > Action**
  2. Verify the "Buy now" button text is white against the gray banner background
  3. Expect white text (#FFFFFF) on gray background (#6D6D6D) with at least 4.5:1 contrast ratio

- [ ] _Action button contrast persists across theme changes_
  1. Go to the [alert-banner docs](http://localhost:4000/components/alert-banner/) and scroll to **Anatomy > Action**
  2. Switch between light, dark, and darkest themes using the theme picker
  3. Expect the "Buy now" button text remains white and legible in all themes

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [x] **Keyboard** — No interactive changes; this is a documentation-only fix adding an attribute to an example code snippet.

- [x] **Screen reader** — No interactive changes; the `static-color` attribute does not affect ARIA semantics or screen reader announcements.