### PR TITLE
style(status-light): clean up code styles

### DIFF
--- a/2nd-gen/packages/core/components/status-light/StatusLight.base.ts
+++ b/2nd-gen/packages/core/components/status-light/StatusLight.base.ts
@@ -16,7 +16,7 @@ import { SpectrumElement } from '@spectrum-web-components/core/element/index.js'
 import { SizedMixin } from '@spectrum-web-components/core/mixins/index.js';
 
 import {
-  STATUSLIGHT_VALID_SIZES,
+  STATUS_LIGHT_VALID_SIZES,
   type StatusLightVariant,
 } from './StatusLight.types.js';
 
@@ -27,7 +27,7 @@ import {
  * @attribute {ElementSize} size - The size of the status light.
  */
 export abstract class StatusLightBase extends SizedMixin(SpectrumElement, {
-  validSizes: STATUSLIGHT_VALID_SIZES,
+  validSizes: STATUS_LIGHT_VALID_SIZES,
   noDefaultSize: true,
 }) {
   // ─────────────────────────

--- a/2nd-gen/packages/core/components/status-light/StatusLight.base.ts
+++ b/2nd-gen/packages/core/components/status-light/StatusLight.base.ts
@@ -91,15 +91,14 @@ export abstract class StatusLightBase extends SizedMixin(SpectrumElement, {
   //     IMPLEMENTATION
   // ──────────────────────
 
-  protected override updated(changes: PropertyValues): void {
-    super.updated(changes);
+  protected override update(changedProperties: PropertyValues): void {
     if (window.__swc?.DEBUG) {
       const constructor = this.constructor as typeof StatusLightBase;
       if (!constructor.VARIANTS.includes(this.variant)) {
         window.__swc.warn(
           this,
           `<${this.localName}> element expects the "variant" attribute to be one of the following:`,
-          'https://opensource.adobe.com/spectrum-web-components/components/status-light/#variants',
+          'https://opensource.adobe.com/spectrum-web-components/second-gen/?path=/docs/components-status-light--docs',
           {
             issues: [...constructor.VARIANTS],
           }
@@ -110,12 +109,13 @@ export abstract class StatusLightBase extends SizedMixin(SpectrumElement, {
         window.__swc.warn(
           this,
           `<${this.localName}> element does not support the disabled state.`,
-          'https://opensource.adobe.com/spectrum-web-components/components/status-light/#states',
+          'https://opensource.adobe.com/spectrum-web-components/second-gen/?path=/docs/components-status-light--docs',
           {
             issues: ['disabled is not a supported property in Spectrum 2'],
           }
         );
       }
     }
+    super.update(changedProperties);
   }
 }

--- a/2nd-gen/packages/core/components/status-light/StatusLight.types.ts
+++ b/2nd-gen/packages/core/components/status-light/StatusLight.types.ts
@@ -10,10 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
-/**
+/*
  * @todo The S1 types can be removed once we are no longer maintaining 1st-gen.
  */
+
 import type { ElementSize } from '@spectrum-web-components/core/mixins/index.js';
+
+// ──────────────────
+//     SHARED
+// ──────────────────
 
 export const STATUS_LIGHT_VALID_SIZES = [
   's',
@@ -30,13 +35,17 @@ export const STATUS_LIGHT_VARIANTS_SEMANTIC = [
   'notice',
 ] as const;
 
+export const STATUS_LIGHT_VARIANTS_SEMANTIC_S2 = [
+  ...STATUS_LIGHT_VARIANTS_SEMANTIC,
+] as const;
+
+// ──────────────────────────────────────────
+//     S1-ONLY (remove with 1st-gen)
+// ──────────────────────────────────────────
+
 export const STATUS_LIGHT_VARIANTS_SEMANTIC_S1 = [
   ...STATUS_LIGHT_VARIANTS_SEMANTIC,
   'accent',
-] as const;
-
-export const STATUS_LIGHT_VARIANTS_SEMANTIC_S2 = [
-  ...STATUS_LIGHT_VARIANTS_SEMANTIC,
 ] as const;
 
 export const STATUS_LIGHT_VARIANTS_COLOR_S1 = [
@@ -51,6 +60,15 @@ export const STATUS_LIGHT_VARIANTS_COLOR_S1 = [
   'cyan',
 ] as const;
 
+export const STATUS_LIGHT_VARIANTS_S1 = [
+  ...STATUS_LIGHT_VARIANTS_SEMANTIC_S1,
+  ...STATUS_LIGHT_VARIANTS_COLOR_S1,
+] as const;
+
+// ──────────────────
+//     CANONICAL
+// ──────────────────
+
 export const STATUS_LIGHT_VARIANTS_COLOR_S2 = [
   ...STATUS_LIGHT_VARIANTS_COLOR_S1,
   'pink',
@@ -60,34 +78,36 @@ export const STATUS_LIGHT_VARIANTS_COLOR_S2 = [
   'silver',
 ] as const;
 
-export const STATUS_LIGHT_VARIANTS_S1 = [
-  ...STATUS_LIGHT_VARIANTS_SEMANTIC_S1,
-  ...STATUS_LIGHT_VARIANTS_COLOR_S1,
-] as const;
-
 export const STATUS_LIGHT_VARIANTS_S2 = [
   ...STATUS_LIGHT_VARIANTS_SEMANTIC_S2,
   ...STATUS_LIGHT_VARIANTS_COLOR_S2,
 ] as const;
 
+// ──────────────────
+//     TYPES
+// ──────────────────
+
+// S1-only (remove with 1st-gen)
 export type StatusLightSemanticVariantS1 =
   (typeof STATUS_LIGHT_VARIANTS_SEMANTIC_S1)[number];
+export type StatusLightColorVariantS1 =
+  (typeof STATUS_LIGHT_VARIANTS_COLOR_S1)[number];
+export type StatusLightVariantS1 = (typeof STATUS_LIGHT_VARIANTS_S1)[number];
+
+// Canonical (S2)
 export type StatusLightSemanticVariantS2 =
   (typeof STATUS_LIGHT_VARIANTS_SEMANTIC_S2)[number];
+export type StatusLightColorVariantS2 =
+  (typeof STATUS_LIGHT_VARIANTS_COLOR_S2)[number];
+export type StatusLightVariantS2 = (typeof STATUS_LIGHT_VARIANTS_S2)[number];
+
+// Base class (S1 | S2)
 export type StatusLightSemanticVariant =
   | StatusLightSemanticVariantS1
   | StatusLightSemanticVariantS2;
-
-export type StatusLightColorVariantS1 =
-  (typeof STATUS_LIGHT_VARIANTS_COLOR_S1)[number];
-export type StatusLightColorVariantS2 =
-  (typeof STATUS_LIGHT_VARIANTS_COLOR_S2)[number];
 export type StatusLightColorVariant =
   | StatusLightColorVariantS1
   | StatusLightColorVariantS2;
-
-export type StatusLightVariantS1 = (typeof STATUS_LIGHT_VARIANTS_S1)[number];
-export type StatusLightVariantS2 = (typeof STATUS_LIGHT_VARIANTS_S2)[number];
 export type StatusLightVariant = StatusLightVariantS1 | StatusLightVariantS2;
 
 export type StatusLightSize = (typeof STATUS_LIGHT_VALID_SIZES)[number];

--- a/2nd-gen/packages/core/components/status-light/StatusLight.types.ts
+++ b/2nd-gen/packages/core/components/status-light/StatusLight.types.ts
@@ -12,21 +12,17 @@
 
 /**
  * @todo The S1 types can be removed once we are no longer maintaining 1st-gen.
- * @todo Rename STATUSLIGHT_ prefix to STATUS_LIGHT_ to align with type prefix
- * naming convention (use underscore separators for multi-word names). This
- * requires updating all imports in 1st-gen and 2nd-gen that reference these
- * constants.
  */
 import type { ElementSize } from '@spectrum-web-components/core/mixins/index.js';
 
-export const STATUSLIGHT_VALID_SIZES = [
+export const STATUS_LIGHT_VALID_SIZES = [
   's',
   'm',
   'l',
   'xl',
 ] as const satisfies readonly ElementSize[];
 
-export const STATUSLIGHT_VARIANTS_SEMANTIC = [
+export const STATUS_LIGHT_VARIANTS_SEMANTIC = [
   'neutral',
   'info',
   'positive',
@@ -34,16 +30,16 @@ export const STATUSLIGHT_VARIANTS_SEMANTIC = [
   'notice',
 ] as const;
 
-export const STATUSLIGHT_VARIANTS_SEMANTIC_S1 = [
-  ...STATUSLIGHT_VARIANTS_SEMANTIC,
+export const STATUS_LIGHT_VARIANTS_SEMANTIC_S1 = [
+  ...STATUS_LIGHT_VARIANTS_SEMANTIC,
   'accent',
 ] as const;
 
-export const STATUSLIGHT_VARIANTS_SEMANTIC_S2 = [
-  ...STATUSLIGHT_VARIANTS_SEMANTIC,
+export const STATUS_LIGHT_VARIANTS_SEMANTIC_S2 = [
+  ...STATUS_LIGHT_VARIANTS_SEMANTIC,
 ] as const;
 
-export const STATUSLIGHT_VARIANTS_COLOR_S1 = [
+export const STATUS_LIGHT_VARIANTS_COLOR_S1 = [
   'fuchsia',
   'indigo',
   'magenta',
@@ -55,8 +51,8 @@ export const STATUSLIGHT_VARIANTS_COLOR_S1 = [
   'cyan',
 ] as const;
 
-export const STATUSLIGHT_VARIANTS_COLOR_S2 = [
-  ...STATUSLIGHT_VARIANTS_COLOR_S1,
+export const STATUS_LIGHT_VARIANTS_COLOR_S2 = [
+  ...STATUS_LIGHT_VARIANTS_COLOR_S1,
   'pink',
   'turquoise',
   'brown',
@@ -64,34 +60,34 @@ export const STATUSLIGHT_VARIANTS_COLOR_S2 = [
   'silver',
 ] as const;
 
-export const STATUSLIGHT_VARIANTS_S1 = [
-  ...STATUSLIGHT_VARIANTS_SEMANTIC_S1,
-  ...STATUSLIGHT_VARIANTS_COLOR_S1,
+export const STATUS_LIGHT_VARIANTS_S1 = [
+  ...STATUS_LIGHT_VARIANTS_SEMANTIC_S1,
+  ...STATUS_LIGHT_VARIANTS_COLOR_S1,
 ] as const;
 
-export const STATUSLIGHT_VARIANTS_S2 = [
-  ...STATUSLIGHT_VARIANTS_SEMANTIC_S2,
-  ...STATUSLIGHT_VARIANTS_COLOR_S2,
+export const STATUS_LIGHT_VARIANTS_S2 = [
+  ...STATUS_LIGHT_VARIANTS_SEMANTIC_S2,
+  ...STATUS_LIGHT_VARIANTS_COLOR_S2,
 ] as const;
 
 export type StatusLightSemanticVariantS1 =
-  (typeof STATUSLIGHT_VARIANTS_SEMANTIC_S1)[number];
+  (typeof STATUS_LIGHT_VARIANTS_SEMANTIC_S1)[number];
 export type StatusLightSemanticVariantS2 =
-  (typeof STATUSLIGHT_VARIANTS_SEMANTIC_S2)[number];
+  (typeof STATUS_LIGHT_VARIANTS_SEMANTIC_S2)[number];
 export type StatusLightSemanticVariant =
   | StatusLightSemanticVariantS1
   | StatusLightSemanticVariantS2;
 
 export type StatusLightColorVariantS1 =
-  (typeof STATUSLIGHT_VARIANTS_COLOR_S1)[number];
+  (typeof STATUS_LIGHT_VARIANTS_COLOR_S1)[number];
 export type StatusLightColorVariantS2 =
-  (typeof STATUSLIGHT_VARIANTS_COLOR_S2)[number];
+  (typeof STATUS_LIGHT_VARIANTS_COLOR_S2)[number];
 export type StatusLightColorVariant =
   | StatusLightColorVariantS1
   | StatusLightColorVariantS2;
 
-export type StatusLightVariantS1 = (typeof STATUSLIGHT_VARIANTS_S1)[number];
-export type StatusLightVariantS2 = (typeof STATUSLIGHT_VARIANTS_S2)[number];
+export type StatusLightVariantS1 = (typeof STATUS_LIGHT_VARIANTS_S1)[number];
+export type StatusLightVariantS2 = (typeof STATUS_LIGHT_VARIANTS_S2)[number];
 export type StatusLightVariant = StatusLightVariantS1 | StatusLightVariantS2;
 
-export type StatusLightSize = (typeof STATUSLIGHT_VALID_SIZES)[number];
+export type StatusLightSize = (typeof STATUS_LIGHT_VALID_SIZES)[number];

--- a/2nd-gen/packages/swc/components/status-light/StatusLight.ts
+++ b/2nd-gen/packages/swc/components/status-light/StatusLight.ts
@@ -15,9 +15,9 @@ import { property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import {
-  STATUSLIGHT_VARIANTS_COLOR_S2,
-  STATUSLIGHT_VARIANTS_S2,
-  STATUSLIGHT_VARIANTS_SEMANTIC_S2,
+  STATUS_LIGHT_VARIANTS_COLOR_S2,
+  STATUS_LIGHT_VARIANTS_S2,
+  STATUS_LIGHT_VARIANTS_SEMANTIC_S2,
   StatusLightBase,
   type StatusLightVariantS2 as StatusLightVariant,
 } from '@spectrum-web-components/core/components/status-light';
@@ -45,17 +45,18 @@ export class StatusLight extends StatusLightBase {
   /**
    * @internal
    */
-  static override readonly VARIANTS_COLOR = STATUSLIGHT_VARIANTS_COLOR_S2;
+  static override readonly VARIANTS_COLOR = STATUS_LIGHT_VARIANTS_COLOR_S2;
 
   /**
    * @internal
    */
-  static override readonly VARIANTS_SEMANTIC = STATUSLIGHT_VARIANTS_SEMANTIC_S2;
+  static override readonly VARIANTS_SEMANTIC =
+    STATUS_LIGHT_VARIANTS_SEMANTIC_S2;
 
   /**
    * @internal
    */
-  static override readonly VARIANTS = STATUSLIGHT_VARIANTS_S2;
+  static override readonly VARIANTS = STATUS_LIGHT_VARIANTS_S2;
 
   /**
    * Changes the color of the status dot. The variant list includes both semantic and non-semantic options.

--- a/2nd-gen/packages/swc/components/status-light/StatusLight.ts
+++ b/2nd-gen/packages/swc/components/status-light/StatusLight.ts
@@ -31,6 +31,9 @@ import styles from './status-light.css';
  * @status preview
  * @since 0.0.1
  *
+ * @property {string} variant - Semantic or non-semantic color variant for the status dot.
+ * @attribute {ElementSize} size - The size of the status light.
+ *
  * @example
  * <swc-status-light variant="positive">Approved</swc-status-light>
  *

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -16,9 +16,9 @@ import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
 import { StatusLight } from '@adobe/spectrum-wc/status-light';
 import {
-  STATUSLIGHT_VALID_SIZES,
-  STATUSLIGHT_VARIANTS_COLOR_S2,
-  STATUSLIGHT_VARIANTS_SEMANTIC_S2,
+  STATUS_LIGHT_VALID_SIZES,
+  STATUS_LIGHT_VARIANTS_COLOR_S2,
+  STATUS_LIGHT_VARIANTS_SEMANTIC_S2,
   StatusLightColorVariantS2,
   StatusLightSemanticVariantS2,
   type StatusLightSize,
@@ -190,7 +190,7 @@ export const Anatomy: Story = {
  */
 export const Sizes: Story = {
   render: (args) => html`
-    ${STATUSLIGHT_VALID_SIZES.map((size) =>
+    ${STATUS_LIGHT_VALID_SIZES.map((size) =>
       template({
         ...args,
         size,
@@ -215,7 +215,7 @@ export const Sizes: Story = {
  */
 export const SemanticVariants: Story = {
   render: (args) => html`
-    ${STATUSLIGHT_VARIANTS_SEMANTIC_S2.map(
+    ${STATUS_LIGHT_VARIANTS_SEMANTIC_S2.map(
       (variant: StatusLightSemanticVariantS2) =>
         template({
           ...args,
@@ -249,7 +249,7 @@ export const SemanticVariants: Story = {
  */
 export const NonSemanticVariants: Story = {
   render: (args) => html`
-    ${STATUSLIGHT_VARIANTS_COLOR_S2.map((variant: StatusLightColorVariantS2) =>
+    ${STATUS_LIGHT_VARIANTS_COLOR_S2.map((variant: StatusLightColorVariantS2) =>
       template({
         ...args,
         variant,


### PR DESCRIPTION
## Description

2nd-gen **status light** cleanup for **SWC-1671**: contributor TypeScript guides (`STATUS_LIGHT_*` naming, types file layout, DEBUG lifecycle/URLs), SWC concrete class polish, and story fixes.

### Core (`StatusLight.types.ts`, `StatusLight.base.ts`)

- Rename constants to **`STATUS_LIGHT_*`** (multi-word prefix per naming guide). No deprecated `STATUSLIGHT_*` re-exports (2nd-gen still preview).
- Reorganize types with **SHARED / S1-ONLY / CANONICAL / TYPES** separators (same idea as `Badge.types.ts`). Add **`StatusLightSize`** derived from valid sizes.
- **DEBUG**: Run validation in **`update()`** before `super.update()` (match `Badge.base.ts` / **17_debug-validation**). **`warn()`** doc links use **2nd-gen Storybook** (`.../second-gen/?path=/docs/components-status-light--docs`, same base as `SECOND_GEN_URL` in `scripts/generate-llms-txt.js`).

### SWC (`StatusLight.ts`, stories)

- Class-level **`@property` / `@attribute`** on the concrete class for CEM parity (e.g. with `ProgressCircle.ts`).
- **`classMap`**: keep **`typeof this.variant !== 'undefined'`** for consistency with **Badge**.
- Stories: import/use **`STATUS_LIGHT_*`** everywhere (e.g. **`Sizes`** story uses `STATUS_LIGHT_VALID_SIZES`).

### Out of scope (documented / deferred)

- **S1-only** blocks in core types: left labeled for removal with 1st-gen; no full “canonical-only core” refactor in this PR.
- **Deprecated aliases** for old constant names: skipped

---

## Motivation and context

- Aligns 2nd-gen status light with **08_component-types**, **10_naming-conventions**, **06_method-patterns**, and **17_debug-validation** so future S1 removal and consumers get predictable exports and DEBUG behavior.

---

## Related issue(s)

- SWC-1671

---

## Screenshots (if appropriate)

None expected (no intentional visual/CSS changes). If VRT diffs appear, confirm against Storybook.

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [ARIA Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added or kept automated tests covering these changes (`yarn test status-light` from `2nd-gen/packages/swc`).
- [ ] I have included a well-written **changeset** if this change should publish a version bump (likely patch for `@spectrum-web-components/core` / `@adobe/spectrum-wc` if applicable).
- [x] I have included updated **documentation** if required (stories/JSDoc updated in-repo).

---

## Reviewer's checklist

- [ ] Includes a GitHub issue with appropriate flag or Jira ticket number **without** a link
- [ ] Includes a thoughtfully written changeset if the change warrants `patch`, `minor`, or `major`
- [ ] Automated tests cover the change and follow project practices
- [ ] Validated on supported browsers (spot-check if scope is narrow)
- [ ] All VRTs approved before golden hash updates (if CI reports diffs)

_After the PR opens, use **branch preview** links from the **github-actions** comment (Storybook second-gen, VRT review URLs) instead of hardcoding PR numbers in manual steps._

### Manual review test cases

- [ ] **Status light — Storybook (2nd-gen)**  
  1. Open **second-gen** Storybook → **Status light** (overview, sizes, semantic / non-semantic variants).  
  2. Confirm layouts and labels render; controls for `variant` and `size` behave as before.

- [ ] **DEBUG (optional, local dev)**  
  1. Run Storybook or app in **development** so `window.__swc.DEBUG` is on.  
  2. Set an **invalid** `variant` on `<swc-status-light>` (e.g. unsupported string) → expect **warn** with message + link to **second-gen** docs.  
  3. Add **`disabled`** attribute on 2nd-gen element → expect **warn** about unsupported disabled state.

- [ ] **VRT**  
  1. If CI reports visual diffs for status light, confirm expected vs golden; update golden hash only if intentional.

### Device review

- [ ] Desktop
- [ ] (emulated) Mobile — spot-check Status light stories if VRT or layout concerns
- [ ] (emulated) iPad — optional

---

## Accessibility testing checklist

See [Accessibility testing guide](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTOR-DOCS/01_contributor-guides/09_accessibility-testing.md).

Status light is **non-interactive** (no focusable host behavior); content in the **default slot** supplies visible text. No change to role model intended.

- [ ] **Keyboard** — No interactive host: tab through a page with status lights and confirm focus order is unchanged and no new focus traps.  
  1. Open 2nd-gen Storybook → Status light **Overview** (or similar).  
  2. Tab past surrounding controls; status light itself should not steal focus.  
  3. Expect no regression vs previous behavior.

- [ ] **Screen reader** — Confirm slotted label still reads as normal text content in context (e.g. VoiceOver on macOS over the Overview story).  
  1. Open the same story.  
  2. Navigate to the status light text.  
  3. Expect the label to be announced with surrounding page semantics unchanged.

