### PR TITLE
chore: turn off asset from SB prod build

### DIFF
--- a/2nd-gen/packages/swc/components/asset/stories/asset.internal.stories.ts
+++ b/2nd-gen/packages/swc/components/asset/stories/asset.internal.stories.ts
@@ -22,7 +22,7 @@ import '@adobe/spectrum-wc/asset';
 //    METADATA
 // ────────────────
 
-const { events, args, argTypes, template } = getStorybookHelpers('swc-asset');
+const { args, argTypes, template } = getStorybookHelpers('swc-asset');
 
 argTypes.variant = {
   ...argTypes.variant,
@@ -39,9 +39,6 @@ const meta: Meta = {
   component: 'swc-asset',
   args,
   argTypes,
-  actions: {
-    handles: events,
-  },
   parameters: {
     docs: {
       subtitle: `Visually represent files, folders, or images in your application`,
@@ -49,7 +46,6 @@ const meta: Meta = {
     flexLayout: 'row-nowrap',
   },
   render: (args) => template(args),
-  tags: ['migrated'],
 };
 
 export default meta;

--- a/2nd-gen/packages/swc/components/asset/test/asset.test.ts
+++ b/2nd-gen/packages/swc/components/asset/test/asset.test.ts
@@ -22,8 +22,8 @@ import {
   getComponents,
   withWarningSpy,
 } from '../../../utils/test-utils.js';
-import meta from '../stories/asset.stories.js';
-import { Overview, Variants } from '../stories/asset.stories.js';
+import meta from '../stories/asset.internal.stories.js';
+import { Overview, Variants } from '../stories/asset.internal.stories.js';
 
 // This file defines dev-only test stories that reuse the main story metadata.
 export default {


### PR DESCRIPTION
disable asset from showing in storybook prod. 

Test:
- should not see asset in preview link
- should see asset if ran locally