### PR TITLE
docs: deploy 2nd-gen Storybook to GitHub Pages at /v2/

### DIFF
--- a/.github/workflows/publish-docs-site.yml
+++ b/.github/workflows/publish-docs-site.yml
@@ -31,6 +31,19 @@ jobs:
       - name: Build Storybook
         run: yarn workspace @spectrum-web-components/1st-gen storybook:build
 
+      - name: Generate 2nd-gen Custom Elements Manifest
+        run: yarn workspace @adobe/swc analyze
+
+      - name: Build 2nd-gen Storybook
+        env:
+          STORYBOOK_BASE_PATH: /spectrum-web-components/v2/
+        run: yarn workspace @adobe/swc storybook:build
+
+      - name: Copy 2nd-gen Storybook to deployment directory
+        run: |
+          mkdir -p 1st-gen/projects/documentation/dist/v2
+          cp -r 2nd-gen/packages/swc/storybook-static/* 1st-gen/projects/documentation/dist/v2/
+
       - name: Add redirects to documentation
         run: echo '/*    /index.html   200' > 1st-gen/projects/documentation/dist/_redirects
 

--- a/2nd-gen/packages/swc/.storybook/main.ts
+++ b/2nd-gen/packages/swc/.storybook/main.ts
@@ -83,6 +83,7 @@ const config = {
   ],
   viteFinal: async (config) => {
     return mergeConfig(config, {
+      base: process.env.STORYBOOK_BASE_PATH || '/',
       plugins: [
         {
           name: 'css-hmr',


### PR DESCRIPTION
## Summary

- Add configurable `STORYBOOK_BASE_PATH` env var to the 2nd-gen Storybook Vite config, defaulting to `/` for local dev
- Extend the `publish-docs-site.yml` workflow to build the 2nd-gen Storybook and deploy it under `/v2/` alongside the existing 1st-gen site

Once deployed, the 2nd-gen Storybook will be available at:
**https://opensource.adobe.com/spectrum-web-components/v2/**

## Changes

| File | Change |
|---|---|
| `2nd-gen/packages/swc/.storybook/main.ts` | Added `base: process.env.STORYBOOK_BASE_PATH \|\| '/'` to `viteFinal` config |
| `.github/workflows/publish-docs-site.yml` | Added 3 steps: generate 2nd-gen CEM, build 2nd-gen Storybook with base path, copy output to `dist/v2/` |

## Test plan

- [ ] `yarn storybook` in `2nd-gen/packages/swc/` still works at `localhost:6006` (no base path regression)
- [ ] `STORYBOOK_BASE_PATH=/spectrum-web-components/v2/ yarn storybook:build` produces correct asset paths
- [ ] PR preview deploys successfully for both 1st-gen and 2nd-gen
- [ ] After merge, `https://opensource.adobe.com/spectrum-web-components/v2/` loads the 2nd-gen Storybook
- [ ] Existing 1st-gen site at `https://opensource.adobe.com/spectrum-web-components/` is unaffected


Made with [Cursor](https://cursor.com)