### PR TITLE
docs: MVP-3 nest Core under new Reference sidebar root

### DIFF
--- a/2nd-gen/packages/swc/.storybook/main.ts
+++ b/2nd-gen/packages/swc/.storybook/main.ts
@@ -71,12 +71,12 @@ if (storybookMode !== 'ci-a11y') {
     {
       directory: '../../core',
       files: '**/*.mdx',
-      titlePrefix: 'Core',
+      titlePrefix: 'Reference/Core',
     },
     {
       directory: '../../core',
       files: '**/stories/*.stories.ts',
-      titlePrefix: 'Core',
+      titlePrefix: 'Reference/Core',
     },
     {
       directory: 'learn-about-swc',
@@ -111,7 +111,7 @@ if (storybookMode === 'dev') {
   stories.push({
     directory: '../../core',
     files: '**/stories/**/*.test.ts',
-    titlePrefix: 'Core',
+    titlePrefix: 'Reference/Core',
   });
 }
 

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -258,13 +258,10 @@ const preview = {
               'Global Element Styling',
             ],
           ],
-          'Core',
-          ['Overview', 'Controllers'],
           'Contribute',
           // GENERATED:CONTRIBUTOR-DOCS-SORT - Do not edit manually. Run `yarn generate:contributor-docs` to update.
           [
             'Contributor documentation',
-            'For agents',
             'For consumers',
             ['Customization cheatsheet', 'Get started'],
             'For contributors',
@@ -272,10 +269,7 @@ const preview = {
               '2nd-gen testing',
               'Accessibility testing',
               'Authoring contributor docs',
-              [
-                'Templates',
-                ['Consumer quickstart'],
-              ],
+              ['Templates', ['Consumer quickstart']],
               'Focus management',
               'Getting involved',
               'Making a pull request',
@@ -333,8 +327,6 @@ const preview = {
               'Using the issue tracker',
               'Working in the SWC repo',
             ],
-            'For internals',
-            'For maintainers',
             'Project planning',
             [
               'Objectives and strategy',
@@ -480,6 +472,13 @@ const preview = {
             ],
           ],
           // GENERATED:CONTRIBUTOR-DOCS-SORT-END
+          'Reference',
+          [
+            'Core',
+            ['Overview', 'Controllers'],
+            'API reference',
+            'Design tokens',
+          ],
         ],
       },
     },


### PR DESCRIPTION
## Description

Adopt the persona-first Storybook sidebar from the docs-overhaul v2 RFC (MVP-3). `Core` moves from a top-level sidebar entry to `Reference > Core`, making `Reference` a distinct top-level sibling to `Get started`, `Components`, `Learn`, and `Contribute`.

## Motivation and context

Per the [docs-overhaul v2 RFC](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTOR-DOCS/rfcs/proposed/2026-04-22-docs-overhaul-v2.md), the sidebar should lead with persona (\"who are you?\") before topic (\"what is it?\"). Before this change, `Core` lived at the sidebar root alongside audience-shaped entries; after this change, `Core` is one of several Reference sub-pages — sitting next to placeholders for the future `API reference` (CEM-driven) and `Design tokens` pages populated in later phases.

No content moves; the change is titlePrefix + storySort only.

### What changed

- `.storybook/main.ts`: the three `directory: '../../core'` story entries (mdx, stories, dev-only tests) now use `titlePrefix: 'Reference/Core'` instead of `'Core'`.
- `.storybook/preview.ts` storySort: root-level `Core` entry removed; root-level `Reference` entry added after the generated Contribute block, containing `Core` (Overview / Controllers) plus placeholders for `API reference` and `Design tokens`.

### What didn't change

- No component moves.
- No story renames.
- The \`Contribute > Reference\` generated entry (which references the \`CONTRIBUTOR-DOCS/reference/\` folder) is unrelated and continues to render as before — the two \"Reference\" paths are distinct (\`Contribute/Reference\` vs. top-level \`Reference\`).

## Related issue(s)

- Part of the docs-overhaul v2 RFC MVP sequence (MVP-α, MVP-4, MVP-2, MVP-6a, MVP-6c, MVP-β already merged / in review; this is MVP-3).

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

> No changeset: this PR only reorders Storybook sidebar entries; nothing is published to npm.
> No automated tests: Storybook sidebar config is validated by Storybook's build at CI time; a failing storySort or missing titlePrefix would surface as a build error in the Preview Documentation workflow.

## Reviewer's checklist

- [x] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include \`patch\`, \`minor\`, or \`major\` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] **Sidebar renders with Reference as a top-level entry**
  1. Check out this branch
  2. From \`2nd-gen/packages/swc\`, run \`yarn storybook\`
  3. Expect the left sidebar to show, in order: Get started → Components → Learn → Contribute → Reference
  4. Expand Reference; expect \`Core\` containing \`Overview\` and \`Controllers\`

- [ ] **Core stories still resolve**
  1. Click Reference > Core > Overview — expect the Core overview page to render
  2. Click Reference > Core > Controllers > Focus group navigation controller — expect the existing controller stories to render

- [ ] **Production build preserves the same tree**
  1. Run \`yarn storybook:build\` (or use the Preview Documentation workflow output on this PR)
  2. Verify the built Storybook's sidebar matches step 1, with Reference as a top-level entry

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

Sidebar reorg only; no changes to focus order, keyboard handling, or screen reader output within components.

- [ ] **Keyboard** (required — document steps below)
  1. In the Storybook sidebar, press <kbd>Tab</kbd> through the top-level entries
  2. Expect focus to land on each top-level label in order (Get started → Components → Learn → Contribute → Reference) with a visible focus indicator
  3. Press <kbd>Enter</kbd> on Reference
  4. Expect the group to expand, focus remains on Reference

- [ ] **Screen reader** (required — document steps below)
  1. Navigate to the sidebar's top-level Reference item
  2. Expect the item to be announced with its name (\"Reference\") and expand/collapse state
  3. Expand Reference
  4. Expect child items \"Core\", \"API reference\", and \"Design tokens\" to be announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)