### PR TITLE
feat(statuslight): ensure visual fidelity for status light

### DIFF
--- a/2nd-gen/packages/core/components/status-light/StatusLight.types.ts
+++ b/2nd-gen/packages/core/components/status-light/StatusLight.types.ts
@@ -93,3 +93,5 @@ export type StatusLightColorVariant =
 export type StatusLightVariantS1 = (typeof STATUSLIGHT_VARIANTS_S1)[number];
 export type StatusLightVariantS2 = (typeof STATUSLIGHT_VARIANTS_S2)[number];
 export type StatusLightVariant = StatusLightVariantS1 | StatusLightVariantS2;
+
+export type StatusLightSize = (typeof STATUSLIGHT_VALID_SIZES)[number];

--- a/2nd-gen/packages/swc/components/status-light/status-light.css
+++ b/2nd-gen/packages/swc/components/status-light/status-light.css
@@ -36,7 +36,7 @@
   font-style: token("default-font-style");
   font-weight: token("regular-font-weight");
   line-height: var(--_swc-statuslight-line-height);
-  color: var(--swc-statuslight-content-color, token("neutral-content-color-default"));
+  color: token("neutral-content-color-default");
 
   &:lang(ja),
   &:lang(zh),
@@ -48,8 +48,6 @@
   &::before {
     --_swc-statuslight-dot-size: var(--swc-statuslight-dot-size, token("status-light-dot-size-medium"));
 
-    box-sizing: border-box;
-    display: inline-block;
     flex-grow: 0;
     flex-shrink: 0;
     inline-size: var(--_swc-statuslight-dot-size);

--- a/2nd-gen/packages/swc/components/status-light/status-light.css
+++ b/2nd-gen/packages/swc/components/status-light/status-light.css
@@ -25,6 +25,7 @@
   --_swc-statuslight-padding-block: var(--swc-statuslight-padding-block, token("component-padding-vertical-100"));
   --_swc-statuslight-top-to-dot: var(--swc-statuslight-top-to-dot, token("status-light-top-to-dot-medium"));
   --_swc-statuslight-text-to-visual: var(--swc-statuslight-text-to-visual, token("status-light-text-to-visual-100"));
+  --_swc-statuslight-line-height: var(--swc-statuslight-line-height, token("line-height-font-size-100"));
 
   display: flex;
   gap: var(--_swc-statuslight-text-to-visual);
@@ -34,7 +35,7 @@
   font-size: var(--swc-statuslight-font-size, token("font-size-100"));
   font-style: token("default-font-style");
   font-weight: token("regular-font-weight");
-  line-height: token("line-height-100");
+  line-height: var(--_swc-statuslight-line-height);
   color: var(--swc-statuslight-content-color, token("neutral-content-color-default"));
 
   &:lang(ja),
@@ -67,6 +68,7 @@
   --swc-statuslight-height: token("component-height-75");
   --swc-statuslight-dot-size: token("status-light-dot-size-small");
   --swc-statuslight-font-size: token("font-size-75");
+  --swc-statuslight-line-height: token("line-height-font-size-75");
 }
 
 :host([size="l"]) {
@@ -76,6 +78,7 @@
   --swc-statuslight-height: token("component-height-200");
   --swc-statuslight-dot-size: token("status-light-dot-size-large");
   --swc-statuslight-font-size: token("font-size-200");
+  --swc-statuslight-line-height: token("line-height-font-size-200");
 }
 
 :host([size="xl"]) {
@@ -85,6 +88,7 @@
   --swc-statuslight-height: token("component-height-300");
   --swc-statuslight-dot-size: token("status-light-dot-size-extra-large");
   --swc-statuslight-font-size: token("font-size-300");
+  --swc-statuslight-line-height: token("line-height-font-size-300");
 }
 
 /* Semantic colors */

--- a/2nd-gen/packages/swc/components/status-light/status-light.css
+++ b/2nd-gen/packages/swc/components/status-light/status-light.css
@@ -87,7 +87,7 @@
   --swc-statuslight-font-size: token("font-size-300");
 }
 
-/* Semantic Colors */
+/* Semantic colors */
 :host([variant="neutral"]) {
   --swc-statuslight-content-color: token("gray-600");
   --swc-statuslight-dot-color: token("neutral-visual-color");
@@ -109,7 +109,7 @@
   --swc-statuslight-dot-color: token("positive-visual-color");
 }
 
-/* Non-Semantic Colors */
+/* Non-semantic colors */
 .swc-StatusLight--yellow {
   --swc-statuslight-dot-color: token("yellow-visual-color");
 }

--- a/2nd-gen/packages/swc/components/status-light/status-light.css
+++ b/2nd-gen/packages/swc/components/status-light/status-light.css
@@ -22,8 +22,7 @@
 }
 
 .swc-StatusLight {
-  --_swc-statuslight-top-to-text: var(--swc-statuslight-top-to-text, token("component-top-to-text-100"));
-  --_swc-statuslight-bottom-to-text: var(--swc-statuslight-bottom-to-text, token("component-bottom-to-text-100"));
+  --_swc-statuslight-padding-block: var(--swc-statuslight-padding-block, token("component-padding-vertical-100"));
   --_swc-statuslight-top-to-dot: var(--swc-statuslight-top-to-dot, token("status-light-top-to-dot-medium"));
   --_swc-statuslight-text-to-visual: var(--swc-statuslight-text-to-visual, token("status-light-text-to-visual-100"));
 
@@ -31,8 +30,7 @@
   gap: var(--_swc-statuslight-text-to-visual);
   align-items: flex-start;
   min-block-size: var(--swc-statuslight-height, token("component-height-100"));
-  padding-block-start: var(--_swc-statuslight-top-to-text);
-  padding-block-end: var(--_swc-statuslight-bottom-to-text);
+  padding-block: var(--_swc-statuslight-padding-block);
   font-size: var(--swc-statuslight-font-size, token("font-size-100"));
   font-style: token("default-font-style");
   font-weight: token("regular-font-weight");
@@ -55,7 +53,7 @@
     flex-shrink: 0;
     inline-size: var(--_swc-statuslight-dot-size);
     block-size: var(--_swc-statuslight-dot-size);
-    margin-block-start: calc(var(--_swc-statuslight-top-to-dot) - var(--_swc-statuslight-top-to-text));
+    margin-block-start: calc(var(--_swc-statuslight-top-to-dot) - var(--_swc-statuslight-padding-block));
     background-color: var(--swc-statuslight-dot-color);
     border-radius: token("corner-radius-full");
     content: "";
@@ -63,8 +61,7 @@
 }
 
 :host([size="s"]) {
-  --swc-statuslight-top-to-text: token("component-top-to-text-75");
-  --swc-statuslight-bottom-to-text: token("component-bottom-to-text-75");
+  --swc-statuslight-padding-block: token("component-padding-vertical-75");
   --swc-statuslight-top-to-dot: token("status-light-top-to-dot-small");
   --swc-statuslight-text-to-visual: token("status-light-text-to-visual-75");
   --swc-statuslight-height: token("component-height-75");
@@ -73,8 +70,7 @@
 }
 
 :host([size="l"]) {
-  --swc-statuslight-top-to-text: token("component-top-to-text-200");
-  --swc-statuslight-bottom-to-text: token("component-bottom-to-text-200");
+  --swc-statuslight-padding-block: token("component-padding-vertical-200");
   --swc-statuslight-top-to-dot: token("status-light-top-to-dot-large");
   --swc-statuslight-text-to-visual: token("status-light-text-to-visual-200");
   --swc-statuslight-height: token("component-height-200");
@@ -83,8 +79,7 @@
 }
 
 :host([size="xl"]) {
-  --swc-statuslight-top-to-text: token("component-top-to-text-300");
-  --swc-statuslight-bottom-to-text: token("component-bottom-to-text-300");
+  --swc-statuslight-padding-block: token("component-padding-vertical-300");
   --swc-statuslight-top-to-dot: token("status-light-top-to-dot-extra-large");
   --swc-statuslight-text-to-visual: token("status-light-text-to-visual-300");
   --swc-statuslight-height: token("component-height-300");

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -16,10 +16,12 @@ import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
 import { StatusLight } from '@adobe/spectrum-wc/status-light';
 import {
+  STATUSLIGHT_VALID_SIZES,
   STATUSLIGHT_VARIANTS_COLOR_S2,
   STATUSLIGHT_VARIANTS_SEMANTIC_S2,
   StatusLightColorVariantS2,
   StatusLightSemanticVariantS2,
+  type StatusLightSize,
 } from '@spectrum-web-components/core/components/status-light';
 
 import '@adobe/spectrum-wc/status-light';
@@ -109,6 +111,13 @@ const nonSemanticLabels = {
   silver: 'Version 1.2.10',
 } as const satisfies Record<StatusLightColorVariantS2, string>;
 
+const sizeLabels = {
+  s: 'Small',
+  m: 'Medium',
+  l: 'Large',
+  xl: 'Extra-large',
+} as const satisfies Record<StatusLightSize, string>;
+
 // ────────────────────
 //    AUTODOCS STORY
 // ────────────────────
@@ -179,10 +188,13 @@ export const Anatomy: Story = {
  */
 export const Sizes: Story = {
   render: (args) => html`
-    ${template({ ...args, size: 's', 'default-slot': 'Small' })}
-    ${template({ ...args, size: 'm', 'default-slot': 'Medium' })}
-    ${template({ ...args, size: 'l', 'default-slot': 'Large' })}
-    ${template({ ...args, size: 'xl', 'default-slot': 'Extra-large' })}
+    ${STATUSLIGHT_VALID_SIZES.map((size) =>
+      template({
+        ...args,
+        size,
+        'default-slot': sizeLabels[size],
+      })
+    )}
   `,
   parameters: { 'section-order': 1 },
   tags: ['options'],

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -139,7 +139,7 @@ export const Playground: Story = {
 };
 
 // ────────────────────
-//    OVERVIEW STORY
+//    OVERVIEW STORIES
 // ────────────────────
 
 export const Overview: Story = {
@@ -302,8 +302,9 @@ export const TextWrapping: Story = {
  *
  * - Semantic variants provide consistent color associations for common statuses
  * - Text labels provide clear context for all users
+ * - Disabled status lights are deprecated for Spectrum 2. Content like "Unavailable" may be used to communicate that concept instead.
  *
- * Non-interactive element
+ * #### Non-interactive element
  *
  * - Status lights have no interactive behavior and are not focusable
  * - Screen readers will announce the status light content as static text
@@ -410,6 +411,7 @@ function withLocaleWrapperRender(
  */
 export const WithLocaleWrapper: Story = {
   render: withLocaleWrapperRender,
+  tags: [ '' ],
   parameters: {
     docs: {
       canvas: { sourceState: 'none' },

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -414,7 +414,6 @@ function withLocaleWrapperRender(
 // @todo: this story is docs-only, but we should start capturing Chromatic baselines for internationalized content in components. SWC-1871
 export const WithLocaleWrapper: Story = {
   render: withLocaleWrapperRender,
-  tags: [''],
   parameters: {
     docs: {
       canvas: { sourceState: 'none' },

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -172,7 +172,6 @@ export const Anatomy: Story = {
     })}
   `,
   tags: ['anatomy'],
-
 };
 
 // ──────────────────────────
@@ -211,7 +210,7 @@ export const Sizes: Story = {
  * - **`positive`**: Approved, complete, success, new, purchased, licensed
  * - **`notice`**: Needs approval, pending, scheduled, syncing, indexing, processing
  * - **`negative`**: Error, alert, rejected, failed
- * 
+ *
  * Semantic status lights should never be used for color coding categories or labels, and vice versa.
  */
 export const SemanticVariants: Story = {
@@ -304,10 +303,17 @@ export const TextWrapping: Story = {
  * - Semantic variants provide consistent color associations for common statuses
  * - Text labels provide clear context for all users
  *
+ * Non-interactive element
+ *
+ * - Status lights have no interactive behavior and are not focusable
+ * - Screen readers will announce the status light content as static text
+ * - No keyboard interaction is required or expected
+ *
  * ### Best practices
  *
  * - Always provide a descriptive text label that explains the status
  * - Use semantic variants (`info`, `positive`, `negative`, `notice`, `neutral`) when the status has specific meaning
+ * - Status lights are not interactive elements - for interactive status indicators, consider using buttons, tags, or links instead
  * - Use meaningful, specific labels (e.g., "Approved" instead of "Green")
  * - Ensure sufficient color contrast between the status light and its background
  * - For non-semantic variants, ensure the text label provides complete context

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -387,6 +387,7 @@ export const Accessibility: Story = {
  * textfield.value from translations.json based on context.globals.lang.
  * Used by the Fonts guide and for locale/font demos. This story is "docs-only."
  */
+// @todo: a withLocaleWrapper could be pulled up into a global decorator/helper to be implemented by more components. SWC-1872
 function withLocaleWrapperRender(
   args: Record<string, unknown> & { lang?: string; 'default-slot'?: string },
   context: { globals: { lang?: string } }
@@ -408,10 +409,12 @@ function withLocaleWrapperRender(
 /**
  * Status light with label driven by the Language toolbar and translations.json.
  * Use this story in the Fonts guide to demonstrate font loading and translated copy.
+ * Learn more about [loading the expected fonts](/docs/guides-customization-fonts--readme).
  */
+// @todo: this story is docs-only, but we should start capturing Chromatic baselines for internationalized content in components. SWC-1871
 export const WithLocaleWrapper: Story = {
   render: withLocaleWrapperRender,
-  tags: [ '' ],
+  tags: [''],
   parameters: {
     docs: {
       canvas: { sourceState: 'none' },

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -40,20 +40,29 @@ argTypes.variant = {
   ...argTypes.variant,
   control: { type: 'select' },
   options: StatusLight.VARIANTS,
+  table: {
+    category: 'attributes',
+    defaultValue: {
+      summary: 'info',
+    },
+  },
 };
 
 argTypes.size = {
   ...argTypes.size,
   control: { type: 'select' },
   options: StatusLight.VALID_SIZES,
+  table: {
+    category: 'attributes',
+    defaultValue: {
+      summary: 'm',
+    },
+  },
 };
 
 /**
  * Status lights describe the condition of an entity. Much like [badges](../?path=/docs/components-badge--readme), they can be used to convey semantic meaning, such as statuses and categories.
  */
-args['default-slot'] = 'Status light';
-args.size = 'm';
-
 export const meta: Meta = {
   title: 'Status light',
   component: 'swc-status-light',
@@ -125,8 +134,6 @@ const sizeLabels = {
 export const Playground: Story = {
   tags: ['autodocs', 'dev'],
   args: {
-    size: 'm',
-    variant: 'info',
     'default-slot': 'Active',
   },
 };
@@ -138,8 +145,6 @@ export const Playground: Story = {
 export const Overview: Story = {
   tags: ['overview'],
   args: {
-    size: 'm',
-    variant: 'info',
     'default-slot': 'Active',
   },
 };
@@ -167,9 +172,7 @@ export const Anatomy: Story = {
     })}
   `,
   tags: ['anatomy'],
-  args: {
-    size: 'm',
-  },
+
 };
 
 // ──────────────────────────
@@ -208,6 +211,8 @@ export const Sizes: Story = {
  * - **`positive`**: Approved, complete, success, new, purchased, licensed
  * - **`notice`**: Needs approval, pending, scheduled, syncing, indexing, processing
  * - **`negative`**: Error, alert, rejected, failed
+ * 
+ * Semantic status lights should never be used for color coding categories or labels, and vice versa.
  */
 export const SemanticVariants: Story = {
   render: (args) => html`

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md
@@ -269,7 +269,7 @@ Size variants (s, m, l, xl) use `:host([size="..."])` and update custom properti
 
 ```css
 :host([size="s"]) {
-  --swc-statuslight-top-to-text: token("component-top-to-text-75");
+  --swc-statuslight-padding-block: token("component-padding-vertical-75");
   --swc-statuslight-height: token("component-height-75");
   --swc-statuslight-dot-size: token("status-light-dot-size-small");
   --swc-statuslight-font-size: token("font-size-75");

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md
@@ -71,11 +71,9 @@ CSS custom properties *normally* can't actually be "private". However, due to sh
 
 ```css
 .swc-StatusLight {
-  --_swc-statuslight-top-to-text: var(--swc-statuslight-top-to-text, token("component-top-to-text-100"));
-  --_swc-statuslight-bottom-to-text: var(--swc-statuslight-bottom-to-text, token("component-bottom-to-text-100"));
+  --_swc-statuslight-padding-block: var(--swc-statuslight-padding-block, token("component-padding-vertical-100"));
 
-  padding-block-start: var(--_swc-statuslight-top-to-text);
-  padding-block-end: var(--_swc-statuslight-bottom-to-text);
+  padding-block: var(--_swc-statuslight-padding-block);
 }
 ```
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/06_property-order-quick-reference.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/06_property-order-quick-reference.md
@@ -104,7 +104,7 @@ From [status-light.css](../../../2nd-gen/packages/swc/components/status-light/st
   inline-size: var(--_swc-statuslight-dot-size);
   block-size: var(--_swc-statuslight-dot-size);
   /* Spacing */
-  margin-block-start: calc(var(--_swc-statuslight-top-to-dot) - var(--_swc-statuslight-top-to-text));
+  margin-block-start: calc(var(--_swc-statuslight-top-to-dot) - var(--_swc-statuslight-padding-block));
   /* Decoration */
   background-color: var(--swc-statuslight-dot-color);
   border-radius: token("corner-radius-full");

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/badge/rendering-and-styling-migration-analysis.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/badge/rendering-and-styling-migration-analysis.md
@@ -19,6 +19,7 @@
     - [CSS => SWC mapping](#css--swc-mapping)
 - [Summary of changes](#summary-of-changes)
     - [CSS => SWC implementation gaps](#css--swc-implementation-gaps)
+    - [TODOs](#todos)
     - [CSS Spectrum 2 changes](#css-spectrum-2-changes)
 - [Resources](#resources)
 


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

Validates and corrects the `swc-status-light` 2nd-gen migration styling, and improves Storybook stories for better documentation and usability.

CSS fix:
- Replace asymmetric `top-to-text`/`bottom-to-text` tokens with the unified `component-padding-vertical` token for `padding-block`.

Story improvements:
- Export `StatusLightSize` type from `StatusLight.types.ts` so stories can derive sizes from the source of truth
- Map over all valid sizes in the `Sizes` story instead of hardcoding each individually
- Declare `defaultValue` summaries in `argTypes` for `variant` and `size` so Storybook's controls panel displays desired defaults correctly
- Remove redundant hardcoded `args` from `Playground`, `Overview`, and `Anatomy` stories now that defaults are reflected through `argTypes`
- Add a semantic variant usage note to the `SemanticVariants` story

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This branch performs styling validation as part of the broader 2nd-gen POC4 component migrations. The token correction ensures consistent vertical spacing across all sizes without duplicating token references, and the story cleanup makes the component's API easier to review during the migration review process.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- fixes SWC-1670 (status light portion)

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

Use the tables below for quick reference to the required design tokens and styles.

### Semantic variants

| Variant    | Token                      |
| ---------- | -------------------------- |
| `info`     | `informative-visual-color` |
| `neutral`  | `neutral-visual-color`     |
| `positive` | `positive-visual-color`    |
| `notice`   | `notice-visual-color`      |
| `negative` | `negative-visual-color`    |

> **Note:** The `accent` variant has been removed for S2.

#### Non-semantic variants

| Variant      | Token                    | New in S2 |
| ------------ | ------------------------ | --------- |
| `celery`     | `celery-visual-color`    |           |
| `chartreuse` | `chartreuse-visual-color`|           |
| `cyan`       | `cyan-visual-color`      |           |
| `fuchsia`    | `fuchsia-visual-color`   |           |
| `indigo`     | `indigo-visual-color`    |           |
| `magenta`    | `magenta-visual-color`   |           |
| `purple`     | `purple-visual-color`    |           |
| `seafoam`    | `seafoam-visual-color`   |           |
| `yellow`     | `yellow-visual-color`    |           |
| `pink`       | `pink-visual-color`      | ✓         |
| `turquoise`  | `turquoise-visual-color` | ✓         |
| `cinnamon`   | `cinnamon-visual-color`  | ✓         |
| `brown`      | `brown-visual-color`     | ✓         |
| `silver`     | `silver-visual-color`    | ✓         |

### Label color — `--swc-statuslight-content-color`

| Condition              | Token                          |
| ---------------------- | ------------------------------ |
| `variant="neutral"`    | `gray-600`                     |
| All other variants     | `neutral-content-color-default`|

## Size-specific tokens

| Property             | Token hook                         | `s`                               | `m` (default)                      | `l`                                | `xl`                                  |
| -------------------- | ---------------------------------- | --------------------------------- | ---------------------------------- | ---------------------------------- | ------------------------------------- |
| Component height     | `--swc-statuslight-height`         | `component-height-75`             | `component-height-100`             | `component-height-200`             | `component-height-300`                |
| Dot size             | `--swc-statuslight-dot-size`       | `status-light-dot-size-small`     | `status-light-dot-size-medium`     | `status-light-dot-size-large`      | `status-light-dot-size-extra-large`   |
| Dot-to-label gap     | `--swc-statuslight-text-to-visual` | `status-light-text-to-visual-75`  | `status-light-text-to-visual-100`  | `status-light-text-to-visual-200`  | `status-light-text-to-visual-300`     |
| Top edge to dot      | `--swc-statuslight-top-to-dot`     | `status-light-top-to-dot-small`   | `status-light-top-to-dot-medium`   | `status-light-top-to-dot-large`    | `status-light-top-to-dot-extra-large` |
| Block padding*     | `--swc-statuslight-padding-block`  | `component-padding-vertical-75`   | `component-padding-vertical-100`   | `component-padding-vertical-200`   | `component-padding-vertical-300`      |
| Font size            | `--swc-statuslight-font-size`      | `font-size-75`                    | `font-size-100`                    | `font-size-200`                    | `font-size-300`                       |

*The CSS intentionally uses `component-padding-vertical-*` via a single `padding-block` shorthand, reflecting more recent design decisions in the S2 Web Desktop scale file.

## Typography tokens

These apply across all sizes unless noted.

| Property    | Token                                                    |
| ----------- | -------------------------------------------------------- |
| Font family | `default-font-family`                                    |
| Font weight | `regular-font-weight`                                    |
| Font style  | `default-font-style`                                     |
| Line height | `line-height-100` (default); `cjk-line-height-100` for `lang="ja"`, `lang="zh"`, `lang="ko"` |

> **Note:** The neutral variant uses `default-font-style` (not italics). This is a change from S1.

- [ ] _Status light renders correctly at all sizes_

    1. Go to the status light Storybook (`/story/status-light--sizes`)
    2. Verify the `s`, `m`, `l`, and `xl` sizes all display with correct vertical spacing, typography tokens, dot sizing, etc. according to the tables above.

- [ ] _Status light renders correctly in all colors_

    1. Go to the status light Storybook (`/story/status-light--sizes`)
    2. Verify the semantic and non-semantic variants render with the correct colored dots according to the tables above.

- [ ] _Status light controls panel shows defaults_

    1. Go to the status light Storybook (`/story/status-light--playground`)
    2. Open the Controls panel
    4. Expect `variant` to show `neutral` as default and `size` to show `m` as default

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

**Required:** Complete each applicable item and document your testing steps.

- [ ] **Keyboard** (required — document steps below)
  <!-- `sp-status-light` is a non-interactive, static indicator element with no focusable parts. -->
  1. Go to the status light Storybook (`/story/status-light--playground`)
  2. Tab through the page
  3. Expect the status light itself receives no focus; confirm no regressions in surrounding Storybook controls

- [ ] **Screen reader** (required — document steps below)
  1. Go to the status light Storybook (`/story/status-light--playground`)
  2. Navigate to the `sp-status-light` element with a screen reader (VoiceOver / NVDA)
  3. Expect the label text is announced; confirm the dot indicator is not announced as a separate interactive element
