### PR TITLE
feat: deploy Gen2 docs website to stable URL from main

### DIFF
--- a/.github/workflows/publish-2ndgen-docs.yml
+++ b/.github/workflows/publish-2ndgen-docs.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - ruben/deploy-docs-website
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Adds a new GitHub Actions workflow (`publish-2ndgen-docs.yml`) that builds and deploys the 2nd-gen Storybook documentation to a stable Azure Blob Storage URL on every push to `main`. Uses `azcopy sync` with `--delete-destination=true` to keep the deployed files clean across deploys.

The docs are published to: `https://swcpreviews.z13.web.core.windows.net/docs/`

> [!NOTE]
> **Future:** When we're ready for a custom domain, we can add an Azure CDN endpoint in front of the blob storage origin and map a domain to it. No workflow changes needed: the deploy target stays the same.



## Motivation and context

PR previews already deploy 2nd-gen Storybook to per-PR paths in Azure, but there is no persistent deployment of the 2nd-gen docs from `main`. This workflow gives us a stable URL that is always up to date with the latest merged changes, reusing the existing Azure storage and authentication infrastructure.

## Related issue(s)

- SWC-1551

## Screenshots (if appropriate)

N/A — CI workflow only.

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [x] ~~I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)~~ N/A
- [x] ~~I have added automated tests to cover my changes.~~ N/A — CI config only
- [x] ~~I have included a well-written changeset if my change needs to be published.~~ No changeset needed — no package changes
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] ~~Includes thoughtfully written changeset~~ N/A
- [ ] ~~Automated tests cover all use cases~~ N/A
- [ ] ~~Validated on all supported browsers~~ N/A
- [ ] ~~All VRTs are approved~~ N/A

### Manual review test cases

- [ ] Verify workflow ran on push to branch
  1. Temporarily added this branch to the workflow's trigger branches and pushed
  2. Workflow ran successfully and deployed to `https://swcpreviews.z13.web.core.windows.net/docs/`
  3. Reverted the branch trigger before merging — workflow will only run on `main` pushes

- [ ] Verify workflow runs on merge to main
  1. Merge this PR to `main`
  2. Check the Actions tab for the "Publish 2nd-Gen Documentation" workflow
  3. Expect it to complete successfully and deploy to `https://swcpreviews.z13.web.core.windows.net/docs/`

- [ ] Verify manual trigger works
  1. Go to Actions > "Publish 2nd-Gen Documentation" > Run workflow
  2. Trigger on `main`
  3. Expect a successful deploy to the same URL

### Device review

N/A — CI workflow only.

## Accessibility testing checklist

N/A — CI workflow only, no UI changes.
