### PR TITLE
chore(illustrated-message): conform to code style guides, storybook and tests

### DIFF
--- a/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
+++ b/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
@@ -26,14 +26,11 @@ import {
  * An illustrated message displays an illustration and a message, typically
  * used in empty states or error pages.
  *
- * @slot - Decorative or informative SVG illustration. Decorative SVGs should include
- *   `aria-hidden="true"`; informative SVGs should include `role="img"` and `aria-label`.
- * @slot heading - The heading element. Must be an `<h2>`–`<h6>` element. The consumer owns
- *   the heading tag and level.
+ * @slot - Decorative or informative SVG illustration
+ * @slot heading - The heading element, h2–h6
  *   @todo SWC-1943 Add slot constraints once the CEM slot constraints work is complete:
  *   `{required} {allowedChildren: h2, h3, h4, h5, h6} {maxChildren: 1}`
- * @slot description - Description text. Links must be real `<a>` elements or link components
- *   with visible names.
+ * @slot description - Supporting description text
  */
 export abstract class IllustratedMessageBase extends SpectrumElement {
   // ─────────────────────────
@@ -57,13 +54,13 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
   // ──────────────────
 
   /**
-   * The size of the illustrated message.
+   * The size of the message
    */
   @property({ type: String, reflect: true })
   public size: IllustratedMessageSize = 'm';
 
   /**
-   * The layout orientation of the illustrated message.
+   * The layout orientation
    */
   @property({ type: String, reflect: true })
   public orientation: IllustratedMessageOrientation = 'vertical';
@@ -101,14 +98,14 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
     }
   }
 
- /**
-  * Validates that the heading slot only contains `<h2>`–`<h6>` elements.
-  * Rendering subclasses must wire this to the heading slot's `slotchange`
-  * event (e.g. `<slot name="heading" @slotchange=${this.handleHeadingSlotChange}>`)
-  * for the validation warning to fire.
-  *
-  * @internal
-  */     
+  /**
+   * @internal
+   *
+   * Validates that the heading slot only contains `<h2>`–`<h6>` elements.
+   * Rendering subclasses must wire this to the heading slot's `slotchange`
+   * event (e.g. `<slot name="heading" @slotchange=${this.handleHeadingSlotChange}>`)
+   * for the validation warning to fire.
+   */
   protected handleHeadingSlotChange(event: Event): void {
     if (window.__swc?.DEBUG) {
       const headingSlot = event.target as HTMLSlotElement;

--- a/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
@@ -67,7 +67,7 @@ export const meta: Meta = {
       type: 'figma',
       url: 'https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=20032-601&p=f&t=v3YDUMXflgtF0NtJ-0',
     },
-    // @todo Add Stackblitz link: stackblitz: { url: '<stackblitz-url>' }
+    // @todo SWC-1992 Add Stackblitz link: stackblitz: { url: '<stackblitz-url>' }
   },
   tags: ['migrated'],
 };

--- a/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
@@ -38,13 +38,20 @@ argTypes.orientation = {
 };
 
 /**
- * An illustrated message displays an illustration and a message, typically
- * used in empty states or error pages.
+ * An illustrated message displays an illustration alongside a heading and
+ * description, typically used in empty states or on error pages.
  *
  * ### Heading level
  *
- * Provide the appropriate `<h2>`–`<h6>` element directly in the `heading`
- * slot to match the document outline. The component does not control the heading level.
+ * Provide the appropriate `<h2>`–`<h6>` element directly in the `heading` slot
+ * to match the document outline. The component validates the slot content in
+ * development but does not control the heading level.
+ *
+ * ### Migration from 1st-gen
+ *
+ * The `heading` and `description` plain-text attributes from 1st-gen
+ * (`sp-illustrated-message`) have been removed. All content must be provided
+ * via slots.
  */
 export const meta: Meta = {
   title: 'Illustrated Message',
@@ -56,6 +63,11 @@ export const meta: Meta = {
     docs: {
       subtitle: 'Display an illustration with a heading and description.',
     },
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=20032-601&p=f&t=v3YDUMXflgtF0NtJ-0',
+    },
+    // @todo Add Stackblitz link: stackblitz: { url: '<stackblitz-url>' }
   },
   tags: ['migrated'],
 };
@@ -75,18 +87,15 @@ const cloudPath = `<path d="M89.3301 28.5C108.54 28.5001 124.013 43.9629 125.408
 const cloudSvg = (a11yAttrs: string) =>
   `<svg slot="" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" ${a11yAttrs}>\n${cloudPath}\n</svg>`;
 
-// ────────────────────
-//    STORIES
-// ────────────────────
-
 const defaultSlots = html`
   ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
   <h2 slot="heading">Illustrated message title</h2>
-  <span slot="description">
-    Illustrated message description. Give more information about what a user can
-    do, expect, or how to make items appear.
-  </span>
+  <span slot="description">Supporting description text.</span>
 `;
+
+// ────────────────────
+//    AUTODOCS STORY
+// ────────────────────
 
 export const Playground: Story = {
   args: {
@@ -106,15 +115,57 @@ export const Overview: Story = {
 };
 
 // ──────────────────────────
+//    ANATOMY STORIES
+// ──────────────────────────
+
+/**
+ * An illustrated message consists of three slots:
+ *
+ * 1. **Default slot**: Decorative or informative SVG illustration displayed
+ *    above (vertical) or beside (horizontal) the heading and description.
+ *    Decorative SVGs must have `aria-hidden="true"`. Informative SVGs must have
+ *    `role="img"` and `aria-label`.
+ * 2. **`heading` slot**: Consumer-provided `<h2>`–`<h6>` element. The component
+ *    does not own the heading tag; the consumer chooses the level to match the
+ *    document outline. The component warns in development if a non-heading element
+ *    is used.
+ * 3. **`description` slot** (optional): Supporting text that elaborates on the
+ *    heading. May contain phrasing content, links, or action elements.
+ */
+export const Anatomy: Story = {
+  render: (args) => html`
+    ${template(
+      args,
+      html`
+        ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
+        <h2 slot="heading">Heading only</h2>
+      `
+    )}
+    ${template(
+      args,
+      html`
+        ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
+        <h2 slot="heading">Heading and description</h2>
+        <span slot="description">Optional supporting description.</span>
+      `
+    )}
+  `,
+  tags: ['anatomy'],
+  parameters: {
+    styles: { display: 'flex', 'flex-direction': 'column', gap: '3rem' },
+  },
+};
+
+// ──────────────────────────
 //    OPTIONS STORIES
 // ──────────────────────────
 
 /**
- * Illustrated messages come in three sizes:
+ * Illustrated messages come in three sizes to fit various contexts:
  *
- * - **Small (s)**: 96px illustration, compact spacing — for space-constrained contexts
- * - **Medium (m)**: 96px illustration, standard spacing — the default
- * - **Large (l)**: 160px illustration, reduced spacing — for prominent empty states
+ * - **Small (`s`)**: 96px illustration, compact spacing, for space-constrained contexts
+ * - **Medium (`m`)**: 96px illustration, standard spacing, the default
+ * - **Large (`l`)**: 160px illustration, reduced spacing, for prominent empty states
  */
 export const Sizes: Story = {
   render: (args) => html`
@@ -123,7 +174,7 @@ export const Sizes: Story = {
       html`
         ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
         <h2 slot="heading">Small</h2>
-        <span slot="description">Size s — 96px illustration</span>
+        <span slot="description">Size s, 96px illustration</span>
       `
     )}
     ${template(
@@ -131,7 +182,7 @@ export const Sizes: Story = {
       html`
         ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
         <h2 slot="heading">Medium</h2>
-        <span slot="description">Size m — 96px illustration (default)</span>
+        <span slot="description">Size m, 96px illustration (default)</span>
       `
     )}
     ${template(
@@ -139,7 +190,7 @@ export const Sizes: Story = {
       html`
         ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
         <h2 slot="heading">Large</h2>
-        <span slot="description">Size l — 160px illustration</span>
+        <span slot="description">Size l, 160px illustration</span>
       `
     )}
   `,
@@ -154,9 +205,9 @@ export const Sizes: Story = {
  * Illustrated messages support two layout orientations:
  *
  * - **Vertical** (default): illustration stacked above the heading and description,
- *   centered — use for full-page or centered empty states
+ *   centered. Use for full-page or centered empty states.
  * - **Horizontal**: illustration beside the heading and description in a row,
- *   left-aligned — use for inline or sidebar empty states
+ *   left-aligned. Use for inline or sidebar empty states.
  */
 export const Orientation: Story = {
   render: (args) => html`
@@ -184,18 +235,105 @@ export const Orientation: Story = {
   },
 };
 
+/**
+ * The `heading` slot accepts any `<h2>`–`<h6>` element. Choose the level that
+ * fits the surrounding document outline. The component validates but does not
+ * restrict the heading level.
+ *
+ * Common patterns:
+ *
+ * - `<h2>` for page-level empty states with no other headings in scope
+ * - `<h3>` for empty states nested inside a page section with its own `<h2>`
+ * - `<h4>` or deeper for empty states inside nested panels or cards
+ */
+export const HeadingLevels: Story = {
+  render: (args) => html`
+    ${template(
+      args,
+      html`
+        ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
+        <h2 slot="heading">Heading h2</h2>
+        <span slot="description">Can be used for full-page empty states.</span>
+      `
+    )}
+    ${template(
+      args,
+      html`
+        ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
+        <h3 slot="heading">Heading h3</h3>
+        <span slot="description">Can be used inside a page section.</span>
+      `
+    )}
+    ${template(
+      args,
+      html`
+        ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
+        <h4 slot="heading">Heading h4</h4>
+        <span slot="description">Can be used inside a panel or card.</span>
+      `
+    )}
+  `,
+  tags: ['options'],
+  parameters: {
+    styles: { display: 'flex', 'flex-direction': 'column', gap: '3rem' },
+    'section-order': 3,
+  },
+};
+HeadingLevels.storyName = 'Heading levels';
+
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+/**
+ * Place an `<a>` element inside the `description` slot to provide a
+ * call-to-action link alongside the supporting text.
+ */
+export const DescriptionWithLink: Story = {
+  render: (args) => html`
+    ${template(
+      args,
+      html`
+        ${unsafeHTML(cloudSvg('aria-hidden="true"'))}
+        <h2 slot="heading">Upload your files</h2>
+        <span slot="description">
+          <a href="#">Select a file</a>
+          from your computer to get started.
+        </span>
+      `
+    )}
+  `,
+  tags: ['behaviors'],
+};
+DescriptionWithLink.storyName = 'Description with link';
+
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────
 
 /**
- * SVGs slotted into the illustration slot should declare their accessibility
- * intent explicitly:
+ * ### Features
  *
- * - **Decorative** (most common): add `aria-hidden="true"` so screen readers
- *   skip the graphic entirely.
- * - **Informative**: add `role="img"` and `aria-label` (or an inline `<title>`)
- *   so screen readers announce the illustration's meaning.
+ * The `<swc-illustrated-message>` element implements the following
+ * accessibility features:
+ *
+ * 1. **Heading ownership**: The consumer provides the `<h2>`–`<h6>` element
+ *    directly in the `heading` slot, preserving full control over heading
+ *    level and ensuring it participates in the document outline.
+ * 2. **Illustration intent**: SVGs in the default slot must declare their
+ *    accessibility intent explicitly via `aria-hidden` or `role="img"`.
+ * 3. **No redundant ARIA**: The component adds no `role` or `aria-*`
+ *    attributes of its own; semantics come entirely from slotted content.
+ *
+ * ### Best practices
+ *
+ * - Decorative illustrations (most common): add `aria-hidden="true"` so
+ *   screen readers skip the graphic and move directly to the heading.
+ * - Informative illustrations: add `role="img"` and `aria-label` (or an
+ *   inline `<title>`) so screen readers announce the illustration's meaning
+ *   before reading the heading and description.
+ * - Choose the heading level (`h2`–`h6`) that fits the surrounding document
+ *   outline, not based on visual size.
  */
 export const IllustrationAccessibility: Story = {
   render: (args) => html`
@@ -207,7 +345,7 @@ export const IllustrationAccessibility: Story = {
         <span slot="description">
           The icon above uses
           <code>aria-hidden="true"</code>
-          — screen readers skip the illustration entirely and move on to the
+          so screen readers skip the illustration entirely and move on to the
           heading and description.
         </span>
       `
@@ -224,7 +362,7 @@ export const IllustrationAccessibility: Story = {
           <code>role="img"</code>
           and
           <code>aria-label</code>
-          — screen readers announce its meaning before reading the heading and
+          so screen readers announce its meaning before reading the heading and
           description.
         </span>
       `

--- a/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.a11y.spec.ts
@@ -49,4 +49,71 @@ test.describe('IllustratedMessage - ARIA Snapshots', () => {
     // the shadow root and must not appear inside the shadow DOM.
     await expect(root.locator('h2[slot="heading"]')).toBeVisible();
   });
+
+  test('should have correct heading for each size variant', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-illustrated-message--sizes',
+      'swc-illustrated-message'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - heading "Small" [level=2]
+      - heading "Medium" [level=2]
+      - heading "Large" [level=2]
+    `);
+  });
+
+  test('should have correct heading for each orientation variant', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-illustrated-message--orientation',
+      'swc-illustrated-message'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - heading "Vertical (default)" [level=2]
+      - heading "Horizontal" [level=2]
+    `);
+  });
+
+  test('should hide decorative illustration from assistive technology', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-illustrated-message--illustration-accessibility',
+      'swc-illustrated-message'
+    );
+    // The first component has aria-hidden="true" on its SVG.
+    // It must not produce an img role in the accessibility tree.
+    const first = root.first();
+    await expect(first.getByRole('img')).toHaveCount(0);
+    // Heading is still accessible
+    await expect(first).toMatchAriaSnapshot(`
+      - heading "Illustrated message title" [level=2]
+    `);
+  });
+
+  test('should expose informative illustration to assistive technology', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-illustrated-message--illustration-accessibility',
+      'swc-illustrated-message'
+    );
+    // The second component has role="img" + aria-label on its SVG.
+    // It must appear as a named image in the accessibility tree.
+    const second = root.nth(1);
+    await expect(
+      second.getByRole('img', { name: 'Cloud storage illustration' })
+    ).toBeVisible();
+    await expect(second).toMatchAriaSnapshot(`
+      - img "Cloud storage illustration"
+      - heading "Illustrated message title" [level=2]
+    `);
+  });
 });

--- a/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.a11y.spec.ts
@@ -89,9 +89,9 @@ test.describe('IllustratedMessage - ARIA Snapshots', () => {
     );
     // The first component has aria-hidden="true" on its SVG.
     // It must not produce an img role in the accessibility tree.
-    const first = root.first();
+    const first = root.locator('swc-illustrated-message').first();
     await expect(first.getByRole('img')).toHaveCount(0);
-    // Heading is still accessible
+    // Heading is still accessible.
     await expect(first).toMatchAriaSnapshot(`
       - heading "Illustrated message title" [level=2]
     `);
@@ -107,7 +107,7 @@ test.describe('IllustratedMessage - ARIA Snapshots', () => {
     );
     // The second component has role="img" + aria-label on its SVG.
     // It must appear as a named image in the accessibility tree.
-    const second = root.nth(1);
+    const second = root.locator('swc-illustrated-message').nth(1);
     await expect(
       second.getByRole('img', { name: 'Cloud storage illustration' })
     ).toBeVisible();

--- a/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
@@ -17,9 +17,17 @@ import { IllustratedMessage } from '@adobe/spectrum-wc/illustrated-message';
 
 import '@adobe/spectrum-wc/illustrated-message';
 
-import { getComponent, withWarningSpy } from '../../../utils/test-utils.js';
-import meta from '../stories/illustrated-message.stories.js';
-import { Overview } from '../stories/illustrated-message.stories.js';
+import {
+  getComponent,
+  getComponents,
+  withWarningSpy,
+} from '../../../utils/test-utils.js';
+import meta, {
+  IllustrationAccessibility,
+  Orientation,
+  Overview,
+  Sizes,
+} from '../stories/illustrated-message.stories.js';
 
 // This file defines dev-only test stories that reuse the main story metadata.
 export default {
@@ -44,7 +52,7 @@ export const OverviewTest: Story = {
       'swc-illustrated-message'
     );
 
-    await step('consumer owns the heading element in light DOM', async () => {
+    await step('confirms heading element lives in light DOM', async () => {
       const headingInLight =
         illustratedMessage.querySelector('[slot="heading"]');
       expect(headingInLight, 'heading element in light DOM').not.toBeNull();
@@ -57,9 +65,162 @@ export const OverviewTest: Story = {
   },
 };
 
+export const DefaultValuesTest: Story = {
+  render: () => html`
+    <swc-illustrated-message></swc-illustrated-message>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const illustratedMessage = await getComponent<IllustratedMessage>(
+      canvasElement,
+      'swc-illustrated-message'
+    );
+
+    await step('reflects default size "m" as attribute', async () => {
+      expect(illustratedMessage.size, 'default size property').toBe('m');
+      expect(
+        illustratedMessage.getAttribute('size'),
+        'default size attribute'
+      ).toBe('m');
+    });
+
+    await step(
+      'reflects default orientation "vertical" as attribute',
+      async () => {
+        expect(
+          illustratedMessage.orientation,
+          'default orientation property'
+        ).toBe('vertical');
+        expect(
+          illustratedMessage.getAttribute('orientation'),
+          'default orientation attribute'
+        ).toBe('vertical');
+      }
+    );
+  },
+};
+
 // ──────────────────────────────────────────────────────────────
-// TEST: Heading slot — valid usage
+// TEST: Properties / Attributes
 // ──────────────────────────────────────────────────────────────
+
+export const PropertyMutationTest: Story = {
+  ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const illustratedMessage = await getComponent<IllustratedMessage>(
+      canvasElement,
+      'swc-illustrated-message'
+    );
+
+    await step(
+      'size reflects to attribute after direct property mutation',
+      async () => {
+        illustratedMessage.size = 's';
+        await illustratedMessage.updateComplete;
+        expect(
+          illustratedMessage.getAttribute('size'),
+          'size attribute reflects "s"'
+        ).toBe('s');
+
+        illustratedMessage.size = 'l';
+        await illustratedMessage.updateComplete;
+        expect(
+          illustratedMessage.getAttribute('size'),
+          'size attribute reflects "l"'
+        ).toBe('l');
+
+        illustratedMessage.size = 'm';
+        await illustratedMessage.updateComplete;
+        expect(
+          illustratedMessage.getAttribute('size'),
+          'size attribute restores to "m"'
+        ).toBe('m');
+      }
+    );
+
+    await step(
+      'orientation reflects to attribute after direct property mutation',
+      async () => {
+        illustratedMessage.orientation = 'horizontal';
+        await illustratedMessage.updateComplete;
+        expect(
+          illustratedMessage.getAttribute('orientation'),
+          'orientation attribute reflects "horizontal"'
+        ).toBe('horizontal');
+
+        illustratedMessage.orientation = 'vertical';
+        await illustratedMessage.updateComplete;
+        expect(
+          illustratedMessage.getAttribute('orientation'),
+          'orientation attribute reflects "vertical"'
+        ).toBe('vertical');
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Slots
+// ──────────────────────────────────────────────────────────────
+
+export const DefaultSlotIllustrationTest: Story = {
+  render: () => html`
+    <swc-illustrated-message>
+      <svg
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 160 160"
+      >
+        <path d="M0 0" />
+      </svg>
+      <h2 slot="heading">Test heading</h2>
+    </swc-illustrated-message>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const illustratedMessage = await getComponent<IllustratedMessage>(
+      canvasElement,
+      'swc-illustrated-message'
+    );
+
+    await step('renders illustration content in the default slot', async () => {
+      const svg = illustratedMessage.querySelector('svg');
+      expect(svg, 'svg element present in default slot').not.toBeNull();
+    });
+
+    await step(
+      'verifies decorative illustration is hidden from assistive tech',
+      async () => {
+        const svg = illustratedMessage.querySelector('svg');
+        expect(
+          svg?.getAttribute('aria-hidden'),
+          'aria-hidden on decorative svg'
+        ).toBe('true');
+      }
+    );
+  },
+};
+
+export const DescriptionSlotTest: Story = {
+  render: () => html`
+    <swc-illustrated-message>
+      <h2 slot="heading">Heading</h2>
+      <span slot="description">Description text here.</span>
+    </swc-illustrated-message>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const illustratedMessage = await getComponent<IllustratedMessage>(
+      canvasElement,
+      'swc-illustrated-message'
+    );
+
+    await step('renders description slot content', async () => {
+      const slotted = illustratedMessage.querySelector('[slot="description"]');
+      expect(slotted, 'description slot element').not.toBeNull();
+      expect(slotted?.textContent?.trim(), 'description text').toBe(
+        'Description text here.'
+      );
+    });
+  },
+};
 
 export const HeadingSlotValidElementsTest: Story = {
   render: () => html`
@@ -93,89 +254,113 @@ export const HeadingSlotValidElementsTest: Story = {
 };
 
 // ──────────────────────────────────────────────────────────────
-// TEST: Heading slot — invalid usage
+// TEST: Variants / States
 // ──────────────────────────────────────────────────────────────
 
-export const HeadingSlotInvalidElementWarningTest: Story = {
-  render: () => html`
-    <swc-illustrated-message>
-      <div slot="heading">Not a heading</div>
-    </swc-illustrated-message>
-  `,
+export const SizesTest: Story = {
+  ...Sizes,
   play: async ({ canvasElement, step }) => {
-    const illustratedMessage = await getComponent<IllustratedMessage>(
+    const elements = await getComponents<IllustratedMessage>(
       canvasElement,
       'swc-illustrated-message'
     );
 
-    await step('warns when heading slot contains a non-heading element', () =>
-      withWarningSpy(async (warnCalls) => {
-        const headingSlot =
-          illustratedMessage.shadowRoot?.querySelector<HTMLSlotElement>(
-            'slot[name="heading"]'
-          );
-        if (!headingSlot) {
-          return;
-        }
-
-        const slotChanged = new Promise<void>((resolve) =>
-          headingSlot.addEventListener('slotchange', () => resolve(), {
-            once: true,
-          })
-        );
-
-        // Replace the slotted element to trigger slotchange
-        const div = document.createElement('div');
-        div.setAttribute('slot', 'heading');
-        div.textContent = 'Not a heading';
-
-        illustratedMessage.querySelector('[slot="heading"]')?.remove();
-        illustratedMessage.appendChild(div);
-
-        await slotChanged;
-
-        expect(
-          warnCalls.length,
-          'warning fired for invalid heading slot element'
-        ).toBeGreaterThan(0);
-        expect(
-          String(warnCalls[0]?.[1] ?? ''),
-          'warning message mentions heading slot'
-        ).toContain('heading');
-      })
-    );
-  },
-};
-
-// ──────────────────────────────────────────────────────────────
-// TEST: Slots
-// ──────────────────────────────────────────────────────────────
-
-export const DescriptionSlotTest: Story = {
-  render: () => html`
-    <swc-illustrated-message>
-      <h2 slot="heading">Heading</h2>
-      <span slot="description">Description text here.</span>
-    </swc-illustrated-message>
-  `,
-  play: async ({ canvasElement, step }) => {
-    const illustratedMessage = await getComponent<IllustratedMessage>(
-      canvasElement,
-      'swc-illustrated-message'
-    );
-
-    await step('renders description slot content', async () => {
-      const slotted = illustratedMessage.querySelector('[slot="description"]');
-      expect(slotted, 'description slot element').not.toBeNull();
-      expect(slotted?.textContent?.trim(), 'description text').toBe(
-        'Description text here.'
+    await step('renders one component per valid size', async () => {
+      expect(elements.length, 'number of size variants rendered').toBe(
+        IllustratedMessage.VALID_SIZES.length
       );
     });
+
+    await step(
+      'each component reflects its size as a property and attribute',
+      async () => {
+        for (const size of IllustratedMessage.VALID_SIZES) {
+          const el = elements.find(
+            (item) => item.getAttribute('size') === size
+          );
+          expect(el, `component with size="${size}"`).not.toBeUndefined();
+          expect(el?.size, `size property is "${size}"`).toBe(size);
+        }
+      }
+    );
+  },
+};
+
+export const OrientationTest: Story = {
+  ...Orientation,
+  play: async ({ canvasElement, step }) => {
+    const elements = await getComponents<IllustratedMessage>(
+      canvasElement,
+      'swc-illustrated-message'
+    );
+
+    await step('renders one component per valid orientation', async () => {
+      expect(elements.length, 'number of orientation variants rendered').toBe(
+        IllustratedMessage.VALID_ORIENTATIONS.length
+      );
+    });
+
+    await step(
+      'each component reflects its orientation as a property and attribute',
+      async () => {
+        for (const orientation of IllustratedMessage.VALID_ORIENTATIONS) {
+          const el = elements.find(
+            (item) => item.getAttribute('orientation') === orientation
+          );
+          expect(
+            el,
+            `component with orientation="${orientation}"`
+          ).not.toBeUndefined();
+          expect(
+            el?.orientation,
+            `orientation property is "${orientation}"`
+          ).toBe(orientation);
+        }
+      }
+    );
+  },
+};
+
+export const IllustrationAccessibilityTest: Story = {
+  ...IllustrationAccessibility,
+  play: async ({ canvasElement, step }) => {
+    const elements = await getComponents<IllustratedMessage>(
+      canvasElement,
+      'swc-illustrated-message'
+    );
+
+    await step(
+      'first component has a decorative illustration (aria-hidden)',
+      async () => {
+        const [first] = elements;
+        const decorativeSvg = first?.querySelector('svg[aria-hidden="true"]');
+        expect(
+          decorativeSvg,
+          'decorative svg with aria-hidden="true" in first component'
+        ).not.toBeNull();
+      }
+    );
+
+    await step(
+      'second component has an informative illustration (role="img" + aria-label)',
+      async () => {
+        const [, second] = elements;
+        const informativeSvg = second?.querySelector('svg[role="img"]');
+        expect(
+          informativeSvg,
+          'informative svg with role="img" in second component'
+        ).not.toBeNull();
+        expect(
+          informativeSvg?.getAttribute('aria-label'),
+          'informative svg has aria-label'
+        ).not.toBeNull();
+      }
+    );
   },
 };
 
 // ──────────────────────────────────────────────────────────────
-// TEST: Size attribute / property
+// TEST: Dev mode warnings
 // ──────────────────────────────────────────────────────────────
 
 export const ValidSizeNoWarningTest: Story = {
@@ -243,10 +428,6 @@ export const InvalidSizeWarningTest: Story = {
   },
 };
 
-// ──────────────────────────────────────────────────────────────
-// TEST: Orientation attribute / property
-// ──────────────────────────────────────────────────────────────
-
 export const ValidOrientationNoWarningTest: Story = {
   render: () => html`
     <swc-illustrated-message>
@@ -310,6 +491,94 @@ export const InvalidOrientationWarningTest: Story = {
           String(warnCalls[0]?.[1] ?? ''),
           'warning message mentions orientation'
         ).toContain('orientation');
+      })
+    );
+  },
+};
+
+export const HeadingSlotInvalidElementWarningTest: Story = {
+  render: () => html`
+    <swc-illustrated-message>
+      <div slot="heading">Not a heading</div>
+    </swc-illustrated-message>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const illustratedMessage = await getComponent<IllustratedMessage>(
+      canvasElement,
+      'swc-illustrated-message'
+    );
+
+    await step('warns when heading slot contains a non-heading element', () =>
+      withWarningSpy(async (warnCalls) => {
+        const headingSlot =
+          illustratedMessage.shadowRoot?.querySelector<HTMLSlotElement>(
+            'slot[name="heading"]'
+          );
+        if (!headingSlot) {
+          return;
+        }
+
+        const slotChanged = new Promise<void>((resolve) =>
+          headingSlot.addEventListener('slotchange', () => resolve(), {
+            once: true,
+          })
+        );
+
+        const div = document.createElement('div');
+        div.setAttribute('slot', 'heading');
+        div.textContent = 'Not a heading';
+
+        illustratedMessage.querySelector('[slot="heading"]')?.remove();
+        illustratedMessage.appendChild(div);
+
+        await slotChanged;
+
+        expect(
+          warnCalls.length,
+          'warning fired for invalid heading slot element'
+        ).toBeGreaterThan(0);
+        expect(
+          String(warnCalls[0]?.[1] ?? ''),
+          'warning message mentions heading slot'
+        ).toContain('heading');
+      })
+    );
+  },
+};
+
+export const HeadingSlotEmptyNoWarningTest: Story = {
+  render: () => html`
+    <swc-illustrated-message>
+      <h2 slot="heading">Initial heading</h2>
+    </swc-illustrated-message>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const illustratedMessage = await getComponent<IllustratedMessage>(
+      canvasElement,
+      'swc-illustrated-message'
+    );
+
+    await step('does not warn when heading slot is empty', () =>
+      withWarningSpy(async (warnCalls) => {
+        const headingSlot =
+          illustratedMessage.shadowRoot?.querySelector<HTMLSlotElement>(
+            'slot[name="heading"]'
+          );
+        if (!headingSlot) {
+          return;
+        }
+
+        const slotChanged = new Promise<void>((resolve) =>
+          headingSlot.addEventListener('slotchange', () => resolve(), {
+            once: true,
+          })
+        );
+
+        illustratedMessage.querySelector('[slot="heading"]')?.remove();
+
+        await slotChanged;
+
+        expect(warnCalls.length, 'no warning for empty heading slot').toBe(0);
       })
     );
   },


### PR DESCRIPTION
## Description

Audit and align the `swc-illustrated-message` component files with CONTRIBUTOR-DOCS code standards. Covers three tickets: code style conformance (SWC-1839), Storybook documentation (SWC-1841), and test suite review (SWC-1840). No behaviour changes — documentation, test structure, and JSDoc only.

**Base class (`IllustratedMessage.base.ts`)**
- Shortened `@property` and `@slot` JSDoc to for controls panel clarity
- Moved `@internal` tag to first line of `handleHeadingSlotChange` JSDoc per JSDoc standards guide

**Stories (`illustrated-message.stories.ts`)**
- Updated `HeadingLevels` story: headings are now "Heading h2/h3/h4"; descriptions explain each heading level's typical use
- Updated `IllustrationAccessibility` JSDoc with required `### Features` / `### Best practices` subsections
- Added `@todo SWC-1992` to the Stackblitz placeholder

**Tests (`illustrated-message.test.ts`)**
- Restructured from 7 ad-hoc sections to the 5 standard sections: Defaults, Properties/Attributes, Slots, Variants/States, Dev mode warnings
- Fixed step labels to start with action verbs (`confirms`, `reflects`, `verifies`)

## Motivation and context

SWC-1839, SWC-1840, SWC-1841 — aligning 2nd-gen component files with the project's CONTRIBUTOR-DOCS style guides before the component ships.

## Related issue(s)

- fixes SWC-1839
- fixes SWC-1840
- fixes SWC-1841

## Screenshots (if appropriate)

N/A — no visual changes.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Stories render correctly in Storybook_
  1. Open Storybook and navigate to **Illustrated Message**
  2. Open the Playground story and verify the controls panel shows short, clean descriptions for `size`, `orientation`, and all slots
  3. Navigate to **Options → Heading levels** and confirm headings read "Heading h2", "Heading h3", "Heading h4" with contextual descriptions
  4. Navigate to the **Accessibility** story and confirm both decorative and informative illustration examples render correctly with correct `### Features` and `### Best practices` documentation

- [ ] _Tests pass_
  1. Run `nx test swc-illustrated-message`
  2. Expect all 5 sections (Defaults, Properties/Attributes, Slots, Variants/States, Dev mode warnings) to pass

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  1. Open the Illustrated Message Storybook overview story
  2. Tab through the page — confirm no focusable elements exist on the component itself (non-interactive)
  3. Confirm no focus traps or regressions in surrounding Storybook chrome

- [ ] **Screen reader** (required — document steps below)
  1. Open the **Accessibility → Illustration accessibility** story
  2. Navigate with a screen reader to the first `swc-illustrated-message` (decorative SVG)
  3. Confirm the illustration is not announced (SVG has `aria-hidden="true"`)
  4. Confirm the heading "Illustrated message title" is announced at level 2
  5. Navigate to the second `swc-illustrated-message` (informative SVG)
  6. Confirm the illustration is announced as an image with label "Cloud storage illustration"
  7. Confirm the heading "Illustrated message title" is announced at level 2 after the image
