### PR TITLE
chore(build): force postcss transformer

### DIFF
--- a/2nd-gen/packages/swc/.storybook/main.ts
+++ b/2nd-gen/packages/swc/.storybook/main.ts
@@ -9,32 +9,13 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import postcssToken from '@adobe/postcss-token';
 import { readCsf } from '@storybook/core/csf-tools';
 import type { Indexer } from '@storybook/types';
 import type { StorybookConfig } from '@storybook/web-components-vite';
-import autoprefixer from 'autoprefixer';
 import { dirname, resolve } from 'path';
-import postcssPresetEnv from 'postcss-preset-env';
 import remarkGfm from 'remark-gfm';
 import { fileURLToPath } from 'url';
 import { mergeConfig } from 'vite';
-
-const postcssPlugins = [
-  postcssToken({ prefix: 'swc' }),
-  autoprefixer(),
-  postcssPresetEnv({
-    stage: 2,
-    features: {
-      'nesting-rules': false,
-      'custom-properties': false,
-      'light-dark-function': false,
-      'logical-properties-and-values': false,
-      'is-pseudo-class': false,
-      'cascade-layers': false,
-    },
-  }),
-];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 type StorybookMode = 'dev' | 'build' | 'ci-a11y';
@@ -172,9 +153,6 @@ const config: StorybookConfig = {
     return mergeConfig(config, {
       css: {
         transformer: 'postcss',
-        postcss: {
-          plugins: postcssPlugins,
-        },
       },
       build: {
         cssMinify: 'esbuild',

--- a/2nd-gen/packages/swc/.storybook/main.ts
+++ b/2nd-gen/packages/swc/.storybook/main.ts
@@ -9,13 +9,32 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import postcssToken from '@adobe/postcss-token';
 import { readCsf } from '@storybook/core/csf-tools';
 import type { Indexer } from '@storybook/types';
 import type { StorybookConfig } from '@storybook/web-components-vite';
+import autoprefixer from 'autoprefixer';
 import { dirname, resolve } from 'path';
+import postcssPresetEnv from 'postcss-preset-env';
 import remarkGfm from 'remark-gfm';
 import { fileURLToPath } from 'url';
 import { mergeConfig } from 'vite';
+
+const postcssPlugins = [
+  postcssToken({ prefix: 'swc' }),
+  autoprefixer(),
+  postcssPresetEnv({
+    stage: 2,
+    features: {
+      'nesting-rules': false,
+      'custom-properties': false,
+      'light-dark-function': false,
+      'logical-properties-and-values': false,
+      'is-pseudo-class': false,
+      'cascade-layers': false,
+    },
+  }),
+];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 type StorybookMode = 'dev' | 'build' | 'ci-a11y';
@@ -153,6 +172,12 @@ const config: StorybookConfig = {
     return mergeConfig(config, {
       css: {
         transformer: 'postcss',
+        postcss: {
+          plugins: postcssPlugins,
+        },
+      },
+      build: {
+        cssMinify: 'esbuild',
       },
       plugins: [
         {

--- a/2nd-gen/packages/swc/.storybook/main.ts
+++ b/2nd-gen/packages/swc/.storybook/main.ts
@@ -151,6 +151,9 @@ const config: StorybookConfig = {
   experimental_indexers: storybookMode === 'dev' ? [testStoryIndexer] : [],
   viteFinal: async (config) => {
     return mergeConfig(config, {
+      css: {
+        transformer: 'postcss',
+      },
       plugins: [
         {
           name: 'css-hmr',

--- a/2nd-gen/packages/swc/vite.config.ts
+++ b/2nd-gen/packages/swc/vite.config.ts
@@ -117,6 +117,7 @@ export default defineConfig({
       },
     },
     target: 'es2018',
+    cssMinify: 'esbuild',
     sourcemap: true,
     emptyOutDir: true,
     outDir: 'dist',

--- a/2nd-gen/packages/swc/vite.config.ts
+++ b/2nd-gen/packages/swc/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
     }),
   ],
   css: {
+    transformer: 'postcss',
     postcss: {
       plugins: postcssPlugins,
     },


### PR DESCRIPTION
## Description

Vite 8 changed two CSS defaults that broke our 2nd-gen build/Storybook output:

- `css.transformer` defaults to `'lightningcss'`
- `build.cssMinify` defaults to `'lightningcss'`, which can rewrite/normalize the emitted CSS even when the transformer is set back to PostCSS.


## Motivation and context

Locally nothing was affected, but on stroybook:build It was introducing itself in our light-dark rules:
<img width="1250" height="100" alt="image (1)" src="https://github.com/user-attachments/assets/92ad8543-8702-4281-8f89-e64a891132de" />

No runtime behavior or public API changes: this is a build-pipeline correctness fix.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/) — N/A, build-config only.
- [ ] I have added automated tests to cover my changes. — N/A, build-pipeline configuration; covered by existing Storybook build + VRT.
- [ ] I have included a well-written changeset if my change needs to be published. — Not needed; no published package output changes.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Library build emits PostCSS-processed CSS_
  1. From `2nd-gen/packages/swc`, run `yarn build`.
  2. Inspect `dist/global-button.css` (and any other file under `dist/` that originates from `stylesheets/`).
  3. Expect: `swc-`-prefixed custom properties (from `@adobe/postcss-token`), vendor prefixes from autoprefixer, and no Lightning-CSS-style rewrites 

- [ ] _Storybook build uses the same pipeline_
  1. From `2nd-gen/packages/swc`, run `yarn storybook:build`.
  2. Serve `storybook-static/` (e.g. `npx serve storybook-static -p 6006`) and load a component story (e.g. Button).
  3. In DevTools, confirm component CSS contains `--swc-…` tokens and the same vendor prefixing as the library build, with no Lightning CSS minification artifacts.

- [ ] _Storybook dev server keeps PostCSS active_
  1. From `2nd-gen/packages/swc`, run `yarn storybook`.
  2. Open any component story.
  3. Expect: identical CSS pipeline as the build; HMR on a `.css` change re-applies styles correctly.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

N/A — this PR only touches Vite/Storybook build configuration. No DOM, ARIA, focus, or screen-reader behavior is affected.

- [ ] **Keyboard** — N/A
- [ ] **Screen reader** — N/A