### PR TITLE
docs: MVP-α consumer landing page + quickstart

### DIFF
--- a/2nd-gen/README.md
+++ b/2nd-gen/README.md
@@ -1,25 +1,22 @@
-# Spectrum Web Components - Second Generation
+# Spectrum Web Components — Second Generation
 
-This workspace contains the second generation of Spectrum Web Components, built with modern tooling and architecture.
+This workspace contains the second generation of Spectrum Web Components (SWC), built on Spectrum 2 design tokens with modern tooling and architecture.
 
 ## Packages
 
-- **[@spectrum-web-components/core](./packages/core)** - Abstract base classes providing behavior and API for 2nd-gen components
-- **[@adobe/spectrum-wc](./packages/swc)** - Concrete component implementations with styling
-
-## About SWC
-
-```bash
-# Install dependencies from repository root
-yarn install
-
-# Build 2nd-gen packages
-yarn build
-
-# Start Storybook
-yarn storybook
-```
+- **[@spectrum-web-components/core](./packages/core)** — abstract base classes providing behavior and API for 2nd-gen components
+- **[@adobe/spectrum-wc](./packages/swc)** — concrete component implementations with styling
 
 ## Documentation
 
-For comprehensive documentation on architecture, development workflows, and migration guides, see the [CONTRIBUTOR-DOCS](../CONTRIBUTOR-DOCS) directory in the repository root.
+- **[Get started (for consumers)](../CONTRIBUTOR-DOCS/00_get-started/for-consumers.md)** — install and render your first component. The same content renders interactively under **Get started** in Storybook.
+- **[Contributor docs](../CONTRIBUTOR-DOCS/README.md)** — architecture, development workflows, migration guides, and project planning.
+
+## Local development
+
+```bash
+# From the repository root
+yarn install
+yarn build
+yarn storybook
+```

--- a/2nd-gen/packages/swc/.storybook/get-started/index.mdx
+++ b/2nd-gen/packages/swc/.storybook/get-started/index.mdx
@@ -44,7 +44,7 @@ React wrappers are planned. No plans for Vue or Svelte support at this time. For
 
 ## Where to go next
 
-- **Components** — browse the full catalog under [Components](/docs/components--docs)
+- **Components** — browse the component catalog in the **Components** section of the sidebar
 - **Customization** — override tokens, themes, and fonts in [Customization guides](/docs/guides-customization-getting-started--docs)
 - **Accessibility** — review [accessibility guidance](/docs/guides-accessibility-guides-overview--docs) for consumers
-- **Contributing** — see [Contributor docs](/docs/contributor-docs--docs) if you want to contribute upstream
+- **Contributing** — see [Getting involved](/docs/contributor-guides-getting-involved--docs) if you want to contribute upstream

--- a/2nd-gen/packages/swc/.storybook/get-started/index.mdx
+++ b/2nd-gen/packages/swc/.storybook/get-started/index.mdx
@@ -1,0 +1,50 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Get started" />
+
+{/* Document title (editable) */}
+
+# Get started
+
+{/* Document content (editable) */}
+
+Install 2nd-gen Spectrum Web Components and render your first component.
+
+## Install
+
+Add the package:
+
+```bash
+yarn add @adobe/spectrum-wc
+```
+
+Import the component you want. The import is side-effectful — it registers the custom element (`<swc-badge>` in this example):
+
+```ts
+import '@adobe/spectrum-wc/components/badge';
+```
+
+Include the SWC stylesheet once at the application root. It ships Spectrum 2 design tokens, typography defaults, and the default application background:
+
+```html
+<link rel="stylesheet" href="/node_modules/@adobe/spectrum-wc/swc.css" />
+```
+
+For deeper customization (theme and scale contexts, fonts, application background overrides), see [Customization](/docs/guides-customization-getting-started--docs).
+
+## Your first component
+
+```html
+<swc-badge variant="positive">Approved</swc-badge>
+```
+
+## Framework support
+
+React wrappers are planned. No plans for Vue or Svelte support at this time. For now, use the native custom-element tags directly in your framework of choice — the elements work anywhere the DOM works.
+
+## Where to go next
+
+- **Components** — browse the full catalog under [Components](/docs/components--docs)
+- **Customization** — override tokens, themes, and fonts in [Customization guides](/docs/guides-customization-getting-started--docs)
+- **Accessibility** — review [accessibility guidance](/docs/guides-accessibility-guides-overview--docs) for consumers
+- **Contributing** — see [Contributor docs](/docs/contributor-docs--docs) if you want to contribute upstream

--- a/2nd-gen/packages/swc/.storybook/main.ts
+++ b/2nd-gen/packages/swc/.storybook/main.ts
@@ -59,6 +59,11 @@ const stories: StorybookConfig['stories'] = [
 if (storybookMode !== 'ci-a11y') {
   stories.push(
     {
+      directory: 'get-started',
+      files: '*.mdx',
+      titlePrefix: 'Get started',
+    },
+    {
       directory: '../components',
       files: '**/*.mdx',
       titlePrefix: 'Components',

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -231,6 +231,7 @@ const preview = {
       storySort: {
         method: 'alphabetical-by-kind',
         order: [
+          'Get started',
           'Learn about SWC',
           ['Overview', 'When to use SWC', '1st-gen vs 2nd-gen'],
           'Core',

--- a/CONTRIBUTOR-DOCS/00_get-started/README.md
+++ b/CONTRIBUTOR-DOCS/00_get-started/README.md
@@ -1,0 +1,25 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../README.md) / Get started
+
+<!-- Document title (editable) -->
+
+# Get started
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>Beneath this doc</strong></summary>
+
+- [Get started (for consumers)](for-consumers.md)
+
+</details>
+
+<!-- Document content (editable) -->
+
+Quick-start guides for people new to Spectrum Web Components.
+
+Start here if you are:
+
+- **A consumer** building an application with SWC — see [Get started (for consumers)](./for-consumers.md).
+- **A contributor** working on the SWC codebase itself — see [Contributor guides](../01_contributor-guides/README.md).

--- a/CONTRIBUTOR-DOCS/00_get-started/for-consumers.md
+++ b/CONTRIBUTOR-DOCS/00_get-started/for-consumers.md
@@ -42,7 +42,7 @@ Include the SWC stylesheet once at the application root. It ships Spectrum 2 des
 <link rel="stylesheet" href="/node_modules/@adobe/spectrum-wc/swc.css" />
 ```
 
-For deeper customization (theme and scale contexts, fonts, application background overrides), see [Customization](/docs/guides-customization-getting-started--docs).
+For deeper customization (theme and scale contexts, fonts, application background overrides), see [Customization: Getting Started](../../2nd-gen/packages/swc/.storybook/guides/customization/getting-started.mdx).
 
 ## Your first component
 
@@ -56,7 +56,7 @@ React wrappers are planned. No plans for Vue or Svelte support at this time. For
 
 ## Where to go next
 
-- **Components** — browse the full catalog in [Storybook](/docs/components--docs)
-- **Customization** — override tokens, themes, and fonts in [Customization guides](/docs/guides-customization-getting-started--docs)
-- **Accessibility** — review [accessibility guidance](/docs/guides-accessibility-guides-overview--docs) for consumers
+- **Components** — browse the component catalog in Storybook (`yarn storybook` locally, or the deployed docs site)
+- **Customization** — override tokens, themes, and fonts. Start with [Customization: Getting Started](../../2nd-gen/packages/swc/.storybook/guides/customization/getting-started.mdx)
+- **Accessibility** — review [accessibility guides](../../2nd-gen/packages/swc/.storybook/guides/accessibility-guides/overview.mdx) for consumers
 - **Contributing** — see [Contributor guides](../01_contributor-guides/README.md) if you want to contribute upstream

--- a/CONTRIBUTOR-DOCS/00_get-started/for-consumers.md
+++ b/CONTRIBUTOR-DOCS/00_get-started/for-consumers.md
@@ -1,0 +1,62 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../README.md) / [Get started](README.md) / Get started (for consumers)
+
+<!-- Document title (editable) -->
+
+# Get started (for consumers)
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [Install](#install)
+- [Your first component](#your-first-component)
+- [Framework support](#framework-support)
+- [Where to go next](#where-to-go-next)
+
+</details>
+
+<!-- Document content (editable) -->
+
+Install 2nd-gen Spectrum Web Components and render your first component.
+
+## Install
+
+Add the package:
+
+```bash
+yarn add @adobe/spectrum-wc
+```
+
+Import the component you want. The import is side-effectful — it registers the custom element (`<swc-badge>` in this example):
+
+```ts
+import '@adobe/spectrum-wc/components/badge';
+```
+
+Include the SWC stylesheet once at the application root. It ships Spectrum 2 design tokens, typography defaults, and the default application background:
+
+```html
+<link rel="stylesheet" href="/node_modules/@adobe/spectrum-wc/swc.css" />
+```
+
+For deeper customization (theme and scale contexts, fonts, application background overrides), see [Customization](/docs/guides-customization-getting-started--docs).
+
+## Your first component
+
+```html
+<swc-badge variant="positive">Approved</swc-badge>
+```
+
+## Framework support
+
+React wrappers are planned. No plans for Vue or Svelte support at this time. For now, use the native custom-element tags directly in your framework of choice — the elements work anywhere the DOM works.
+
+## Where to go next
+
+- **Components** — browse the full catalog in [Storybook](/docs/components--docs)
+- **Customization** — override tokens, themes, and fonts in [Customization guides](/docs/guides-customization-getting-started--docs)
+- **Accessibility** — review [accessibility guidance](/docs/guides-accessibility-guides-overview--docs) for consumers
+- **Contributing** — see [Contributor guides](../01_contributor-guides/README.md) if you want to contribute upstream

--- a/CONTRIBUTOR-DOCS/01_contributor-guides/07_authoring-contributor-docs/README.md
+++ b/CONTRIBUTOR-DOCS/01_contributor-guides/07_authoring-contributor-docs/README.md
@@ -28,6 +28,14 @@
 
 </details>
 
+<details open>
+<summary><strong>Beneath this doc</strong></summary>
+
+- Templates
+    - [[Quickstart title]](templates/consumer-quickstart.md)
+
+</details>
+
 <!-- Document content (editable) -->
 
 ## Overview

--- a/CONTRIBUTOR-DOCS/01_contributor-guides/07_authoring-contributor-docs/templates/consumer-quickstart.md
+++ b/CONTRIBUTOR-DOCS/01_contributor-guides/07_authoring-contributor-docs/templates/consumer-quickstart.md
@@ -1,0 +1,81 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../../../README.md) / [Contributor guides](../../README.md) / [Authoring contributor docs](../README.md) / Templates / [Quickstart title]
+
+<!-- Document title (editable) -->
+
+# [Quickstart title]
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [Install](#install)
+- [Your first [thing]](#your-first-thing)
+- [Framework support](#framework-support)
+- [Where to go next](#where-to-go-next)
+- [Authoring notes (remove when copying)](#authoring-notes-remove-when-copying)
+
+</details>
+
+<!-- Document content (editable) -->
+
+[One-sentence hook: what a reader will be able to do after this page. Keep it consumer-focused, not maintainer-focused.]
+
+## Install
+
+[The absolute minimum install steps. Prefer one canonical path (Vanilla / npm). Alternatives go under a later section, not here.]
+
+```bash
+yarn add [package]
+```
+
+[Side-effectful import block, if applicable.]
+
+```ts
+import '[package]/[entry]';
+```
+
+[Stylesheet or bootstrap step, if applicable.]
+
+```html
+<link rel="stylesheet" href="[stylesheet path]" />
+```
+
+[One-line pointer out to customization / advanced setup. No deep overrides on this page.]
+
+## Your first [thing]
+
+[Minimal copy-paste example that works with only the Install steps above. No optional props, no advanced patterns.]
+
+```html
+[example]
+```
+
+## Framework support
+
+[One line per supported or planned framework. Do not expand into a multi-framework tab section — link out to per-framework guides if they exist.]
+
+## Where to go next
+
+[4–5 bullet links, each one line. Group by audience or by depth, not by alphabetical order.]
+
+- **[Reference]** — [one-line hook]
+- **[Customization]** — [one-line hook]
+- **[Accessibility]** — [one-line hook]
+- **[Contributing]** — [one-line hook]
+
+---
+
+## Authoring notes (remove when copying)
+
+**When to use this template.** Consumer-facing quickstart pages that answer "I just installed this — what now?" Not for deep feature guides, not for maintainer setup.
+
+**Keep it short.** A consumer should finish reading in under 5 minutes. If the page grows past that, split it.
+
+**Canonical path only.** Show the one recommended install flow. Alternatives (CDN, framework-specific, edge cases) live on dedicated pages and link in.
+
+**Heading discipline.** Sentence case. Keyword-first phrasing (`Install`, `Framework support` — not `Installing SWC` or `What about frameworks`).
+
+**No prose paragraphs over three sentences.** Prefer code blocks, bullets, and short transitions.

--- a/CONTRIBUTOR-DOCS/01_contributor-guides/README.md
+++ b/CONTRIBUTOR-DOCS/01_contributor-guides/README.md
@@ -18,6 +18,7 @@
 - [Participating in PR reviews](05_participating-in-pr-reviews.md)
 - [Releasing SWC](06_releasing-swc.md)
 - [Authoring contributor docs](07_authoring-contributor-docs/README.md)
+    - Templates
 - [Patching dependencies](08_patching-dependencies.md)
 - [Accessibility testing](09_accessibility-testing.md)
 - [Maintaining StackBlitz examples for Spectrum Web Components](10_using-stackblitz.md)

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
@@ -27,6 +27,8 @@
 - Asset
     - [Asset migration roadmap](asset/rendering-and-styling-migration-analysis.md)
 - Avatar
+    - [Avatar accessibility migration analysis](avatar/accessibility-migration-analysis.md)
+    - [Avatar — 2nd-Gen Migration Plan](avatar/migration-plan.md)
     - [Avatar accessibility migration analysis](avatar/rendering-and-styling-migration-analysis.md)
 - Badge
     - [Badge accessibility migration analysis](badge/accessibility-migration-analysis.md)

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/avatar/rendering-and-styling-migration-analysis.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/avatar/rendering-and-styling-migration-analysis.md
@@ -45,14 +45,14 @@ This doc defines how the **avatar image** should work for **accessibility**—th
 1. **SWC style** — Spectrum **CSS** / **design tokens** and **usage guidance** applied to a native **`<img>`** (or equivalent) in **light** DOM.
 2. **Component** — **`<swc-avatar>`** (no **`href`**) that **encapsulates** the same **visual** **language**, **`src`**, **`label`** → shadow **`<img alt>`**, **`isDecorative`**, and **dev** **warnings**, matching **1st-gen** **`<sp-avatar>`** without **`href`** in spirit.
 
-**Linked** avatars (hyperlink affordance) use a **separate** **component**: **`swc-avatar-link`** (see [Avatar link accessibility migration analysis](../avatar-link/accessibility-migration-analysis.md)).
+**Linked** avatars (hyperlink affordance) use a **separate** **component**: **`swc-avatar-link`** (see Avatar link accessibility migration analysis — forthcoming).
 
 **1st-gen** **`<sp-avatar>`** mixes **avatar image** and **`href`** on one tag; **2nd-gen** splits **`<swc-avatar>`** (static) **or** **styled** **`<img>`** from **`swc-avatar-link`**.
 
 ### Also read
 
 - [Avatar migration roadmap](./rendering-and-styling-migration-analysis.md) for layout, CSS, and DOM.
-- [Avatar link accessibility migration analysis](../avatar-link/accessibility-migration-analysis.md) for **`href`**, keyboard, and link naming.
+- Avatar link accessibility migration analysis (forthcoming) for **`href`**, keyboard, and link naming.
 
 ### Avatar image as an SWC style
 
@@ -172,7 +172,7 @@ This doc defines how the **avatar image** should work for **accessibility**—th
 - [ ] Guidance covers decorative vs informative **`alt`**, **`aria-hidden`**, and **`isDecorative`** / **`label`** on **`<swc-avatar>`**.
 - [ ] **`<swc-avatar>`** uses dev warnings like **1st-gen**; **SWC** **style** path documents optional lint or docs checks.
 - [ ] Avatar image is not keyboard-focusable on either path.
-- [ ] **`swc-avatar-link`** owns linked cases; cross-link [Avatar link accessibility migration analysis](../avatar-link/accessibility-migration-analysis.md) from Storybook.
+- [ ] **`swc-avatar-link`** owns linked cases; cross-link the Avatar link accessibility migration analysis (forthcoming) from Storybook.
 
 ---
 
@@ -182,5 +182,5 @@ This doc defines how the **avatar image** should work for **accessibility**—th
 - [Understanding 1.1.1 Non-text content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content)
 - [Using ARIA (read this first)](https://www.w3.org/WAI/ARIA/apg/practices/read-me-first/)
 - [Avatar migration roadmap](./rendering-and-styling-migration-analysis.md)
-- [Avatar link accessibility migration analysis](../avatar-link/accessibility-migration-analysis.md)
+- Avatar link accessibility migration analysis (forthcoming)
 - [SWC-915](https://jira.corp.adobe.com/browse/SWC-915) (resolved)—**avatar image** accessibility for **`<sp-avatar>`** without **`href`** (Adobe internal Jira)

--- a/CONTRIBUTOR-DOCS/README.md
+++ b/CONTRIBUTOR-DOCS/README.md
@@ -16,6 +16,8 @@
 <details open>
 <summary><strong>Beneath this doc</strong></summary>
 
+- [Get started](00_get-started/README.md)
+    - [Get started (for consumers)](00_get-started/for-consumers.md)
 - [Contributor guides](01_contributor-guides/README.md)
     - [Getting involved](01_contributor-guides/01_getting-involved.md)
     - [Using the issue tracker](01_contributor-guides/02_using-the-issue-tracker.md)
@@ -66,6 +68,8 @@ Spectrum Web Components is currently in transition from its first generation (1s
 These docs contain essential information about the SWC project for both maintainers (members of the core team) and contributors from outside the core team.
 
 The docs are organized into sections to help you find the information you need:
+
+**[Get started](./00_get-started/README.md)** - Quick-start guides for people new to SWC. Start here if you're a consumer installing SWC in your application; the same content renders interactively under **Get started** in Storybook.
 
 **[Contributor Guides](./01_contributor-guides/README.md)** - Topical guides for working on the project. This section includes guides for getting started, understanding processes, and accomplishing specific tasks like adding new components or editing these contributor docs themselves. When you change doc structure or headings, see [Authoring contributor docs](./01_contributor-guides/07_authoring-contributor-docs/README.md) to regenerate navigation and verify links.
 


### PR DESCRIPTION
## Summary

Adds the first consumer-facing docs path for 2nd-gen Spectrum Web Components. Lands a `Get started` landing page authored in Markdown under `CONTRIBUTOR-DOCS/for-consumers/get-started.md` and wires it into the Storybook sidebar as the first entry. This also seeds the `consumer-quickstart` template used by subsequent consumer guides.

**Stack position:** 1 of 7 — base for this PR is `main`.

Part of the docs-overhaul-v2 rollout. See RFC: [`CONTRIBUTOR-DOCS/rfcs/proposed/2026-04-22-docs-overhaul-v2.md`](../blob/caseyisonit/docs-mvp-alpha-consumer-landing/CONTRIBUTOR-DOCS/rfcs/proposed/2026-04-22-docs-overhaul-v2.md).

## Motivation

`/2nd-gen/README.md` was 25 lines and only pointed back to `CONTRIBUTOR-DOCS`. A consumer who wanted to use `<swc-badge>` in their app had nowhere to land. This PR closes the #1 consumer gap with a real "hello world" — install, first component, framework note, where to go next.

## Related

- Addresses MVP-α in the approved docs-overhaul-v2 plan
- Supersedes `2nd-gen/packages/swc/.storybook/guides/customization/getting-started.mdx` for the onboarding path (the stylesheet-setup content is folded into the new quickstart)

## Accessibility testing checklist

Docs-only change — no interactive component surface affected.

- [x] **Keyboard** — no new focusable components added; existing Storybook navigation unchanged.
- [x] **Screen reader** — headings, lists, and code blocks render as semantic markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)