### PR TITLE
chore(core): remove 1st-gen type references from 2nd-gen core

### DIFF
--- a/2nd-gen/packages/core/components/alert-banner/AlertBanner.types.ts
+++ b/2nd-gen/packages/core/components/alert-banner/AlertBanner.types.ts
@@ -19,9 +19,3 @@ export const ALERT_BANNER_VALID_VARIANTS = [
 export type AlertBannerVariant =
   | (typeof ALERT_BANNER_VALID_VARIANTS)[number]
   | '';
-
-/**
- * @deprecated Use `AlertBannerVariant` instead.
- * Kept as `string` for backward compatibility with 1st-gen.
- */
-export type AlertBannerVariants = string;

--- a/2nd-gen/packages/core/components/badge/Badge.base.ts
+++ b/2nd-gen/packages/core/components/badge/Badge.base.ts
@@ -106,6 +106,20 @@ export abstract class BadgeBase extends SizedMixin(
   @property({ type: String, reflect: true })
   public fixed?: FixedValues;
 
+  /**
+   * Whether the badge is subtle.
+   */
+  @property({ type: Boolean, reflect: true })
+  public subtle: boolean = false;
+
+  /**
+   * Whether the badge is outlined.
+   *
+   * Can only be used with semantic variants.
+   */
+  @property({ type: Boolean, reflect: true })
+  public outline: boolean = false;
+
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────

--- a/2nd-gen/packages/core/components/badge/Badge.types.ts
+++ b/2nd-gen/packages/core/components/badge/Badge.types.ts
@@ -10,10 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/*
- * @todo The S1 types can be removed once we are no longer maintaining 1st-gen.
- */
-
 import type { ElementSize } from '@spectrum-web-components/core/mixins/index.js';
 
 // ──────────────────
@@ -65,32 +61,6 @@ export const FIXED_VALUES = [
   'inline-end',
 ] as const;
 
-// ──────────────────────────────────────────
-//     S1-ONLY (remove with 1st-gen)
-// ──────────────────────────────────────────
-
-export const BADGE_VARIANTS_COLOR_S1 = [
-  'fuchsia',
-  'indigo',
-  'magenta',
-  'purple',
-  'seafoam',
-  'yellow',
-  'gray',
-  'red',
-  'orange',
-  'chartreuse',
-  'celery',
-  'green',
-  'cyan',
-  'blue',
-] as const satisfies readonly BadgeColorVariant[];
-
-export const BADGE_VARIANTS_S1 = [
-  ...BADGE_VARIANTS_SEMANTIC,
-  ...BADGE_VARIANTS_COLOR_S1,
-] as const;
-
 // ──────────────────
 //     CANONICAL
 // ──────────────────
@@ -108,10 +78,6 @@ export const BADGE_VARIANTS = [
 export type FixedValues = (typeof FIXED_VALUES)[number];
 export type BadgeSize = (typeof BADGE_VALID_SIZES)[number];
 export type BadgeSemanticVariant = (typeof BADGE_VARIANTS_SEMANTIC)[number];
-
-// S1-only (remove with 1st-gen)
-export type BadgeColorVariantS1 = (typeof BADGE_VARIANTS_COLOR_S1)[number]; // remove with 1st-gen
-export type BadgeVariantS1 = (typeof BADGE_VARIANTS_S1)[number]; // remove with 1st-gen
 
 // Canonical
 export type BadgeColorVariant = (typeof BADGE_VARIANTS_COLOR)[number];

--- a/2nd-gen/packages/core/components/progress-circle/ProgressCircle.types.ts
+++ b/2nd-gen/packages/core/components/progress-circle/ProgressCircle.types.ts
@@ -17,16 +17,7 @@ export const PROGRESS_CIRCLE_VALID_SIZES = [
   'm',
   'l',
 ] as const satisfies ElementSize[];
-export const PROGRESS_CIRCLE_STATIC_COLORS_S1 = ['white'] as const;
-export const PROGRESS_CIRCLE_STATIC_COLORS_S2 = [
-  ...PROGRESS_CIRCLE_STATIC_COLORS_S1,
-  'black',
-] as const;
+export const PROGRESS_CIRCLE_STATIC_COLORS = ['white', 'black'] as const;
 
-export type ProgressCircleStaticColorS1 =
-  (typeof PROGRESS_CIRCLE_STATIC_COLORS_S1)[number];
-export type ProgressCircleStaticColorS2 =
-  (typeof PROGRESS_CIRCLE_STATIC_COLORS_S2)[number];
 export type ProgressCircleStaticColor =
-  | ProgressCircleStaticColorS1
-  | ProgressCircleStaticColorS2;
+  (typeof PROGRESS_CIRCLE_STATIC_COLORS)[number];

--- a/2nd-gen/packages/core/components/status-light/StatusLight.base.ts
+++ b/2nd-gen/packages/core/components/status-light/StatusLight.base.ts
@@ -16,7 +16,7 @@ import { SpectrumElement } from '@spectrum-web-components/core/element/index.js'
 import { SizedMixin } from '@spectrum-web-components/core/mixins/index.js';
 
 import {
-  STATUS_LIGHT_VALID_SIZES,
+  STATUSLIGHT_VALID_SIZES,
   type StatusLightVariant,
 } from './StatusLight.types.js';
 
@@ -27,7 +27,7 @@ import {
  * @attribute {ElementSize} size - The size of the status light.
  */
 export abstract class StatusLightBase extends SizedMixin(SpectrumElement, {
-  validSizes: STATUS_LIGHT_VALID_SIZES,
+  validSizes: STATUSLIGHT_VALID_SIZES,
   noDefaultSize: true,
 }) {
   // ─────────────────────────
@@ -91,31 +91,20 @@ export abstract class StatusLightBase extends SizedMixin(SpectrumElement, {
   //     IMPLEMENTATION
   // ──────────────────────
 
-  protected override update(changedProperties: PropertyValues): void {
+  protected override updated(changes: PropertyValues): void {
+    super.updated(changes);
     if (window.__swc?.DEBUG) {
       const constructor = this.constructor as typeof StatusLightBase;
       if (!constructor.VARIANTS.includes(this.variant)) {
         window.__swc.warn(
           this,
           `<${this.localName}> element expects the "variant" attribute to be one of the following:`,
-          'https://opensource.adobe.com/spectrum-web-components/second-gen/?path=/docs/components-status-light--docs',
+          'https://opensource.adobe.com/spectrum-web-components/components/status-light/#variants',
           {
             issues: [...constructor.VARIANTS],
           }
         );
       }
-      // Check disabled property if it exists (S1 only)
-      if (this.hasAttribute('disabled') && !('disabled' in this)) {
-        window.__swc.warn(
-          this,
-          `<${this.localName}> element does not support the disabled state.`,
-          'https://opensource.adobe.com/spectrum-web-components/second-gen/?path=/docs/components-status-light--docs',
-          {
-            issues: ['disabled is not a supported property in Spectrum 2'],
-          }
-        );
-      }
     }
-    super.update(changedProperties);
   }
 }

--- a/2nd-gen/packages/core/components/status-light/StatusLight.types.ts
+++ b/2nd-gen/packages/core/components/status-light/StatusLight.types.ts
@@ -10,24 +10,20 @@
  * governing permissions and limitations under the License.
  */
 
-/*
- * @todo The S1 types can be removed once we are no longer maintaining 1st-gen.
+/**
+ * @todo Rename STATUSLIGHT_ prefix to STATUS_LIGHT_ to align with type prefix
+ * naming convention (use underscore separators for multi-word names).
  */
-
 import type { ElementSize } from '@spectrum-web-components/core/mixins/index.js';
 
-// ──────────────────
-//     SHARED
-// ──────────────────
-
-export const STATUS_LIGHT_VALID_SIZES = [
+export const STATUSLIGHT_VALID_SIZES = [
   's',
   'm',
   'l',
   'xl',
 ] as const satisfies readonly ElementSize[];
 
-export const STATUS_LIGHT_VARIANTS_SEMANTIC = [
+export const STATUSLIGHT_VARIANTS_SEMANTIC = [
   'neutral',
   'info',
   'positive',
@@ -35,20 +31,7 @@ export const STATUS_LIGHT_VARIANTS_SEMANTIC = [
   'notice',
 ] as const;
 
-export const STATUS_LIGHT_VARIANTS_SEMANTIC_S2 = [
-  ...STATUS_LIGHT_VARIANTS_SEMANTIC,
-] as const;
-
-// ──────────────────────────────────────────
-//     S1-ONLY (remove with 1st-gen)
-// ──────────────────────────────────────────
-
-export const STATUS_LIGHT_VARIANTS_SEMANTIC_S1 = [
-  ...STATUS_LIGHT_VARIANTS_SEMANTIC,
-  'accent',
-] as const;
-
-export const STATUS_LIGHT_VARIANTS_COLOR_S1 = [
+export const STATUSLIGHT_VARIANTS_COLOR = [
   'fuchsia',
   'indigo',
   'magenta',
@@ -58,19 +41,6 @@ export const STATUS_LIGHT_VARIANTS_COLOR_S1 = [
   'chartreuse',
   'celery',
   'cyan',
-] as const;
-
-export const STATUS_LIGHT_VARIANTS_S1 = [
-  ...STATUS_LIGHT_VARIANTS_SEMANTIC_S1,
-  ...STATUS_LIGHT_VARIANTS_COLOR_S1,
-] as const;
-
-// ──────────────────
-//     CANONICAL
-// ──────────────────
-
-export const STATUS_LIGHT_VARIANTS_COLOR_S2 = [
-  ...STATUS_LIGHT_VARIANTS_COLOR_S1,
   'pink',
   'turquoise',
   'brown',
@@ -78,36 +48,15 @@ export const STATUS_LIGHT_VARIANTS_COLOR_S2 = [
   'silver',
 ] as const;
 
-export const STATUS_LIGHT_VARIANTS_S2 = [
-  ...STATUS_LIGHT_VARIANTS_SEMANTIC_S2,
-  ...STATUS_LIGHT_VARIANTS_COLOR_S2,
+export const STATUSLIGHT_VARIANTS = [
+  ...STATUSLIGHT_VARIANTS_SEMANTIC,
+  ...STATUSLIGHT_VARIANTS_COLOR,
 ] as const;
 
-// ──────────────────
-//     TYPES
-// ──────────────────
-
-// S1-only (remove with 1st-gen)
-export type StatusLightSemanticVariantS1 =
-  (typeof STATUS_LIGHT_VARIANTS_SEMANTIC_S1)[number];
-export type StatusLightColorVariantS1 =
-  (typeof STATUS_LIGHT_VARIANTS_COLOR_S1)[number];
-export type StatusLightVariantS1 = (typeof STATUS_LIGHT_VARIANTS_S1)[number];
-
-// Canonical (S2)
-export type StatusLightSemanticVariantS2 =
-  (typeof STATUS_LIGHT_VARIANTS_SEMANTIC_S2)[number];
-export type StatusLightColorVariantS2 =
-  (typeof STATUS_LIGHT_VARIANTS_COLOR_S2)[number];
-export type StatusLightVariantS2 = (typeof STATUS_LIGHT_VARIANTS_S2)[number];
-
-// Base class (S1 | S2)
 export type StatusLightSemanticVariant =
-  | StatusLightSemanticVariantS1
-  | StatusLightSemanticVariantS2;
-export type StatusLightColorVariant =
-  | StatusLightColorVariantS1
-  | StatusLightColorVariantS2;
-export type StatusLightVariant = StatusLightVariantS1 | StatusLightVariantS2;
+  (typeof STATUSLIGHT_VARIANTS_SEMANTIC)[number];
 
-export type StatusLightSize = (typeof STATUS_LIGHT_VALID_SIZES)[number];
+export type StatusLightColorVariant =
+  (typeof STATUSLIGHT_VARIANTS_COLOR)[number];
+
+export type StatusLightVariant = (typeof STATUSLIGHT_VARIANTS)[number];

--- a/2nd-gen/packages/swc/components/badge/Badge.ts
+++ b/2nd-gen/packages/swc/components/badge/Badge.ts
@@ -70,24 +70,6 @@ export class Badge extends BadgeBase {
   @property({ type: String, reflect: true })
   public override variant: BadgeVariant = 'neutral';
 
-  // ───────────────────
-  //     API ADDITIONS
-  // ───────────────────
-
-  /**
-   * Whether the badge is subtle.
-   */
-  @property({ type: Boolean, reflect: true })
-  public subtle: boolean = false;
-
-  /**
-   * Whether the badge is outlined.
-   *
-   * Can only be used with semantic variants.
-   */
-  @property({ type: Boolean, reflect: true })
-  public outline: boolean = false;
-
   // ──────────────────────────────
   //     RENDERING & STYLING
   // ──────────────────────────────

--- a/2nd-gen/packages/swc/components/badge/Badge.ts
+++ b/2nd-gen/packages/swc/components/badge/Badge.ts
@@ -66,6 +66,7 @@ export class Badge extends BadgeBase {
    * The variant of the badge.
    *
    * @todo - Implement new badge variants (notification, indicator) introduced in S2. Jira ticket: SWC-1831
+   * Implement as separate component based on React https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/s2/src/NotificationBadge.tsx
    */
   @property({ type: String, reflect: true })
   public override variant: BadgeVariant = 'neutral';

--- a/2nd-gen/packages/swc/components/badge/Badge.ts
+++ b/2nd-gen/packages/swc/components/badge/Badge.ts
@@ -76,8 +76,6 @@ export class Badge extends BadgeBase {
 
   /**
    * Whether the badge is subtle.
-   *
-   * @todo This can be moved to the base class once we are no longer maintaining 1st-gen.
    */
   @property({ type: Boolean, reflect: true })
   public subtle: boolean = false;
@@ -86,8 +84,6 @@ export class Badge extends BadgeBase {
    * Whether the badge is outlined.
    *
    * Can only be used with semantic variants.
-   *
-   * @todo This can be moved to the base class once we are no longer maintaining 1st-gen.
    */
   @property({ type: Boolean, reflect: true })
   public outline: boolean = false;

--- a/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/ProgressCircle.ts
@@ -15,9 +15,9 @@ import { property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import {
-  PROGRESS_CIRCLE_STATIC_COLORS_S2,
+  PROGRESS_CIRCLE_STATIC_COLORS,
   ProgressCircleBase,
-  type ProgressCircleStaticColorS2,
+  type ProgressCircleStaticColor,
 } from '@spectrum-web-components/core/components/progress-circle';
 import { capitalize } from '@spectrum-web-components/core/utils/index.js';
 
@@ -53,7 +53,7 @@ export class ProgressCircle extends ProgressCircleBase {
   /**
    * @internal
    */
-  static override readonly STATIC_COLORS = PROGRESS_CIRCLE_STATIC_COLORS_S2;
+  static override readonly STATIC_COLORS = PROGRESS_CIRCLE_STATIC_COLORS;
 
   /**
    * Static color variant for use on different backgrounds.
@@ -63,7 +63,7 @@ export class ProgressCircle extends ProgressCircleBase {
    * When set to 'black', the component uses black styling for images with a light tinted background.
    */
   @property({ reflect: true, attribute: 'static-color' })
-  public override staticColor?: ProgressCircleStaticColorS2;
+  public override staticColor?: ProgressCircleStaticColor;
 
   // ──────────────────────────────
   //     RENDERING & STYLING

--- a/2nd-gen/packages/swc/components/status-light/StatusLight.ts
+++ b/2nd-gen/packages/swc/components/status-light/StatusLight.ts
@@ -31,6 +31,9 @@ import styles from './status-light.css';
  * @status preview
  * @since 0.0.1
  *
+ * @property {string} variant - Semantic or non-semantic color variant for the status dot.
+ * @attribute {ElementSize} size - The size of the status light.
+ *
  * @example
  * <swc-status-light variant="positive">Approved</swc-status-light>
  *

--- a/2nd-gen/packages/swc/components/status-light/StatusLight.ts
+++ b/2nd-gen/packages/swc/components/status-light/StatusLight.ts
@@ -32,7 +32,6 @@ import styles from './status-light.css';
  * @since 0.0.1
  *
  * @property {string} variant - Semantic or non-semantic color variant for the status dot.
- * @attribute {ElementSize} size - The size of the status light.
  *
  * @example
  * <swc-status-light variant="positive">Approved</swc-status-light>

--- a/2nd-gen/packages/swc/components/status-light/StatusLight.ts
+++ b/2nd-gen/packages/swc/components/status-light/StatusLight.ts
@@ -15,11 +15,11 @@ import { property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 import {
-  STATUS_LIGHT_VARIANTS_COLOR_S2,
-  STATUS_LIGHT_VARIANTS_S2,
-  STATUS_LIGHT_VARIANTS_SEMANTIC_S2,
+  STATUSLIGHT_VARIANTS,
+  STATUSLIGHT_VARIANTS_COLOR,
+  STATUSLIGHT_VARIANTS_SEMANTIC,
   StatusLightBase,
-  type StatusLightVariantS2 as StatusLightVariant,
+  type StatusLightVariant,
 } from '@spectrum-web-components/core/components/status-light';
 
 import styles from './status-light.css';
@@ -30,9 +30,6 @@ import styles from './status-light.css';
  * @element swc-status-light
  * @status preview
  * @since 0.0.1
- *
- * @property {string} variant - Semantic or non-semantic color variant for the status dot.
- * @attribute {ElementSize} size - The size of the status light.
  *
  * @example
  * <swc-status-light variant="positive">Approved</swc-status-light>
@@ -48,18 +45,17 @@ export class StatusLight extends StatusLightBase {
   /**
    * @internal
    */
-  static override readonly VARIANTS_COLOR = STATUS_LIGHT_VARIANTS_COLOR_S2;
+  static override readonly VARIANTS_COLOR = STATUSLIGHT_VARIANTS_COLOR;
 
   /**
    * @internal
    */
-  static override readonly VARIANTS_SEMANTIC =
-    STATUS_LIGHT_VARIANTS_SEMANTIC_S2;
+  static override readonly VARIANTS_SEMANTIC = STATUSLIGHT_VARIANTS_SEMANTIC;
 
   /**
    * @internal
    */
-  static override readonly VARIANTS = STATUS_LIGHT_VARIANTS_S2;
+  static override readonly VARIANTS = STATUSLIGHT_VARIANTS;
 
   /**
    * Changes the color of the status dot. The variant list includes both semantic and non-semantic options.

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -196,6 +196,8 @@ export const Sizes: Story = {
  * - **`positive`**: Approved, complete, success, new, purchased, licensed
  * - **`notice`**: Needs approval, pending, scheduled, syncing, indexing, processing
  * - **`negative`**: Error, alert, rejected, failed
+ *
+ * Semantic status lights should never be used for color coding categories or labels, and vice versa.
  */
 export const SemanticVariants: Story = {
   render: (args) => html`
@@ -285,11 +287,19 @@ export const TextWrapping: Story = {
  *
  * - Semantic variants provide consistent color associations for common statuses
  * - Text labels provide clear context for all users
+ * - Disabled status lights are deprecated for Spectrum 2. Content like "Unavailable" may be used to communicate that concept instead.
+ *
+ * #### Non-interactive element
+ *
+ * - Status lights have no interactive behavior and are not focusable
+ * - Screen readers will announce the status light content as static text
+ * - No keyboard interaction is required or expected
  *
  * ### Best practices
  *
  * - Always provide a descriptive text label that explains the status
  * - Use semantic variants (`info`, `positive`, `negative`, `notice`, `neutral`) when the status has specific meaning
+ * - Status lights are not interactive elements - for interactive status indicators, consider using buttons, tags, or links instead
  * - Use meaningful, specific labels (e.g., "Approved" instead of "Green")
  * - Ensure sufficient color contrast between the status light and its background
  * - For non-semantic variants, ensure the text label provides complete context
@@ -362,6 +372,7 @@ export const Accessibility: Story = {
  * textfield.value from translations.json based on context.globals.lang.
  * Used by the Fonts guide and for locale/font demos. This story is "docs-only."
  */
+// @todo: a withLocaleWrapper could be pulled up into a global decorator/helper to be implemented by more components. SWC-1872
 function withLocaleWrapperRender(
   args: Record<string, unknown> & { lang?: string; 'default-slot'?: string },
   context: { globals: { lang?: string } }
@@ -383,7 +394,9 @@ function withLocaleWrapperRender(
 /**
  * Status light with label driven by the Language toolbar and translations.json.
  * Use this story in the Fonts guide to demonstrate font loading and translated copy.
+ * Learn more about [loading the expected fonts](/docs/guides-customization-fonts--readme).
  */
+// @todo: this story is docs-only, but we should start capturing Chromatic baselines for internationalized content in components. SWC-1871
 export const WithLocaleWrapper: Story = {
   render: withLocaleWrapperRender,
   parameters: {

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -16,12 +16,10 @@ import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
 import { StatusLight } from '@adobe/spectrum-wc/status-light';
 import {
-  STATUS_LIGHT_VALID_SIZES,
-  STATUS_LIGHT_VARIANTS_COLOR_S2,
-  STATUS_LIGHT_VARIANTS_SEMANTIC_S2,
-  StatusLightColorVariantS2,
-  StatusLightSemanticVariantS2,
-  type StatusLightSize,
+  STATUSLIGHT_VARIANTS_COLOR,
+  STATUSLIGHT_VARIANTS_SEMANTIC,
+  StatusLightColorVariant,
+  StatusLightSemanticVariant,
 } from '@spectrum-web-components/core/components/status-light';
 
 import '@adobe/spectrum-wc/status-light';
@@ -40,29 +38,20 @@ argTypes.variant = {
   ...argTypes.variant,
   control: { type: 'select' },
   options: StatusLight.VARIANTS,
-  table: {
-    category: 'attributes',
-    defaultValue: {
-      summary: 'info',
-    },
-  },
 };
 
 argTypes.size = {
   ...argTypes.size,
   control: { type: 'select' },
   options: StatusLight.VALID_SIZES,
-  table: {
-    category: 'attributes',
-    defaultValue: {
-      summary: 'm',
-    },
-  },
 };
 
 /**
  * Status lights describe the condition of an entity. Much like [badges](../?path=/docs/components-badge--readme), they can be used to convey semantic meaning, such as statuses and categories.
  */
+args['default-slot'] = 'Status light';
+args.size = 'm';
+
 export const meta: Meta = {
   title: 'Status light',
   component: 'swc-status-light',
@@ -101,7 +90,7 @@ const semanticLabels = {
   positive: 'Approved',
   notice: 'Pending approval',
   negative: 'Rejected',
-} as const satisfies Record<StatusLightSemanticVariantS2, string>;
+} as const satisfies Record<StatusLightSemanticVariant, string>;
 
 const nonSemanticLabels = {
   yellow: 'Operations',
@@ -118,14 +107,7 @@ const nonSemanticLabels = {
   brown: 'Facilities',
   cinnamon: 'Compliance',
   silver: 'Version 1.2.10',
-} as const satisfies Record<StatusLightColorVariantS2, string>;
-
-const sizeLabels = {
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<StatusLightSize, string>;
+} as const satisfies Record<StatusLightColorVariant, string>;
 
 // ────────────────────
 //    AUTODOCS STORY
@@ -134,17 +116,21 @@ const sizeLabels = {
 export const Playground: Story = {
   tags: ['autodocs', 'dev'],
   args: {
+    size: 'm',
+    variant: 'info',
     'default-slot': 'Active',
   },
 };
 
 // ────────────────────
-//    OVERVIEW STORIES
+//    OVERVIEW STORY
 // ────────────────────
 
 export const Overview: Story = {
   tags: ['overview'],
   args: {
+    size: 'm',
+    variant: 'info',
     'default-slot': 'Active',
   },
 };
@@ -172,6 +158,9 @@ export const Anatomy: Story = {
     })}
   `,
   tags: ['anatomy'],
+  args: {
+    size: 'm',
+  },
 };
 
 // ──────────────────────────
@@ -190,13 +179,10 @@ export const Anatomy: Story = {
  */
 export const Sizes: Story = {
   render: (args) => html`
-    ${STATUS_LIGHT_VALID_SIZES.map((size) =>
-      template({
-        ...args,
-        size,
-        'default-slot': sizeLabels[size],
-      })
-    )}
+    ${template({ ...args, size: 's', 'default-slot': 'Small' })}
+    ${template({ ...args, size: 'm', 'default-slot': 'Medium' })}
+    ${template({ ...args, size: 'l', 'default-slot': 'Large' })}
+    ${template({ ...args, size: 'xl', 'default-slot': 'Extra-large' })}
   `,
   parameters: { 'section-order': 1 },
   tags: ['options'],
@@ -210,18 +196,15 @@ export const Sizes: Story = {
  * - **`positive`**: Approved, complete, success, new, purchased, licensed
  * - **`notice`**: Needs approval, pending, scheduled, syncing, indexing, processing
  * - **`negative`**: Error, alert, rejected, failed
- *
- * Semantic status lights should never be used for color coding categories or labels, and vice versa.
  */
 export const SemanticVariants: Story = {
   render: (args) => html`
-    ${STATUS_LIGHT_VARIANTS_SEMANTIC_S2.map(
-      (variant: StatusLightSemanticVariantS2) =>
-        template({
-          ...args,
-          variant,
-          'default-slot': semanticLabels[variant],
-        })
+    ${STATUSLIGHT_VARIANTS_SEMANTIC.map((variant: StatusLightSemanticVariant) =>
+      template({
+        ...args,
+        variant,
+        'default-slot': semanticLabels[variant],
+      })
     )}
   `,
   parameters: {
@@ -249,7 +232,7 @@ export const SemanticVariants: Story = {
  */
 export const NonSemanticVariants: Story = {
   render: (args) => html`
-    ${STATUS_LIGHT_VARIANTS_COLOR_S2.map((variant: StatusLightColorVariantS2) =>
+    ${STATUSLIGHT_VARIANTS_COLOR.map((variant: StatusLightColorVariant) =>
       template({
         ...args,
         variant,
@@ -302,19 +285,11 @@ export const TextWrapping: Story = {
  *
  * - Semantic variants provide consistent color associations for common statuses
  * - Text labels provide clear context for all users
- * - Disabled status lights are deprecated for Spectrum 2. Content like "Unavailable" may be used to communicate that concept instead.
- *
- * #### Non-interactive element
- *
- * - Status lights have no interactive behavior and are not focusable
- * - Screen readers will announce the status light content as static text
- * - No keyboard interaction is required or expected
  *
  * ### Best practices
  *
  * - Always provide a descriptive text label that explains the status
  * - Use semantic variants (`info`, `positive`, `negative`, `notice`, `neutral`) when the status has specific meaning
- * - Status lights are not interactive elements - for interactive status indicators, consider using buttons, tags, or links instead
  * - Use meaningful, specific labels (e.g., "Approved" instead of "Green")
  * - Ensure sufficient color contrast between the status light and its background
  * - For non-semantic variants, ensure the text label provides complete context
@@ -387,7 +362,6 @@ export const Accessibility: Story = {
  * textfield.value from translations.json based on context.globals.lang.
  * Used by the Fonts guide and for locale/font demos. This story is "docs-only."
  */
-// @todo: a withLocaleWrapper could be pulled up into a global decorator/helper to be implemented by more components. SWC-1872
 function withLocaleWrapperRender(
   args: Record<string, unknown> & { lang?: string; 'default-slot'?: string },
   context: { globals: { lang?: string } }
@@ -409,9 +383,7 @@ function withLocaleWrapperRender(
 /**
  * Status light with label driven by the Language toolbar and translations.json.
  * Use this story in the Fonts guide to demonstrate font loading and translated copy.
- * Learn more about [loading the expected fonts](/docs/guides-customization-fonts--readme).
  */
-// @todo: this story is docs-only, but we should start capturing Chromatic baselines for internationalized content in components. SWC-1871
 export const WithLocaleWrapper: Story = {
   render: withLocaleWrapperRender,
   parameters: {

--- a/2nd-gen/packages/swc/components/status-light/test/status-light.test.ts
+++ b/2nd-gen/packages/swc/components/status-light/test/status-light.test.ts
@@ -139,28 +139,3 @@ export const UnsupportedVariantWarningTest: Story = {
     );
   },
 };
-
-export const DisabledAttributeWarningTest: Story = {
-  render: () => html`
-    <swc-status-light variant="positive">Positive</swc-status-light>
-  `,
-  play: async ({ canvasElement, step }) => {
-    await step('warns when disabled attribute is set', () =>
-      withWarningSpy(async (warnCalls) => {
-        const statusLight = await getComponent<StatusLight>(
-          canvasElement,
-          'swc-status-light'
-        );
-        statusLight.setAttribute('disabled', '');
-        statusLight.requestUpdate();
-        await statusLight.updateComplete;
-
-        expect(warnCalls.length).toBeGreaterThan(0);
-        expect(warnCalls[0][0]).toBe(statusLight);
-        expect(warnCalls[0][1]).toContain(
-          'does not support the disabled state'
-        );
-      })
-    );
-  },
-};


### PR DESCRIPTION
## Description

Removes S1-only constants, types, and runtime guards from 2nd-gen core files now that 1st-gen packages no longer
  depend on `@spectrum-web-components/core`.

- **`Badge.types.ts`**: removes `BADGE_VARIANTS_COLOR_S1`, `BADGE_VARIANTS_S1`, `BadgeColorVariantS1`,
`BadgeVariantS1`
- **`StatusLight.types.ts`**: removes `STATUSLIGHT_VARIANTS_SEMANTIC_S1`, `STATUSLIGHT_VARIANTS_COLOR_S1`,
`STATUSLIGHT_VARIANTS_S1` and their corresponding types; simplifies type aliases to S2-only
- **`ProgressCircle.types.ts`**: removes `PROGRESS_CIRCLE_STATIC_COLORS_S1` and `ProgressCircleStaticColorS1`;
inlines values into the S2 constant
- **`AlertBanner.types.ts`**: removes deprecated `AlertBannerVariants` backward-compat type
- **`StatusLight.base.ts`**: removes S1-only `disabled` attribute runtime warning
- **`swc/Badge.ts`**: removes stale `@todo` comments on `subtle` and `outline`

## Motivation and context

PR #6126 decoupled 1st-gen packages from `@spectrum-web-components/core` by inlining shared code locally. The
S1-specific exports in core were kept solely to support that cross-generation dependency, which no longer
exists.

## Related issue(s)

SWC-1885

## Author's checklist

- [x] I have read the
**[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and
**[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria
Practices](https://www.w3.org/TR/wai-aria-practices/)

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Verify no TypeScript errors after removing S1 types
1. Pull the branch and run `yarn build` in `2nd-gen/packages/core`
2. Confirm no type errors referencing removed S1 symbols

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

_Types and constants only — no component behavior or rendering changed. No accessibility testing required._