### PR TITLE
feat(combobox): add selectedItemValue read-only property

### DIFF
--- a/.changeset/combobox-selected-item-value.md
+++ b/.changeset/combobox-selected-item-value.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/combobox': minor
+---
+
+- **Added**: `selectedItemValue` read-only property that exposes the matched menu item's `value` when the combobox's display text corresponds to an available option. Returns `''` when no option matches. Resolves #4283.

--- a/1st-gen/packages/combobox/src/Combobox.ts
+++ b/1st-gen/packages/combobox/src/Combobox.ts
@@ -107,6 +107,21 @@ export class Combobox extends Textfield {
   private itemValue = '';
 
   /**
+   * The `value` of the currently matched menu item, if one exists.
+   * Returns an empty string when the current input text doesn't match
+   * any option's `itemText`.
+   *
+   * Unlike `value` (which always reflects the displayed text),
+   * `selectedItemValue` returns the option's identifier — useful when
+   * menu items have a `value` attribute distinct from their text content.
+   *
+   * @readonly
+   */
+  public get selectedItemValue(): string {
+    return this.itemValue;
+  }
+
+  /**
    * An array of options to present in the Menu provided while typing into the input
    */
   @property({ type: Array })

--- a/1st-gen/packages/combobox/test/combobox.test.ts
+++ b/1st-gen/packages/combobox/test/combobox.test.ts
@@ -832,6 +832,90 @@ describe('Combobox', () => {
       expect(el.open).to.be.true;
     });
   });
+  describe('selectedItemValue', () => {
+    it('returns the matched option value after keyboard selection', async () => {
+      const el = await comboboxFixture();
+      await elementUpdated(el);
+
+      expect(el.selectedItemValue).to.equal('');
+
+      el.focusElement.focus();
+      const opened = oneEvent(el, 'sp-opened');
+      el.focusElement.dispatchEvent(arrowDownEvent());
+      await opened;
+      await elementUpdated(el);
+
+      const changed = oneEvent(el, 'change');
+      el.focusElement.dispatchEvent(enterEvent());
+      await changed;
+      await elementUpdated(el);
+
+      expect(el.value).to.equal('Apple');
+      expect(el.selectedItemValue).to.equal('apple');
+    });
+    it('returns the matched option value after click selection', async () => {
+      const el = await comboboxFixture();
+      await elementUpdated(el);
+
+      expect(el.selectedItemValue).to.equal('');
+
+      const opened = oneEvent(el, 'sp-opened');
+      el.focusElement.click();
+      await opened;
+
+      const item = el.shadowRoot.querySelector(
+        '[value="cherry"]'
+      ) as HTMLElement;
+
+      const closed = oneEvent(el, 'sp-closed');
+      await mouseClickOn(item);
+      await closed;
+      await elementUpdated(el);
+
+      expect(el.value).to.equal('Cherry');
+      expect(el.selectedItemValue).to.equal('cherry');
+    });
+    it('resolves when value is set programmatically to matching text', async () => {
+      const el = await comboboxFixture();
+      await elementUpdated(el);
+
+      el.value = 'Banana';
+      await elementUpdated(el);
+
+      expect(el.value).to.equal('Banana');
+      expect(el.selectedItemValue).to.equal('banana');
+    });
+    it('returns empty string when value does not match any option', async () => {
+      const el = await comboboxFixture();
+      await elementUpdated(el);
+
+      el.value = 'Pineapple';
+      await elementUpdated(el);
+
+      expect(el.selectedItemValue).to.equal('');
+    });
+    it('returns empty string when value is cleared', async () => {
+      const el = await comboboxFixture();
+      await elementUpdated(el);
+
+      el.value = 'Apple';
+      await elementUpdated(el);
+      expect(el.selectedItemValue).to.equal('apple');
+
+      el.value = '';
+      await elementUpdated(el);
+      expect(el.selectedItemValue).to.equal('');
+    });
+    it('returns empty string for partial text that does not exactly match', async () => {
+      const el = await comboboxFixture();
+      await elementUpdated(el);
+
+      el.value = 'App';
+      await elementUpdated(el);
+
+      expect(el.selectedItemValue).to.equal('');
+    });
+  });
   describe('pending state', () => {
     it('renders a progress circle', async () => {
       const el = await comboboxFixture();

--- a/1st-gen/packages/combobox/test/helpers.ts
+++ b/1st-gen/packages/combobox/test/helpers.ts
@@ -31,6 +31,7 @@ export type TestableCombobox = HTMLElement & {
   options: ComboboxOption[];
   shadowRoot: ShadowRoot;
   value: string;
+  selectedItemValue: string;
   pending: boolean;
 };
 


### PR DESCRIPTION
## Description

Add a public read-only getter `selectedItemValue` to `sp-combobox` that exposes the selected menu item's `value` (identifier) when the combobox's display text matches an available option. Returns `''` when no option matches.

Currently, `combobox.value` always returns the display text (e.g., `"Red"`). There is no way to retrieve the underlying menu item's `value` attribute (e.g., `"red"`). Internally, the component already tracks this via a private `itemValue` field — this PR simply exposes it through a public getter.

### Changes

- **`Combobox.ts`**: Added `selectedItemValue` public getter that returns the internal `itemValue`
- **`test/helpers.ts`**: Added `selectedItemValue` to the `TestableCombobox` type
- **`combobox.test.ts`**: Added 6 test cases covering keyboard selection, click selection, programmatic value setting, non-matching input, clearing, and partial text
- **Changeset**: Minor version bump for `@spectrum-web-components/combobox`

## Motivation and context

When menu items have a `value` attribute distinct from their text content (e.g., `<sp-menu-item value="red">Red</sp-menu-item>`), consumers need a way to retrieve the item's identifier after selection. This is especially important for forms where the display text and the submitted value differ — for example, country pickers where `itemText` is "United States" but `value` is "us".

The maintainer (@Westbrook) confirmed this approach in the issue discussion, suggesting a parallel property to surface the matched item key.

## Related issue(s)

- fixes #4283

## Screenshots (if appropriate)

N/A — this is a programmatic API addition with no visual changes.

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Verify selectedItemValue after click selection_
  1. Go to Combobox Storybook story
  2. Open DevTools console, run: `const combo = document.querySelector('sp-combobox');`
  3. Select "Red" from the dropdown
  4. Run: `console.log(combo.value, combo.selectedItemValue)`
  5. Expect `"Red"` and `"red"` respectively

- [ ] _Verify selectedItemValue is empty for free-form text_
  1. Type "Purple" (not in the options list) into the combobox
  2. Run: `console.log(combo.selectedItemValue)`
  3. Expect `""`

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [x] **Keyboard** — No keyboard behavior changes. The new property is a read-only getter with no DOM or ARIA impact.
- [x] **Screen reader** — No screen reader impact. This is a JavaScript-only API addition that does not modify the accessibility tree.

Made with [Cursor](https://cursor.com)