### PR TITLE
chore(storybook): review and complete storybook docs

### DIFF
--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -504,7 +504,6 @@ export const Inline: Story = {
   tags: ['behaviors'],
 };
 
-
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────

--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -86,6 +86,28 @@ argTypes['icon-slot'] = {
     'Accepts an icon element. The control is disabled. Use the Anatomy story to see icon usage. Enhancements to this control will be added in a future release.',
 };
 
+argTypes.outline = {
+  ...argTypes.outline,
+  control: { type: 'boolean' },
+  table: {
+    category: 'attributes',
+    defaultValue: {
+      summary: 'false',
+    },
+  },
+};
+
+argTypes.subtle = {
+  ...argTypes.subtle,
+  control: { type: 'boolean' },
+  table: {
+    category: 'attributes',
+    defaultValue: {
+      summary: 'false',
+    },
+  },
+};
+
 /**
  * Similar to [status lights](/docs/components-status-light--readme), they use color and text to convey status or category information.
  *
@@ -437,6 +459,51 @@ export const TextWrapping: Story = {
   `,
   tags: ['behaviors'],
 };
+
+/**
+ * Badges flow naturally within prose text to annotate inline content such as headings,
+ * labels, list items, or table cells.
+ *
+ * Because `<swc-badge>` renders as `inline-flex`, it participates in the normal
+ * text flow without any extra wrapper styling required. Use small (`s`) badges in
+ * most inline contexts to avoid disrupting line height.
+ */
+export const Inline: Story = {
+  render: (args) => html`
+    <p>
+      Design system components
+      ${template({
+        ...args,
+        variant: 'accent',
+        'default-slot': 'Beta',
+        size: 's',
+      })}
+    </p>
+    <p>
+      API documentation
+      ${template({
+        ...args,
+        variant: 'positive',
+        'default-slot': 'Stable',
+        size: 's',
+      })}
+    </p>
+    <p>
+      Legacy components
+      ${template({
+        ...args,
+        variant: 'notice',
+        'default-slot': 'Deprecated',
+        size: 's',
+      })}
+    </p>
+  `,
+  parameters: {
+    flexLayout: 'column-stretch',
+  },
+  tags: ['behaviors'],
+};
+
 
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES

--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -88,23 +88,17 @@ argTypes['icon-slot'] = {
 
 argTypes.outline = {
   ...argTypes.outline,
-  control: { type: 'boolean' },
   table: {
-    category: 'attributes',
-    defaultValue: {
-      summary: 'false',
-    },
+    ...argTypes.outline?.table,
+    defaultValue: { summary: 'false' },
   },
 };
 
 argTypes.subtle = {
   ...argTypes.subtle,
-  control: { type: 'boolean' },
   table: {
-    category: 'attributes',
-    defaultValue: {
-      summary: 'false',
-    },
+    ...argTypes.subtle?.table,
+    defaultValue: { summary: 'false' },
   },
 };
 

--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -77,6 +77,15 @@ argTypes['icon-slot'] = {
     'Accepts an icon element. The control is disabled. Use the Anatomy story to see icon usage. Enhancements to this control will be added in a future release.',
 };
 
+// @todo: create a select dropdown with all available/acceptable icons for a component.
+// For now, this arg is turned off in the control table since the string doesn't get parsed as HTML: SWC-1853
+argTypes['icon-slot'] = {
+  ...argTypes['icon-slot'],
+  control: false,
+  description:
+    'Accepts an icon element. The control is disabled. Use the Anatomy story to see icon usage. Enhancements to this control will be added in a future release.',
+};
+
 /**
  * Similar to [status lights](/docs/components-status-light--readme), they use color and text to convey status or category information.
  *

--- a/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
+++ b/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
@@ -42,6 +42,17 @@ argTypes['static-color'] = {
   options: [undefined, ...Divider.STATIC_COLORS],
 };
 
+argTypes.vertical = {
+  ...argTypes.vertical,
+  control: { type: 'boolean' },
+  table: {
+    category: 'attributes',
+    defaultValue: {
+      summary: 'false',
+    },
+  },
+};
+
 /**
  * A divider is a visual separator that brings clarity to a layout by grouping and dividing
  * content in close proximity. Dividers help establish rhythm and hierarchy, making it easier
@@ -218,6 +229,63 @@ export const StaticColors: Story = {
   tags: ['options'],
 };
 StaticColors.storyName = 'Static colors';
+
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+/**
+ * ### Automatic ARIA role
+ *
+ * The `<swc-divider>` element automatically sets `role="separator"` on the host,
+ * providing the correct semantic meaning for assistive technologies without any
+ * additional markup required.
+ *
+ * ### Vertical orientation and layout
+ *
+ * When `vertical` is set, the component automatically sets `aria-orientation="vertical"`.
+ *
+ * Vertical dividers are designed to separate **horizontally adjacent** content.
+ * The component CSS sets `block-size: 100%` so the divider fills its container's
+ * height — but the parent flex row must have an **explicit height** for that
+ * percentage to resolve. Without a defined height, the divider collapses to zero
+ * and is invisible.
+ *
+ * ```html
+ * <div style="display: flex; align-items: center; gap: 8px; block-size: 24px;">
+ *   <span>Files</span>
+ *   <swc-divider vertical size="s"></swc-divider>
+ *   <span>Folders</span>
+ * </div>
+ * ```
+ */
+export const VerticalLayout: Story = {
+  render: (args) => html`
+    <div
+      style="display: flex; align-items: center; gap: 8px; block-size: 24px;"
+    >
+      <span>Files</span>
+      ${template({ ...args, size: 's', vertical: true })}
+      <span>Folders</span>
+      ${template({ ...args, size: 's', vertical: true })}
+      <span>Recently shared</span>
+    </div>
+    <div
+      style="display: flex; align-items: center; gap: 8px; block-size: 24px;"
+    >
+      <span>Home</span>
+      ${template({ ...args, size: 'm', vertical: true })}
+      <span>Projects</span>
+      ${template({ ...args, size: 'm', vertical: true })}
+      <span>Reports</span>
+    </div>
+  `,
+  parameters: {
+    flexLayout: 'column-stretch',
+  },
+  tags: ['behaviors'],
+};
+VerticalLayout.storyName = 'Vertical layout';
 
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES

--- a/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
+++ b/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
@@ -44,12 +44,9 @@ argTypes['static-color'] = {
 
 argTypes.vertical = {
   ...argTypes.vertical,
-  control: { type: 'boolean' },
   table: {
-    category: 'attributes',
-    defaultValue: {
-      summary: 'false',
-    },
+    ...argTypes.vertical?.table,
+    defaultValue: { summary: 'false' },
   },
 };
 
@@ -235,49 +232,34 @@ StaticColors.storyName = 'Static colors';
 // ──────────────────────────────
 
 /**
- * ### Automatic ARIA role
+ * ### Layout orientation
  *
- * The `<swc-divider>` element automatically sets `role="separator"` on the host,
- * providing the correct semantic meaning for assistive technologies without any
- * additional markup required.
+ * Dividers can be oriented **horizontally** (default) or **vertically** to match
+ * the layout they serve:
  *
- * ### Vertical orientation and layout
+ * - **Horizontal dividers** separate stacked content, such as sections beneath headings
+ * - **Vertical dividers** separate side-by-side items in a flex row (e.g., navigation breadcrumbs, toolbars)
  *
- * When `vertical` is set, the component automatically sets `aria-orientation="vertical"`.
- *
- * Vertical dividers are designed to separate **horizontally adjacent** content.
- * The component CSS sets `block-size: 100%` so the divider fills its container's
- * height — but the parent flex row must have an **explicit height** for that
- * percentage to resolve. Without a defined height, the divider collapses to zero
- * and is invisible.
- *
- * ```html
- * <div style="display: flex; align-items: center; gap: 8px; block-size: 24px;">
- *   <span>Files</span>
- *   <swc-divider vertical size="s"></swc-divider>
- *   <span>Folders</span>
- * </div>
- * ```
+ * Vertical dividers require the parent to have an **explicit height** (`block-size`) —
+ * without it, `block-size: 100%` resolves to zero and the divider is invisible.
  */
-export const VerticalLayout: Story = {
+export const LayoutOrientation: Story = {
   render: (args) => html`
-    <div
+    <nav
       style="display: flex; align-items: center; gap: 8px; block-size: 24px;"
     >
+      <span>Overview</span>
+      ${template({ ...args, size: 's', vertical: true })}
       <span>Files</span>
       ${template({ ...args, size: 's', vertical: true })}
-      <span>Folders</span>
-      ${template({ ...args, size: 's', vertical: true })}
-      <span>Recently shared</span>
-    </div>
-    <div
-      style="display: flex; align-items: center; gap: 8px; block-size: 24px;"
-    >
-      <span>Home</span>
-      ${template({ ...args, size: 'm', vertical: true })}
-      <span>Projects</span>
-      ${template({ ...args, size: 'm', vertical: true })}
-      <span>Reports</span>
+      <span>Settings</span>
+    </nav>
+    <div style="margin-block-start: 16px;">
+      <h4 style="margin: 0 0 8px 0;">Project details</h4>
+      ${template({ ...args, size: 'l' })}
+      <p style="margin: 8px 0 0 0;">
+        Review the project timeline and deliverables.
+      </p>
     </div>
   `,
   parameters: {
@@ -285,7 +267,7 @@ export const VerticalLayout: Story = {
   },
   tags: ['behaviors'],
 };
-VerticalLayout.storyName = 'Vertical layout';
+LayoutOrientation.storyName = 'Layout orientation';
 
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES

--- a/2nd-gen/packages/swc/components/icon/stories/icon.internal.stories.ts
+++ b/2nd-gen/packages/swc/components/icon/stories/icon.internal.stories.ts
@@ -225,7 +225,7 @@ export const AvailableIcons: Story = {
       )}
     `;
   },
-  tags: ['options', '!test'],
+  tags: ['options'],
   parameters: {
     docs: {
       canvas: {

--- a/2nd-gen/packages/swc/components/icon/stories/icon.internal.stories.ts
+++ b/2nd-gen/packages/swc/components/icon/stories/icon.internal.stories.ts
@@ -225,7 +225,7 @@ export const AvailableIcons: Story = {
       )}
     `;
   },
-  tags: ['options'],
+  tags: ['options', '!test'],
   parameters: {
     docs: {
       canvas: {

--- a/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
@@ -47,14 +47,6 @@ argTypes['static-color'] = {
   options: [undefined, ...ProgressCircle.STATIC_COLORS],
 };
 
-argTypes.indeterminate = {
-  ...argTypes.indeterminate,
-  table: {
-    category: 'attributes',
-    defaultValue: { summary: 'true' },
-  },
-};
-
 /**
  * They can represent determinate or indeterminate progress.
  */
@@ -99,7 +91,6 @@ const sizeLabels = {
 export const Playground: Story = {
   tags: ['autodocs', 'dev'],
   args: {
-    indeterminate: true,
     size: 'm',
     label: 'Processing request',
   },
@@ -112,7 +103,6 @@ export const Playground: Story = {
 export const Overview: Story = {
   tags: ['overview'],
   args: {
-    indeterminate: true,
     label: 'Processing request',
   },
 };
@@ -175,9 +165,6 @@ export const Sizes: Story = {
     )}
   `,
   tags: ['options'],
-  args: {
-    indeterminate: true,
-  },
 };
 
 /**
@@ -196,7 +183,6 @@ export const StaticColors: Story = {
     )}
   `,
   args: {
-    indeterminate: true,
     label: 'Processing media',
   },
   tags: ['options'],
@@ -234,12 +220,11 @@ export const ProgressValues: Story = {
 ProgressValues.storyName = 'Progress values';
 
 /**
- * When no `progress` value is set, the component displays an animated indeterminate
- * loading indicator. This is the default state.
- * The `aria-valuenow` attribute is removed, signaling to assistive technologies
- * that the operation duration is unknown.
+ * The default state — when `progress` is not set, the component displays an animated
+ * loading indicator. The `aria-valuenow` attribute is omitted, signaling to assistive
+ * technologies that the operation duration is unknown.
  *
- * Use indeterminate progress when:
+ * Use the default (no `progress`) when:
  * - The operation duration is unknown
  * - Progress cannot be accurately measured
  * - Multiple sub-operations are running in parallel
@@ -263,8 +248,9 @@ export const Indeterminate: Story = {
  * typical button heights and `static-color="white"` on high-emphasis (filled)
  * buttons where the icon sits on a colored background.
  *
- * Use `indeterminate` when the duration is unknown — the most common case for
- * button loading states.
+ * Button loading states typically omit `progress` since the duration is unknown.
+ *
+ * @todo Refactor to use `<swc-button>` once the button component is available.
  */
 export const InButton: Story = {
   render: (args) => html`
@@ -289,7 +275,6 @@ export const InButton: Story = {
         ...args,
         size: 's',
         'static-color': 'white',
-        indeterminate: true,
         label: 'Saving',
       })}
       Saving…
@@ -314,7 +299,6 @@ export const InButton: Story = {
       ${template({
         ...args,
         size: 's',
-        indeterminate: true,
         label: 'Processing',
       })}
       Processing…
@@ -342,7 +326,7 @@ InButton.storyName = 'Progress circle in a button';
  * 2. **Labeling**: Uses the `label` attribute value as `aria-label`, or rely on `aria-label` / `aria-labelledby` you set on the host
  * 3. **Progress state** (determinate):
  *     - Sets `aria-valuenow` with the current `progress` value
- * 4. **Loading state** (indeterminate):
+ * 4. **Loading state** (indeterminate — default when `progress` is unset):
  *     - When no `progress` value is set, `aria-valuenow` is omitted
  *     - Screen readers understand this as an ongoing operation with unknown duration
  * 5. **Status communication**: Screen readers announce progress updates as values change
@@ -376,7 +360,6 @@ InButton.storyName = 'Progress circle in a button';
 export const Accessibility: Story = {
   tags: ['a11y'],
   args: {
-    indeterminate: true,
     size: 'l',
     label: 'Syncing files',
   },

--- a/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
@@ -246,6 +246,82 @@ export const ProgressValues: Story = {
   },
 };
 
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+/**
+ * ### Progress circle in a button
+ *
+ * A common pattern is pairing a progress circle with a button to communicate
+ * that an action is in progress after the user clicks. Use `size="s"` to match
+ * typical button heights and `static-color="white"` on high-emphasis (filled)
+ * buttons where the icon sits on a colored background.
+ *
+ * Use `indeterminate` when the duration is unknown — the most common case for
+ * button loading states.
+ */
+export const InButton: Story = {
+  render: (args) => html`
+    <button
+      style="
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 16px;
+        border: none;
+        border-radius: 16px;
+        background: var(--spectrum-accent-background-color-default, #378ef0);
+        color: #fff;
+        font: inherit;
+        font-size: 14px;
+        cursor: default;
+        opacity: 0.9;
+      "
+      disabled
+    >
+      ${template({
+        ...args,
+        size: 's',
+        'static-color': 'white',
+        indeterminate: true,
+        label: 'Saving',
+      })}
+      Saving…
+    </button>
+    <button
+      style="
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 16px;
+        border: 2px solid var(--spectrum-accent-background-color-default, #378ef0);
+        border-radius: 16px;
+        background: transparent;
+        color: var(--spectrum-accent-background-color-default, #378ef0);
+        font: inherit;
+        font-size: 14px;
+        cursor: default;
+        opacity: 0.9;
+      "
+      disabled
+    >
+      ${template({
+        ...args,
+        size: 's',
+        indeterminate: true,
+        label: 'Processing',
+      })}
+      Processing…
+    </button>
+  `,
+  parameters: {
+    flexLayout: true,
+  },
+  tags: ['behaviors'],
+};
+InButton.storyName = 'Progress circle in a button';
+
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────

--- a/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
@@ -118,7 +118,6 @@ export const Overview: Story = {
  * 3. **Label** - Accessible text describing the operation (not visually rendered).
  *
  * > **A11y Note:** Light DOM children are not projected into the shadow tree, so content between the opening and closing tags does not supply an accessible name. Use the `label` attribute or property, or `aria-label` / `aria-labelledby` on the host.
- *
  */
 export const Anatomy: Story = {
   render: () => html`

--- a/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
@@ -241,8 +241,6 @@ export const Indeterminate: Story = {
 // ──────────────────────────────
 
 /**
- * ### Progress circle in a button
- *
  * A common pattern is pairing a progress circle with a button to communicate
  * that an action is in progress after the user clicks. Use `size="s"` to match
  * typical button heights and `static-color="white"` on high-emphasis (filled)
@@ -252,7 +250,7 @@ export const Indeterminate: Story = {
  *
  * @todo Refactor to use `<swc-button>` once the button component is available.
  */
-export const InButton: Story = {
+export const LoadingButton: Story = {
   render: (args) => html`
     <button
       style="
@@ -309,7 +307,7 @@ export const InButton: Story = {
   },
   tags: ['behaviors'],
 };
-InButton.storyName = 'Progress circle in a button';
+LoadingButton.storyName = 'Loading button';
 
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES

--- a/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
@@ -47,6 +47,14 @@ argTypes['static-color'] = {
   options: [undefined, ...ProgressCircle.STATIC_COLORS],
 };
 
+argTypes.indeterminate = {
+  ...argTypes.indeterminate,
+  table: {
+    category: 'attributes',
+    defaultValue: { summary: 'true' },
+  },
+};
+
 /**
  * They can represent determinate or indeterminate progress.
  */
@@ -91,7 +99,9 @@ const sizeLabels = {
 export const Playground: Story = {
   tags: ['autodocs', 'dev'],
   args: {
-    label: 'Uploading document',
+    indeterminate: true,
+    size: 'm',
+    label: 'Processing request',
   },
 };
 
@@ -102,7 +112,8 @@ export const Playground: Story = {
 export const Overview: Story = {
   tags: ['overview'],
   args: {
-    label: 'Uploading document',
+    indeterminate: true,
+    label: 'Processing request',
   },
 };
 
@@ -165,7 +176,7 @@ export const Sizes: Story = {
   `,
   tags: ['options'],
   args: {
-    progress: 25,
+    indeterminate: true,
   },
 };
 
@@ -185,7 +196,7 @@ export const StaticColors: Story = {
     )}
   `,
   args: {
-    progress: 60,
+    indeterminate: true,
     label: 'Processing media',
   },
   tags: ['options'],
@@ -198,6 +209,29 @@ export const StaticColors: Story = {
 // ──────────────────────────
 //    STATES STORIES
 // ──────────────────────────
+
+/**
+ * Progress circles can show specific progress values from 0% to 100%.
+ * Set the `progress` attribute to a value between 0 and 100 to represent determinate progress.
+ * This automatically sets `aria-valuenow` to the provided value for screen readers.
+ */
+export const ProgressValues: Story = {
+  render: (args) => html`
+    ${template({ ...args, progress: 0, label: 'Starting download' })}
+    ${template({ ...args, progress: 25, label: 'Downloading (25%)' })}
+    ${template({ ...args, progress: 50, label: 'Downloading (50%)' })}
+    ${template({ ...args, progress: 75, label: 'Downloading (75%)' })}
+    ${template({ ...args, progress: 100, label: 'Download complete' })}
+  `,
+  tags: ['states'],
+  args: {
+    size: 'm',
+  },
+  parameters: {
+    'section-order': 2,
+  },
+};
+ProgressValues.storyName = 'Progress values';
 
 /**
  * When no `progress` value is set, the component displays an animated indeterminate
@@ -214,35 +248,6 @@ export const Indeterminate: Story = {
   tags: ['states'],
   args: {
     label: 'Processing request',
-  },
-  parameters: {
-    'section-order': 1,
-  },
-};
-
-/**
- * Progress circles can show specific progress values from 0% to 100%.
- * Set the `progress` attribute to a value between 0 and 100 to represent determinate progress.
- * This automatically sets `aria-valuenow` to the provided value for screen readers.
- */
-export const ProgressValues: Story = {
-  render: () => html`
-    <swc-progress-circle
-      progress="0"
-      label="Starting download"
-    ></swc-progress-circle>
-    <swc-progress-circle
-      progress="25"
-      label="Downloading (25%)"
-    ></swc-progress-circle>
-    <swc-progress-circle
-      progress="50"
-      label="Downloading (50%)"
-    ></swc-progress-circle>
-  `,
-  tags: ['states'],
-  parameters: {
-    'section-order': 2,
   },
 };
 
@@ -371,8 +376,8 @@ InButton.storyName = 'Progress circle in a button';
 export const Accessibility: Story = {
   tags: ['a11y'],
   args: {
-    progress: 60,
+    indeterminate: true,
     size: 'l',
-    label: 'Uploading presentation slides',
+    label: 'Syncing files',
   },
 };

--- a/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.a11y.spec.ts
@@ -33,8 +33,7 @@ test.describe('Progress Circle - ARIA Snapshots', () => {
       'swc-progress-circle'
     );
     await expect(root).toMatchAriaSnapshot(`
-      - progressbar "Processing request":
-        - img
+      - progressbar "Processing request"
     `);
   });
 

--- a/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.a11y.spec.ts
@@ -33,7 +33,8 @@ test.describe('Progress Circle - ARIA Snapshots', () => {
       'swc-progress-circle'
     );
     await expect(root).toMatchAriaSnapshot(`
-      - progressbar "Uploading document"
+      - progressbar "Processing request":
+        - img
     `);
   });
 

--- a/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
@@ -26,7 +26,6 @@ import meta from '../stories/progress-circle.stories.js';
 import {
   Indeterminate,
   Overview,
-  ProgressValues,
   Sizes,
   StaticColors,
 } from '../stories/progress-circle.stories.js';
@@ -277,7 +276,17 @@ export const LightDomWithLabelDeprecationOnlyTest: Story = {
 // ──────────────────────────────────────────────────────────────
 
 export const ProgressValuesTest: Story = {
-  ...ProgressValues,
+  render: () => html`
+    ${[0, 25, 50, 75, 100].map(
+      (progress) => html`
+        <swc-progress-circle
+          progress=${progress}
+          label="Progress ${progress}%"
+          size="m"
+        ></swc-progress-circle>
+      `
+    )}
+  `,
   play: async ({ canvasElement, step }) => {
     const circles = await getComponents<ProgressCircle>(
       canvasElement,

--- a/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/test/progress-circle.test.ts
@@ -55,13 +55,13 @@ export const OverviewTest: Story = {
     );
 
     await step(
-      'renders determinate progress with an accessible label',
+      'renders indeterminate progress with an accessible label',
       async () => {
         expect(progressCircle.getAttribute('role')).toBe('progressbar');
         expect(progressCircle.getAttribute('aria-label')).toBe(
           progressCircle.label
         );
-        expect(progressCircle.hasAttribute('progress')).toBe(false);
+        expect(progressCircle.getAttribute('aria-valuenow')).toBeNull();
       }
     );
   },

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -416,4 +416,5 @@ export const WithLocaleWrapper: Story = {
       source: { code: null },
     },
   },
+  tags: ['!test'],
 };


### PR DESCRIPTION
## Description

Adds missing Behaviors stories to three POC components based on 1st-gen patterns, and excludes docs-only stories
from automated test runs.

**Stories added:**
- `badge`: `Inline` — demonstrates `<swc-badge>` flowing naturally within paragraph text as `inline-flex`
- `divider`: `Vertical layout` — demonstrates vertical dividers in a flex row with a fixed container height
(required for `block-size: 100%` to resolve)
- `progress-circle`: `Progress circle in a button` — ports the 1st-gen `inButton` pattern using native
`<button>` elements (no `swc-button` in 2nd-gen yet)

**Test exclusions:**
- `status-light` `WithLocaleWrapper`: tagged `['!test']` — docs-only locale demo, not a functional test target
- `icon` `AvailableIcons`: tagged `['!test']` — dynamic full-catalog render is not suitable for CI snapshot
testing

**Test updates:**
- `progress-circle.test.ts`: added descriptive second arguments to all `expect()` calls to satisfy the testing
styleguide

## Motivation and context

SWC-1673 — as part of the POC component work, all components should have complete Storybook documentation that captures valid 1st-gen content, conforms to authoring and code style guidelines, and accurately reflects the
2nd-gen API.

## Related issue(s)

- SWC-1673

---

## Author's checklist

- [x] I have read the CONTRIBUTING and PULL_REQUESTS documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria
Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Jira ticket number without a link
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Verify Behaviors section renders correctly in Badge docs
1. Open the local Storybook and navigate to **Badge → Docs**
2. Scroll to the **Behaviors** section
3. Confirm the **Inline** story shows badges flowing within paragraph text (not as a flex row)

- [ ] Verify Behaviors section renders correctly in Divider docs
1. Navigate to **Divider → Docs**
2. Scroll to the **Behaviors** section
3. Confirm the **Vertical layout** story shows visible (non-collapsed) vertical dividers within fixed-height
rows

- [ ] Verify Behaviors section renders correctly in Progress circle docs
1. Navigate to **Progress circle → Docs**
2. Scroll to the **Behaviors** section
3. Confirm the **Progress circle in a button** story shows both a filled and an outline button with a spinning
progress circle inside

## Accessibility testing checklist

- [ ] **Keyboard** — No focusable parts in any of the new stories (badge, divider, progress-circle are
non-interactive). Confirm no regressions in focus behavior on surrounding Storybook page controls.

- [ ] **Screen reader** — Open each new story canvas directly and confirm with VoiceOver or NVDA:
1. Navigate to **Badge → Docs → Inline** story; confirm each badge is announced with its label text
2. Navigate to **Divider → Docs → Vertical layout**; confirm dividers are announced as `separator`
3. Navigate to **Progress circle → Docs → Progress circle in a button**; confirm the progress circle is
announced as `progressbar` with the label ("Saving" / "Processing") and that the disabled button state is
communicated