### PR TITLE
docs: MVP-6c clarify 'when to use SWC' project-fit guide

### DIFF
--- a/2nd-gen/packages/swc/.storybook/learn-about-swc/when-to-use-swc.mdx
+++ b/2nd-gen/packages/swc/.storybook/learn-about-swc/when-to-use-swc.mdx
@@ -1,9 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import headerImage from '../assets/images/banner_principles_S2_desktop_2x_1689964204945.png';
-import '@spectrum-web-components/accordion/sp-accordion.js';
-import '@spectrum-web-components/accordion/sp-accordion-item.js';
-import '@spectrum-web-components/theme/sp-theme.js';
-import '@spectrum-web-components/theme/src/themes.js';
 
 <Meta title="When to use SWC" />
 
@@ -11,72 +7,38 @@ import '@spectrum-web-components/theme/src/themes.js';
 
 # When to use SWC
 
-Spectrum Web Components (SWC) is a good choice when you want to build interfaces that match the Spectrum design system and can run in many different environments. This page explains when SWC is the right tool and when you may need extra support or a different approach.
+Spectrum Web Components (SWC) is a component library for building Spectrum-aligned UIs that run in plain HTML, JavaScript, or inside a framework. This page is a quick project-fit check — not a tutorial.
 
-## SWC is a good choice when
+## SWC is a good fit when
 
-<sp-theme system="spectrum" scale="medium" color="light" >
-    <sp-accordion allow-multiple size="m" class="docs-accordion">
-        <sp-accordion-item label="You need Spectrum-aligned UI in a web environment">
-            SWC gives you ready-made components that follow Spectrum design and behavior. Use them when your project must look and feel like other Adobe experiences.
-        </sp-accordion-item>
-
-        <sp-accordion-item label="You want components that work without a specific framework">
-            SWC works in plain HTML, JavaScript, or TypeScript. It also works with
-            frameworks like React through wrapper packages. This makes it a good option
-            for teams using mixed technologies.
-        </sp-accordion-item>
-
-        <sp-accordion-item label="You want consistent behavior across products">
-            Because SWC components share a common architecture and API, they behave the
-            same across all projects. This reduces the amount of one-off code your team
-            needs to maintain.
-        </sp-accordion-item>
-
-        <sp-accordion-item label="You want built-in accessibility">
-            SWC includes accessibility features that follow Spectrum and web standards.
-            This helps teams meet accessibility requirements without writing them from
-            scratch.
-        </sp-accordion-item>
-
-        <sp-accordion-item label="You only need a few components">
-            Since SWC ships as individual packages, you can install only the components you need. This keeps your project lighter and easier to maintain.
-        </sp-accordion-item>
-
-    </sp-accordion>
-
-</sp-theme>
+| Situation                                    | Why SWC helps                                                           |
+| -------------------------------------------- | ----------------------------------------------------------------------- |
+| You need Spectrum 2 UI in a web environment  | Ready-made components match Spectrum design and behavior out of the box |
+| You work across frameworks or none at all    | Custom elements work in vanilla HTML/TS and inside React / Vue / Svelte |
+| You want consistent behavior across products | Shared architecture + API means components behave the same everywhere   |
+| You need accessibility built in              | Spectrum and web-standard a11y features ship with every component       |
+| You only need part of the library            | Per-component packages keep your bundle small                           |
 
 ## SWC may not be enough on its own
 
-<sp-theme system="spectrum" scale="medium" color="light" >
-    <sp-accordion allow-multiple size="m" class="docs-accordion">
-        <sp-accordion-item label="Your project depends on framework-specific features">
-            If your app uses advanced React, Vue, or Angular patterns, you might need extra setup or wrapper components. SWC can still work, but you may need additional engineering support.
-        </sp-accordion-item>
+| Situation                                       | What to plan for                                                    |
+| ----------------------------------------------- | ------------------------------------------------------------------- |
+| Deep framework-specific features                | You may need framework wrappers or extra engineering support        |
+| A fully custom (non-Spectrum) design system     | Expect to build custom components or heavy style overrides          |
+| Large 1st-gen SWC codebase migrating to 2nd-gen | APIs and patterns changed — budget time for refactoring and testing |
 
-        <sp-accordion-item label="You need a custom design system">
-            SWC is built to match Spectrum. If your product uses patterns that do not follow Spectrum, you may need custom components or additional styling.
-        </sp-accordion-item>
+## Quick decision checklist
 
-        <sp-accordion-item label="You are migrating large 1st-gen codebases">
-            SWC 2nd-gen changes some APIs and patterns. Large migrations may require planning, refactoring, or testing before you switch fully.
-        </sp-accordion-item>
+Answer these for your project:
 
-    </sp-accordion>
+- [ ] Does your product need to follow Spectrum 2 design?
+- [ ] Do you want framework-agnostic components?
+- [ ] Should SWC handle UI rather than custom components you maintain?
+- [ ] Does your project need built-in accessibility support?
+- [ ] Are you using a small set of components rather than the full library?
 
-</sp-theme>
+**Mostly yes → SWC is likely a good fit.** Mostly no → consider pairing SWC with a custom system, or evaluate another option.
 
-## Questions to help you decide
+## Still not sure?
 
-- Does your product need to follow Spectrum 2 design?
-- Do you want framework-agnostic components?
-- Will your team maintain custom UI, or should SWC handle that?
-- Does your project need built-in accessibility support?
-- Are you using only a small set of components or the full library?
-
-**If you answered “yes” to most of these, SWC is likely a good fit.**
-
-### Still not sure?
-
-Check the examples in the component documentation or explore how other Adobe teams use SWC. You can also reach out to the SWC team if you need help deciding whether SWC is the right fit for your project.
+Browse real examples in the **Components** section of the sidebar, or reach out to the SWC team if you need help deciding whether SWC is right for your project.


### PR DESCRIPTION
## Summary

Clarifies the `when-to-use-swc` page as a project-fit guide ("is SWC the right tool for my project?") rather than a component-picker. Removes the accordion-prose format in favor of a clearer scannable structure.

**Stack position:** 5 of 7 — base is [#6203](https://github.com/adobe/spectrum-web-components/pull/6203) (MVP-6a component matrix).

Part of the docs-overhaul-v2 rollout. See RFC: [`CONTRIBUTOR-DOCS/rfcs/proposed/2026-04-22-docs-overhaul-v2.md`](../blob/caseyisonit/docs-mvp-6c-when-to-use-cleanup/CONTRIBUTOR-DOCS/rfcs/proposed/2026-04-22-docs-overhaul-v2.md).

## Motivation

The original plan proposed a "which component do I need?" flowchart for this page, which was a category error — the page answers a different question (project fit) than a component-picker would. This PR commits to option A from the plan: restructure the existing project-fit content for scannability rather than silently retitle it.

## Related

- Addresses MVP-6c in the approved docs-overhaul-v2 plan

## Accessibility testing checklist

Docs-only change — static content only.

- [x] **Keyboard** — no interactive widgets; standard markdown heading/link flow.
- [x] **Screen reader** — headings restructured into a keyword-first hierarchy for easier scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)