### PR TITLE
chore: add in new status label

### DIFF
--- a/2nd-gen/packages/swc/.storybook/blocks/StatusBadge.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/StatusBadge.tsx
@@ -17,12 +17,16 @@ import customElements from '../custom-elements.json' with { type: 'json' };
 // Register the badge component for use in the docs iframe
 import '../../components/badge/index.js';
 
-type Status = 'preview' | 'deprecated' | 'internal';
+type Status = 'preview' | 'deprecated' | 'internal' | 'unsupported';
 
-const STATUS_CONFIG: Record<Status, { label: string; variant: string }> = {
-  preview: { label: 'Preview', variant: 'notice' },
-  deprecated: { label: 'Deprecated', variant: 'negative' },
-  internal: { label: 'Internal', variant: 'neutral' },
+const STATUS_CONFIG: Record<
+  Status,
+  { label: string; variant: string; outline?: boolean }
+> = {
+  preview: { label: 'Preview', variant: 'fuchsia' },
+  deprecated: { label: 'Deprecated', variant: 'negative', outline: true },
+  internal: { label: 'Internal', variant: 'neutral', outline: true },
+  unsupported: { label: 'Unsupported', variant: 'negative' },
 };
 
 /**
@@ -102,12 +106,17 @@ export const StatusBadge = ({ of }: { of?: any }) => {
 
   return (
     <div style={{ display: 'flex', gap: '6px', marginBottom: '12px' }}>
-      {statusConfig && (
-        <Badge variant={statusConfig.variant}>{statusConfig.label}</Badge>
-      )}
       {since && (
         <Badge variant="neutral" outline>
           {`Since ${since}`}
+        </Badge>
+      )}
+      {statusConfig && (
+        <Badge
+          variant={statusConfig.variant}
+          outline={statusConfig?.outline ?? false}
+        >
+          {statusConfig.label}
         </Badge>
       )}
     </div>

--- a/2nd-gen/packages/swc/components/asset/Asset.ts
+++ b/2nd-gen/packages/swc/components/asset/Asset.ts
@@ -56,8 +56,7 @@ const folder = (label: string): TemplateResult => html`
 
 /**
  * @element swc-asset
- * @status preview
- * @since 0.0.1
+ * @status unsupported
  * @slot - content to be displayed when no `variant` is set (typically an `<img>` element)
  *
  * @example

--- a/2nd-gen/packages/swc/components/avatar/Avatar.ts
+++ b/2nd-gen/packages/swc/components/avatar/Avatar.ts
@@ -23,6 +23,8 @@ import styles from './avatar.css';
  * technology.
  *
  * @element swc-avatar
+ * @status preview
+ * @since 0.0.1
  *
  * @example
  * <swc-avatar src="/path/to/image.jpg" alt="Jane Doe"></swc-avatar>


### PR DESCRIPTION
Adding in `unsupported` status label for components still actively in migration not ready to be used by consumers. 

Deeper discussions about status will happen on thursday but this implements the decision from monday.


Test:
- if you run storybook locally, Asset should be flagged as `unsupported`