### PR TITLE
feat(convoAI): toggle send button state

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { CSSResultArray, html, TemplateResult } from 'lit';
+import { CSSResultArray, html, type PropertyValues, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
@@ -34,6 +34,9 @@ import styles from './prompt-field.css';
  *
  * @element swc-prompt-field
  *
+ * @fires swc-prompt-send-ready - Fired when the send control becomes actionable (was not ready, now ready). Not emitted on first paint. `detail.value` is the current prompt string.
+ * @fires swc-prompt-send-idle - Fired when the send control stops being actionable (e.g. text cleared and `populated` is false, or `state` becomes `stop`).
+ *
  * @slot artifact - Optional attachment preview; pair with `uploaded-artifact` for shell layout.
  */
 export class PromptField extends SpectrumElement {
@@ -50,7 +53,10 @@ export class PromptField extends SpectrumElement {
   @property({ type: String, reflect: true, attribute: 'uploaded-artifact' })
   public uploadedArtifact: 'none' | 'card' | 'media' = 'none';
 
-  /** When `true`, the send button is enabled. Set this based on whether the textarea has content. */
+  /**
+   * When `true`, the send button is enabled even if the textarea is empty (e.g. attachment-only send).
+   * Otherwise send is enabled when `value` has non-whitespace content.
+   */
   @property({ type: Boolean, reflect: true })
   public populated = false;
 
@@ -66,8 +72,56 @@ export class PromptField extends SpectrumElement {
   @property({ type: String })
   public value = '';
 
+  private _sendReady = false;
+
   public static override get styles(): CSSResultArray {
     return [styles];
+  }
+
+  /** Whether the send affordance is enabled (`state` is not `stop`, and there is text or `populated`). */
+  private _isSendReady(): boolean {
+    if (this.state === 'stop') {
+      return false;
+    }
+    return this.populated || this.value.trim().length > 0;
+  }
+
+  protected override firstUpdated(_changedProperties: PropertyValues): void {
+    super.firstUpdated(_changedProperties);
+    this._sendReady = this._isSendReady();
+  }
+
+  protected override updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+    if (
+      !changedProperties.has('value') &&
+      !changedProperties.has('populated') &&
+      !changedProperties.has('state')
+    ) {
+      return;
+    }
+    const next = this._isSendReady();
+    if (next === this._sendReady) {
+      return;
+    }
+    if (next) {
+      this.dispatchEvent(
+        new CustomEvent('swc-prompt-send-ready', {
+          bubbles: true,
+          composed: true,
+          detail: { value: this.value },
+        })
+      );
+    } else {
+      this.dispatchEvent(
+        new CustomEvent('swc-prompt-send-idle', {
+          bubbles: true,
+          composed: true,
+          detail: { value: this.value },
+        })
+      );
+    }
+    this._sendReady = next;
   }
 
   private _handleInput(event: Event): void {
@@ -83,7 +137,7 @@ export class PromptField extends SpectrumElement {
   }
 
   private _handleSendClick(): void {
-    if (!this.populated) {
+    if (!this._isSendReady()) {
       return;
     }
     this.dispatchEvent(
@@ -128,7 +182,7 @@ export class PromptField extends SpectrumElement {
     return html`
       <button
         class="swc-PromptField-send"
-        ?disabled=${!this.populated}
+        ?disabled=${!this._isSendReady()}
         aria-label="Send"
         @click=${this._handleSendClick}
       >

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -198,6 +198,13 @@
   transition: background 130ms ease;
 }
 
+.swc-PromptField-send:focus-visible,
+.swc-PromptField-send:focus {
+  outline-width: 2px;
+  outline-color: token("focus-indicator-color");
+  outline-offset: 2px;
+}
+
 .swc-PromptField-send:disabled {
   color: token("gray-400");
   background: token("gray-100");
@@ -211,6 +218,16 @@
 .swc-PromptField-send swc-icon {
   --swc-icon-inline-size: 20px;
   --swc-icon-block-size: 20px;
+}
+
+.swc-PromptField-stop swc-icon {
+  --swc-icon-inline-size: 20px;
+  --swc-icon-block-size: 20px;
+}
+
+.swc-PromptField-send:not(:disabled) swc-icon,
+.swc-PromptField-stop:not(:disabled) swc-icon {
+  color: token("white");
 }
 
 /* Stop button (filled black circle, right side) */
@@ -232,11 +249,6 @@
 
 .swc-PromptField-stop:hover {
   background: token("gray-800");
-}
-
-.swc-PromptField-stop swc-icon {
-  --swc-icon-inline-size: 20px;
-  --swc-icon-block-size: 20px;
 }
 
 /* ─────────────────────────────────────
@@ -293,7 +305,6 @@
 .swc-PromptField-disclaimer-text {
   display: inline;
 }
-
 
 .swc-PromptField-disclaimer-link {
   color: token("gray-700");

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -130,8 +130,7 @@ export const Anatomy: Story = {
 /**
  * The `state` attribute controls which action button appears on the right side of the action bar:
  *
- * - **`default`** — Send button is shown but disabled (no content yet)
- * - **`send`** — Send button is enabled (content present); set via `populated` attribute
+ * - **`default`** / **`send`** — Send button is shown; enabled when the textarea has non-whitespace text or `populated` is set
  * - **`stop`** — Stop button is shown while the AI is generating a response
  */
 export const State: Story = {
@@ -268,7 +267,7 @@ export const UploadedArtifact: Story = {
  *
  * - The `<textarea>` has an `aria-label` matching the `label` property
  * - All icon buttons carry descriptive `aria-label` attributes
- * - The send button uses `disabled` natively when `populated` is false
+ * - The send button uses `disabled` natively when there is no non-whitespace `value` and `populated` is false
  *
  * ### Best practices
  *

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -165,3 +165,66 @@ export const EventsTest: Story = {
     );
   },
 };
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Send availability events
+// ──────────────────────────────────────────────────────────────
+
+export const SendAvailabilityTest: Story = {
+  ...Overview,
+  args: {
+    ...Overview.args,
+    state: 'default',
+    populated: false,
+    value: '',
+  },
+  play: async ({ canvasElement, step }) => {
+    const el = await getComponent<PromptField>(
+      canvasElement,
+      'swc-prompt-field'
+    );
+
+    await step(
+      'fires swc-prompt-send-ready when typing makes send actionable',
+      async () => {
+        let detailValue = '';
+        el.addEventListener(
+          'swc-prompt-send-ready',
+          ((event: CustomEvent<{ value: string }>) => {
+            detailValue = event.detail.value;
+          }) as EventListener,
+          { once: true }
+        );
+
+        const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>(
+          '.swc-PromptField-textarea'
+        );
+        textarea!.value = 'hello';
+        textarea!.dispatchEvent(new Event('input', { bubbles: true }));
+
+        await el.updateComplete;
+        expect(detailValue).toBe('hello');
+      }
+    );
+
+    await step('fires swc-prompt-send-idle when text cleared', async () => {
+      let idleFired = false;
+      el.addEventListener(
+        'swc-prompt-send-idle',
+        () => {
+          idleFired = true;
+        },
+        { once: true }
+      );
+
+      const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>(
+        '.swc-PromptField-textarea'
+      );
+      textarea!.value = '';
+      textarea!.dispatchEvent(new Event('input', { bubbles: true }));
+
+      await el.updateComplete;
+      expect(idleFired).toBe(true);
+    });
+  },
+};


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- N/A

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

- [ ] _Descriptive Test Statement_
  1. Go [here](url)
  2. Do this action
  3. Expect this result

- [ ] _Descriptive Test Statement_
  1. Go [here](url)
  2. Do this action
  3. Expect this result

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

<!---
    Manual accessibility testing is required because automated tools cannot catch all issues (e.g. focus order, screen reader announcements, keyboard flow).
    You must document your keyboard and screen reader testing steps below. Reviewers will use this checklist during review.
    See: [Accessibility testing guide](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTOR-DOCS/01_contributor-guides/09_accessibility-testing.md)
-->

**Required:** Complete each applicable item and document your testing steps (replace the placeholders with your component-specific instructions).

- [ ] **Keyboard** (required — document steps below) — _What to test for:_ Focus order is logical; <kbd>Tab</kbd> reaches the component and all interactive descendants; <kbd>Enter</kbd>/<kbd>Space</kbd> activate where appropriate; arrow keys work for tabs, menus, sliders, etc.; no focus traps; <kbd>Escape</kbd> dismisses when applicable; focus indicator is visible.
  1. Go [here](url)
  2. Do this action
  3. Expect this result

- [ ] **Screen reader** (required — document steps below) — _What to test for:_ Role and name are announced correctly; state changes (e.g. expanded, selected) are announced; labels and relationships are clear; no unnecessary or duplicate announcements.
  1. Go [here](url)
  2. Do this action
  3. Expect this result
