### PR TITLE
fix(coachmark): make step count separator configurable for localization

### DIFF
--- a/1st-gen/packages/coachmark/src/Coachmark.ts
+++ b/1st-gen/packages/coachmark/src/Coachmark.ts
@@ -84,6 +84,9 @@ export class Coachmark extends Popover {
   @property({ type: Number, attribute: 'total-steps' })
   public totalSteps?: number;
 
+  @property({ type: String, attribute: 'step-count-of' })
+  public stepCountOf = 'of';
+
   @property({ type: String, attribute: 'primary-cta' })
   primaryCTA?: string;
 
@@ -268,7 +271,7 @@ export class Coachmark extends Popover {
       <div class="step" role="status">
         <span aria-live="polite">
           <slot name="step-count">
-            ${this.currentStep} of ${this.totalSteps}
+            ${this.currentStep} ${this.stepCountOf} ${this.totalSteps}
           </slot>
         </span>
       </div>


### PR DESCRIPTION
## Description

The Coachmark component's step count (e.g., "1 of 3") had the "of" string hardcoded, preventing localization. This PR adds a `step-count-of` attribute (property: `stepCountOf`) that defaults to `"of"` and is used in the step count template.

Clients can now set `step-count-of="von"` for German or `step-count-of="de"` for Spanish without needing to use the `step-count` slot override. The existing slot override still works for full customization.

```html
<sp-coachmark step-count-of="von" current-step="1" total-steps="3">
  ...
</sp-coachmark>
```

Fixes #4780

---

This contribution was developed with AI assistance (Claude Code).