### PR TITLE
fix(overlay): popover tooltip renders in ioswebkit

### DIFF
--- a/.changeset/overlay-ios-visualviewport-positioning.md
+++ b/.changeset/overlay-ios-visualviewport-positioning.md
@@ -1,0 +1,7 @@
+---
+'@spectrum-web-components/overlay': patch
+---
+
+**Fixed**: Overlay positioning on iOS Safari and WKWebView hosts (such as the Adobe Express iOS app). Popovers opened via `Overlay.open()` or the `trigger` Lit directive previously rendered `visualViewport.offsetTop` pixels (typically 30-40 px) below their trigger when the layout viewport diverged from the visual viewport — for example with the URL bar showing, with pinch-zoom, with the virtual keyboard open, or when a host app overlaid a bottom sheet.
+
+`PlacementController` now subtracts `visualViewport.offsetLeft / offsetTop` from the computed coordinates on WebKit (where the popover top layer paints relative to the visual viewport), and subscribes to `visualViewport`'s `resize` and `scroll` so an open overlay re-anchors to its trigger when the viewports realign. Other browsers are unaffected.

--- a/1st-gen/packages/overlay/src/PlacementController.ts
+++ b/1st-gen/packages/overlay/src/PlacementController.ts
@@ -210,15 +210,35 @@ export class PlacementController implements ReactiveController {
     );
 
     // Recompute placement when the visual viewport diverges from the layout
-    // viewport (iOS URL bar showing/hiding, pinch-zoom, virtual keyboard,
-    // host-app bottom sheets, etc.). Floating UI's `autoUpdate` does not
-    // observe `window.visualViewport`, so without this an open overlay can
-    // drift away from its trigger on iOS WebKit until the next resize.
-    // See `computePlacement` for the corresponding offset compensation.
+    // viewport (URL bar showing/hiding, pinch-zoom, virtual keyboard, host-app
+    // bottom sheets, etc.). Floating UI's `autoUpdate` does not observe
+    // `window.visualViewport`, so without this an open overlay can drift away
+    // from its trigger on WebKit (iOS Safari, WKWebView, and desktop Safari
+    // when pinch-zoomed) until the next resize. See `computePlacement` for the
+    // corresponding offset compensation.
+    //
+    // Listeners are passive (we never `preventDefault` in `updatePlacement`)
+    // and rAF-coalesced so a burst of `resize`/`scroll` events during a URL
+    // bar collapse or pinch gesture compresses to one Floating UI compute per
+    // frame.
     const visualViewport = window.visualViewport;
+    let visualViewportRafId = 0;
+    const onVisualViewportChange = (): void => {
+      if (visualViewportRafId) {
+        return;
+      }
+      visualViewportRafId = requestAnimationFrame(() => {
+        visualViewportRafId = 0;
+        this.updatePlacement();
+      });
+    };
     if (visualViewport && isWebKit()) {
-      visualViewport.addEventListener('resize', this.updatePlacement);
-      visualViewport.addEventListener('scroll', this.updatePlacement);
+      visualViewport.addEventListener('resize', onVisualViewportChange, {
+        passive: true,
+      });
+      visualViewport.addEventListener('scroll', onVisualViewportChange, {
+        passive: true,
+      });
     }
 
     // Define the cleanup function to remove event listeners and reset placements.
@@ -241,8 +261,11 @@ export class PlacementController implements ReactiveController {
       cleanupAncestorResize();
       cleanupElementResize();
       if (visualViewport && isWebKit()) {
-        visualViewport.removeEventListener('resize', this.updatePlacement);
-        visualViewport.removeEventListener('scroll', this.updatePlacement);
+        visualViewport.removeEventListener('resize', onVisualViewportChange);
+        visualViewport.removeEventListener('scroll', onVisualViewportChange);
+        if (visualViewportRafId) {
+          cancelAnimationFrame(visualViewportRafId);
+        }
       }
     };
   }

--- a/1st-gen/packages/overlay/src/PlacementController.ts
+++ b/1st-gen/packages/overlay/src/PlacementController.ts
@@ -209,6 +209,18 @@ export class PlacementController implements ReactiveController {
       }
     );
 
+    // Recompute placement when the visual viewport diverges from the layout
+    // viewport (iOS URL bar showing/hiding, pinch-zoom, virtual keyboard,
+    // host-app bottom sheets, etc.). Floating UI's `autoUpdate` does not
+    // observe `window.visualViewport`, so without this an open overlay can
+    // drift away from its trigger on iOS WebKit until the next resize.
+    // See `computePlacement` for the corresponding offset compensation.
+    const visualViewport = window.visualViewport;
+    if (visualViewport && isWebKit()) {
+      visualViewport.addEventListener('resize', this.updatePlacement);
+      visualViewport.addEventListener('scroll', this.updatePlacement);
+    }
+
     // Define the cleanup function to remove event listeners and reset placements.
     this.cleanup = () => {
       this.host.elements?.forEach((element) => {
@@ -228,6 +240,10 @@ export class PlacementController implements ReactiveController {
       });
       cleanupAncestorResize();
       cleanupElementResize();
+      if (visualViewport && isWebKit()) {
+        visualViewport.removeEventListener('resize', this.updatePlacement);
+        visualViewport.removeEventListener('scroll', this.updatePlacement);
+      }
     };
   }
 
@@ -357,11 +373,30 @@ export class PlacementController implements ReactiveController {
       }
     );
 
+    // On iOS WebKit (Safari and WKWebView hosts such as the Adobe Express
+    // iOS app) the layout viewport and the visual viewport can diverge by
+    // tens of pixels — for example when the URL bar is showing, when the
+    // page is pinch-zoomed, when the virtual keyboard is open, or when a
+    // native bottom sheet is overlaid. Floating UI computes `(x, y)` from
+    // `getBoundingClientRect()`, which is in layout-viewport coordinates,
+    // but the overlay is rendered in the top layer via the native popover
+    // API and therefore painted relative to the visual viewport. Without
+    // this compensation the overlay lands `visualViewport.offsetTop` px
+    // below (and `offsetLeft` px to the side of) its trigger on iOS while
+    // appearing correct on every other browser.
+    let translateX = x;
+    let translateY = y;
+    const visualViewport = window.visualViewport;
+    if (visualViewport && isWebKit()) {
+      translateX -= visualViewport.offsetLeft;
+      translateY -= visualViewport.offsetTop;
+    }
+
     // Update the overlay's style with the computed position.
     Object.assign(target.style, {
       top: '0px',
       left: '0px',
-      translate: `${roundByDPR(x)}px ${roundByDPR(y)}px`,
+      translate: `${roundByDPR(translateX)}px ${roundByDPR(translateY)}px`,
     });
 
     // Set the 'actual-placement' attribute on the target element.

--- a/1st-gen/packages/overlay/src/PlacementController.ts
+++ b/1st-gen/packages/overlay/src/PlacementController.ts
@@ -155,6 +155,16 @@ export class PlacementController implements ReactiveController {
   private target!: HTMLElement;
 
   /**
+   * Incremented whenever the active placement session ends (`cleanup`) or a
+   * new session begins, so async `computePlacement` runs that started under an
+   * older session do not write styles after teardown or across stacked
+   * `placeOverlay` calls.
+   *
+   * @private
+   */
+  private placementGeneration = 0;
+
+  /**
    * Creates an instance of the PlacementController.
    *
    * @param {ReactiveElement & { elements: OpenableElement[] }} host - The host element that uses this controller.
@@ -180,6 +190,13 @@ export class PlacementController implements ReactiveController {
     target: HTMLElement = this.target,
     options: OverlayOptionsV1 = this.options
   ): Promise<void> {
+    // If `placeOverlay` runs twice before `hostUpdated` clears the prior
+    // session (rapid open, programmatic toggles), tear down the previous
+    // listeners first so `visualViewport` handlers and pending rAFs cannot
+    // leak.
+    this.cleanup?.();
+    this.cleanup = undefined;
+
     // Set the target and options for the overlay.
     this.target = target;
     this.options = options;
@@ -223,12 +240,16 @@ export class PlacementController implements ReactiveController {
     // frame.
     const visualViewport = window.visualViewport;
     let visualViewportRafId = 0;
+    let visualViewportPlacementCancelled = false;
     const onVisualViewportChange = (): void => {
-      if (visualViewportRafId) {
+      if (visualViewportPlacementCancelled || visualViewportRafId) {
         return;
       }
       visualViewportRafId = requestAnimationFrame(() => {
         visualViewportRafId = 0;
+        if (visualViewportPlacementCancelled) {
+          return;
+        }
         this.updatePlacement();
       });
     };
@@ -243,6 +264,10 @@ export class PlacementController implements ReactiveController {
 
     // Define the cleanup function to remove event listeners and reset placements.
     this.cleanup = () => {
+      this.placementGeneration += 1;
+      // Invalidate any `visualViewport` rAF callback scheduled before this
+      // cleanup runs, so `updatePlacement` cannot start after teardown.
+      visualViewportPlacementCancelled = true;
       this.host.elements?.forEach((element) => {
         element.addEventListener(
           'sp-closed',
@@ -265,6 +290,7 @@ export class PlacementController implements ReactiveController {
         visualViewport.removeEventListener('scroll', onVisualViewportChange);
         if (visualViewportRafId) {
           cancelAnimationFrame(visualViewportRafId);
+          visualViewportRafId = 0;
         }
       }
     };
@@ -321,12 +347,25 @@ export class PlacementController implements ReactiveController {
   async computePlacement(): Promise<void> {
     const { options, target } = this;
 
+    const genAtStart = this.placementGeneration;
+    const placementStillValid = (): boolean =>
+      (this.host as Overlay).open &&
+      this.placementGeneration === genAtStart &&
+      !!this.target &&
+      this.target === target;
+
     // Wait for document fonts to be ready before computing placement.
     await (document.fonts ? document.fonts.ready : Promise.resolve());
+    if (!placementStillValid()) {
+      return;
+    }
 
     if (isWebKit()) {
       // Computing placement requires a frame for layout stability in WebKit
       await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+    if (!placementStillValid()) {
+      return;
     }
 
     // Determine the flip middleware based on the type of trigger element.
@@ -395,6 +434,9 @@ export class PlacementController implements ReactiveController {
         strategy: 'fixed',
       }
     );
+    if (!placementStillValid()) {
+      return;
+    }
 
     // On iOS WebKit (Safari and WKWebView hosts such as the Adobe Express
     // iOS app) the layout viewport and the visual viewport can diverge by
@@ -416,6 +458,9 @@ export class PlacementController implements ReactiveController {
     }
 
     // Update the overlay's style with the computed position.
+    if (!placementStillValid()) {
+      return;
+    }
     Object.assign(target.style, {
       top: '0px',
       left: '0px',
@@ -437,6 +482,9 @@ export class PlacementController implements ReactiveController {
     });
 
     // Update the tip element's style with the computed arrow position.
+    if (!placementStillValid()) {
+      return;
+    }
     if (tipElement && middlewareData.arrow) {
       const { x: arrowX, y: arrowY } = middlewareData.arrow;
 

--- a/1st-gen/packages/overlay/stories/overlay-ios-positioning.stories.ts
+++ b/1st-gen/packages/overlay/stories/overlay-ios-positioning.stories.ts
@@ -1,0 +1,415 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+ * Regression story for the iOS WebKit visual-viewport offset bug.
+ *
+ * Symptom (before the fix): an `sp-popover` opened via the `trigger` Lit
+ * directive landed ~30-40 px below its trigger on iOS Safari / WKWebView
+ * hosts such as the Adobe Express iOS app, while rendering correctly on
+ * Android. Cause: Floating UI computes `(x, y)` from `getBoundingClientRect`
+ * (layout-viewport coordinates), but the overlay is rendered in the top
+ * layer via the native popover API and painted relative to the visual
+ * viewport. When the two viewports diverge (URL bar showing, pinch-zoom,
+ * virtual keyboard, host-app bottom sheet, …) the overlay drifts away from
+ * its trigger by exactly `visualViewport.offsetTop / offsetLeft`.
+ *
+ * Fix: `PlacementController.computePlacement` now subtracts those offsets
+ * on WebKit, and `placeOverlay` subscribes to `visualViewport`'s `resize`
+ * and `scroll` so the overlay re-positions when the viewports realign.
+ *
+ * This story is designed to be opened on a real iOS device. It mirrors the
+ * bug-report screenshot (a vertical list of rows, each with an info button
+ * that opens an `sp-popover tip` above it) and shows live visual-viewport
+ * telemetry so you can confirm the overlay tracks the trigger as the URL
+ * bar hides/shows, the page is pinch-zoomed, etc.
+ */
+
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  TemplateResult,
+} from '@spectrum-web-components/base';
+import { trigger } from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
+
+import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/dialog/sp-dialog.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-info-outline.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/switch/sp-switch.js';
+
+export default {
+  title: 'Overlay/Bug Repros/iOS Popover Positioning',
+  parameters: {
+    // Manual repro that needs to run on an iOS device. Skip Chromatic and
+    // the visual-regression test runner.
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        component:
+          'Reproduces the iOS-only offset bug where `sp-popover` opened via the `trigger` directive lands ~30-40 px below its trigger. Open this story on an iOS device, optionally enable the simulated bottom sheet, then tap an info button.',
+      },
+    },
+  },
+};
+
+interface Row {
+  id: string;
+  label: string;
+  detail: string;
+}
+
+const ROWS: Row[] = [
+  {
+    id: 'a1',
+    label: 'CE Tester 01 - A1',
+    detail: 'Project A1 — owned by you. Last edited 10 days ago.',
+  },
+  {
+    id: 'b2',
+    label: 'CE Tester 01 - B2',
+    detail: 'Project B2 — shared with your team. Last edited 3 days ago.',
+  },
+  {
+    id: 'b1',
+    label: 'CE Tester 01 - B1',
+    detail: 'Project B1 — owned by you. Last edited yesterday.',
+  },
+  {
+    id: 'c4',
+    label: 'CE Tester 01 - C4',
+    detail: 'Project C4 — read-only. Last edited 1 month ago.',
+  },
+  {
+    id: 'd7',
+    label: 'CE Tester 01 - D7',
+    detail: 'Project D7 — pending approval. Last edited just now.',
+  },
+];
+
+class IosPopoverRepro extends LitElement {
+  static override styles: CSSResultGroup = css`
+    :host {
+      display: block;
+      font-family: var(--spectrum-sans-font-family-stack, sans-serif);
+      color: var(--spectrum-neutral-content-color-default, #222);
+      min-height: 100dvh;
+      padding-bottom: env(safe-area-inset-bottom);
+      padding-top: env(safe-area-inset-top);
+    }
+
+    .telemetry {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      background: var(--spectrum-gray-75, #f5f5f5);
+      border-bottom: 1px solid var(--spectrum-gray-300, #ddd);
+      padding: 12px 16px;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .telemetry h3 {
+      margin: 0 0 6px;
+      font-size: 13px;
+    }
+
+    .telemetry-grid {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      column-gap: 12px;
+      row-gap: 2px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      padding: 12px 16px;
+      background: var(--spectrum-gray-50, #fafafa);
+      border-bottom: 1px solid var(--spectrum-gray-200, #eee);
+    }
+
+    .row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--spectrum-gray-200, #eee);
+      min-height: 56px;
+    }
+
+    .row-label {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .row-avatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 8px;
+      background: linear-gradient(135deg, #b39df0, #6b6bf5);
+      display: grid;
+      place-items: center;
+      color: white;
+      font-weight: 600;
+    }
+
+    /*
+         * Simulates the Adobe Express bottom sheet from the bug screenshot.
+         * It is purely visual — no top-layer interaction — so the popover
+         * still renders above it. The point is to anchor visually where the
+         * popover *should* land relative to the trigger row.
+         */
+    .fake-sheet {
+      position: fixed;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: white;
+      border-top-left-radius: 16px;
+      border-top-right-radius: 16px;
+      box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.15);
+      padding: 16px 16px calc(16px + env(safe-area-inset-bottom));
+      z-index: 0;
+    }
+
+    .fake-sheet h4 {
+      text-align: center;
+      margin: 0 0 8px;
+    }
+
+    .fake-sheet .grabber {
+      width: 36px;
+      height: 4px;
+      border-radius: 2px;
+      background: var(--spectrum-gray-400, #bbb);
+      margin: 0 auto 12px;
+    }
+
+    sp-popover {
+      max-width: 280px;
+    }
+
+    .popover-body {
+      padding: 4px 4px 0;
+      font-size: 13px;
+      line-height: 1.4;
+    }
+  `;
+
+  private vv: ReturnType<typeof this.snapshotViewport>;
+
+  private showSheet = false;
+
+  public constructor() {
+    super();
+    this.vv = this.snapshotViewport();
+  }
+
+  private snapshotViewport(): {
+    layoutW: number;
+    layoutH: number;
+    vvW: number;
+    vvH: number;
+    offsetTop: number;
+    offsetLeft: number;
+    pageTop: number;
+    pageLeft: number;
+    scale: number;
+    dpr: number;
+    isWebKit: boolean;
+    ua: string;
+  } {
+    const vv = window.visualViewport;
+    return {
+      layoutW: window.innerWidth,
+      layoutH: window.innerHeight,
+      vvW: vv?.width ?? 0,
+      vvH: vv?.height ?? 0,
+      offsetTop: vv?.offsetTop ?? 0,
+      offsetLeft: vv?.offsetLeft ?? 0,
+      pageTop: vv?.pageTop ?? 0,
+      pageLeft: vv?.pageLeft ?? 0,
+      scale: vv?.scale ?? 1,
+      dpr: window.devicePixelRatio || 1,
+      isWebKit:
+        /AppleWebKit/.test(navigator.userAgent) &&
+        !/Chrome|CriOS|Edg/.test(navigator.userAgent),
+      ua: navigator.userAgent,
+    };
+  }
+
+  private onViewportChange = (): void => {
+    this.vv = this.snapshotViewport();
+    this.requestUpdate();
+    // Ask any open overlays to recompute placement when the visual
+    // viewport shifts (URL bar, keyboard, host-app sheet, scroll).
+    document.dispatchEvent(new Event('sp-update-overlays'));
+  };
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    window.visualViewport?.addEventListener('resize', this.onViewportChange);
+    window.visualViewport?.addEventListener('scroll', this.onViewportChange);
+    window.addEventListener('orientationchange', this.onViewportChange);
+  }
+
+  public override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.visualViewport?.removeEventListener('resize', this.onViewportChange);
+    window.visualViewport?.removeEventListener('scroll', this.onViewportChange);
+    window.removeEventListener('orientationchange', this.onViewportChange);
+  }
+
+  private toggleSheet(checked: boolean): void {
+    this.showSheet = checked;
+    this.requestUpdate();
+    // The sheet appearing / disappearing changes layout height, so ask
+    // any open overlays to recompute.
+    document.dispatchEvent(new Event('sp-update-overlays'));
+  }
+
+  private renderInfoPopover = (row: Row) => (): TemplateResult => html`
+    <sp-popover tip placement="top">
+      <sp-dialog size="s" no-divider>
+        <h2 slot="heading">${row.label}</h2>
+        <div class="popover-body">${row.detail}</div>
+      </sp-dialog>
+    </sp-popover>
+  `;
+
+  private renderRow(row: Row): TemplateResult {
+    return html`
+      <div class="row">
+        <div class="row-label">
+          <div class="row-avatar">${row.label.slice(-2)}</div>
+          <span>${row.label}</span>
+        </div>
+        <sp-action-button
+          quiet
+          label="About ${row.label}"
+          aria-label="About ${row.label}"
+          ${trigger(this.renderInfoPopover(row), {
+            triggerInteraction: 'click',
+            overlayOptions: { placement: 'top' },
+          })}
+        >
+          <sp-icon-info-outline slot="icon"></sp-icon-info-outline>
+        </sp-action-button>
+      </div>
+    `;
+  }
+
+  private renderTelemetry(): TemplateResult {
+    return html`
+      <div class="telemetry">
+        <h3>Viewport telemetry (live)</h3>
+        <div class="telemetry-grid">
+          <span>isWebKit</span>
+          <span>${String(this.vv.isWebKit)}</span>
+          <span>layout (innerW × innerH)</span>
+          <span>${this.vv.layoutW} × ${this.vv.layoutH}</span>
+          <span>visualViewport (w × h)</span>
+          <span>${this.vv.vvW.toFixed(1)} × ${this.vv.vvH.toFixed(1)}</span>
+          <span>visualViewport offset (L, T)</span>
+          <span>
+            ${this.vv.offsetLeft.toFixed(1)}, ${this.vv.offsetTop.toFixed(1)}
+          </span>
+          <span>visualViewport page (L, T)</span>
+          <span>
+            ${this.vv.pageLeft.toFixed(1)}, ${this.vv.pageTop.toFixed(1)}
+          </span>
+          <span>scale / DPR</span>
+          <span>${this.vv.scale.toFixed(2)} / ${this.vv.dpr}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  protected override render(): TemplateResult {
+    return html`
+      ${this.renderTelemetry()}
+      <div class="controls">
+        <sp-switch
+          ?checked=${this.showSheet}
+          @change=${(event: Event) =>
+            this.toggleSheet((event.target as HTMLInputElement).checked)}
+        >
+          Simulate Express bottom sheet
+        </sp-switch>
+        <sp-button
+          variant="secondary"
+          treatment="outline"
+          @click=${() => {
+            this.vv = this.snapshotViewport();
+            this.requestUpdate();
+            document.dispatchEvent(new Event('sp-update-overlays'));
+          }}
+        >
+          Recompute overlays
+        </sp-button>
+      </div>
+      ${ROWS.map((row) => this.renderRow(row))}
+      ${this.showSheet
+        ? html`
+            <div class="fake-sheet" aria-hidden="true">
+              <div class="grabber"></div>
+              <h4>Projects</h4>
+              <p style="text-align:center; margin:0;">
+                Visually anchors where the popover should
+                <em>not</em>
+                overlap.
+              </p>
+            </div>
+          `
+        : ''}
+    `;
+  }
+}
+
+if (!customElements.get('overlay-ios-popover-repro')) {
+  customElements.define('overlay-ios-popover-repro', IosPopoverRepro);
+}
+
+export const IosPopoverPositioning = (): TemplateResult => html`
+  <overlay-ios-popover-repro></overlay-ios-popover-repro>
+`;
+
+IosPopoverPositioning.storyName = 'iOS popover positioning repro';
+
+IosPopoverPositioning.swc_vrt = {
+  skip: true,
+};
+
+IosPopoverPositioning.parameters = {
+  chromatic: { disableSnapshot: true },
+  docs: {
+    description: {
+      story: [
+        'Regression coverage for the iOS WebKit visual-viewport offset bug.',
+        '',
+        'How to verify on an iOS device (Safari or a WKWebView host):',
+        '1. Tap any "info" button. The popover should land cleanly above its trigger.',
+        '2. Pinch-zoom in, scroll until the URL bar shows/hides, or open a host-app bottom sheet (toggle "Simulate Express bottom sheet"). Tap an info button again — the popover should still anchor to the trigger.',
+        '3. Open a popover, then change the visual viewport (scroll, pinch, keyboard). The telemetry panel updates and the open popover should re-anchor automatically.',
+        '',
+        'Before the fix the popover landed `visualViewport.offsetTop` px below its trigger on iOS WebKit and did not move when the visual viewport changed.',
+      ].join('\n'),
+    },
+  },
+};

--- a/1st-gen/packages/overlay/test/overlay-visual-viewport.test.ts
+++ b/1st-gen/packages/overlay/test/overlay-visual-viewport.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+  nextFrame,
+  oneEvent,
+} from '@open-wc/testing';
+
+import { Overlay } from '@spectrum-web-components/overlay';
+import { isWebKit } from '@spectrum-web-components/shared';
+
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/overlay/sp-overlay.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+
+/**
+ * Regression coverage for the iOS WebKit visual-viewport positioning fix
+ * in `PlacementController`. The fix has two parts:
+ *
+ * 1. Subtract `visualViewport.offsetLeft / offsetTop` from the computed
+ *    overlay translate on WebKit, so the overlay anchors to its trigger
+ *    in the visual viewport (the coordinate system the popover top layer
+ *    is actually painted in on iOS).
+ * 2. Subscribe to `visualViewport`'s `resize` and `scroll` events while
+ *    the overlay is open so it re-anchors when the viewports realign
+ *    (URL bar, virtual keyboard, host-app bottom sheet, pinch-zoom).
+ *
+ * The arithmetic in (1) is two trivial lines and can only meaningfully be
+ * verified on a real iOS device — the Storybook story
+ * `overlay-ios-positioning.stories.ts` exists for that. Trying to assert
+ * it in a headless WebKit run is fragile because Floating UI's `shift`
+ * middleware reads the same `visualViewport` offsets to compute its
+ * viewport boundary, so any stub we apply also moves the boundary and
+ * `shift` cancels out our compensation in unpredictable ways.
+ *
+ * What we *can* test reliably here is (2): if the WebKit branch of
+ * `placeOverlay` ever stops attaching the `visualViewport` listeners (or
+ * stops removing them on close), the runtime fix becomes a no-op for
+ * mid-life viewport changes and we leak listeners. That's the regression
+ * this test guards against.
+ */
+describe('PlacementController visualViewport listeners', () => {
+  before(function () {
+    if (!isWebKit()) {
+      this.skip();
+    }
+  });
+
+  it('attaches and cleans up visualViewport listeners across the open/close lifecycle', async () => {
+    const vv = window.visualViewport!;
+    const addCalls: string[] = [];
+    const removeCalls: string[] = [];
+    const originalAdd = vv.addEventListener.bind(vv);
+    const originalRemove = vv.removeEventListener.bind(vv);
+    vv.addEventListener = ((
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions
+    ) => {
+      addCalls.push(type);
+      return originalAdd(type, listener, options);
+    }) as typeof vv.addEventListener;
+    vv.removeEventListener = ((
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions
+    ) => {
+      removeCalls.push(type);
+      return originalRemove(type, listener, options);
+    }) as typeof vv.removeEventListener;
+
+    try {
+      const container = await fixture<HTMLDivElement>(html`
+        <div>
+          <sp-button id="trigger">Open</sp-button>
+          <sp-overlay
+            trigger="trigger@click"
+            type="auto"
+            placement="bottom"
+            offset="0"
+          >
+            <sp-popover>
+              <p>positioned popover content</p>
+            </sp-popover>
+          </sp-overlay>
+        </div>
+      `);
+      const trigger = container.querySelector('#trigger') as HTMLElement;
+      const overlay = container.querySelector('sp-overlay') as Overlay;
+      await elementUpdated(overlay);
+
+      const opened = oneEvent(overlay, 'sp-opened');
+      trigger.click();
+      await opened;
+      await nextFrame();
+
+      // `placeOverlay` ran while the overlay opened, so the WebKit
+      // branch should have subscribed to both visualViewport events.
+      expect(
+        addCalls,
+        'addEventListener should have been called for resize'
+      ).to.include('resize');
+      expect(
+        addCalls,
+        'addEventListener should have been called for scroll'
+      ).to.include('scroll');
+
+      const closed = oneEvent(overlay, 'sp-closed');
+      overlay.open = false;
+      await closed;
+      await nextFrame();
+
+      expect(
+        removeCalls,
+        'removeEventListener should have been called for resize'
+      ).to.include('resize');
+      expect(
+        removeCalls,
+        'removeEventListener should have been called for scroll'
+      ).to.include('scroll');
+    } finally {
+      vv.addEventListener = originalAdd;
+      vv.removeEventListener = originalRemove;
+    }
+  });
+});


### PR DESCRIPTION

## Description
On iOS Safari and WKWebView hosts (such as the Adobe Express iOS app), `sp-popover` opened via `Overlay.open()` or the `trigger` Lit directive lands `visualViewport.offsetTop` pixels below its trigger — typically 30–40 px — whenever the layout viewport diverges from the visual viewport (URL bar showing, pinch-zoom, virtual keyboard open, host-app bottom sheet).
This PR fixes the offset and keeps the overlay anchored as the viewports realign.

### What changed
- **`PlacementController.computePlacement`** — on WebKit, subtract `visualViewport.offsetLeft / offsetTop` from the computed translate before applying it. Floating UI calculates `(x, y)` from `getBoundingClientRect()` (layout viewport) but the overlay paints in the top layer relative to the visual viewport; this closes the gap.
- **`PlacementController.placeOverlay`** — on WebKit, subscribe to `window.visualViewport` `resize` and `scroll`, and recompute placement on each event, so an open overlay re-anchors when the URL bar shows/hides, the keyboard opens, etc. Floating UI's `autoUpdate` does not observe `visualViewport`. Listeners are torn down on close.
- Both branches are gated on `isWebKit()` so Chromium and Firefox are unaffected.
- New regression Storybook story under **Overlay → Bug Repros → iOS Popover Positioning** that mirrors the bug-report screenshot and prints live `visualViewport` telemetry for on-device verification.
- New WebKit-only unit test that asserts the `visualViewport` `resize` and `scroll` listeners are attached on open and removed on close.
- Changeset added (`patch` to `@spectrum-web-components/overlay`).

## Motivation and context
Reported by Adobe Express iOS engineering: popovers anchored to toolbar buttons render below their triggers in the iOS app. The bug reproduces in plain iOS Safari any time the URL bar is visible and disappears when the page is scrolled enough that the URL bar collapses. Root cause is a coordinate-system mismatch between Floating UI's layout-viewport input and the top layer's visual-viewport rendering on iOS WebKit.
## Related issue(s)
- fixes SWC-2031 <SWC-2031> <!-- replace with the Jira ticket key, no link per repo policy -->

## Screenshots (if appropriate)
| Before (iOS, URL bar showing) | After |
| --- | --- |
| _attach the original screenshot from the Slack/GitHub report_ | _attach a screenshot from the new `iOS Popover Positioning` story after the fix_ |

## Author's checklist
- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist
- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases
- [ ] _iOS Safari — popover anchors to trigger with URL bar visible_
  1. Open this [story](https://swcpreviews.z13.web.core.windows.net/pr-6194/docs/first-gen-storybook/?path=/docs/overlay-bug-repros-ios-popover-positioning--docs)
  2. Go to iOS device mode and Tap the "..." button on any row while the URL bar is showing (`visualViewport.offsetTop > 0` in the telemetry panel).
  3. Expect the popover to anchor flush to the button (no vertical gap).


### Device review
- [x] Did it pass in Desktop?
- [x] Did it pass in (emulated) Mobile?
- [x] Did it pass in (emulated) iPad?

## Accessibility testing checklist
- [ ] **Keyboard** (required — document steps below)
  1. Open **Overlay → Bug Repros → iOS Popover Positioning** in desktop Safari.
  2. Tab to a row's "..." button and press <kbd>Enter</kbd> / <kbd>Space</kbd> to open the popover; press <kbd>Escape</kbd> to dismiss.
  3. Expect focus to move into the popover on open and return to the trigger on close — no change from current behavior; this fix is positional only.
- [ ] **Screen reader** (required — document steps below)
  1. With VoiceOver on, navigate to a row's "..." button on iOS Safari and activate it.
  2. Expect VoiceOver to announce the popover's role/name as it does on `main`; re-anchoring fires only `sp-update-overlays` and does not announce.
  3. Confirm there are no duplicate or unexpected announcements when the URL bar shows/hides while the popover is open.
