### PR TITLE
feat(docs): add RTL decorator

### DIFF
--- a/2nd-gen/packages/swc/.storybook/decorators/language.ts
+++ b/2nd-gen/packages/swc/.storybook/decorators/language.ts
@@ -15,15 +15,30 @@ import { addons, makeDecorator, useEffect } from '@storybook/preview-api';
 import type {} from '../storybook-env';
 
 const DEFAULT_KIT_ID = 'obc6cux';
+const RTL_LANGS = new Set(['ar', 'fa', 'he']);
 
 let languageListenerAttached = false;
 
+function resolveTextDirection(
+  lang: string | false,
+  textDirection: string | undefined
+): 'ltr' | 'rtl' {
+  if (textDirection === 'ltr' || textDirection === 'rtl') {
+    return textDirection;
+  }
+
+  return RTL_LANGS.has(String(lang ?? 'en-US')) ? 'rtl' : 'ltr';
+}
+
 /**
- * Applies the selected language (lang/dir) to the document and loads the corresponding
+ * Applies the selected language/dir to the document and loads the corresponding
  * Adobe Fonts kit if needed. Safe to call from the decorator or from a toolbar listener
  * so that font loading works even when the decorator does not re-run (e.g. on some docs pages).
  */
-function applyLanguageAndFontKit(lang: string | false, isRTL: boolean): void {
+function applyLanguageAndFontKit(
+  lang: string | false,
+  textDirection: 'ltr' | 'rtl'
+): void {
   const langAttr = lang ? String(lang) : 'en-US';
   const root = document.documentElement;
 
@@ -33,7 +48,10 @@ function applyLanguageAndFontKit(lang: string | false, isRTL: boolean): void {
     root.setAttribute('lang', langAttr);
     hasChanged = true;
   }
-  root.setAttribute('dir', isRTL ? 'rtl' : 'ltr');
+
+  // Apply both semantic and CSS direction so docs/stories and bidi behavior stay aligned.
+  root.setAttribute('dir', textDirection);
+  root.style.direction = textDirection;
 
   // If the fonts are actively loading, do not re-trigger the load
   if (window.FontsLoading === true) {
@@ -173,35 +191,41 @@ function attachLanguageChangeListener(): void {
   languageListenerAttached = true;
   try {
     const channel = addons.getChannel();
-    channel.on('globalsUpdated', (payload: { globals?: { lang?: string } }) => {
-      const lang = payload?.globals?.lang ?? 'en-US';
-      const isRTL = ['ar', 'fa', 'he'].includes(lang);
-      applyLanguageAndFontKit(lang, isRTL);
-    });
+    channel.on(
+      'globalsUpdated',
+      (payload: { globals?: { lang?: string; textDirection?: string } }) => {
+        const lang = payload?.globals?.lang ?? 'en-US';
+        const textDirection = resolveTextDirection(
+          lang,
+          payload?.globals?.textDirection
+        );
+        applyLanguageAndFontKit(lang, textDirection);
+      }
+    );
   } catch {
     // Storybook event bus not available (e.g. in test env); decorator-only path still works.
   }
 }
 
-/**
- * @type import('@storybook/csf').DecoratorFunction<import('@storybook/web-components').WebComponentsFramework>
- **/
 export const withLanguageWrapper = makeDecorator({
   name: 'withLanguageWrapper',
   parameterName: 'lang',
   wrapper: (StoryFn, context) => {
-    const { globals: { lang = false } = {}, id, viewMode } = context;
+    const {
+      globals: { lang = false, textDirection = 'auto' } = {},
+      id,
+      viewMode,
+    } = context;
 
-    // Add a textDirection property to the globals for use in the stories
-    // fa/Farsi is currently not included in the storybook toolbar map
-    const isRTL = ['ar', 'fa', 'he'].includes(lang);
-    context.globals.textDirection = isRTL ? 'rtl' : 'ltr';
+    // Keep an explicit, resolved direction available for stories.
+    const resolvedTextDirection = resolveTextDirection(lang, textDirection);
+    context.globals.resolvedTextDirection = resolvedTextDirection;
 
     attachLanguageChangeListener();
 
     useEffect(() => {
-      applyLanguageAndFontKit(lang, isRTL);
-    }, [lang, id, viewMode]);
+      applyLanguageAndFontKit(lang, resolvedTextDirection);
+    }, [lang, resolvedTextDirection, id, viewMode]);
 
     return StoryFn(context);
   },

--- a/2nd-gen/packages/swc/.storybook/decorators/language.ts
+++ b/2nd-gen/packages/swc/.storybook/decorators/language.ts
@@ -27,7 +27,7 @@ function resolveTextDirection(
     return textDirection;
   }
 
-  return RTL_LANGS.has(String(lang ?? 'en-US')) ? 'rtl' : 'ltr';
+  return RTL_LANGS.has(lang || 'en-US') ? 'rtl' : 'ltr';
 }
 
 /**
@@ -49,9 +49,7 @@ function applyLanguageAndFontKit(
     hasChanged = true;
   }
 
-  // Apply both semantic and CSS direction so docs/stories and bidi behavior stay aligned.
   root.setAttribute('dir', textDirection);
-  root.style.direction = textDirection;
 
   // If the fonts are actively loading, do not re-trigger the load
   if (window.FontsLoading === true) {
@@ -217,9 +215,7 @@ export const withLanguageWrapper = makeDecorator({
       viewMode,
     } = context;
 
-    // Keep an explicit, resolved direction available for stories.
     const resolvedTextDirection = resolveTextDirection(lang, textDirection);
-    context.globals.resolvedTextDirection = resolvedTextDirection;
 
     attachLanguageChangeListener();
 

--- a/2nd-gen/packages/swc/.storybook/decorators/language.ts
+++ b/2nd-gen/packages/swc/.storybook/decorators/language.ts
@@ -39,7 +39,7 @@ function applyLanguageAndFontKit(
   lang: string | false,
   textDirection: 'ltr' | 'rtl'
 ): void {
-  const langAttr = lang ? String(lang) : 'en-US';
+  const langAttr = lang || 'en-US';
   const root = document.documentElement;
 
   // Set the language on the document root and track if it has changed

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -116,11 +116,29 @@ const preview = {
         dynamicTitle: true,
       },
     },
+    textDirection: {
+      name: 'Direction',
+      description:
+        'Text direction for stories. Auto follows language; LTR/RTL overrides it.',
+      defaultValue: 'auto',
+      type: 'string',
+      toolbar: {
+        title: 'Direction',
+        icon: 'transfer',
+        items: [
+          { value: 'auto', title: 'Auto' },
+          { value: 'ltr', title: 'LTR' },
+          { value: 'rtl', title: 'RTL' },
+        ],
+        dynamicTitle: true,
+      },
+    },
   },
   initialGlobals: {
     theme: 'light',
     scale: 'medium',
     lang: 'en-US',
+    textDirection: 'auto',
   },
   decorators: [
     withContext,


### PR DESCRIPTION
## Description

Adds a dedicated **Direction** Storybook toolbar control (`auto` / `LTR` / `RTL`) alongside the existing **Language** control. Direction resolution:

- **Auto** — follows locale (RTL for Arabic, Hebrew, and Farsi when applicable; otherwise LTR).
- **LTR** / **RTL** — explicit override, independent of language (so typography/font kit can stay on one locale while layout direction is forced).

The `withLanguageWrapper` decorator applies the resolved direction on the preview root using both:

- `dir` on `document.documentElement` (semantic / bidi), and
- `direction` via inline CSS on the same element (explicit visual direction).

`context.globals.resolvedTextDirection` is set so stories or tooling can read the final `ltr` | `rtl` value. The `globalsUpdated` listener was updated so direction changes apply even when the decorator does not re-run (e.g. some docs flows).

## Motivation and context

Language alone implied RTL for some locales, which made it awkward to test **LTR vs RTL** without changing locale, especially when pairing a specific font/locale with a fixed reading direction. A separate Direction control fixes that.

This also **unblocks Chromatic VRT**: you can template permutations (e.g. theme × scale × **explicit LTR/RTL**) without relying on switching to an RTL locale only to get `dir`/layout. Stories or Chromatic configuration can key off `globals.textDirection` / `resolvedTextDirection`.


## Author's checklist

- [ ] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed the Accessibility Practices for this feature, see: [ARIA Practices](https://www.w3.org/TR/wai-aria-practices/) _(toolbar sets document `dir`; no new interactive component in the library.)_
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it _(consider a short note in the Fonts / customization guide about **Direction** vs **Language**)._

---

## Reviewer's checklist

### Manual review test cases

- [ ] **Direction toolbar + document root**
  1. Open any 2nd-gen Storybook story.
  2. Set **Language** to English and **Direction** to **RTL**.
  3. Inspect `<html>`: expect `dir="rtl"` and inline `direction: rtl` (or equivalent).
  4. Set **Direction** to **LTR**; expect `dir="ltr"` and LTR CSS.

- [ ] **Auto follows locale**
  1. Set **Direction** to **Auto**.
  2. Switch **Language** between English and Arabic (or Hebrew).
  3. Expect RTL when locale is RTL and LTR for English, without manual Direction overrides fighting Auto.
