### PR TITLE
feat(illustrated-message): slot-based heading API + gen1 deprecation

### DIFF
--- a/1st-gen/packages/illustrated-message/src/IllustratedMessage.ts
+++ b/1st-gen/packages/illustrated-message/src/IllustratedMessage.ts
@@ -36,6 +36,17 @@ export class IllustratedMessage extends SpectrumElement {
     return [headingStyles, bodyStyles, messageStyles];
   }
 
+  protected override firstUpdated(): void {
+    if (window.__swc?.DEBUG) {
+      window.__swc.warn(
+        this,
+        `<${this.localName}> has been deprecated and will be removed from the project in an upcoming version. Learn more about Spectrum 2 (https://s2.spectrum.adobe.com/) as an alternative.`,
+        'https://s2.spectrum.adobe.com/',
+        { level: 'deprecation' }
+      );
+    }
+  }
+
   @property()
   public heading = '';
 

--- a/1st-gen/packages/illustrated-message/src/IllustratedMessage.ts
+++ b/1st-gen/packages/illustrated-message/src/IllustratedMessage.ts
@@ -36,22 +36,51 @@ export class IllustratedMessage extends SpectrumElement {
     return [headingStyles, bodyStyles, messageStyles];
   }
 
-  protected override firstUpdated(): void {
-    if (window.__swc?.DEBUG) {
+  /**
+   * @deprecated Use `<h2 slot="heading">` instead.
+   */
+  @property()
+  public get heading(): string {
+    return this._heading;
+  }
+
+  public set heading(value: string) {
+    if (window.__swc?.DEBUG && value) {
       window.__swc.warn(
         this,
-        `<${this.localName}> has been deprecated and will be removed from the project in an upcoming version. Learn more about Spectrum 2 (https://s2.spectrum.adobe.com/) as an alternative.`,
-        'https://s2.spectrum.adobe.com/',
+        `The "heading" property on <${this.localName}> has been deprecated and will be removed in a future release. Use <h2 slot="heading"> instead.`,
+        'https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/',
         { level: 'deprecation' }
       );
     }
+    this._heading = value;
+    this.requestUpdate('heading', this._heading);
   }
 
-  @property()
-  public heading = '';
+  private _heading = '';
 
+  /**
+   * @deprecated Use `<span slot="description">` instead.
+   */
   @property()
-  public description = '';
+  public get description(): string {
+    return this._description;
+  }
+
+  public set description(value: string) {
+    if (window.__swc?.DEBUG && value) {
+      window.__swc.warn(
+        this,
+        `The "description" property on <${this.localName}> has been deprecated and will be removed in a future release. Use <span slot="description"> instead.`,
+        'https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/',
+        { level: 'deprecation' }
+      );
+    }
+    this._description = value;
+    this.requestUpdate('description', this._description);
+  }
+
+  private _description = '';
 
   protected override render(): TemplateResult {
     return html`

--- a/1st-gen/packages/illustrated-message/test/illustrated-message.test.ts
+++ b/1st-gen/packages/illustrated-message/test/illustrated-message.test.ts
@@ -30,9 +30,12 @@ describe('Illustrated Message', () => {
       window.__swc.verbose = false;
       consoleWarnStub.restore();
     });
-    it('warns of deprecation', async () => {
-      const el = document.createElement('sp-illustrated-message');
-      document.body.append(el);
+    it('warns when deprecated "heading" property is used', async () => {
+      const el = await fixture<IllustratedMessage>(html`
+        <sp-illustrated-message
+          heading="Drag and Drop Your File"
+        ></sp-illustrated-message>
+      `);
 
       await elementUpdated(el);
 
@@ -41,6 +44,10 @@ describe('Illustrated Message', () => {
       expect(
         spyCall.args[0].includes('deprecated'),
         'confirm deprecation message'
+      ).to.be.true;
+      expect(
+        spyCall.args[0].includes('heading'),
+        'confirm message references heading property'
       ).to.be.true;
       expect(
         spyCall.args[spyCall.args.length - 1],
@@ -52,8 +59,48 @@ describe('Illustrated Message', () => {
           level: 'deprecation',
         },
       });
+    });
 
-      el.remove();
+    it('warns when deprecated "description" property is used', async () => {
+      const el = await fixture<IllustratedMessage>(html`
+        <sp-illustrated-message
+          description="Additional descriptive text"
+        ></sp-illustrated-message>
+      `);
+
+      await elementUpdated(el);
+
+      expect(consoleWarnStub.called).to.be.true;
+      const spyCall = consoleWarnStub.getCall(0);
+      expect(
+        spyCall.args[0].includes('deprecated'),
+        'confirm deprecation message'
+      ).to.be.true;
+      expect(
+        spyCall.args[0].includes('description'),
+        'confirm message references description property'
+      ).to.be.true;
+      expect(
+        spyCall.args[spyCall.args.length - 1],
+        'confirm `data` shape'
+      ).to.deep.equal({
+        data: {
+          localName: 'sp-illustrated-message',
+          type: 'api',
+          level: 'deprecation',
+        },
+      });
+    });
+
+    it('does not warn when slot-based API is used', async () => {
+      await fixture<IllustratedMessage>(html`
+        <sp-illustrated-message>
+          <h2 slot="heading">Drag and Drop Your File</h2>
+          <span slot="description">Additional descriptive text</span>
+        </sp-illustrated-message>
+      `);
+
+      expect(consoleWarnStub.called).to.be.false;
     });
   });
 

--- a/1st-gen/packages/illustrated-message/test/illustrated-message.test.ts
+++ b/1st-gen/packages/illustrated-message/test/illustrated-message.test.ts
@@ -9,13 +9,52 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { expect, fixture, html } from '@open-wc/testing';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { stub } from 'sinon';
 
 import '@spectrum-web-components/illustrated-message/sp-illustrated-message.js';
 
 import { IllustratedMessage } from '../';
 
 describe('Illustrated Message', () => {
+  describe('dev mode', () => {
+    let consoleWarnStub!: ReturnType<typeof stub>;
+    before(() => {
+      consoleWarnStub = stub(console, 'warn');
+    });
+    afterEach(() => {
+      consoleWarnStub.resetHistory();
+    });
+    after(() => {
+      consoleWarnStub.restore();
+    });
+    it('warns of deprecation', async () => {
+      const el = document.createElement('sp-illustrated-message');
+      document.body.append(el);
+
+      await elementUpdated(el);
+
+      expect(consoleWarnStub.called).to.be.true;
+      const spyCall = consoleWarnStub.getCall(0);
+      expect(
+        spyCall.args[0].includes('deprecated'),
+        'confirm deprecation message'
+      ).to.be.true;
+      expect(
+        spyCall.args[spyCall.args.length - 1],
+        'confirm `data` shape'
+      ).to.deep.equal({
+        data: {
+          localName: 'sp-illustrated-message',
+          type: 'api',
+          level: 'deprecation',
+        },
+      });
+
+      el.remove();
+    });
+  });
+
   it('loads', async () => {
     const el = await fixture<IllustratedMessage>(html`
       <sp-illustrated-message

--- a/1st-gen/packages/illustrated-message/test/illustrated-message.test.ts
+++ b/1st-gen/packages/illustrated-message/test/illustrated-message.test.ts
@@ -20,12 +20,14 @@ describe('Illustrated Message', () => {
   describe('dev mode', () => {
     let consoleWarnStub!: ReturnType<typeof stub>;
     before(() => {
+      window.__swc.verbose = true;
       consoleWarnStub = stub(console, 'warn');
     });
     afterEach(() => {
       consoleWarnStub.resetHistory();
     });
     after(() => {
+      window.__swc.verbose = false;
       consoleWarnStub.restore();
     });
     it('warns of deprecation', async () => {

--- a/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
+++ b/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
@@ -16,10 +16,8 @@ import { property } from 'lit/decorators.js';
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
 
 import {
-  ILLUSTRATED_MESSAGE_VALID_HEADING_LEVELS,
   ILLUSTRATED_MESSAGE_VALID_ORIENTATIONS,
   ILLUSTRATED_MESSAGE_VALID_SIZES,
-  type IllustratedMessageHeadingLevel,
   type IllustratedMessageOrientation,
   type IllustratedMessageSize,
 } from './IllustratedMessage.types.js';
@@ -30,8 +28,10 @@ import {
  *
  * @slot - Decorative or informative SVG illustration. Decorative SVGs should include
  *   `aria-hidden="true"`; informative SVGs should include `role="img"` and `aria-label`.
- * @slot heading - Heading text. Must be a single `<span>` element — the shadow DOM owns the
- *   heading tag and level. Consumers who previously slotted an `<h2>` must switch to `<span>`.
+ * @slot heading - The heading element. Must be an `<h2>`–`<h6>` element. The consumer owns
+ *   the heading tag and level.
+ *   @todo SWC-1943 Add slot constraints once the CEM slot constraints work is complete:
+ *   `{required} {allowedChildren: h2, h3, h4, h5, h6} {maxChildren: 1}`
  * @slot description - Description text. Links must be real `<a>` elements or link components
  *   with visible names.
  */
@@ -39,12 +39,6 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
   // ─────────────────────────
   //     API TO OVERRIDE
   // ─────────────────────────
-
-  /**
-   * @internal
-   */
-  static readonly VALID_HEADING_LEVELS: readonly IllustratedMessageHeadingLevel[] =
-    ILLUSTRATED_MESSAGE_VALID_HEADING_LEVELS;
 
   /**
    * @internal
@@ -63,12 +57,6 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
   // ──────────────────
 
   /**
-   * The heading level of the illustrated message title. Accepts 2–6.
-   */
-  @property({ type: Number, reflect: true, attribute: 'heading-level' })
-  public headingLevel: IllustratedMessageHeadingLevel = 2;
-
-  /**
    * The size of the illustrated message.
    */
   @property({ type: String, reflect: true })
@@ -83,15 +71,6 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────
-
-  /**
-   * Returns a valid heading level clamped to 2–6.
-   *
-   * @internal
-   */
-  protected getHeadingLevel(): number {
-    return Math.max(2, Math.min(6, this.headingLevel));
-  }
 
   protected override updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
@@ -120,30 +99,6 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
         );
       }
 
-      if (
-        changedProperties.has('headingLevel') &&
-        (this.headingLevel < 2 || this.headingLevel > 6)
-      ) {
-        window.__swc.warn(
-          this,
-          `<${this.localName}> received an invalid "heading-level" value of "${this.headingLevel}". Valid values are 2–6. The value has been clamped to ${this.getHeadingLevel()}.`,
-          'https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/',
-          { issues: [`heading-level="${this.headingLevel}"`] }
-        );
-      }
-
-      const headingSlot = this.shadowRoot?.querySelector<HTMLSlotElement>(
-        'slot[name="heading"]'
-      );
-      const assigned = headingSlot?.assignedElements() ?? [];
-      if (assigned.length > 0 && assigned[0].tagName.toLowerCase() !== 'span') {
-        window.__swc.warn(
-          this,
-          `<${this.localName}> expects the "heading" slot to contain a single <span> element. The shadow DOM owns the heading tag. Received: <${assigned[0].tagName.toLowerCase()}>.`,
-          'https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/',
-          { issues: [`heading slot: <${assigned[0].tagName.toLowerCase()}>`] }
-        );
-      }
     }
   }
 }

--- a/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
+++ b/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
@@ -99,6 +99,21 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
         );
       }
 
+      const headingSlot = this.shadowRoot?.querySelector<HTMLSlotElement>(
+        'slot[name="heading"]'
+      );
+      if (headingSlot) {
+        for (const el of headingSlot.assignedElements()) {
+          if (!['H2', 'H3', 'H4', 'H5', 'H6'].includes(el.tagName)) {
+            window.__swc.warn(
+              this,
+              `<${this.localName}> heading slot received a <${el.tagName.toLowerCase()}> element. Only <h2>–<h6> elements are allowed in the heading slot.`,
+              'https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/',
+              { issues: [`heading slot: <${el.tagName.toLowerCase()}>`] }
+            );
+          }
+        }
+      }
     }
   }
 }

--- a/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
+++ b/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
@@ -72,6 +72,21 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
   //     IMPLEMENTATION
   // ──────────────────────
 
+  protected override firstUpdated(changedProperties: PropertyValues): void {
+    super.firstUpdated(changedProperties);
+    if (window.__swc?.DEBUG) {
+      const headingSlot = this.shadowRoot?.querySelector<HTMLSlotElement>(
+        'slot[name="heading"]'
+      );
+      if (headingSlot) {
+        headingSlot.addEventListener('slotchange', () =>
+          this.warnInvalidHeadingSlot(headingSlot)
+        );
+        this.warnInvalidHeadingSlot(headingSlot);
+      }
+    }
+  }
+
   protected override updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
     if (window.__swc?.DEBUG) {
@@ -98,21 +113,18 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
           { issues: [`orientation="${this.orientation}"`] }
         );
       }
+    }
+  }
 
-      const headingSlot = this.shadowRoot?.querySelector<HTMLSlotElement>(
-        'slot[name="heading"]'
-      );
-      if (headingSlot) {
-        for (const el of headingSlot.assignedElements()) {
-          if (!['H2', 'H3', 'H4', 'H5', 'H6'].includes(el.tagName)) {
-            window.__swc.warn(
-              this,
-              `<${this.localName}> heading slot received a <${el.tagName.toLowerCase()}> element. Only <h2>–<h6> elements are allowed in the heading slot.`,
-              'https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/',
-              { issues: [`heading slot: <${el.tagName.toLowerCase()}>`] }
-            );
-          }
-        }
+  private warnInvalidHeadingSlot(headingSlot: HTMLSlotElement): void {
+    for (const el of headingSlot.assignedElements()) {
+      if (!['H2', 'H3', 'H4', 'H5', 'H6'].includes(el.tagName)) {
+        window.__swc?.warn(
+          this,
+          `<${this.localName}> heading slot received a <${el.tagName.toLowerCase()}> element. Only <h2>–<h6> elements are allowed in the heading slot.`,
+          'https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/',
+          { issues: [`heading slot: <${el.tagName.toLowerCase()}>`] }
+        );
       }
     }
   }

--- a/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
+++ b/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
@@ -74,16 +74,14 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
 
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
-    if (window.__swc?.DEBUG) {
-      const headingSlot = this.shadowRoot?.querySelector<HTMLSlotElement>(
-        'slot[name="heading"]'
+    const headingSlot = this.shadowRoot?.querySelector<HTMLSlotElement>(
+      'slot[name="heading"]'
+    );
+    if (headingSlot) {
+      headingSlot.addEventListener('slotchange', () =>
+        this.warnInvalidHeadingSlot(headingSlot)
       );
-      if (headingSlot) {
-        headingSlot.addEventListener('slotchange', () =>
-          this.warnInvalidHeadingSlot(headingSlot)
-        );
-        this.warnInvalidHeadingSlot(headingSlot);
-      }
+      this.warnInvalidHeadingSlot(headingSlot);
     }
   }
 
@@ -117,6 +115,9 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
   }
 
   private warnInvalidHeadingSlot(headingSlot: HTMLSlotElement): void {
+    if (!window.__swc?.DEBUG) {
+      return;
+    }
     for (const el of headingSlot.assignedElements()) {
       if (!['H2', 'H3', 'H4', 'H5', 'H6'].includes(el.tagName)) {
         window.__swc?.warn(

--- a/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.types.ts
+++ b/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.types.ts
@@ -12,10 +12,6 @@
 
 import type { ElementSize } from '@spectrum-web-components/core/mixins/index.js';
 
-export const ILLUSTRATED_MESSAGE_VALID_HEADING_LEVELS = [
-  2, 3, 4, 5, 6,
-] as const satisfies readonly number[];
-
 export const ILLUSTRATED_MESSAGE_VALID_SIZES = [
   's',
   'm',
@@ -26,9 +22,6 @@ export const ILLUSTRATED_MESSAGE_VALID_ORIENTATIONS = [
   'vertical',
   'horizontal',
 ] as const satisfies readonly string[];
-
-export type IllustratedMessageHeadingLevel =
-  (typeof ILLUSTRATED_MESSAGE_VALID_HEADING_LEVELS)[number];
 
 export type IllustratedMessageSize =
   (typeof ILLUSTRATED_MESSAGE_VALID_SIZES)[number];

--- a/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
@@ -18,8 +18,7 @@ import styles from './illustrated-message.css';
 
 /**
  * @element swc-illustrated-message
- * @status preview
- * @todo SWC-1944 Update to `@status unsupported`.
+ * @status unsupported
  * @since 0.0.1
  *
  * @example

--- a/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
@@ -19,19 +19,20 @@ import styles from './illustrated-message.css';
 /**
  * @element swc-illustrated-message
  * @status preview
+ * @todo SWC-1944 Update to `@status unsupported`.
  * @since 0.0.1
  *
  * @example
  * <swc-illustrated-message>
  *   <svg slot="" aria-hidden="true" viewBox="0 0 200 160"><!-- illustration --></svg>
- *   <span slot="heading">Create your first asset.</span>
+ *   <h2 slot="heading">Create your first asset.</h2>
  *   <span slot="description">Get started by uploading or importing some assets.</span>
  * </swc-illustrated-message>
  *
  * @example
- * <swc-illustrated-message heading-level="3">
+ * <swc-illustrated-message>
  *   <svg slot="" aria-hidden="true" viewBox="0 0 200 160"><!-- illustration --></svg>
- *   <span slot="heading">No results found.</span>
+ *   <h3 slot="heading">No results found.</h3>
  *   <span slot="description">Try adjusting your search or filters.</span>
  * </swc-illustrated-message>
  */
@@ -45,35 +46,13 @@ export class IllustratedMessage extends IllustratedMessageBase {
   }
 
   protected override render(): TemplateResult {
-    const level = this.getHeadingLevel();
-    const headingClass = 'swc-IllustratedMessage-heading';
-    const heading = html`<slot name="heading"></slot>`;
-
     return html`
       <div class="swc-IllustratedMessage">
         <div class="swc-IllustratedMessage-illustration">
           <slot></slot>
         </div>
         <div class="swc-IllustratedMessage-content">
-          ${level === 2
-            ? html`
-                <h2 class=${headingClass}>${heading}</h2>
-              `
-            : level === 3
-              ? html`
-                  <h3 class=${headingClass}>${heading}</h3>
-                `
-              : level === 4
-                ? html`
-                    <h4 class=${headingClass}>${heading}</h4>
-                  `
-                : level === 5
-                  ? html`
-                      <h5 class=${headingClass}>${heading}</h5>
-                    `
-                  : html`
-                      <h6 class=${headingClass}>${heading}</h6>
-                    `}
+          <slot name="heading"></slot>
           <div class="swc-IllustratedMessage-description">
             <slot name="description"></slot>
           </div>

--- a/2nd-gen/packages/swc/components/illustrated-message/illustrated-message.css
+++ b/2nd-gen/packages/swc/components/illustrated-message/illustrated-message.css
@@ -40,8 +40,18 @@
 }
 
 /* @todo SWC-1838 — heading typography (size, weight, line-height, color) */
-.swc-IllustratedMessage-heading {
+
+/*
+ * Reset native heading styles (font-size, font-weight, margin) so component tokens can take over.
+ * The :not([class]) guard leaves intentionally-classed headings untouched.
+ */
+::slotted(h2:not([class])),
+::slotted(h3:not([class])),
+::slotted(h4:not([class])),
+::slotted(h5:not([class])),
+::slotted(h6:not([class])) {
   margin: 0;
+  font: inherit;
 }
 
 /* @todo SWC-1838 — description typography (size, weight, line-height, color) */

--- a/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
@@ -15,8 +15,6 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
-import { IllustratedMessage } from '@adobe/spectrum-wc/illustrated-message';
-
 import '../../icon';
 
 // ────────────────
@@ -27,28 +25,15 @@ const { args, argTypes, template } = getStorybookHelpers(
   'swc-illustrated-message'
 );
 
-argTypes['heading-level'] = {
-  ...argTypes['heading-level'],
-  control: { type: 'select' },
-  options: IllustratedMessage.VALID_HEADING_LEVELS,
-  table: {
-    category: 'attributes',
-    defaultValue: { summary: '2' },
-  },
-};
-
 /**
  * An illustrated message displays an illustration and a message, typically
  * used in empty states or error pages.
  *
  * ### Heading level
  *
- * The `heading-level` attribute controls the semantic heading level rendered
- * in shadow DOM (`h2`–`h6`) to match the document outline. It does not affect
- * the visual appearance — all levels render at the same size.
- *
- * Set `heading-level` based on the heading hierarchy of the page, not visual
- * preference.
+ * Provide the appropriate `<h2>`–`<h6>` element directly in the `heading`
+ * slot to match the document outline. The component does not control the
+ * heading level — the consumer does.
  */
 export const meta: Meta = {
   title: 'Illustrated Message',
@@ -84,7 +69,7 @@ const cloudIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="95" height="95
 
 const defaultSlots = html`
   <span slot="">${unsafeHTML(cloudIcon)}</span>
-  <span slot="heading">Illustrated message title</span>
+  <h2 slot="heading">Illustrated message title</h2>
   <span slot="description">
     Illustrated message description. Give more information about what a user can
     do, expect, or how to make items appear.
@@ -102,23 +87,6 @@ export const Overview: Story = {
 };
 
 /**
- * The `heading-level` attribute controls the semantic heading level rendered
- * in shadow DOM (`h2`–`h6`) to match the document outline. It does not affect
- * the visual appearance — all levels render at the same size.
- *
- * Set `heading-level` based on the heading hierarchy of the page, not visual
- * preference.
- */
-export const HeadingLevels: Story = {
-  render: (args) => html`
-    ${IllustratedMessage.VALID_HEADING_LEVELS.map((level) =>
-      template({ ...args, 'heading-level': level }, defaultSlots)
-    )}
-  `,
-  tags: ['options'],
-};
-
-/**
  * SVGs slotted into the illustration slot should declare their accessibility
  * intent explicitly:
  *
@@ -133,7 +101,7 @@ export const IllustrationAccessibility: Story = {
       args,
       html`
         <span slot="">${unsafeHTML(cloudIcon)}</span>
-        <span slot="heading">Illustrated message title</span>
+        <h2 slot="heading">Illustrated message title</h2>
         <span slot="description">
           The icon above uses
           <code>aria-hidden="true"</code>
@@ -146,7 +114,7 @@ export const IllustrationAccessibility: Story = {
       args,
       html`
         <span slot="">${unsafeHTML(cloudIcon)}</span>
-        <span slot="heading">Illustrated message title</span>
+        <h2 slot="heading">Illustrated message title</h2>
         <span slot="description">
           The icon above uses
           <code>role="img"</code>

--- a/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
@@ -15,7 +15,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
-import '../../icon';
+import '@adobe/spectrum-wc/illustrated-message';
 
 // ────────────────
 //    METADATA

--- a/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
@@ -32,8 +32,7 @@ const { args, argTypes, template } = getStorybookHelpers(
  * ### Heading level
  *
  * Provide the appropriate `<h2>`–`<h6>` element directly in the `heading`
- * slot to match the document outline. The component does not control the
- * heading level — the consumer does.
+ * slot to match the document outline. The component does not control the heading level.
  */
 export const meta: Meta = {
   title: 'Illustrated Message',

--- a/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.a11y.spec.ts
@@ -37,17 +37,16 @@ test.describe('IllustratedMessage - ARIA Snapshots', () => {
     `);
   });
 
-  test('should render correct heading levels for heading-levels story', async ({
+  test('should have heading in light DOM (consumer-owned)', async ({
     page,
   }) => {
-    await gotoStory(
+    const root = await gotoStory(
       page,
-      'components-illustrated-message--heading-levels',
+      'components-illustrated-message--overview',
       'swc-illustrated-message'
     );
-    const headings = page.locator('swc-illustrated-message');
-    await expect(headings.nth(0).locator('h2')).toBeVisible();
-    await expect(headings.nth(1).locator('h3')).toBeVisible();
-    await expect(headings.nth(2).locator('h4')).toBeVisible();
+    // The heading is slotted from light DOM — it must be queryable from outside
+    // the shadow root and must not appear inside the shadow DOM.
+    await expect(root.locator('h2[slot="heading"]')).toBeVisible();
   });
 });

--- a/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
@@ -44,27 +44,26 @@ export const OverviewTest: Story = {
       'swc-illustrated-message'
     );
 
-    await step('renders with default heading-level 2', async () => {
-      expect(illustratedMessage.headingLevel, 'default heading level').toBe(2);
-    });
+    await step('consumer owns the heading element in light DOM', async () => {
+      const headingInLight = illustratedMessage.querySelector('[slot="heading"]');
+      expect(headingInLight, 'heading element in light DOM').not.toBeNull();
 
-    await step('renders an h2 element in shadow DOM by default', async () => {
-      expect(
-        illustratedMessage.shadowRoot?.querySelector('h2'),
-        'h2 in shadow DOM'
-      ).not.toBeNull();
+      const headingInShadow = illustratedMessage.shadowRoot?.querySelector(
+        'h1, h2, h3, h4, h5, h6'
+      );
+      expect(headingInShadow, 'no heading element in shadow DOM').toBeNull();
     });
   },
 };
 
 // ──────────────────────────────────────────────────────────────
-// TEST: Properties / Attributes
+// TEST: Heading slot — valid usage
 // ──────────────────────────────────────────────────────────────
 
-export const AllHeadingLevelsTest: Story = {
+export const HeadingSlotValidElementsTest: Story = {
   render: () => html`
     <swc-illustrated-message>
-      <span slot="heading">Heading level test</span>
+      <h2 slot="heading">Heading test</h2>
     </swc-illustrated-message>
   `,
   play: async ({ canvasElement, step }) => {
@@ -73,30 +72,33 @@ export const AllHeadingLevelsTest: Story = {
       'swc-illustrated-message'
     );
 
-    for (const level of [3, 4, 5, 6] as const) {
-      await step(
-        `renders h${level} when heading-level is set to ${level}`,
-        async () => {
-          illustratedMessage.setAttribute('heading-level', String(level));
+    for (const tag of ['h2', 'h3', 'h4', 'h5', 'h6'] as const) {
+      await step(`does not warn when heading slot contains <${tag}>`, () =>
+        withWarningSpy(async (warnCalls) => {
+          const heading = document.createElement(tag);
+          heading.setAttribute('slot', 'heading');
+          heading.textContent = `Heading as ${tag}`;
+
+          illustratedMessage.querySelector('[slot="heading"]')?.remove();
+          illustratedMessage.appendChild(heading);
+          illustratedMessage.requestUpdate();
           await illustratedMessage.updateComplete;
-          expect(
-            illustratedMessage.shadowRoot?.querySelector(`h${level}`),
-            `h${level} in shadow DOM`
-          ).not.toBeNull();
-          expect(
-            illustratedMessage.shadowRoot?.querySelector(`h${level - 1}`),
-            `h${level - 1} absent after heading-level change`
-          ).toBeNull();
-        }
+
+          expect(warnCalls.length, `no warning for valid <${tag}>`).toBe(0);
+        })
       );
     }
   },
 };
 
-export const HeadingLevelClampTest: Story = {
+// ──────────────────────────────────────────────────────────────
+// TEST: Heading slot — invalid usage
+// ──────────────────────────────────────────────────────────────
+
+export const HeadingSlotInvalidElementWarningTest: Story = {
   render: () => html`
     <swc-illustrated-message>
-      <span slot="heading">Clamped heading</span>
+      <div slot="heading">Not a heading</div>
     </swc-illustrated-message>
   `,
   play: async ({ canvasElement, step }) => {
@@ -105,18 +107,21 @@ export const HeadingLevelClampTest: Story = {
       'swc-illustrated-message'
     );
 
-    await step('clamps heading-level="1" to h2, never renders h1', async () => {
-      illustratedMessage.setAttribute('heading-level', '1');
-      await illustratedMessage.updateComplete;
-      expect(
-        illustratedMessage.shadowRoot?.querySelector('h1'),
-        'h1 must not exist in shadow DOM'
-      ).toBeNull();
-      expect(
-        illustratedMessage.shadowRoot?.querySelector('h2'),
-        'h2 rendered after clamping'
-      ).not.toBeNull();
-    });
+    await step('warns when heading slot contains a non-heading element', () =>
+      withWarningSpy(async (warnCalls) => {
+        illustratedMessage.requestUpdate();
+        await illustratedMessage.updateComplete;
+
+        expect(
+          warnCalls.length,
+          'warning fired for invalid heading slot element'
+        ).toBeGreaterThan(0);
+        expect(
+          String(warnCalls[0]?.[1] ?? ''),
+          'warning message mentions heading slot'
+        ).toContain('heading');
+      })
+    );
   },
 };
 
@@ -127,6 +132,7 @@ export const HeadingLevelClampTest: Story = {
 export const DescriptionSlotTest: Story = {
   render: () => html`
     <swc-illustrated-message>
+      <h2 slot="heading">Heading</h2>
       <span slot="description">Description text here.</span>
     </swc-illustrated-message>
   `,
@@ -147,70 +153,13 @@ export const DescriptionSlotTest: Story = {
 };
 
 // ──────────────────────────────────────────────────────────────
-// TEST: Dev mode warnings
-// ──────────────────────────────────────────────────────────────
-
-export const InvalidHeadingLevelWarningTest: Story = {
-  render: () => html`
-    <swc-illustrated-message>
-      <span slot="heading">Test</span>
-    </swc-illustrated-message>
-  `,
-  play: async ({ canvasElement, step }) => {
-    const illustratedMessage = await getComponent<IllustratedMessage>(
-      canvasElement,
-      'swc-illustrated-message'
-    );
-
-    await step('warns when heading-level is set to an out-of-range value', () =>
-      withWarningSpy(async (warnCalls) => {
-        illustratedMessage.setAttribute('heading-level', '1');
-        await illustratedMessage.updateComplete;
-
-        expect(
-          warnCalls.length,
-          'warning count for invalid heading-level'
-        ).toBeGreaterThan(0);
-        expect(
-          String(warnCalls[0]?.[1] || ''),
-          'warning message mentions heading-level'
-        ).toContain('heading-level');
-      })
-    );
-  },
-};
-
-export const ValidHeadingLevelNoWarningTest: Story = {
-  render: () => html`
-    <swc-illustrated-message>
-      <span slot="heading">Test</span>
-    </swc-illustrated-message>
-  `,
-  play: async ({ canvasElement, step }) => {
-    const illustratedMessage = await getComponent<IllustratedMessage>(
-      canvasElement,
-      'swc-illustrated-message'
-    );
-
-    await step('does not warn when a valid heading-level is set', () =>
-      withWarningSpy(async (warnCalls) => {
-        illustratedMessage.setAttribute('heading-level', '3');
-        await illustratedMessage.updateComplete;
-
-        expect(warnCalls.length, 'no warnings for valid heading-level').toBe(0);
-      })
-    );
-  },
-};
-
-// ──────────────────────────────────────────────────────────────
 // TEST: Size attribute / property
 // ──────────────────────────────────────────────────────────────
 
 export const ValidSizeNoWarningTest: Story = {
   render: () => html`
     <swc-illustrated-message>
-      <span slot="heading">Test</span>
+      <h2 slot="heading">Test</h2>
     </swc-illustrated-message>
   `,
   play: async ({ canvasElement, step }) => {
@@ -245,7 +194,7 @@ export const ValidSizeNoWarningTest: Story = {
 export const InvalidSizeWarningTest: Story = {
   render: () => html`
     <swc-illustrated-message>
-      <span slot="heading">Test</span>
+      <h2 slot="heading">Test</h2>
     </swc-illustrated-message>
   `,
   play: async ({ canvasElement, step }) => {
@@ -264,7 +213,7 @@ export const InvalidSizeWarningTest: Story = {
           'warning count for invalid size'
         ).toBeGreaterThan(0);
         expect(
-          String(warnCalls[0]?.[1] || ''),
+          String(warnCalls[0]?.[1] ?? ''),
           'warning message mentions size'
         ).toContain('size');
       })
@@ -279,7 +228,7 @@ export const InvalidSizeWarningTest: Story = {
 export const ValidOrientationNoWarningTest: Story = {
   render: () => html`
     <swc-illustrated-message>
-      <span slot="heading">Test</span>
+      <h2 slot="heading">Test</h2>
     </swc-illustrated-message>
   `,
   play: async ({ canvasElement, step }) => {
@@ -317,7 +266,7 @@ export const ValidOrientationNoWarningTest: Story = {
 export const InvalidOrientationWarningTest: Story = {
   render: () => html`
     <swc-illustrated-message>
-      <span slot="heading">Test</span>
+      <h2 slot="heading">Test</h2>
     </swc-illustrated-message>
   `,
   play: async ({ canvasElement, step }) => {
@@ -336,39 +285,9 @@ export const InvalidOrientationWarningTest: Story = {
           'warning count for invalid orientation'
         ).toBeGreaterThan(0);
         expect(
-          String(warnCalls[0]?.[1] || ''),
+          String(warnCalls[0]?.[1] ?? ''),
           'warning message mentions orientation'
         ).toContain('orientation');
-      })
-    );
-  },
-};
-
-export const InvalidHeadingSlotWarningTest: Story = {
-  render: () => html`
-    <swc-illustrated-message>
-      <h3 slot="heading">Heading as h3</h3>
-    </swc-illustrated-message>
-  `,
-  play: async ({ canvasElement, step }) => {
-    const illustratedMessage = await getComponent<IllustratedMessage>(
-      canvasElement,
-      'swc-illustrated-message'
-    );
-
-    await step('warns when heading slot contains a non-span element', () =>
-      withWarningSpy(async (warnCalls) => {
-        illustratedMessage.requestUpdate();
-        await illustratedMessage.updateComplete;
-
-        expect(
-          warnCalls.length,
-          'warning count for non-span heading slot'
-        ).toBeGreaterThan(0);
-        expect(
-          String(warnCalls[0]?.[1] || ''),
-          'warning message mentions heading slot'
-        ).toContain('heading');
       })
     );
   },

--- a/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
@@ -110,6 +110,20 @@ export const HeadingSlotInvalidElementWarningTest: Story = {
 
     await step('warns when heading slot contains a non-heading element', () =>
       withWarningSpy(async (warnCalls) => {
+        const headingSlot =
+          illustratedMessage.shadowRoot?.querySelector<HTMLSlotElement>(
+            'slot[name="heading"]'
+          );
+        if (!headingSlot) {
+          return;
+        }
+
+        const slotChanged = new Promise<void>((resolve) =>
+          headingSlot.addEventListener('slotchange', () => resolve(), {
+            once: true,
+          })
+        );
+
         // Replace the slotted element to trigger slotchange
         const div = document.createElement('div');
         div.setAttribute('slot', 'heading');
@@ -117,6 +131,8 @@ export const HeadingSlotInvalidElementWarningTest: Story = {
 
         illustratedMessage.querySelector('[slot="heading"]')?.remove();
         illustratedMessage.appendChild(div);
+
+        await slotChanged;
 
         expect(
           warnCalls.length,

--- a/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
@@ -45,7 +45,8 @@ export const OverviewTest: Story = {
     );
 
     await step('consumer owns the heading element in light DOM', async () => {
-      const headingInLight = illustratedMessage.querySelector('[slot="heading"]');
+      const headingInLight =
+        illustratedMessage.querySelector('[slot="heading"]');
       expect(headingInLight, 'heading element in light DOM').not.toBeNull();
 
       const headingInShadow = illustratedMessage.shadowRoot?.querySelector(
@@ -109,8 +110,13 @@ export const HeadingSlotInvalidElementWarningTest: Story = {
 
     await step('warns when heading slot contains a non-heading element', () =>
       withWarningSpy(async (warnCalls) => {
-        illustratedMessage.requestUpdate();
-        await illustratedMessage.updateComplete;
+        // Replace the slotted element to trigger slotchange
+        const div = document.createElement('div');
+        div.setAttribute('slot', 'heading');
+        div.textContent = 'Not a heading';
+
+        illustratedMessage.querySelector('[slot="heading"]')?.remove();
+        illustratedMessage.appendChild(div);
 
         expect(
           warnCalls.length,

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/17_debug-validation.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/17_debug-validation.md
@@ -17,6 +17,9 @@
     - [firstUpdated() — One-time setup validation](#firstupdated--one-time-setup-validation)
     - [updated() — Post-render validation](#updated--post-render-validation)
     - [connectedCallback() — Environment validation](#connectedcallback--environment-validation)
+- [Deprecation warnings](#deprecation-warnings)
+    - [Warning structure](#warning-structure)
+    - [Testing deprecation warnings](#testing-deprecation-warnings)
 - [Warning message format](#warning-message-format)
 
 </details>
@@ -192,6 +195,59 @@ public override connectedCallback(): void {
     }
   }
 }
+```
+
+## Deprecation warnings
+
+Use `{ level: 'deprecation' }` when a property or attribute has been superseded by a new API. This signals to consumers that they need to migrate, not just fix a configuration error.
+
+**When to use deprecation warnings:**
+
+- A property is being replaced by a slot (consumer-owned HTML)
+- A property value is being renamed (e.g. `variant="cta"` → `variant="accent"`)
+- An attribute is being removed, or replaced by a different attribute
+
+
+### Warning structure
+
+The key difference from other warnings is `{ level: 'deprecation' }` instead of `{ issues: [...] }`.
+
+```ts
+if (window.__swc?.DEBUG) {
+  window.__swc.warn(
+    this,
+    `The "oldProp" property on <${this.localName}> has been deprecated and will be removed in a future release. Use "newProp" instead.`,
+    'https://opensource.adobe.com/spectrum-web-components/components/your-component/',
+    { level: 'deprecation' }
+  );
+}
+```
+
+### Testing deprecation warnings
+
+Write separate test cases that verify:
+
+1. The warning fires when the deprecated API is used
+2. The warning does **not** fire when the recommended API is used
+
+```ts
+it('warns when deprecated "heading" property is used', async () => {
+  const el = await fixture(html`
+    <sp-illustrated-message heading="Title"></sp-illustrated-message>
+  `);
+  await elementUpdated(el);
+  expect(consoleWarnStub.called).to.be.true;
+  expect(consoleWarnStub.getCall(0).args[0]).to.include('heading');
+});
+
+it('does not warn when slot-based API is used', async () => {
+  await fixture(html`
+    <sp-illustrated-message>
+      <h2 slot="heading">Title</h2>
+    </sp-illustrated-message>
+  `);
+  expect(consoleWarnStub.called).to.be.false;
+});
 ```
 
 ## Warning message format

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/17_debug-validation.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/17_debug-validation.md
@@ -18,7 +18,7 @@
     - [updated() — Post-render validation](#updated--post-render-validation)
     - [connectedCallback() — Environment validation](#connectedcallback--environment-validation)
 - [Deprecation warnings](#deprecation-warnings)
-    - [Warning structure](#warning-structure)
+    - [Deprecation warning structure](#deprecation-warning-structure)
     - [Testing deprecation warnings](#testing-deprecation-warnings)
 - [Warning message format](#warning-message-format)
 
@@ -208,7 +208,7 @@ Use `{ level: 'deprecation' }` when a property or attribute has been superseded 
 - An attribute is being removed, or replaced by a different attribute
 
 
-### Warning structure
+### Deprecation warning structure
 
 The key difference from other warnings is `{ level: 'deprecation' }` instead of `{ issues: [...] }`.
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
@@ -54,6 +54,7 @@
     - [Help text migration roadmap](help-text/rendering-and-styling-migration-analysis.md)
 - Illustrated Message
     - [Illustrated message accessibility migration analysis](illustrated-message/accessibility-migration-analysis.md)
+    - [`sp-illustrated-message` Migration Plan](illustrated-message/migration-plan.md)
     - [Illustrated message migration roadmap](illustrated-message/rendering-and-styling-migration-analysis.md)
 - Infield Button
     - [In-field button migration roadmap](infield-button/rendering-and-styling-migration-analysis.md)

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/illustrated-message/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/illustrated-message/migration-plan.md
@@ -1,4 +1,48 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../../../README.md) / [Project planning](../../README.md) / [Components](../README.md) / Illustrated Message / `sp-illustrated-message` Migration Plan
+
+<!-- Document title (editable) -->
+
 # `sp-illustrated-message` Migration Plan
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [Table of contents](#table-of-contents)
+- [1st-gen API surface](#1st-gen-api-surface)
+    - [Properties / attributes](#properties--attributes)
+    - [Methods](#methods)
+    - [Events](#events)
+    - [Slots](#slots)
+    - [CSS custom properties](#css-custom-properties)
+    - [Shadow DOM output (rendered HTML)](#shadow-dom-output-rendered-html)
+- [Dependencies](#dependencies)
+- [Changes overview](#changes-overview)
+    - [Must ship — breaking or a11y-required](#must-ship--breaking-or-a11y-required)
+    - [Additive — ships when ready, zero breakage for consumers already on 2nd-gen](#additive--ships-when-ready-zero-breakage-for-consumers-already-on-2nd-gen)
+- [2nd-gen API decisions](#2nd-gen-api-decisions)
+    - [Properties / attributes (2nd-gen)](#properties--attributes-2nd-gen)
+    - [Slots (2nd-gen)](#slots-2nd-gen)
+    - [CSS custom properties (2nd-gen)](#css-custom-properties-2nd-gen)
+- [Architecture: core vs SWC split](#architecture-core-vs-swc-split)
+- [Migration checklist](#migration-checklist)
+    - [Preparation (this ticket)](#preparation-this-ticket)
+    - [Setup](#setup)
+    - [API](#api)
+    - [Styling](#styling)
+    - [Accessibility](#accessibility)
+    - [Testing](#testing)
+    - [Documentation](#documentation)
+    - [Review](#review)
+- [Blockers and open questions](#blockers-and-open-questions)
+- [References](#references)
+
+</details>
+
+<!-- Document content (editable) -->
 
 > **SWC-1834** · Planning output. Must be reviewed before implementation begins.
 


### PR DESCRIPTION
## Description

### 2nd-gen
- Removes the `heading-level` prop from `swc-illustrated-message`. The consumer now provides an `<h2>`–`<h6>` element directly in the `heading` slot — the component no longer owns the heading tag or level.
- Updates CSS to reset native heading styles via `::slotted(hN:not([class]))` so component tokens can take over.
- Adds `@todo SWC-1943` (slot constraints) and `@todo SWC-1944` (`@status unsupported`) to track follow-up work.
- Rewrites tests to reflect the new slot-based API.
- Updates stories to use `<h2 slot="heading">`.

### 1st-gen
- Adds a `firstUpdated` deprecation warning on `sp-illustrated-message` pointing to https://s2.spectrum.adobe.com/.
- Adds a deprecation test following the avatar/iconset pattern.

## Motivation and context

The previous API had the shadow DOM own the heading tag (`<h2>`–`<h6>`), controlled via a `heading-level` prop. This is a breaking change that simplifies the API — consumers own their heading semantics, which is more consistent with how slots are used across the design system and gives teams direct control over document outline hierarchy.

The gen1 `sp-illustrated-message` is no longer maintained. The deprecation warning directs consumers to Spectrum 2.

## Related issue(s)

- SWC-1835

## Screenshots (if appropriate)

---

## Author's checklist

- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Heading slot renders correctly with consumer-provided heading element
  1. Open the Illustrated Message story in Storybook
  2. Verify the heading renders with `<h2 slot="heading">` in light DOM
  3. Inspect the shadow DOM — confirm no `<h2>`–`<h6>` exists there

- [ ] Deprecation warning fires for `sp-illustrated-message` in gen1
  1. Open the gen1 Storybook on port 8008
  2. Navigate to the Illustrated Message story
  3. Open browser devtools console
  4. Expect a `[SWC] DEPRECATION NOTICE` warning mentioning Spectrum 2

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  1. Open the Illustrated Message story in Storybook
  2. Tab into the component
  3. Verify focus moves logically through the heading, description, and any interactive content in slots

- [ ] **Screen reader** (required — document steps below)
  1. Open the Illustrated Message story in Storybook with a screen reader active
  2. Navigate to the component
  3. Verify the heading level is announced correctly based on the element provided (e.g. `<h2>` announces as "heading level 2")
  4. Verify the description content is announced after the heading
