### PR TITLE
style(progress-circle): clean up code styles

### DIFF
--- a/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
+++ b/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
@@ -69,6 +69,8 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
   // ──────────────────
 
   /**
+   * @todo Revisit the default API for `indeterminate` and `progress`. SWC-1891
+   *
    * Whether the progress circle shows indeterminate progress (loading state).
    *
    * When true, displays an animated loading indicator instead of a specific progress value.

--- a/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
+++ b/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { PropertyValues } from 'lit';
-import { property, query } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
 
 import {
   LanguageResolutionController,
@@ -18,7 +18,6 @@ import {
 } from '@spectrum-web-components/core/controllers/language-resolution.js';
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
 import { SizedMixin } from '@spectrum-web-components/core/mixins/index.js';
-import { getLabelFromSlot } from '@spectrum-web-components/core/utils/get-label-from-slot.js';
 
 import {
   PROGRESS_CIRCLE_VALID_SIZES,
@@ -30,14 +29,6 @@ import {
  * Can be used in both determinate (with specific progress value) and indeterminate (loading) states.
  *
  * @attribute {ElementSize} size - The size of the progress circle.
- *
- * @todo Why do we support both the slot and the label attribute? Should we deprecate the slot?
- *
- * @todo Figure out why our tool chain doesn't respect the line breaks in this slot description.
- *
- * @slot - Accessible label for the progress circle.
- *
- *   Used to provide context about what is loading or progressing.
  */
 export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
   validSizes: PROGRESS_CIRCLE_VALID_SIZES,
@@ -107,23 +98,10 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
   //     IMPLEMENTATION
   // ──────────────────────
 
-  /**
-   * @internal
-   */
-  @query('slot')
-  private slotEl!: HTMLSlotElement;
-
   protected makeRotation(rotation: number): string | undefined {
     return this.indeterminate
       ? undefined
       : `transform: rotate(${rotation}deg);`;
-  }
-
-  protected handleSlotchange(): void {
-    const labelFromSlot = getLabelFromSlot(this.label, this.slotEl);
-    if (labelFromSlot) {
-      this.label = labelFromSlot;
-    }
   }
 
   protected override firstUpdated(changes: PropertyValues): void {
@@ -174,8 +152,7 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
       return Boolean(
         this.label ||
         this.getAttribute('aria-label') ||
-        this.getAttribute('aria-labelledby') ||
-        this.slotEl.assignedNodes().length
+        this.getAttribute('aria-labelledby')
       );
     };
 
@@ -183,13 +160,12 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
       if (!hasAccessibleName() && this.getAttribute('role') === 'progressbar') {
         window.__swc?.warn(
           this,
-          '<sp-progress-circle> elements need one of the following to be accessible:',
+          '<swc-progress-circle> elements need one of the following to be accessible:',
           'https://opensource.adobe.com/spectrum-web-components/components/progress-circle/#accessibility',
           {
             type: 'accessibility',
             issues: [
               'value supplied to the "label" attribute, which will be displayed visually as part of the element, or',
-              'text content supplied directly to the <sp-progress-circle> element, or',
               'value supplied to the "aria-label" attribute, which will only be provided to screen readers, or',
               'an element ID reference supplied to the "aria-labelledby" attribute, which will be provided by screen readers and will need to be managed manually by the parent application.',
             ],

--- a/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
+++ b/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
@@ -87,7 +87,8 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
   /**
    * Progress value from 0 to 100.
    *
-   * Only relevant when indeterminate is false.
+   * Only relevant when indeterminate is false. Values outside that range or
+   * non-finite numbers are clamped to 0–100 (non-finite becomes 0).
    */
   @property({ type: Number })
   public progress = 0;
@@ -97,6 +98,23 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────
+
+  private static clampProgress(value: number): number {
+    if (!Number.isFinite(value)) {
+      return 0;
+    }
+    return Math.min(100, Math.max(0, value));
+  }
+
+  protected override willUpdate(changes: PropertyValues): void {
+    if (changes.has('progress')) {
+      const clamped = ProgressCircleBase.clampProgress(this.progress);
+      if (clamped !== this.progress) {
+        this.progress = clamped;
+      }
+    }
+    super.willUpdate(changes);
+  }
 
   protected override firstUpdated(changes: PropertyValues): void {
     super.firstUpdated(changes);

--- a/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
+++ b/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
@@ -98,12 +98,6 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
   //     IMPLEMENTATION
   // ──────────────────────
 
-  protected makeRotation(rotation: number): string | undefined {
-    return this.indeterminate
-      ? undefined
-      : `transform: rotate(${rotation}deg);`;
-  }
-
   protected override firstUpdated(changes: PropertyValues): void {
     super.firstUpdated(changes);
     if (!this.hasAttribute('role')) {

--- a/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
+++ b/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
@@ -99,6 +99,34 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
   //     IMPLEMENTATION
   // ──────────────────────
 
+  /** True when light DOM has element nodes or non-whitespace text (no default slot). */
+  private static hasMeaningfulLightDomChildren(host: HTMLElement): boolean {
+    for (const node of host.childNodes) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        return true;
+      }
+      if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private warnDeprecatedLightDomChildren(): void {
+    if (!window.__swc?.DEBUG) {
+      return;
+    }
+    if (!ProgressCircleBase.hasMeaningfulLightDomChildren(this)) {
+      return;
+    }
+    window.__swc.warn(
+      this,
+      `<${this.localName}> no longer has a default slot. Light DOM children are not rendered and are not used for an accessible name. Use the "label" attribute or property, or "aria-label" / "aria-labelledby" on the host instead.`,
+      'https://opensource.adobe.com/spectrum-web-components/second-gen/?path=/docs/components-progress-circle--docs',
+      { level: 'deprecation' }
+    );
+  }
+
   private static clampProgress(value: number): number {
     if (!Number.isFinite(value)) {
       return 0;
@@ -169,11 +197,12 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
     };
 
     if (window.__swc?.DEBUG) {
+      this.warnDeprecatedLightDomChildren();
       if (!hasAccessibleName() && this.getAttribute('role') === 'progressbar') {
         window.__swc?.warn(
           this,
-          '<swc-progress-circle> elements need one of the following to be accessible:',
-          'https://opensource.adobe.com/spectrum-web-components/components/progress-circle/#accessibility',
+          `<${this.localName}> elements need one of the following to be accessible:`,
+          'https://opensource.adobe.com/spectrum-web-components/second-gen/?path=/docs/components-progress-circle--docs',
           {
             type: 'accessibility',
             issues: [

--- a/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
+++ b/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
@@ -123,12 +123,12 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
       } else {
         this.setAttribute('aria-valuemin', '0');
         this.setAttribute('aria-valuemax', '100');
-        this.setAttribute('aria-valuenow', '' + this.progress);
+        this.setAttribute('aria-valuenow', String(this.progress));
         this.setAttribute('aria-valuetext', this.formatProgress());
       }
     }
     if (!this.indeterminate && changes.has('progress')) {
-      this.setAttribute('aria-valuenow', '' + this.progress);
+      this.setAttribute('aria-valuenow', String(this.progress));
       this.setAttribute('aria-valuetext', this.formatProgress());
     }
     if (!this.indeterminate && changes.has(languageResolverUpdatedSymbol)) {

--- a/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
+++ b/2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts
@@ -102,10 +102,10 @@ export abstract class ProgressCircleBase extends SizedMixin(SpectrumElement, {
   /** True when light DOM has element nodes or non-whitespace text (no default slot). */
   private static hasMeaningfulLightDomChildren(host: HTMLElement): boolean {
     for (const node of host.childNodes) {
-      if (node.nodeType === Node.ELEMENT_NODE) {
-        return true;
-      }
-      if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) {
+      if (
+        node.nodeType === Node.ELEMENT_NODE ||
+        (node.nodeType === Node.TEXT_NODE && node.textContent?.trim())
+      ) {
         return true;
       }
     }

--- a/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
@@ -93,7 +93,7 @@ export class ProgressCircle extends ProgressCircleBase {
           <circle
             cx="50%"
             cy="50%"
-            r=${`calc(50% - ${strokeWidth / 1}px)`}
+            r=${`calc(50% - ${strokeWidth}px)`}
             stroke-width=${strokeWidth}
           />
           <circle

--- a/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
@@ -42,6 +42,8 @@ import styles from './progress-circle.css';
  *
  * @example
  * <swc-progress-circle indeterminate label="Loading..."></swc-progress-circle>
+ *
+ * Light DOM children are not projected into the shadow tree. Use the `label` attribute or property, or `aria-label` / `aria-labelledby` on the host, for an accessible name.
  */
 export class ProgressCircle extends ProgressCircleBase {
   // ────────────────────
@@ -87,7 +89,6 @@ export class ProgressCircle extends ProgressCircleBase {
             typeof this.size !== 'undefined',
         })}
       >
-        <slot @slotchange=${this.handleSlotchange}></slot>
         <svg fill="none" width="100%" height="100%" class="swc-outerCircle">
           <circle
             class="swc-innerCircle"

--- a/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
@@ -31,7 +31,7 @@ import styles from './progress-circle.css';
  * @status preview
  * @since 0.0.1
  *
- * @property {string} static-color - Static color variant for use on different backgrounds.
+ * @property {string} staticColor - Reflected as the `static-color` attribute. Static color variant for use on different backgrounds.
  * @property {number} progress - Progress value between 0 and 100.
  * @property {boolean} indeterminate - Indeterminate state for loading.
  * @property {string} size - Size of the component.
@@ -80,7 +80,7 @@ export class ProgressCircle extends ProgressCircleBase {
       <div
         class=${classMap({
           ['swc-ProgressCircle']: true,
-          [`swc-ProgressCircle--indeterminate`]: this.indeterminate,
+          ['swc-ProgressCircle--indeterminate']: this.indeterminate,
           [`swc-ProgressCircle--static${capitalize(this.staticColor)}`]:
             typeof this.staticColor !== 'undefined',
           [`swc-ProgressCircle--size${this.size?.toUpperCase()}`]:

--- a/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
@@ -89,9 +89,8 @@ export class ProgressCircle extends ProgressCircleBase {
             typeof this.size !== 'undefined',
         })}
       >
-        <svg fill="none" width="100%" height="100%" class="swc-outerCircle">
+        <svg fill="none" width="100%" height="100%">
           <circle
-            class="swc-innerCircle"
             cx="50%"
             cy="50%"
             r=${`calc(50% - ${strokeWidth / 1}px)`}

--- a/2nd-gen/packages/swc/components/progress-circle/progress-circle.css
+++ b/2nd-gen/packages/swc/components/progress-circle/progress-circle.css
@@ -100,10 +100,6 @@
   --swc-progress-circle-fill-border-color: token("static-black-track-indicator-color");
 }
 
-slot {
-  display: none;
-}
-
 @media (forced-colors: active) {
   .swc-ProgressCircle {
     --swc-progress-circle-fill-border-color: Highlight;

--- a/2nd-gen/packages/swc/components/progress-circle/progress-circle.css
+++ b/2nd-gen/packages/swc/components/progress-circle/progress-circle.css
@@ -103,7 +103,6 @@
 @media (forced-colors: active) {
   .swc-ProgressCircle {
     --swc-progress-circle-fill-border-color: Highlight;
-    --swc-progress-circle-track-color: Canvas;
 
     @media (prefers-color-scheme: dark) {
       --swc-progress-circle-track-border-color: token("static-white-track-color");

--- a/2nd-gen/packages/swc/components/progress-circle/progress-circle.css
+++ b/2nd-gen/packages/swc/components/progress-circle/progress-circle.css
@@ -103,6 +103,7 @@
 @media (forced-colors: active) {
   .swc-ProgressCircle {
     --swc-progress-circle-fill-border-color: Highlight;
+    --swc-progress-circle-track-color: Canvas;
 
     @media (prefers-color-scheme: dark) {
       --swc-progress-circle-track-border-color: token("static-white-track-color");

--- a/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
@@ -103,10 +103,10 @@ export const Overview: Story = {
  *
  * 1. **Track** - Background ring showing the full progress range
  * 2. **Fill** - Colored ring segment showing current progress
- * 3. **Label** - Accessible text describing the operation (not visually rendered)
+ * 3. **Label** - Accessible text describing the operation (not visually rendered), provided via the `label` attribute or property, or `aria-label` / `aria-labelledby` on the host
  *
  * ### Content
- * - **Default slot**: Alternative way to provide an accessible label (the `label` attribute is preferred)
+ *
  * - **Label**: Accessible text describing what is loading or progressing (not visually rendered)
  */
 export const Anatomy: Story = {
@@ -246,9 +246,7 @@ export const Indeterminate: Story = {
  * #### ARIA implementation
  *
  * 1. **ARIA role**: Automatically sets `role="progressbar"` for proper semantic meaning
- * 2. **Labeling**:
- *     - Uses the `label` attribute value as `aria-label`
- *     - Alternative: Content in the default slot can provide the label
+ * 2. **Labeling**: Uses the `label` attribute value as `aria-label`, or rely on `aria-label` / `aria-labelledby` you set on the host
  * 3. **Progress state** (determinate):
  *     - Sets `aria-valuenow` with the current `progress` value
  * 4. **Loading state** (indeterminate):

--- a/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
@@ -202,10 +202,10 @@ export const AriaLabelledbyAccessibleNameTest: Story = {
 };
 
 // ──────────────────────────────────────────────────────────────
-// TEST: Slots
+// TEST: Light DOM (no default slot)
 // ──────────────────────────────────────────────────────────────
 
-export const SlotLabelTest: Story = {
+export const LightDomChildrenDoNotSetLabelTest: Story = {
   render: () => html`
     <swc-progress-circle>Loading data</swc-progress-circle>
   `,
@@ -215,10 +215,24 @@ export const SlotLabelTest: Story = {
       'swc-progress-circle'
     );
 
-    await step('uses slot content as the label', async () => {
-      expect(progressCircle.label).toBe('Loading data');
-      expect(progressCircle.getAttribute('aria-label')).toBe('Loading data');
-    });
+    await step(
+      'does not use light DOM text as the label or accessible name',
+      async () => {
+        expect(progressCircle.label).toBe('');
+        expect(progressCircle.getAttribute('aria-label')).toBeNull();
+      }
+    );
+
+    await step(
+      'warns in dev mode when there is no accessible name (light DOM text alone is insufficient)',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          progressCircle.progress = 10;
+          await progressCircle.updateComplete;
+
+          expect(warnCalls.length).toBeGreaterThan(0);
+        })
+    );
   },
 };
 

--- a/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
@@ -257,6 +257,35 @@ export const ProgressValuesTest: Story = {
   },
 };
 
+export const ProgressClampTest: Story = {
+  render: () => html`
+    <swc-progress-circle
+      progress="150"
+      label="Clamped high"
+    ></swc-progress-circle>
+    <swc-progress-circle
+      progress="-20"
+      label="Clamped low"
+    ></swc-progress-circle>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const circles = await getComponents<ProgressCircle>(
+      canvasElement,
+      'swc-progress-circle'
+    );
+
+    await step('clamps progress above 100 to 100', async () => {
+      expect(circles[0].progress).toBe(100);
+      expect(circles[0].getAttribute('aria-valuenow')).toBe('100');
+    });
+
+    await step('clamps progress below 0 to 0', async () => {
+      expect(circles[1].progress).toBe(0);
+      expect(circles[1].getAttribute('aria-valuenow')).toBe('0');
+    });
+  },
+};
+
 export const IndeterminateTest: Story = {
   ...Indeterminate,
   play: async ({ canvasElement, step }) => {

--- a/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
@@ -224,13 +224,51 @@ export const LightDomChildrenDoNotSetLabelTest: Story = {
     );
 
     await step(
-      'warns in dev mode when there is no accessible name (light DOM text alone is insufficient)',
+      'warns in dev mode: deprecation for light DOM children and accessibility when there is no name',
       () =>
         withWarningSpy(async (warnCalls) => {
           progressCircle.progress = 10;
           await progressCircle.updateComplete;
 
-          expect(warnCalls.length).toBeGreaterThan(0);
+          expect(warnCalls.length).toBeGreaterThanOrEqual(2);
+          expect(
+            warnCalls.some((call) =>
+              String(call[1] ?? '').includes('no longer has a default slot')
+            )
+          ).toBe(true);
+          expect(
+            warnCalls.some((call) =>
+              String(call[1] ?? '').includes('accessible')
+            )
+          ).toBe(true);
+        })
+    );
+  },
+};
+
+export const LightDomWithLabelDeprecationOnlyTest: Story = {
+  render: () => html`
+    <swc-progress-circle label="Uploading" progress="5">
+      Ignored slot content
+    </swc-progress-circle>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const progressCircle = await getComponent<ProgressCircle>(
+      canvasElement,
+      'swc-progress-circle'
+    );
+
+    await step(
+      'still deprecates light DOM when label provides the accessible name',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          progressCircle.progress = 6;
+          await progressCircle.updateComplete;
+
+          expect(warnCalls.length).toBe(1);
+          expect(String(warnCalls[0]?.[1] ?? '')).toContain(
+            'no longer has a default slot'
+          );
         })
     );
   },

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/06_method-patterns.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/06_method-patterns.md
@@ -33,7 +33,7 @@ Within the [IMPLEMENTATION section](02_class-structure.md#section-implementation
 2. **protected** methods second (including lifecycle overrides)
 3. **private** methods last
 
-**Exception:** Keep lifecycle overrides in **Lit order** (e.g. `firstUpdated` before `updated`). A **private method** that only those hooks call may sit **between** them so the file reads in execution order; if the private method is used more broadly, put it **after** all protected members instead.
+**Exception:** Keep lifecycle overrides in **Lit order** (e.g. `firstUpdated` before `updated`). You may place a **private method** **between** those hooks **when only those hooks call it** (and nothing else in the class does), so the file reads in execution order; if the method is also used elsewhere, put it **after** all protected members instead.
 
 **Example from [ProgressCircle.base.ts](../../../2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts) — IMPLEMENTATION section:**
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/06_method-patterns.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/06_method-patterns.md
@@ -27,24 +27,24 @@ This guide explains how to order and name methods in 2nd-gen component classes.
 
 ## Method ordering
 
-Within the [IMPLEMENTATION section](02_class-structure.md#section-implementation) of a base class, or the [RENDERING & STYLING section](02_class-structure.md#section-rendering-and-styling) of a concrete class, order methods by access level:
+Within the [IMPLEMENTATION section](02_class-structure.md#section-implementation) of a base class, or the [RENDERING & STYLING section](02_class-structure.md#section-rendering-and-styling) of a concrete class, use this **default** order by access level:
 
 1. **public** methods first
-2. **protected** methods second (including lifecycle)
+2. **protected** methods second (including lifecycle overrides)
 3. **private** methods last
 
-**Example from ProgressCircle.base.ts — IMPLEMENTATION section:**
+**Exception:** Keep lifecycle overrides in **Lit order** (e.g. `firstUpdated` before `updated`). A **private method** that only those hooks call may sit **between** them so the file reads in execution order; if the private method is used more broadly, put it **after** all protected members instead.
+
+**Example from [ProgressCircle.base.ts](../../../2nd-gen/packages/core/components/progress-circle/ProgressCircle.base.ts) — IMPLEMENTATION section:**
 
 ```ts
-// Protected methods (lifecycle and helpers)
-protected makeRotation(rotation: number): string | undefined { ... }
-protected handleSlotchange(): void { ... }
+// Protected — firstUpdated
 protected override firstUpdated(changes: PropertyValues): void { ... }
 
-// Private methods
+// Private — used by updated()
 private formatProgress(): string { ... }
 
-// Protected lifecycle (later in call order)
+// Protected — updated
 protected override updated(changes: PropertyValues): void { ... }
 ```
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/07_jsdoc-standards.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/07_jsdoc-standards.md
@@ -142,6 +142,23 @@ Declares the slots the component provides. Use this on the **base class**. If th
 - Default slot: `@slot - Description`
 - Named slot: `@slot name - Description`
 
+**CEM:** Put the full slot description on **one line** with the `@slot` tag. The Custom Elements Manifest analyzer does not preserve extra JSDoc lines as part of the slot description; continuation lines are easy to lose or merge unpredictably in generated manifests and Storybook. If you need more detail, add it in the class prose (above the tags) or in component stories—not on following lines under `@slot`.
+
+```ts
+// ✅ Good — single line per slot
+/**
+ * @slot - Text label of the badge.
+ * @slot icon - Optional icon to the left of the label.
+ */
+
+// ❌ Bad — multiline slot description (do not rely on this for CEM)
+/**
+ * @slot - Short summary on the first line.
+ *
+ *   Extra lines you meant as part of the same slot description.
+ */
+```
+
 **Example from Badge.base.ts:**
 
 ```ts

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/07_jsdoc-standards.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/07_jsdoc-standards.md
@@ -384,14 +384,14 @@ Standard JSDoc tags for function parameters and return values. Use them on metho
 - `@returns {Type} Description`
 
 ```ts
-// ✅ Good — describes non-obvious parameter
+// ✅ Good — documents parameter and return when types alone are not enough
 /**
- * Creates a CSS rotation string for the progress indicator.
+ * Whether the string is a supported banner variant.
  *
- * @param rotation - The rotation angle in degrees
- * @returns The CSS rotation value, or undefined if not needed
+ * @param variant - Candidate variant from an attribute or property
+ * @returns True when `variant` is in `ALERT_BANNER_VALID_VARIANTS`
  */
-protected makeRotation(rotation: number): string | undefined { ... }
+protected isValidVariant(variant: string): boolean { ... }
 ```
 
 `@param` and `@returns` are optional when the types and names are self-explanatory.

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/07_jsdoc-standards.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/07_jsdoc-standards.md
@@ -124,7 +124,7 @@ export class Badge extends BadgeBase {
 /**
  * @element swc-progress-circle
  *
- * @property {string} static-color - Static color variant for use on different backgrounds.
+ * @property {string} staticColor - Reflected as the `static-color` attribute. Static color variant for use on different backgrounds.
  * @property {number} progress - Progress value between 0 and 100.
  *
  * @example
@@ -195,13 +195,15 @@ Declares properties at the class level for CEM tools. This is different from the
 
 **Format:** `@property {Type} name - Description`
 
+Use the **JavaScript property name** in the tag (e.g. `staticColor`), not the HTML attribute spelling when it differs (e.g. `static-color`). Hyphenated names are not valid JSDoc namepaths and trigger `jsdoc/valid-types`. Mention the attribute in the description when useful.
+
 **Example from ProgressCircle.ts:**
 
 ```ts
 /**
  * @element swc-progress-circle
  *
- * @property {string} static-color - Static color variant for use on different backgrounds.
+ * @property {string} staticColor - Reflected as the `static-color` attribute. Static color variant for use on different backgrounds.
  * @property {number} progress - Progress value between 0 and 100.
  * @property {boolean} indeterminate - Indeterminate state for loading.
  * @property {string} size - Size of the component.

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/17_debug-validation.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/17_debug-validation.md
@@ -32,7 +32,16 @@ The `window.__swc` object provides debug utilities:
 ```ts
 interface SWCDebug {
   DEBUG: boolean;
-  warn(element: HTMLElement, message: string, url?: string, options?: { issues?: string[] }): void;
+  warn(
+    element: HTMLElement,
+    message: string,
+    url?: string,
+    options?: {
+      type?: string;
+      level?: 'default' | 'low' | 'medium' | 'high' | 'deprecation';
+      issues?: string[];
+    }
+  ): void;
 }
 ```
 


### PR DESCRIPTION
## Description

This change set completes **2nd-gen progress circle** work under **SWC-1671** and related **contributor documentation** updates.

### Progress circle (2nd-gen only)

- **Default slot removed** from core base and SWC template. Accessible naming uses **`label`** / **`aria-label`** / **`aria-labelledby`** only. Stories, tests, and DEBUG messaging updated; `LightDomChildrenDoNotSetLabelTest` covers the no-slot behavior.
- **Dead code removed**: `makeRotation` from `ProgressCircle.base.ts` (1st-gen still uses its own implementation).
- **Template/CSS**: Removed unused `swc-outerCircle` / `swc-innerCircle` classes; dropped redundant `strokeWidth / 1`; removed unused **`--swc-progress-circle-track-color`** in forced-colors.
- **ARIA / behavior**: `aria-valuenow` uses **`String(this.progress)`**; **`progress`** is **clamped to 0–100** (non-finite → `0`) in `willUpdate`; **`ProgressClampTest`** added.
- **DEBUG**: Warning copy uses **`swc-progress-circle`**; doc link points at **2nd-gen Storybook** (`SECOND_GEN_URL` pattern: `.../second-gen/?path=/docs/components-progress-circle--docs`).

### Contributor docs

- **JSDoc standards (`07_jsdoc-standards.md`)**: Document that **`@slot` descriptions should stay on one line** for CEM; generic bad example for multiline slots; `@param`/`@returns` example updated (no removed `makeRotation` reference).
- **Method patterns (`06_method-patterns.md`)**: **Method ordering** — default public → protected → private, with a short **exception** for private methods placed between lifecycle overrides for readability; **ProgressCircle** example brought in sync with the current base.

## Motivation and context

- **Slot vs `label`**: 2nd-gen base is not shared with 1st-gen; a hidden default slot duplicated labeling and complicated CEM. Single path for names reduces confusion and matches preview API direction.
- **Quality follow-ups**: Remove dead code and unused CSS, align DEBUG help with 2nd-gen docs, harden `progress` for SVG and `aria-valuenow`.
- **Docs**: Encode CEM slot line-break behavior and clarify lifecycle ordering without contradicting the access-level default.

## Related issue(s)

- SWC-1671

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes. (slot behavior, clamping, existing story tests)
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it. (stories + CONTRIBUTOR-DOCS)

---

## Reviewer's checklist

### Manual review test cases

- [x] **Progress circle — labeling**
  1. Open [2nd-gen Storybook → Progress circle](https://swcpreviews.z13.web.core.windows.net/pr-6146/docs/second-gen-storybook/?path=/story/components-progress-circle--playground).
  2. In the browser inspector, you should be able to change the label attribute on `<swc-progress-circle>`, this will in turn change or set the `aria-label` attribute.
  3. Confirm slot removal - light DOM text in `<swc-progress-circle>` does not set `label` or `aria-label`.
- [x] **Progress circle — clamp**
  1. Set `progress` above 100 or below 0 (attribute or property - Storybook will limit you in the controls, a better test is to set this in the inspector)
  2. Expect value clamped to 0–100 and `aria-valuenow` changes to match.
- [ ] **Visual regressions**
  1. Confirm that there are no visual regressions in the Progress Circle due to changes in this PR


## Accessibility testing checklist

Progress circle is largely **decorative + `progressbar` semantics**; keyboard surface unchanged. Spot-check **screen reader** announces progress / label when `label` is set and determinate `progress` updates. (To do this in VoiceOver: turn on VoiceOver inside the Storybook Canvas, control + option + shift + down until you're on the progress circle)

