### PR TITLE
fix: make coachmark step count separator localizable

### DIFF
--- a/1st-gen/packages/coachmark/src/Coachmark.ts
+++ b/1st-gen/packages/coachmark/src/Coachmark.ts
@@ -84,6 +84,9 @@ export class Coachmark extends Popover {
   @property({ type: Number, attribute: 'total-steps' })
   public totalSteps?: number;
 
+  @property({ type: String, attribute: 'step-count-of' })
+  public stepCountOf = 'of';
+
   @property({ type: String, attribute: 'primary-cta' })
   primaryCTA?: string;
 
@@ -268,7 +271,7 @@ export class Coachmark extends Popover {
       <div class="step" role="status">
         <span aria-live="polite">
           <slot name="step-count">
-            ${this.currentStep} of ${this.totalSteps}
+            ${this.currentStep} ${this.stepCountOf} ${this.totalSteps}
           </slot>
         </span>
       </div>


### PR DESCRIPTION
## Summary

The Coachmark component has a hardcoded "of" string in the step count display (e.g., "1 of 3"). This adds a `step-count-of` property so the separator can be localized.

## Changes

`1st-gen/packages/coachmark/src/Coachmark.ts`:
- Added `stepCountOf` property with `step-count-of` attribute (defaults to `"of"`)
- Changed the step count template from hardcoded `${this.currentStep} of ${this.totalSteps}` to `${this.currentStep} ${this.stepCountOf} ${this.totalSteps}`

## Usage

```html
<!-- Default (English) -->
<sp-coachmark current-step="1" total-steps="3">...</sp-coachmark>
<!-- Outputs: "1 of 3" -->

<!-- Localized (Spanish) -->
<sp-coachmark current-step="1" total-steps="3" step-count-of="de">...</sp-coachmark>
<!-- Outputs: "1 de 3" -->
```

The existing `step-count` slot still works as a complete override for custom formatting.

Fixes #4780

This contribution was developed with AI assistance (Claude Code).