### PR TITLE
fix(overlay): respect receives-focus

### DIFF
--- a/.changeset/overlay-receives-focus-false-modal.md
+++ b/.changeset/overlay-receives-focus-false-modal.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/overlay': patch
+---
+
+**Fixed**: `receives-focus="false"` on Overlay is now respected for `type="modal"` and `type="page"` overlays. The focus-trap is now created with `initialFocus: false` when `receives-focus="false"`, so <kbd>Tab</kbd> is still trapped inside the modal but focus is not moved on open.

--- a/.changeset/overlay-receives-focus-false-modal.md
+++ b/.changeset/overlay-receives-focus-false-modal.md
@@ -2,4 +2,4 @@
 '@spectrum-web-components/overlay': patch
 ---
 
-**Fixed**: `receives-focus="false"` on Overlay is now respected for `type="modal"` and `type="page"` overlays. The focus-trap is now created with `initialFocus: false` when `receives-focus="false"`, so <kbd>Tab</kbd> is still trapped inside the modal but focus is not moved on open.
+**Fixed**: `receives-focus="false"` on Overlay is now respected for `type="modal"` and `type="page"` overlays. Modals and pages now leave focus on the trigger when receives-focus="false". The focus-trap is still active so Tab/Shift+Tab continue to cycle within the dialog.

--- a/1st-gen/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/1st-gen/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -360,6 +360,115 @@ export const longContent = (
 
 longContent.decorators = [isOverlayOpen];
 
+const scrollableDialogBody = html`
+  <p>
+    Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Sed ac dolor sit
+    amet purus malesuada congue. Donec quis nibh at felis congue commodo. Ut
+    enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit
+    laboriosam, nisi ut aliquid ex ea commodi consequatur? Sed ac dolor sit amet
+    purus malesuada congue. Nam libero tempore, cum soluta nobis est eligendi
+    optio cumque nihil impedit quo minus id quod maxime placeat facere possimus,
+    omnis voluptas assumenda est, omnis dolor repellendus.
+  </p>
+  <p>
+    Curabitur ligula sapien, pulvinar a vestibulum quis, facilisis vel sapien.
+    Fusce nibh. Proin pede metus, vulputate nec, fermentum fringilla, vehicula
+    vitae, justo. Aenean placerat. Aliquam erat volutpat. Et harum quidem rerum
+    facilis est et expedita distinctio. Fusce nibh. Temporibus autem quibusdam
+    et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et
+    voluptates repudiandae sint et molestiae non recusandae.
+  </p>
+  <p>
+    Curabitur vitae diam non enim vestibulum interdum. Sed elit dui,
+    pellentesque a, faucibus vel, interdum nec, diam. Praesent vitae arcu tempor
+    neque lacinia pretium. Ut tempus purus at lorem. Phasellus rhoncus.
+    Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus
+    saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae.
+  </p>
+  <p>
+    Integer vulputate sem a nibh rutrum consequat. Class aptent taciti sociosqu
+    ad litora torquent per conubia nostra, per inceptos hymenaeos. Duis
+    bibendum, lectus ut viverra rhoncus, dolor nunc faucibus libero, eget
+    facilisis enim ipsum id lacus. Aliquam erat volutpat. Aenean id metus id
+    velit ullamcorper pulvinar. Morbi scelerisque luctus velit. Aliquam erat
+    volutpat. Fusce dui leo, imperdiet in, aliquam sit amet, feugiat eu, orci.
+  </p>
+  <p>
+    Sed elit dui, pellentesque a, faucibus vel, interdum nec, diam. Praesent
+    vitae arcu tempor neque lacinia pretium. Etiam dictum tincidunt diam. Et
+    harum quidem rerum facilis est et expedita distinctio. Duis ante orci,
+    molestie vitae vehicula venenatis, tincidunt ac pede. Integer lacinia.
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+    deserunt mollit anim id est laborum.
+  </p>
+  <p>
+    <a href="#example">an inline link near the bottom of the dialog</a>
+  </p>
+  <p>
+    Mauris tincidunt sem sed arcu. Praesent in mauris eu tortor porttitor
+    accumsan. Aenean id metus id velit ullamcorper pulvinar. Donec iaculis
+    gravida nulla. Duis bibendum, lectus ut viverra rhoncus, dolor nunc faucibus
+    libero, eget facilisis enim ipsum id lacus.
+  </p>
+`;
+
+export const receivesFocusComparison = (
+  args: StoryArgs = {}
+): TemplateResult => {
+  return html`
+    <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+      <overlay-trigger
+        type="modal"
+        @close=${handleClose(args)}
+        triggered-by="click"
+        .receivesFocus=${'false'}
+      >
+        <sp-button slot="trigger" variant="primary">
+          Open with receives-focus="false"
+        </sp-button>
+        <sp-dialog-wrapper
+          slot="click-content"
+          headline='receives-focus="false"'
+          dismissable
+          underlay
+          size="s"
+        >
+          <p>
+            The dialog opens scrolled to the top. Focus stays on the trigger
+            button — the inline link further down is NOT auto-focused, so the
+            dialog body does not auto-scroll to reveal it.
+          </p>
+          ${scrollableDialogBody}
+        </sp-dialog-wrapper>
+      </overlay-trigger>
+      <overlay-trigger
+        type="modal"
+        @close=${handleClose(args)}
+        triggered-by="click"
+        .receivesFocus=${'true'}
+      >
+        <sp-button slot="trigger" variant="primary">
+          Open with receives-focus="true"
+        </sp-button>
+        <sp-dialog-wrapper
+          slot="click-content"
+          headline='receives-focus="true"'
+          dismissable
+          underlay
+          size="s"
+        >
+          <p>
+            When this dialog opens, focus moves to the first focusable element —
+            the link further down — so the body scrolls to reveal it. This is
+            the default auto-focus behavior.
+          </p>
+          ${scrollableDialogBody}
+        </sp-dialog-wrapper>
+      </overlay-trigger>
+    </div>
+  `;
+};
+
 export const longHeading = (
   args: StoryArgs = {},
   context: { viewMode?: string } = {}

--- a/1st-gen/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/1st-gen/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -469,6 +469,10 @@ export const receivesFocusComparison = (
   `;
 };
 
+receivesFocusComparison.swc_vrt = {
+  skip: true,
+};
+
 export const longHeading = (
   args: StoryArgs = {},
   context: { viewMode?: string } = {}

--- a/1st-gen/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/1st-gen/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -428,7 +428,7 @@ export const receivesFocusComparison = (
         </sp-button>
         <sp-dialog-wrapper
           slot="click-content"
-          headline='receives-focus="false"'
+          headline="receives-focus is false"
           dismissable
           underlay
           size="s"
@@ -452,7 +452,7 @@ export const receivesFocusComparison = (
         </sp-button>
         <sp-dialog-wrapper
           slot="click-content"
-          headline='receives-focus="true"'
+          headline="receives-focus is true"
           dismissable
           underlay
           size="s"

--- a/1st-gen/packages/overlay/src/Overlay.ts
+++ b/1st-gen/packages/overlay/src/Overlay.ts
@@ -596,8 +596,14 @@ export class Overlay extends ComputedOverlayBase {
     }
     if (targetOpenState) {
       const focusTrap = await import('focus-trap');
+      // When `receives-focus="false"`, pass `initialFocus: false` so the trap
+      // still captures Tab but does not move focus on activation. Without this,
+      // focus-trap would move focus before `applyFocus` runs, bypassing the
+      // `receivesFocus === 'false'` guard there.
+      const initialFocus =
+        this.receivesFocus === 'false' ? false : focusEl || undefined;
       this._focusTrap = focusTrap.createFocusTrap(this.dialogEl, {
-        initialFocus: focusEl || undefined,
+        initialFocus,
         tabbableOptions: {
           getShadowRoot: true,
         },

--- a/1st-gen/packages/overlay/test/overlay-trigger-extended.test.ts
+++ b/1st-gen/packages/overlay/test/overlay-trigger-extended.test.ts
@@ -177,6 +177,74 @@ describe('Overlay Trigger - extended', () => {
 
     expect(popover.placement, `placement after scrolling`).to.equal('bottom');
   });
+  it('does not auto-focus overlay content when `receives-focus="false"` on a modal', async () => {
+    const el = await fixture<HTMLDivElement>(html`
+      <div>
+        <overlay-trigger
+          type="modal"
+          placement="top"
+          triggered-by="click"
+          receives-focus="false"
+        >
+          <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+          <sp-popover slot="click-content" tip>
+            <sp-dialog no-divider>
+              Body copy with
+              <a href="https://example.com/">an inline link</a>
+              that should not be auto-focused on open.
+            </sp-dialog>
+          </sp-popover>
+        </overlay-trigger>
+      </div>
+    `);
+
+    const trigger = el.querySelector('overlay-trigger') as OverlayTrigger;
+    const button = el.querySelector('sp-button') as Button;
+    const link = el.querySelector('a') as HTMLAnchorElement;
+
+    button.click();
+    await elementUpdated(trigger);
+    await overlayOpened(trigger.clickOverlayElement, 300);
+
+    expect(
+      document.activeElement,
+      'link inside overlay should not receive focus'
+    ).to.not.equal(link);
+  });
+  it('auto-focuses the first focusable in overlay content when `receives-focus="true"` on a modal', async () => {
+    const el = await fixture<HTMLDivElement>(html`
+      <div>
+        <overlay-trigger
+          type="modal"
+          placement="top"
+          triggered-by="click"
+          receives-focus="true"
+        >
+          <sp-button slot="trigger" variant="primary">Toggle Dialog</sp-button>
+          <sp-popover slot="click-content" tip>
+            <sp-dialog no-divider>
+              Body copy with
+              <a href="https://example.com/">an inline link</a>
+              that should be auto-focused on open.
+            </sp-dialog>
+          </sp-popover>
+        </overlay-trigger>
+      </div>
+    `);
+
+    const trigger = el.querySelector('overlay-trigger') as OverlayTrigger;
+    const button = el.querySelector('sp-button') as Button;
+    const link = el.querySelector('a') as HTMLAnchorElement;
+
+    button.click();
+    await elementUpdated(trigger);
+    await overlayOpened(trigger.clickOverlayElement, 300);
+
+    expect(
+      document.activeElement,
+      'link inside overlay should receive focus'
+    ).to.equal(link);
+  });
   // @TODO: skipping this test because its flaky. Will review in the migration to Spectrum 2.
   it.skip('occludes content behind the overlay', async () => {
     const el = await fixture<HTMLDivElement>(html`

--- a/1st-gen/packages/overlay/test/overlay-trigger-extended.test.ts
+++ b/1st-gen/packages/overlay/test/overlay-trigger-extended.test.ts
@@ -201,6 +201,7 @@ describe('Overlay Trigger - extended', () => {
     const trigger = el.querySelector('overlay-trigger') as OverlayTrigger;
     const button = el.querySelector('sp-button') as Button;
 
+    button.focus();
     button.click();
     await elementUpdated(trigger);
     await overlayOpened(trigger.clickOverlayElement, 300);

--- a/1st-gen/packages/overlay/test/overlay-trigger-extended.test.ts
+++ b/1st-gen/packages/overlay/test/overlay-trigger-extended.test.ts
@@ -200,7 +200,6 @@ describe('Overlay Trigger - extended', () => {
 
     const trigger = el.querySelector('overlay-trigger') as OverlayTrigger;
     const button = el.querySelector('sp-button') as Button;
-    const link = el.querySelector('a') as HTMLAnchorElement;
 
     button.click();
     await elementUpdated(trigger);
@@ -208,8 +207,8 @@ describe('Overlay Trigger - extended', () => {
 
     expect(
       document.activeElement,
-      'link inside overlay should not receive focus'
-    ).to.not.equal(link);
+      'focus should remain on the trigger when receives-focus="false"'
+    ).to.equal(button);
   });
   it('auto-focuses the first focusable in overlay content when `receives-focus="true"` on a modal', async () => {
     const el = await fixture<HTMLDivElement>(html`


### PR DESCRIPTION

<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

Fixes a bug where `receives-focus="false"` on `<overlay-trigger>` was silently ignored for `type="modal"` (and `type="page"`) overlays, causing focus to jump to the first focusable descendant of the overlay content on open. Reported by a customer with an inline link buried down inside an `<sp-dialog-wrapper>` body.

### Root cause

In `1st-gen/packages/overlay/src/Overlay.ts` → `managePopoverOpen`, `focus-trap` was created with `initialFocus: focusEl || undefined` and `.activate()`d **before** `applyFocus` ran. `applyFocus` is where `receivesFocus === 'false'` is respected, but by then the trap had already moved focus to `focusEl`. The flag worked for non-trapped overlays but never for modals.

### Fix

When `receivesFocus === 'false'`, pass `initialFocus: false` to `focus-trap`. `focus-trap` documents this value as "no initially focused element" and also disables the `fallbackFocus` callback. The trap still captures <kbd>Tab</kbd>/<kbd>Shift+Tab</kbd> inside the modal; it just doesn't move focus on activation. The existing `applyFocus` early-return continues to cover the non-trap path.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

`receives-focus="false"` is the documented escape hatch for consumers who don't want a modal dialog to steal focus into its body content on open. The previous behavior made the attribute ineffective for the most common use case (modal dialogs), which is particularly disruptive when a modal contains long, scrolling content — the browser auto-scrolls to the focused element, so the dialog appears mid-scroll rather than at the top, and sighted users lose the beginning of the content.

This is strictly a bug fix: the attribute's contract did not change.


## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases


- [ ] _`receives-focus="false"` on a modal does not steal focus_
  1. Run Storybook locally and open [**Dialog Wrapper / Receives Focus Comparison**](https://swcpreviews.z13.web.core.windows.net/pr-6193/docs/first-gen-storybook/?path=/story/dialog-wrapper--receives-focus-comparison).
  2. Click the **Open with receives-focus="false"** button.
  3. Expect the dialog to open scrolled to the top, with focus remaining on the trigger button. The inline link near the bottom of the body should not be focused and the dialog body should not auto-scroll.

- [ ] _`receives-focus="true"` still auto-focuses the first focusable_
  1. From the same story, click the **Open with receives-focus="true"** button.
  2. Expect the dialog to open with focus on the inline link, and the body to be scrolled so the link is visible (default browser behavior when an off-screen element is focused).

- [ ] _Focus trap still works when initial focus is suppressed_
  1. Open the `receives-focus="false"` dialog from the comparison story.
  2. Press <kbd>Tab</kbd> repeatedly.
  3. Expect focus to cycle through interactive elements inside the dialog (link, dismiss button) and wrap — focus must not escape to elements outside the dialog.

## Accessibility testing checklist

<!---
    Manual accessibility testing is required because automated tools cannot catch all issues (e.g. focus order, screen reader announcements, keyboard flow).
    You must document your keyboard and screen reader testing steps below. Reviewers will use this checklist during review.
    See: [Accessibility testing guide](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTOR-DOCS/01_contributor-guides/09_accessibility-testing.md)
-->

**Required:** Complete each applicable item and document your testing steps (replace the placeholders with your component-specific instructions).

- [ ] **Keyboard** (required — document steps below) — _What to test for:_ Focus order is logical; <kbd>Tab</kbd> reaches the component and all interactive descendants; <kbd>Enter</kbd>/<kbd>Space</kbd> activate where appropriate; arrow keys work for tabs, menus, sliders, etc.; no focus traps; <kbd>Escape</kbd> dismisses when applicable; focus indicator is visible.
  1. Open **Dialog Wrapper / Receives Focus Comparison** in Storybook.
  2. <kbd>Tab</kbd> to the **Open with receives-focus="false"** button and activate it with <kbd>Enter</kbd>.
  3. Expect focus to stay on the trigger button (dialog opens behind/over it). Press <kbd>Tab</kbd> — focus enters the dialog at the dismiss button (or the first focusable inside the modal) and continues to cycle through dialog-internal elements (link, etc.) without leaking out to page content. Press <kbd>Shift+Tab</kbd> — focus cycles backward inside the dialog.
  5. Press <kbd>Escape</kbd>. Expect the dialog to close and focus to return to the trigger button.
  6. Repeat steps 2–4 for **Open with receives-focus="true"**. Expect focus to move to the inline link on open, then cycle inside the dialog on subsequent <kbd>Tab</kbd>s, and return to the trigger on <kbd>Escape</kbd>.

- [ ] **Screen reader** (required — document steps below) — _What to test for:_ Role and name are announced correctly; state changes (e.g. expanded, selected) are announced; labels and relationships are clear; no unnecessary or duplicate announcements.
  1. With VoiceOver (macOS) or NVDA (Windows) active, open **Dialog Wrapper / Receives Focus Comparison**.
  2. Navigate to the **Open with receives-focus="false"** button and activate it.
  3. Expect the dialog's role (`dialog`) and accessible name (headline) to be announced on open. The virtual cursor should not jump to the link inside the dialog; the user remains on the trigger and can explore the dialog content at their own pace via the screen reader's reading commands.
  4. Dismiss the dialog with <kbd>Escape</kbd>. Expect focus announcement to return to the trigger button.
  5. Activate the **Open with receives-focus="true"** trigger. Expect the dialog role and name to be announced, then the inline link announcement (since focus moves there).
  7. In both cases, confirm no duplicate or stale announcements, and that the focus trap boundary is not audibly escaped while the dialog is open.
