### PR TITLE
feat: style validation doc examples

### DIFF
--- a/.cursor/rules/stories-format.mdc
+++ b/.cursor/rules/stories-format.mdc
@@ -46,6 +46,10 @@ Required structure with visual separators between sections:
 //    AUTODOCS STORY
 // ────────────────────
 
+// ────────────────────
+//    OVERVIEW STORIES
+// ────────────────────
+
 // ──────────────────────────
 //    ANATOMY STORIES
 // ──────────────────────────
@@ -117,6 +121,26 @@ export const Sizes: Story = {
     tags: ['options'],
 };
 ```
+
+### `template()` and slot content
+
+`getStorybookHelpers('<tag>')` returns a `template(args)` function. Use `template({ ...args, ... })` as the default so attributes/properties from the Custom Elements Manifest and Storybook controls stay wired to the component.
+
+Slot args (`default-slot`, `icon-slot`, etc.) accept strings only — they are injected via `innerHTML`. Plain text and self-contained HTML strings work fine.
+
+When slot content can't be expressed as a string — for example, an imported icon or `TemplateResult` content, a Lit binding like `size=${size}`, or a `.map()` call — write the host element directly with `html` instead:
+
+```typescript
+// slot content is a TemplateResult; use html directly
+html`
+  <swc-badge variant=${args.variant} size=${args.size}>
+    <swc-icon slot="icon">${checkmarkIconForSize(args.size)}</swc-icon>
+    ${args['default-slot']}
+  </swc-badge>
+`
+```
+
+Avoid duplicating SVG or nested components as long HTML strings just to force them through a `*-slot` arg.
 
 ### Documentation sections (auto-generated)
 

--- a/2nd-gen/packages/core/components/badge/Badge.base.ts
+++ b/2nd-gen/packages/core/components/badge/Badge.base.ts
@@ -102,58 +102,30 @@ export abstract class BadgeBase extends SizedMixin(
 
   /**
    * The fixed position of the badge.
-   *
-   * @todo The purpose of the bespoke getter and setter is unclear, as it
-   * looks like they may be behaving just like a standard Lit reactive
-   * property. Explore replacing after milestone 2.
    */
-  @property({ reflect: true })
-  public get fixed(): FixedValues | undefined {
-    return this._fixed;
-  }
-
-  public set fixed(fixed: FixedValues | undefined) {
-    if (fixed === this.fixed) {
-      return;
-    }
-    const oldValue = this.fixed;
-    this._fixed = fixed;
-    if (fixed) {
-      this.setAttribute('fixed', fixed);
-    } else {
-      this.removeAttribute('fixed');
-    }
-    this.requestUpdate('fixed', oldValue);
-  }
-
-  private _fixed?: FixedValues;
+  @property({ type: String, reflect: true })
+  public fixed?: FixedValues;
 
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────
 
   /**
-   * Used for rendering gap when the badge has an icon.
-   *
    * @internal
+   *
+   * Used for rendering gap when the badge has an icon.
    */
   protected get hasIcon(): boolean {
     return this.slotContentIsPresent;
   }
 
-  /**
-   * @todo Migrate from update() to updated() for consistency with other
-   * components. The standard pattern is to use updated() for post-render
-   * validation (debug warnings).
-   */
   protected override update(changedProperties: PropertyValues): void {
-    super.update(changedProperties);
     if (window.__swc?.DEBUG) {
       const constructor = this.constructor as typeof BadgeBase;
       if (!constructor.VARIANTS.includes(this.variant)) {
         window.__swc.warn(
           this,
-          `<${this.localName}> element expect the "variant" attribute to be one of the following:`,
+          `<${this.localName}> element expects the "variant" attribute to be one of the following:`,
           'https://opensource.adobe.com/spectrum-web-components/components/badge/#variants',
           {
             issues: [...constructor.VARIANTS],
@@ -176,5 +148,6 @@ export abstract class BadgeBase extends SizedMixin(
         );
       }
     }
+    super.update(changedProperties);
   }
 }

--- a/2nd-gen/packages/core/components/divider/Divider.base.ts
+++ b/2nd-gen/packages/core/components/divider/Divider.base.ts
@@ -29,7 +29,7 @@ import {
  */
 export abstract class DividerBase extends SizedMixin(SpectrumElement, {
   validSizes: DIVIDER_VALID_SIZES,
-  /**@todo the design spec says the default size is small but we declare no default size */
+  /** @todo Size `s` is noted as the default in Spectrum design documentation, so be aware there is a discrepancy between the t-shirt API, which supports `m` as the default, and this component's use of `noDefaultSize` (visual default via CSS). SWC-1847 */
   noDefaultSize: true,
 }) {
   // ──────────────────
@@ -51,17 +51,33 @@ export abstract class DividerBase extends SizedMixin(SpectrumElement, {
 
   /**
    * The static color variant to use for the divider.
-   *
-   * @todo Add runtime validation separately. When implementing,
-   * access STATIC_COLORS from this.constructor.STATIC_COLORS to ensure
-   * correct values are used.
    */
-  @property({ reflect: true, attribute: 'static-color' })
+  @property({ type: String, reflect: true, attribute: 'static-color' })
   public staticColor?: DividerStaticColor;
 
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────
+
+  protected override update(changedProperties: PropertyValues): void {
+    if (window.__swc?.DEBUG) {
+      const constructor = this.constructor as typeof DividerBase;
+      if (
+        typeof this.staticColor !== 'undefined' &&
+        !constructor.STATIC_COLORS.includes(this.staticColor)
+      ) {
+        window.__swc.warn(
+          this,
+          `<${this.localName}> element expects the "static-color" attribute to be one of the following:`,
+          'https://opensource.adobe.com/spectrum-web-components/components/divider/',
+          {
+            issues: [...constructor.STATIC_COLORS],
+          }
+        );
+      }
+    }
+    super.update(changedProperties);
+  }
 
   protected override firstUpdated(changed: PropertyValues<this>): void {
     super.firstUpdated(changed);

--- a/2nd-gen/packages/swc/components/badge/Badge.ts
+++ b/2nd-gen/packages/swc/components/badge/Badge.ts
@@ -104,8 +104,8 @@ export class Badge extends BadgeBase {
         class=${classMap({
           ['swc-Badge']: true,
           [`swc-Badge--${this.variant}`]: typeof this.variant !== 'undefined',
-          [`swc-Badge--subtle`]: this.subtle,
-          [`swc-Badge--outline`]: this.outline,
+          ['swc-Badge--subtle']: this.subtle,
+          ['swc-Badge--outline']: this.outline,
           [`swc-Badge--fixed-${this.fixed}`]: typeof this.fixed !== 'undefined',
         })}
       >
@@ -114,7 +114,7 @@ export class Badge extends BadgeBase {
           () => html`
             <div
               class=${classMap({
-                [`swc-Badge-icon`]: true,
+                ['swc-Badge-icon']: true,
               })}
             >
               <slot name="icon"></slot>

--- a/2nd-gen/packages/swc/components/badge/Badge.ts
+++ b/2nd-gen/packages/swc/components/badge/Badge.ts
@@ -64,9 +64,11 @@ export class Badge extends BadgeBase {
 
   /**
    * The variant of the badge.
+   *
+   * @todo - Implement new badge variants (notification, indicator) introduced in S2. Jira ticket: SWC-1831
    */
   @property({ type: String, reflect: true })
-  public override variant: BadgeVariant = 'informative';
+  public override variant: BadgeVariant = 'neutral';
 
   // ───────────────────
   //     API ADDITIONS
@@ -107,6 +109,7 @@ export class Badge extends BadgeBase {
           ['swc-Badge--subtle']: this.subtle,
           ['swc-Badge--outline']: this.outline,
           [`swc-Badge--fixed-${this.fixed}`]: typeof this.fixed !== 'undefined',
+          [`swc-Badge--no-label`]: !this.slotHasContent,
         })}
       >
         ${when(

--- a/2nd-gen/packages/swc/components/badge/badge.css
+++ b/2nd-gen/packages/swc/components/badge/badge.css
@@ -11,7 +11,7 @@
  */
 
 :host {
-  display: inline-block;
+  display: inline-flex;
   place-self: start;
   vertical-align: middle;
 }
@@ -20,17 +20,20 @@
   box-sizing: border-box;
 }
 
+/* @todo Size `s` is noted as the default in Spectrum design documentation, so be aware there is a discrepancy between the t-shirt API, which supports `m` as the default. SWC-1847 */
 .swc-Badge {
   --_swc-badge-border-width: token("border-width-200");
-  --_swc-badge-border-width-deduction: calc(var(--_swc-badge-border-width) * 2);
-  --_swc-badge-padding-block: token("component-top-to-text-100") token("component-bottom-to-text-100");
+  --_swc-badge-padding-block: var(--swc-badge-padding-block, token("component-padding-vertical-100"));
+  --_swc-badge-padding-inline-start: var(--swc-badge-padding-inline-start, var(--swc-badge-padding-inline, token("component-edge-to-text-100")));
+  --_swc-badge-padding-inline: var(--swc-badge-padding-inline, token("component-edge-to-text-100"));
 
   display: inline-flex;
   gap: var(--swc-badge-gap, token("text-to-visual-100"));
   align-items: center;
   min-block-size: var(--swc-badge-height, token("component-height-100"));
-  padding-block: calc(var(--swc-badge-padding-block, var(--_swc-badge-padding-block)) - var(--_swc-badge-border-width-deduction));
-  padding-inline: calc(var(--swc-badge-padding-inline, token("component-edge-to-text-100")) - var(--_swc-badge-border-width-deduction));
+  padding-block: calc(var(--_swc-badge-padding-block) - var(--_swc-badge-border-width));
+  padding-inline-start: calc(var(--_swc-badge-padding-inline-start) - var(--_swc-badge-border-width));
+  padding-inline-end: calc(var(--_swc-badge-padding-inline) - var(--_swc-badge-border-width));
   color: var(--swc-badge-label-icon-color, token("white"));
   background: var(--swc-badge-background-color, token("accent-background-color-default"));
   border: var(--_swc-badge-border-width) solid var(--swc-badge-border-color, transparent);
@@ -38,8 +41,15 @@
   cursor: default;
 }
 
-.swc-Badge:has(.swc-Badge-icon) {
-  --swc-badge-padding-inline: var(--swc-badge-with-icon-padding-inline, token("component-edge-to-visual-100"));
+.swc-Badge:where(:has(.swc-Badge-icon):not(.swc-Badge--no-label)) {
+  --swc-badge-padding-inline-start: var(--swc-badge-with-icon-padding-inline, token("component-edge-to-visual-100"));
+}
+
+.swc-Badge--no-label:where(:has(.swc-Badge-icon)) {
+  --swc-badge-padding-block: var(--swc-badge-with-icon-only-padding-block, token("component-edge-to-visual-only-100"));
+  --swc-badge-padding-inline-start: var(--swc-badge-with-icon-only-padding-inline, token("component-edge-to-visual-only-100"));
+  --swc-badge-padding-inline: var(--swc-badge-with-icon-only-padding-inline, token("component-edge-to-visual-only-100"));
+  --swc-badge-gap: 0;
 }
 
 .swc-Badge-label {
@@ -70,7 +80,9 @@
   --swc-badge-gap: token("text-to-visual-75");
   --swc-badge-padding-inline: token("component-edge-to-text-75");
   --swc-badge-with-icon-padding-inline: token("component-edge-to-visual-75");
-  --swc-badge-padding-block: token("component-top-to-text-75") token("component-bottom-to-text-75");
+  --swc-badge-with-icon-only-padding-inline: token("component-edge-to-visual-only-75");
+  --swc-badge-with-icon-only-padding-block: token("component-edge-to-visual-only-75");
+  --swc-badge-padding-block: token("component-padding-vertical-75");
   --swc-badge-font-size: token("font-size-75");
   --swc-badge-icon-size: token("workflow-icon-size-75");
 }
@@ -81,7 +93,9 @@
   --swc-badge-gap: token("text-to-visual-200");
   --swc-badge-padding-inline: token("component-edge-to-text-200");
   --swc-badge-with-icon-padding-inline: token("component-edge-to-visual-200");
-  --swc-badge-padding-block: token("component-top-to-text-200") token("component-bottom-to-text-200");
+  --swc-badge-with-icon-only-padding-inline: token("component-edge-to-visual-only-200");
+  --swc-badge-with-icon-only-padding-block: token("component-edge-to-visual-only-200");
+  --swc-badge-padding-block: token("component-padding-vertical-200");
   --swc-badge-font-size: token("font-size-200");
   --swc-badge-icon-size: token("workflow-icon-size-200");
 }
@@ -92,7 +106,9 @@
   --swc-badge-gap: token("text-to-visual-300");
   --swc-badge-padding-inline: token("component-edge-to-text-300");
   --swc-badge-with-icon-padding-inline: token("component-edge-to-visual-300");
-  --swc-badge-padding-block: token("component-top-to-text-300") token("component-bottom-to-text-300");
+  --swc-badge-with-icon-only-padding-inline: token("component-edge-to-visual-only-300");
+  --swc-badge-with-icon-only-padding-block: token("component-edge-to-visual-only-300");
+  --swc-badge-padding-block: token("component-padding-vertical-300");
   --swc-badge-font-size: token("font-size-300");
   --swc-badge-icon-size: token("workflow-icon-size-300");
 }

--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -10,13 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-import { html } from 'lit';
+import { html, TemplateResult } from 'lit';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
 import { Badge } from '@adobe/spectrum-wc/badge';
 
 import '@adobe/spectrum-wc/badge';
+import '@adobe/spectrum-wc/icon';
 
 import {
   BADGE_VALID_SIZES,
@@ -29,6 +30,12 @@ import {
   FIXED_VALUES,
   type FixedValues,
 } from '../../../../core/components/badge/Badge.types.js';
+import {
+  Checkmark75Icon,
+  Checkmark100Icon,
+  Checkmark200Icon,
+  Checkmark300Icon,
+} from '../../icon/elements/index.js';
 
 // ────────────────
 //    METADATA
@@ -44,7 +51,7 @@ argTypes.variant = {
   table: {
     category: 'attributes',
     defaultValue: {
-      summary: 'informative',
+      summary: 'neutral',
     },
   },
 };
@@ -71,6 +78,15 @@ argTypes.size = {
       summary: 'm',
     },
   },
+};
+
+// @todo: create a select dropdown with all available/acceptable icons for a component.
+// For now, this arg is turned off in the control table since the string doesn't get parsed as HTML: SWC-1853
+argTypes['icon-slot'] = {
+  ...argTypes['icon-slot'],
+  control: false,
+  description:
+    'Accepts an icon element. The control is disabled. Use the Anatomy story to see icon usage. Enhancements to this control will be added in a future release.',
 };
 
 /**
@@ -152,6 +168,18 @@ const nonSemanticLabels = {
 
 const allVariantsLabels = { ...semanticLabels, ...nonSemanticLabels };
 
+const checkmarkIconForSize = (size: string): TemplateResult => {
+  const validSize: BadgeSize = BADGE_VALID_SIZES.includes(size as BadgeSize)
+    ? (size as BadgeSize)
+    : 'm';
+  return {
+    s: Checkmark75Icon,
+    m: Checkmark100Icon,
+    l: Checkmark200Icon,
+    xl: Checkmark300Icon,
+  }[validSize]();
+};
+
 const fixedLabels = {
   'block-start': 'Block start',
   'block-end': 'Block end',
@@ -166,8 +194,6 @@ const fixedLabels = {
 export const Playground: Story = {
   render: (args) => template(args),
   args: {
-    size: 'm',
-    variant: 'informative',
     'default-slot': 'Active',
   },
   tags: ['autodocs', 'dev'],
@@ -183,8 +209,6 @@ export const Overview: Story = {
   `,
   tags: ['overview'],
   args: {
-    size: 'm',
-    variant: 'informative',
     'default-slot': 'Active',
   },
 };
@@ -206,19 +230,31 @@ export const Overview: Story = {
  * - **icon slot**: (optional) - Visual indicator positioned before the label
  */
 export const Anatomy: Story = {
-  render: (args) => html`
-    ${template({ ...args, 'default-slot': 'Label only' })}
-    ${template({ ...args, 'icon-slot': '✓', 'aria-label': 'Icon only' })}
-    ${template({
-      ...args,
-      'icon-slot': '✓',
-      'default-slot': 'Icon and label',
-    })}
-  `,
+  render: (args) => {
+    const size = args.size as BadgeSize;
+    return html`
+      ${template({ ...args, 'default-slot': 'Label only' })}
+      <swc-badge
+        variant=${args.variant}
+        size=${size}
+        role="img"
+        aria-label="Checkmark"
+      >
+        <swc-icon size=${size} slot="icon">
+          ${checkmarkIconForSize(size)}
+        </swc-icon>
+      </swc-badge>
+      <swc-badge variant=${args.variant} size=${size}>
+        <swc-icon size=${size} slot="icon">
+          ${checkmarkIconForSize(size)}
+        </swc-icon>
+        Icon and label
+      </swc-badge>
+    `;
+  },
   tags: ['anatomy'],
   args: {
-    variant: 'informative',
-    size: 'm',
+    variant: 'neutral',
   },
 };
 
@@ -236,20 +272,25 @@ export const Anatomy: Story = {
  *
  * The `m` size is the default and most frequently used option. Use larger sizes sparingly to create a hierarchy of importance on a page.
  */
+
+// @todo - We should make sure to capture icon-only badges in all sizes for VRTs: SWC-1852
 export const Sizes: Story = {
   render: (args) => html`
-    ${BADGE_VALID_SIZES.map((size) =>
-      template({
-        ...args,
-        size,
-        'default-slot': sizeLabels[size],
-      })
+    ${BADGE_VALID_SIZES.map(
+      (size) => html`
+        <swc-badge variant=${args.variant} size=${size}>
+          <swc-icon size=${size} slot="icon">
+            ${checkmarkIconForSize(size)}
+          </swc-icon>
+          ${sizeLabels[size]}
+        </swc-badge>
+      `
     )}
   `,
   parameters: { 'section-order': 1 },
   tags: ['options'],
   args: {
-    variant: 'informative',
+    variant: 'neutral',
   },
 };
 
@@ -291,7 +332,6 @@ SemanticVariants.storyName = 'Semantic variants';
  * - Creating department, team, or project color schemes
  *
  * > **Note**: 2nd-gen adds `pink`, `turquoise`, `brown`, `cinnamon`, and `silver` variants.
- * 1st-gen variants `gray`, `red`, `orange`, `green`, and `blue` are not available in 2nd-gen.
  */
 export const NonSemanticVariants: Story = {
   render: (args) => html`
@@ -374,16 +414,13 @@ export const Fixed: Story = {
       template({
         ...args,
         fixed,
+        variant: 'neutral',
         'default-slot': fixedLabels[fixed],
       })
     )}
   `,
   parameters: { 'section-order': 6 },
   tags: ['options'],
-  args: {
-    variant: 'informative',
-    size: 'm',
-  },
 };
 
 // ──────────────────────────────
@@ -400,16 +437,12 @@ export const TextWrapping: Story = {
   render: (args) => html`
     ${template({
       ...args,
-      variant: 'informative',
+      variant: 'notice',
       'default-slot': 'Document review pending approval from manager',
       style: 'max-inline-size: 120px',
     })}
   `,
   tags: ['behaviors'],
-  args: {
-    variant: 'informative',
-    size: 'm',
-  },
 };
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
@@ -432,11 +465,28 @@ export const TextWrapping: Story = {
  * - Screen readers will announce the badge content as static text
  * - No keyboard interaction is required or expected
  *
+ * ### Text label
+ *
+ * Badges with visible text are announced directly by screen readers. The text in the default slot is the accessible name.
+ *
+ * ### Icon + text
+ *
+ * When an icon accompanies a text label, the icon is decorative and should be hidden from assistive technology.
+ * Apply `aria-hidden="true"` to the `<swc-icon>` so screen readers only announce the label text.
+ *
+ * ### Icon only
+ *
+ * When space is limited and no visible label is shown, the badge **must** have an accessible name.
+ * Set `role="img"` and `aria-label` directly on the `<swc-badge>` element to describe the badge's meaning.
+ * `role="img"` is required because custom elements have no implicit ARIA role — without it, `aria-label` is not
+ * permitted by the ARIA specification and will fail automated accessibility checks.
+ * Without both attributes, the badge has no accessible name and fails WCAG 1.1.1.
+ *
  * ### Best practices
  *
  * - Use semantic variants (`positive`, `negative`, `notice`, `informative`, `neutral`, `accent`) when the status has specific meaning
  * - Include clear, descriptive labels that explain the status without relying on color alone
- * - For icon-only badges, provide descriptive text in the default slot or use the `aria-label` attribute directly on the element
+ * - For icon-only badges, always set `role="img"` and `aria-label` on `swc-badge`
  * - Ensure sufficient color contrast between the badge and its background
  * - Badges are not interactive elements - for interactive status indicators, consider using buttons, tags, or links instead
  * - When using multiple badges together, ensure they're clearly associated with their related content
@@ -486,9 +536,26 @@ export const Accessibility: Story = {
       variant: 'silver',
       'default-slot': 'Version 1.2.10',
     })}
+
+    <!-- Icon + text: icon is decorative, aria-hidden="true" hides it from assistive technology -->
+    <swc-badge variant="positive" size=${args.size}>
+      <swc-icon size=${args.size} slot="icon" aria-hidden="true">
+        ${checkmarkIconForSize(args.size)}
+      </swc-icon>
+      Approved
+    </swc-badge>
+
+    <!-- Icon-only: role and aria-label provides the accessible name and purpose when no visible text is present -->
+    <swc-badge
+      variant="positive"
+      size=${args.size}
+      role="img"
+      aria-label="Approved"
+    >
+      <swc-icon size=${args.size} slot="icon">
+        ${checkmarkIconForSize(args.size)}
+      </swc-icon>
+    </swc-badge>
   `,
   tags: ['a11y'],
-  args: {
-    size: 'm',
-  },
 };

--- a/2nd-gen/packages/swc/components/badge/test/badge.test.ts
+++ b/2nd-gen/packages/swc/components/badge/test/badge.test.ts
@@ -61,7 +61,7 @@ export const OverviewTest: Story = {
     const badge = await getComponent<Badge>(canvasElement, 'swc-badge');
 
     await step('renders expected default values and slot content', async () => {
-      expect(badge.variant).toBe('informative');
+      expect(badge.variant).toBe('neutral');
       expect(badge.size).toBe('m');
       expect(badge.textContent?.trim()).toBeTruthy();
     });
@@ -139,7 +139,7 @@ export const AnatomyTest: Story = {
       expect(badgeWithIcon).toBeTruthy();
       const slottedIcon = badgeWithIcon?.querySelector('[slot="icon"]');
       expect(slottedIcon).toBeTruthy();
-      expect(slottedIcon?.textContent?.trim()).toBeTruthy();
+      expect(slottedIcon?.children.length).toBeGreaterThan(0);
     });
   },
 };

--- a/2nd-gen/packages/swc/components/divider/Divider.ts
+++ b/2nd-gen/packages/swc/components/divider/Divider.ts
@@ -40,7 +40,7 @@ export class Divider extends DividerBase {
           [`swc-Divider--size${this.size?.toUpperCase()}`]: this.size != null,
           [`swc-Divider--static${capitalize(this.staticColor)}`]:
             this.staticColor != null,
-          [`swc-Divider--vertical`]: this.vertical,
+          ['swc-Divider--vertical']: this.vertical,
         })}
       ></div>
     `;

--- a/2nd-gen/packages/swc/components/divider/divider.css
+++ b/2nd-gen/packages/swc/components/divider/divider.css
@@ -18,6 +18,7 @@
   box-sizing: border-box;
 }
 
+/* @todo capture visual regression tests for WHCM (forced-colors) and more static color sizes in Chromatic. SWC-1848 */
 .swc-Divider {
   --_swc-divider-thickness: var(--swc-divider-thickness, token("divider-thickness-medium"));
 

--- a/2nd-gen/packages/swc/components/divider/divider.css
+++ b/2nd-gen/packages/swc/components/divider/divider.css
@@ -25,8 +25,16 @@
   inline-size: 100%;
   block-size: var(--_swc-divider-thickness);
   background-color: var(--swc-divider-background-color, token("gray-200"));
-  border: none;
   border-radius: var(--_swc-divider-thickness);
+}
+
+:host([size="s"]) {
+  --swc-divider-thickness: token("divider-thickness-small");
+}
+
+:host([size="l"]) {
+  --swc-divider-thickness: token("divider-thickness-large");
+  --swc-divider-background-color: token("gray-800");
 }
 
 .swc-Divider:not(.swc-Divider--vertical) {
@@ -38,16 +46,6 @@
   inline-size: var(--_swc-divider-thickness);
   block-size: 100%;
   min-block-size: token("divider-vertical-minimum-height");
-  margin-block: 0;
-}
-
-:host([size="s"]) {
-  --swc-divider-thickness: token("divider-thickness-small");
-}
-
-:host([size="l"]) {
-  --swc-divider-thickness: token("divider-thickness-large");
-  --swc-divider-background-color: token("gray-800");
 }
 
 .swc-Divider--staticWhite {

--- a/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
+++ b/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
@@ -28,6 +28,12 @@ argTypes.size = {
   ...argTypes.size,
   control: { type: 'select' },
   options: Divider.VALID_SIZES,
+  table: {
+    category: 'attributes',
+    defaultValue: {
+      summary: 'm',
+    },
+  },
 };
 
 argTypes['static-color'] = {
@@ -84,9 +90,9 @@ export const Playground: Story = {
 
 export const Overview: Story = {
   render: (args) => html`
-    <h3>Content above the divider</h3>
+    <h3>Account settings</h3>
     ${template({ ...args, size: 'm' })}
-    <p>Content below the divider</p>
+    <p>Update your personal details, password, and preferences.</p>
   `,
   parameters: {
     flexLayout: 'column-stretch',
@@ -105,9 +111,9 @@ export const Overview: Story = {
  */
 export const Anatomy: Story = {
   render: (args) => html`
-    <h4>Content above the divider</h4>
+    <h4>Account settings</h4>
     ${template({ ...args, size: 'm' })}
-    <p>Content below the divider</p>
+    <p>Update your personal details, password, and preferences.</p>
   `,
   tags: ['anatomy'],
   parameters: {
@@ -129,19 +135,19 @@ export const Anatomy: Story = {
 export const Sizes: Story = {
   render: (args) => html`
     <div>
-      <h3>Small</h3>
+      <h3>Team members</h3>
       ${template({ ...args, size: 's' })}
-      <p>Content below the small divider.</p>
+      <p>Manage your team roles and access permissions.</p>
     </div>
     <div>
-      <h3>Medium</h3>
+      <h3>Account settings</h3>
       ${template({ ...args, size: 'm' })}
-      <p>Content below the medium divider.</p>
+      <p>Update your personal details, password, and preferences.</p>
     </div>
     <div>
-      <h3>Large</h3>
+      <h3>Projects</h3>
       ${template({ ...args, size: 'l' })}
-      <p>Content below the large divider.</p>
+      <p>Track progress across your projects.</p>
     </div>
   `,
   parameters: {
@@ -156,24 +162,24 @@ export const Sizes: Story = {
  */
 export const Vertical: Story = {
   render: (args) => html`
-    <h4>Small</h4>
+    <h4>Profile</h4>
     ${template({
       ...args,
       size: 's',
     })}
-    <p>Content next to the small divider.</p>
-    <h4>Medium</h4>
+    <p>Your profile name appears when you log in.</p>
+    <h4>Account settings</h4>
     ${template({
       ...args,
       size: 'm',
     })}
-    <p>Content next to the medium divider.</p>
-    <h4>Large</h4>
+    <p>Update your password and preferences.</p>
+    <h4>Projects</h4>
     ${template({
       ...args,
       size: 'l',
     })}
-    <p>Content next to the large divider.</p>
+    <p>Track progress across your projects.</p>
   `,
   parameters: {
     'section-order': 2,

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md
@@ -58,12 +58,11 @@ CSS custom properties *normally* can't actually be "private". However, due to sh
 ```css
 .swc-Badge {
   --_swc-badge-border-width: token("border-width-200");
-  --_swc-badge-border-width-deduction: calc(var(--_swc-badge-border-width) * 2);
-  --_swc-badge-padding-block-start: token("component-top-to-text-100");
-  --_swc-badge-padding-block-end: token("component-bottom-to-text-100");
+  --_swc-badge-padding-inline-start: var(--swc-badge-padding-inline-start, var(--swc-badge-padding-inline, token("component-edge-to-text-100")));
+  --_swc-badge-padding-block: var(--swc-badge-padding-block, token("component-padding-vertical-100"));
 
-  padding-block-start: calc(var(--swc-badge-padding-block-start, var(--_swc-badge-padding-block-start)) - var(--_swc-badge-border-width-deduction));
-  padding-block-end: calc(var(--swc-badge-padding-block-end, var(--_swc-badge-padding-block-end)) - var(--_swc-badge-border-width-deduction));
+  padding-inline-start: calc(var(--_swc-badge-padding-inline-start) - var(--_swc-badge-border-width));
+  padding-block: calc(var(--_swc-badge-padding-block) - var(--_swc-badge-border-width));
   background: var(--swc-badge-background-color, token("accent-background-color-default"));
 }
 ```

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/04_spectrum-swc-migration.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/04_spectrum-swc-migration.md
@@ -148,21 +148,15 @@ Badge clearly distinguishes between **exposed customization** and **internal imp
   display: inline-flex;
   align-items: center;
   gap: var(--swc-badge-gap, token('text-to-visual-100'));
-  padding-inline: var(
-    --swc-badge-padding-inline,
-    token('component-edge-to-text-100')
-  );
-  padding-block: var(
-    --swc-badge-padding-block,
-    token('component-top-to-text-100')
-    token('component-bottom-to-text-100')
-  );
+  padding-inline-start: calc(var(--_swc-badge-padding-inline-start) - var(--_swc-badge-border-width));
+  padding-inline-end: calc(var(--_swc-badge-padding-inline) - var(--_swc-badge-border-width));
+  padding-block: calc(var(--_swc-badge-padding-block) - var(--_swc-badge-border-width));
 }
 ```
 
 ```css
-.swc-Badge:has(.swc-Badge-icon) {
-  --swc-badge-padding-inline: token('component-edge-to-visual-100');
+.swc-Badge:where(:has(.swc-Badge-icon):not(.swc-Badge--no-label)) {
+  --swc-badge-padding-inline-start: var(--swc-badge-with-icon-padding-inline, token('component-edge-to-visual-100'));
 }
 ```
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/02_class-structure.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/02_class-structure.md
@@ -181,10 +181,10 @@ protected get hasIcon(): boolean {
 }
 
 protected override update(changedProperties: PropertyValues): void {
-  super.update(changedProperties);
   if (window.__swc?.DEBUG) {
-    // ...variant validation...
+    // ...variant validation (before super.update so it runs before render)...
   }
+  super.update(changedProperties);
 }
 ```
 
@@ -311,6 +311,8 @@ protected override render(): TemplateResult {
   `;
 }
 ```
+
+For `classMap` object keys (bracketed string keys vs plain quoted keys, mixing with template literal keys, and what to avoid), see [classMap patterns](09_rendering-patterns.md#classmap-patterns).
 
 ## Section comment format
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/17_debug-validation.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/17_debug-validation.md
@@ -60,17 +60,28 @@ Different validation concerns belong in different lifecycle methods. Choose base
 - Property combinations that are invalid together
 - Required properties that affect rendering
 
-**Why update():**
+**Why `update()` (and where to put your code):**
 
-- Runs before render, so warnings appear before DOM changes
-- Can short-circuit or adjust state before template evaluation
-- Consistent with Lit's unidirectional data flow
+Lit’s [`update()`](https://lit.dev/docs/components/lifecycle/#update) “reflects property values to attributes and calls `render()` to update the component’s internal DOM.” In `LitElement`, that happens **inside** `super.update()` when your class extends Lit. So:
+
+- If you call `super.update()` **first** and then run DEBUG code, that code runs **after** `render()` has run for this cycle (still before Lit calls [`updated()`](https://lit.dev/docs/components/lifecycle/#updated)).
+- For DEBUG that should fire **before** `render()` and DOM commit, run it **before** `super.update()` in your override, or use [`willUpdate()`](https://lit.dev/docs/components/lifecycle/#willupdate) (Lit calls it before `update()`).
+
+The [reactive update cycle](https://lit.dev/docs/components/lifecycle/#reactive-update-cycle) runs at microtask timing, generally before the browser paints the next frame—but “before paint” is not the same as “before `render()`” inside your component.
+
+**References (Lit):**
+
+- [Lifecycle: `update()`](https://lit.dev/docs/components/lifecycle/#update)
+- [Lifecycle: `willUpdate()`](https://lit.dev/docs/components/lifecycle/#willupdate)
+- [Lifecycle: `updated()`](https://lit.dev/docs/components/lifecycle/#updated)
+- [Reactive update cycle](https://lit.dev/docs/components/lifecycle/#reactive-update-cycle)
+
+**Implementation note:** This repo’s `lit-element` version is the source of truth for exact ordering inside `LitElement.prototype.update` (e.g. `render()` then `super.update()` on `ReactiveElement`, then committing the template). See the `update(changedProperties)` method in the installed `lit-element` package under `node_modules`.
 
 **Example from Badge.base.ts:**
 
 ```ts
 protected override update(changedProperties: PropertyValues): void {
-  super.update(changedProperties);
   if (window.__swc?.DEBUG) {
     const constructor = this.constructor as typeof BadgeBase;
     // Validate variant value
@@ -92,6 +103,7 @@ protected override update(changedProperties: PropertyValues): void {
       );
     }
   }
+  super.update(changedProperties);
 }
 ```
 
@@ -138,9 +150,9 @@ protected override firstUpdated(changed: PropertyValues): void {
 
 **Why updated():**
 
-- Runs after render, so DOM reflects current state
-- Can check rendered output and slot assignments
-- Good for "the current state is problematic" warnings
+- Lit’s [`updated()`](https://lit.dev/docs/components/lifecycle/#updated) runs after the element’s DOM has been updated and rendered for this cycle.
+- DOM reflects current state; you can check rendered output and slot assignments.
+- Good for “the current state is problematic” warnings.
 
 **Example:**
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
@@ -30,6 +30,7 @@
     - [Avatar migration roadmap](avatar/rendering-and-styling-migration-analysis.md)
 - Badge
     - [Badge accessibility migration analysis](badge/accessibility-migration-analysis.md)
+    - [Badge Styling Validation](badge/badge-styling-validation.md)
     - [Badge migration roadmap](badge/rendering-and-styling-migration-analysis.md)
 - Button
     - [Button migration roadmap](button/rendering-and-styling-migration-analysis.md)
@@ -41,6 +42,7 @@
     - [Color field migration roadmap](color-field/rendering-and-styling-migration-analysis.md)
 - Divider
     - [Divider accessibility migration analysis](divider/accessibility-migration-analysis.md)
+    - [Divider Styling Validation](divider/divider-styling-validation.md)
     - [Divider migration roadmap](divider/rendering-and-styling-migration-analysis.md)
 - Dropzone
     - [Dropzone migration roadmap](dropzone/rendering-and-styling-migration-analysis.md)
@@ -70,6 +72,7 @@
     - [Progress bar migration roadmap](progress-bar/rendering-and-styling-migration-analysis.md)
 - Progress Circle
     - [Progress circle accessibility migration analysis](progress-circle/accessibility-migration-analysis.md)
+    - [Progress circle styling validation](progress-circle/progress-circle-styling-validation.md)
     - [Progress Circle migration roadmap](progress-circle/rendering-and-styling-migration-analysis.md)
 - Radio
     - [Radio migration roadmap](radio/rendering-and-styling-migration-analysis.md)
@@ -80,6 +83,7 @@
 - Status Light
     - [Status light accessibility migration analysis](status-light/accessibility-migration-analysis.md)
     - [Status Light migration roadmap](status-light/rendering-and-styling-migration-analysis.md)
+    - [Status light styling validation](status-light/statuslight-styling-validation.md)
 - Swatch
     - [Swatch migration roadmap](swatch/rendering-and-styling-migration-analysis.md)
 - Swatch Group

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/badge/badge-styling-validation.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/badge/badge-styling-validation.md
@@ -1,0 +1,125 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../../../README.md) / [Project planning](../../README.md) / [Components](../README.md) / Badge / Badge Styling Validation
+
+<!-- Document title (editable) -->
+
+# Badge Styling Validation
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [CSS Custom Properties (Consumer Overrides)](#css-custom-properties-consumer-overrides)
+    - [Background color — `--swc-badge-background-color`](#background-color----swc-badge-background-color)
+    - [Label and icon color — `--swc-badge-label-icon-color`](#label-and-icon-color----swc-badge-label-icon-color)
+    - [Size-specific tokens](#size-specific-tokens)
+
+</details>
+
+<!-- Document content (editable) -->
+
+Figma reference: [S2 - Web Desktop scale, Badge (S) component set 36806:6700](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=36806-6700&m=dev)
+
+## CSS Custom Properties (Consumer Overrides)
+
+### Background color — `--swc-badge-background-color`
+
+#### Bold fill style (default)
+
+
+| Variant       | Token                                      |
+| ------------- | ------------------------------------------ |
+| `accent`      | `accent-background-color-default`          |
+| `informative` | `informative-background-color-default`     |
+| `neutral`     | `neutral-subdued-background-color-default` |
+| `positive`    | `positive-background-color-default`        |
+| `notice`      | `notice-background-color-default`          |
+| `negative`    | `negative-background-color-default`        |
+| `gray`        | `gray-background-color-default`            |
+| `red`         | `red-background-color-default`             |
+| `orange`      | `orange-background-color-default`          |
+| `yellow`      | `yellow-background-color-default`          |
+| `chartreuse`  | `chartreuse-background-color-default`      |
+| `celery`      | `celery-background-color-default`          |
+| `green`       | `green-background-color-default`           |
+| `seafoam`     | `seafoam-background-color-default`         |
+| `cyan`        | `cyan-background-color-default`            |
+| `blue`        | `blue-background-color-default`            |
+| `indigo`      | `indigo-background-color-default`          |
+| `purple`      | `purple-background-color-default`          |
+| `fuchsia`     | `fuchsia-background-color-default`         |
+| `magenta`     | `magenta-background-color-default`         |
+| `pink`        | `pink-background-color-default`            |
+| `turquoise`   | `turquoise-background-color-default`       |
+| `brown`       | `brown-background-color-default`           |
+| `cinnamon`    | `cinnamon-background-color-default`        |
+| `silver`      | `silver-background-color-default`          |
+
+
+#### Subtle fill style (`subtle` attribute)
+
+
+| Variant       | Token                                         |
+| ------------- | --------------------------------------------- |
+| `accent`      | `accent-subtle-background-color-default`      |
+| `informative` | `informative-subtle-background-color-default` |
+| `neutral`     | `neutral-subtle-background-color-default`     |
+| `positive`    | `positive-subtle-background-color-default`    |
+| `notice`      | `notice-subtle-background-color-default`      |
+| `negative`    | `negative-subtle-background-color-default`    |
+| `gray`        | `gray-subtle-background-color-default`        |
+| `red`         | `red-subtle-background-color-default`         |
+| `orange`      | `orange-subtle-background-color-default`      |
+| `yellow`      | `yellow-subtle-background-color-default`      |
+| `chartreuse`  | `chartreuse-subtle-background-color-default`  |
+| `celery`      | `celery-subtle-background-color-default`      |
+| `green`       | `green-subtle-background-color-default`       |
+| `seafoam`     | `seafoam-subtle-background-color-default`     |
+| `cyan`        | `cyan-subtle-background-color-default`        |
+| `blue`        | `blue-subtle-background-color-default`        |
+| `indigo`      | `indigo-subtle-background-color-default`      |
+| `purple`      | `purple-subtle-background-color-default`      |
+| `fuchsia`     | `fuchsia-subtle-background-color-default`     |
+| `magenta`     | `magenta-subtle-background-color-default`     |
+| `pink`        | `pink-subtle-background-color-default`        |
+| `turquoise`   | `turquoise-subtle-background-color-default`   |
+| `brown`       | `brown-subtle-background-color-default`       |
+| `cinnamon`    | `cinnamon-subtle-background-color-default`    |
+| `silver`      | `silver-subtle-background-color-default`      |
+
+
+#### Outline style (`outline` attribute, semantic variants only)
+
+
+| Variant       | Background token           | Border color token         |
+| ------------- | -------------------------- | -------------------------- |
+| `accent`      | `background-layer-2-color` | `accent-visual-color`      |
+| `informative` | `background-layer-2-color` | `informative-visual-color` |
+| `neutral`     | `background-layer-2-color` | `neutral-visual-color`     |
+| `positive`    | `background-layer-2-color` | `positive-visual-color`    |
+| `notice`      | `background-layer-2-color` | `notice-visual-color`      |
+| `negative`    | `background-layer-2-color` | `negative-visual-color`    |
+
+
+### Label and icon color — `--swc-badge-label-icon-color`
+
+
+| Condition                                                        | Token       |
+| ---------------------------------------------------------------- | ----------- |
+| Bold fill — most variants                                        | `white`     |
+| Bold fill — `notice`, `yellow`, `chartreuse`, `celery`, `orange` | `black`     |
+| Subtle fill — all variants                                       | `gray-1000` |
+| Outline — all semantic variants                                  | `gray-1000` |
+
+
+### Size-specific tokens
+
+
+| Size | `--swc-badge-height`   | `--swc-badge-corner-radius`             | `--swc-badge-gap`    | `--swc-badge-padding-inline` | `--swc-badge-with-icon-padding-inline` | `--swc-badge-font-size` | `--swc-badge-icon-size`  |  `--swc-badge-line-height`    |
+| ---- | ---------------------- | --------------------------------------- | -------------------- | ---------------------------- | -------------------------------------- | ----------------------- | ------------------------ |  ---------------------------  |
+| `s`  | `component-height-75`  | `corner-radius-medium-size-small`       | `text-to-visual-75`  | `component-edge-to-text-75`  | `component-edge-to-visual-75`          | `font-size-75`          | `workflow-icon-size-75`  |  `line-height-font-size-75`   |
+| `m`  | `component-height-100` | `corner-radius-medium-size-medium`      | `text-to-visual-100` | `component-edge-to-text-100` | `component-edge-to-visual-100`         | `font-size-100`         | `workflow-icon-size-100` |  `line-height-font-size-100`  |
+| `l`  | `component-height-200` | `corner-radius-medium-size-large`       | `text-to-visual-200` | `component-edge-to-text-200` | `component-edge-to-visual-200`         | `font-size-200`         | `workflow-icon-size-200` |  `line-height-font-size-200`  |
+| `xl` | `component-height-300` | `corner-radius-medium-size-extra-large` | `text-to-visual-300` | `component-edge-to-text-300` | `component-edge-to-visual-300`         | `font-size-300`         | `workflow-icon-size-300` |  `line-height-font-size-300`  |

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/badge/rendering-and-styling-migration-analysis.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/badge/rendering-and-styling-migration-analysis.md
@@ -343,6 +343,14 @@ No significant structural changes.
 
 **Note**: Fixed positioning exists in both SWC and Spectrum 2 CSS but is not in the design spec. Consider whether to keep this for 2nd gen.
 
+### TODOs
+
+#### 31 March 2026
+
+Fixed positioning is documented in the design system guidance. Badges can be placed floating in a container or fixed to any edge, losing their default corner rounding on the fixed edge.
+
+New variants for badge, including notification and indicator were created. Further support and implementation for these missing variants (that are new to S2) are captured in SWC-1831.
+
 ### CSS Spectrum 2 changes
 
 **No significant structural changes.**

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/divider/divider-styling-validation.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/divider/divider-styling-validation.md
@@ -1,0 +1,61 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../../../README.md) / [Project planning](../../README.md) / [Components](../README.md) / Divider / Divider Styling Validation
+
+<!-- Document title (editable) -->
+
+# Divider Styling Validation
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [CSS Custom Properties (Consumer Overrides)](#css-custom-properties-consumer-overrides)
+    - [Thickness — `--swc-divider-thickness`](#thickness----swc-divider-thickness)
+    - [Background color — `--swc-divider-background-color`](#background-color----swc-divider-background-color)
+- [Minimum dimensions](#minimum-dimensions)
+
+</details>
+
+<!-- Document content (editable) -->
+
+Figma reference: [S2 - Web Desktop scale, Divider component set 13642:351](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=13642-351&m=dev)
+
+## CSS Custom Properties (Consumer Overrides)
+
+### Thickness — `--swc-divider-thickness`
+
+Overrides the divider line thickness. Internally aliased to `--_swc-divider-thickness`, which also drives `border-radius` so the line cap stays rounded.
+
+
+| Size          | Token                      |
+| ------------- | -------------------------- |
+| `s`           | `divider-thickness-small`  |
+| `m` (default) | `divider-thickness-medium` |
+| `l`           | `divider-thickness-large`  |
+
+
+### Background color — `--swc-divider-background-color`
+
+
+| Condition                               | Token                   |
+| --------------------------------------- | ----------------------- |
+| Default (`s`, `m`)                      | `gray-200`              |
+| `size="l"` (default)                    | `gray-800`              |
+| `static-color="white"` (`s`, `m`)       | `transparent-white-200` |
+| `static-color="white"` + `size="l"`     | `transparent-white-800` |
+| `static-color="black"` (`s`, `m`)       | `transparent-black-200` |
+| `static-color="black"` + `size="l"`     | `transparent-black-800` |
+| Forced colors (`forced-colors: active`) | `CanvasText`            |
+
+
+## Minimum dimensions
+
+These are not exposed as custom properties — they are set directly from tokens.
+
+
+| Property          | Selector                                   | Token                              |
+| ----------------- | ------------------------------------------ | ---------------------------------- |
+| `min-inline-size` | `.swc-Divider:not(.swc-Divider--vertical)` | `divider-horizontal-minimum-width` |
+| `min-block-size`  | `.swc-Divider--vertical`                   | `divider-vertical-minimum-height`  |

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/progress-circle/progress-circle-styling-validation.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/progress-circle/progress-circle-styling-validation.md
@@ -1,0 +1,65 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../../../README.md) / [Project planning](../../README.md) / [Components](../README.md) / Progress Circle / Progress circle styling validation
+
+<!-- Document title (editable) -->
+
+# Progress circle styling validation
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [CSS custom properties (consumer overrides)](#css-custom-properties-consumer-overrides)
+    - [Track color — `--swc-progress-circle-track-border-color`](#track-color----swc-progress-circle-track-border-color)
+    - [Fill (indicator) color — `--swc-progress-circle-fill-border-color`](#fill-indicator-color----swc-progress-circle-fill-border-color)
+- [Size-specific tokens](#size-specific-tokens)
+- [Forced colors](#forced-colors)
+
+</details>
+
+<!-- Document content (editable) -->
+
+Figma reference: [S2 - Web Desktop scale, Progress circle (M) 13120:362](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=13120-362&m=dev)
+
+## CSS custom properties (consumer overrides)
+
+### Track color — `--swc-progress-circle-track-border-color`
+
+| Condition       | Token                        |
+| --------------- | ---------------------------- |
+| Default         | `track-color`                |
+| `static-color="white"` | `static-white-track-color`  |
+| `static-color="black"` | `static-black-track-color`  |
+
+### Fill (indicator) color — `--swc-progress-circle-fill-border-color`
+
+| Condition       | Token                              |
+| --------------- | ---------------------------------- |
+| Default         | `accent-content-color-default`     |
+| `static-color="white"` | `static-white-track-indicator-color` |
+| `static-color="black"` | `static-black-track-indicator-color` |
+
+> **Note:** `static-color="black"` is new in S2. S1 only supported `static-color="white"`.
+
+## Size-specific tokens
+
+| Property    | Token hook                          | `s`                            | `m` (default)                   | `l`                            |
+| ----------- | ----------------------------------- | ------------------------------ | ------------------------------- | ------------------------------ |
+| Size        | `--swc-progress-circle-size`        | `progress-circle-size-small`   | `progress-circle-size-medium`   | `progress-circle-size-large`   |
+| Stroke width | `--swc-progress-circle-thickness`  | `progress-circle-thickness-small` | `progress-circle-thickness-medium` | `progress-circle-thickness-large` |
+
+> **Note:** Progress circle supports only three sizes (S, M, L). There is no `xl` size, unlike Badge and Status Light.
+
+## Forced colors
+
+The `@media (forced-colors: active)` block overrides both fill and track colors using system color keywords and nested `prefers-color-scheme` queries.
+
+| Property                                 | Value                         | Condition                                  |
+| ---------------------------------------- | ----------------------------- | ------------------------------------------ |
+| `--swc-progress-circle-fill-border-color` | `Highlight`                  | All forced-colors contexts                 |
+| `--swc-progress-circle-track-border-color` | `token("static-white-track-color")` | `forced-colors` + `prefers-color-scheme: dark` |
+| `--swc-progress-circle-track-border-color` | `token("static-black-track-color")` | `forced-colors` + `prefers-color-scheme: light` |
+
+> **⚠️ Bug:** The forced-colors block currently sets `--swc-progress-circle-track-color: Canvas` (line 109 of `progress-circle.css`). This property name does not exist in the component — the correct exposed property is `--swc-progress-circle-track-border-color`. The `Canvas` system color override has no effect as written. The nested `prefers-color-scheme` rules below it do correctly target `--swc-progress-circle-track-border-color` and will apply. The standalone `--swc-progress-circle-track-color: Canvas` line should be removed or corrected.

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/status-light/statuslight-styling-validation.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/status-light/statuslight-styling-validation.md
@@ -1,0 +1,100 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../../../README.md) / [Project planning](../../README.md) / [Components](../README.md) / Status Light / Status light styling validation
+
+<!-- Document title (editable) -->
+
+# Status light styling validation
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [CSS custom properties (consumer overrides)](#css-custom-properties-consumer-overrides)
+    - [Dot color — `--swc-statuslight-dot-color`](#dot-color----swc-statuslight-dot-color)
+    - [Label color — `--swc-statuslight-content-color`](#label-color----swc-statuslight-content-color)
+- [Size-specific tokens](#size-specific-tokens)
+- [Typography tokens](#typography-tokens)
+
+</details>
+
+<!-- Document content (editable) -->
+
+Figma reference: [S2 - Web Desktop scale, Status light 36797:954](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=36797-954&m=dev)
+
+Token spec reference: [S2 Token specs, Status light 10725:497](https://www.figma.com/design/eoZHKJH9a3LJkHYCGt60Vb/S2-Token-specs?node-id=10725-497&m=dev)
+
+## CSS custom properties (consumer overrides)
+
+### Dot color — `--swc-statuslight-dot-color`
+
+#### Semantic variants
+
+| Variant    | Token                      |
+| ---------- | -------------------------- |
+| `info`     | `informative-visual-color` |
+| `neutral`  | `neutral-visual-color`     |
+| `positive` | `positive-visual-color`    |
+| `notice`   | `notice-visual-color`      |
+| `negative` | `negative-visual-color`    |
+
+> **Note:** The `accent` variant has been removed for S2.
+
+#### Non-semantic variants
+
+| Variant      | Token                    | New in S2 |
+| ------------ | ------------------------ | --------- |
+| `celery`     | `celery-visual-color`    |           |
+| `chartreuse` | `chartreuse-visual-color`|           |
+| `cyan`       | `cyan-visual-color`      |           |
+| `fuchsia`    | `fuchsia-visual-color`   |           |
+| `indigo`     | `indigo-visual-color`    |           |
+| `magenta`    | `magenta-visual-color`   |           |
+| `purple`     | `purple-visual-color`    |           |
+| `seafoam`    | `seafoam-visual-color`   |           |
+| `yellow`     | `yellow-visual-color`    |           |
+| `pink`       | `pink-visual-color`      | ✓         |
+| `turquoise`  | `turquoise-visual-color` | ✓         |
+| `cinnamon`   | `cinnamon-visual-color`  | ✓         |
+| `brown`      | `brown-visual-color`     | ✓         |
+| `silver`     | `silver-visual-color`    | ✓         |
+
+> **Note:** The five new S2 color tokens resolve as follows: `pink-800` (light) / `pink-900` (dark), and the same pattern for `turquoise`, `cinnamon`, `brown`, and `silver`.
+
+### Label color — `--swc-statuslight-content-color`
+
+| Condition              | Token                          |
+| ---------------------- | ------------------------------ |
+| `variant="neutral"`    | `gray-600`                     |
+| All other variants     | `neutral-content-color-default`|
+
+## Size-specific tokens
+
+| Property             | Token hook                         | `s`                               | `m` (default)                      | `l`                                | `xl`                                  |
+| -------------------- | ---------------------------------- | --------------------------------- | ---------------------------------- | ---------------------------------- | ------------------------------------- |
+| Component height     | `--swc-statuslight-height`         | `component-height-75`             | `component-height-100`             | `component-height-200`             | `component-height-300`                |
+| Dot size             | `--swc-statuslight-dot-size`       | `status-light-dot-size-small`     | `status-light-dot-size-medium`     | `status-light-dot-size-large`      | `status-light-dot-size-extra-large`   |
+| Dot-to-label gap     | `--swc-statuslight-text-to-visual` | `status-light-text-to-visual-75`  | `status-light-text-to-visual-100`  | `status-light-text-to-visual-200`  | `status-light-text-to-visual-300`     |
+| Top edge to dot      | `--swc-statuslight-top-to-dot`     | `status-light-top-to-dot-small`   | `status-light-top-to-dot-medium`   | `status-light-top-to-dot-large`    | `status-light-top-to-dot-extra-large` |
+| Block padding ⚠️     | `--swc-statuslight-padding-block`  | `component-padding-vertical-75`   | `component-padding-vertical-100`   | `component-padding-vertical-200`   | `component-padding-vertical-300`      |
+| Font size            | `--swc-statuslight-font-size`      | `font-size-75`                    | `font-size-100`                    | `font-size-200`                    | `font-size-300`                       |
+| Line height          | `--swc-statuslight-line-height`    |  `line-height-font-size-75`       | `line-height-font-size-100`        | `line-height-font-size-200`        | `line-height-font-size-300`           | 
+
+> **Note:** The `status-light-text-to-visual-*` tokens are new in S2. In S1, the component referenced the global `text-to-visual-*` tokens directly.
+
+> **Note:** The spec page in S2 Token specs contains a typo listing the XL dot size token as `status-light-dot-extra-large`. The correct token name — confirmed in the Component level token changes frame and used in the CSS — is `status-light-dot-size-extra-large`.
+
+> **Note:** Figma's S2 Token specs file lists separate `component-top-to-text-*` and `component-bottom-to-text-*` tokens. The CSS intentionally uses `component-padding-vertical-*` via a single `padding-block` shorthand, reflecting more recent design decisions in the S2 Web Desktop scale file. The Desktop scale file takes precedence over the token spec file when they differ.
+
+## Typography tokens
+
+These apply across all sizes unless noted.
+
+| Property    | Token                                                    |
+| ----------- | -------------------------------------------------------- |
+| Font family | `default-font-family`                                    |
+| Font weight | `regular-font-weight`                                    |
+| Font style  | `default-font-style`                                     |
+
+> **Note:** The neutral variant uses `default-font-style` (not italics). This is a change from S1.


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

During a sync meeting, this work was shared as part of a discussion around how to validate styles for 2nd-gen components. This PR provides the example style validation documents I had Claude create for me. 

Steps I took to create these: 
1. spun up claude code
2. connected to the [Figma console mcp](https://docs.figma-console-mcp.southleft.com/)
3. made sure to have the component's S2 desktop page open AND the components token spec page open in separate Figma tabs (you must use the Figma desktop app as opposed to the browser)
4. asked claude to create a list of tokens with a prompt similar to these: 
```
you will play the role of a senior engineer, gathering design information for their future PR reviewers. we need to document all tokens used in the status light in figma to properly validate that we're using them in the code implementation. 
```
5. the author validates the style doc against Figma making sure to have all tokens listed, variants covered, any gotchas from the rendering and style migration doc.
6. once I validated the tokens claude provided to me, i then have claude compare the stylesheet to the list of tokens it created
```
making sure to follow the css resolution for tokens, validate that our stylesheet correctly includes all tokens and styles you noted in '/Users/marissahuysentruyt/Desktop/projects/spectrum-web-components/CONTRIBUTOR-DOCS/03_project-planning/03_components/status-light/statuslight-styling-validation.md'
```
7. sometimes claude will catch the discrepancies, for instance, the new vertical padding tokens: 
<img width="973" height="282" alt="Screenshot 2026-04-08 at 9 22 14 AM" src="https://github.com/user-attachments/assets/229b4dde-e57d-4640-8a52-9abee05a3934" />
8. my final step is always to do a quick check of making sure i can follow the custom property resolutions back to the tokens in the browser inspector manually. with the style validation doc though, it felt faster than needing to have figma open to cross-check.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

These style validation docs were created to provide a central list of component tokens to the PR reviewer, aimed to make reviewing easier.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- created in part for swc-1670

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

- [ ] _contributor docs navigation is updated_
    1. pull down the branch
    2. navigate to the CONTRIBUTOR-DOCS directory `cd CONTRIBUTOR-DOCS`
    3. run the update nav script `node 01_contributor-guides/07_authoring-contributor-docs/update-nav.js `
    4. no additional missing contributor doc links should appear (apart from a badge `TODO` heading that is being addressed in #6133)
    5. make sure the docs make sense. 
    6. reviewers are free to check the tokens listed are correct by spot checking against the respective component's S2 Desktop page and token specs pages (available upon request 😊)


### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

<!---
    Manual accessibility testing is required because automated tools cannot catch all issues (e.g. focus order, screen reader announcements, keyboard flow).
    You must document your keyboard and screen reader testing steps below. Reviewers will use this checklist during review.
    See: [Accessibility testing guide](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTOR-DOCS/01_contributor-guides/09_accessibility-testing.md)
-->

**Required:** Complete each applicable item and document your testing steps (replace the placeholders with your component-specific instructions).

documentation updates only
