### PR TITLE
docs: MVP-5 extend CEM + scaffold composable block library

### DIFF
--- a/2nd-gen/packages/swc/.storybook/DocumentTemplate.mdx
+++ b/2nd-gen/packages/swc/.storybook/DocumentTemplate.mdx
@@ -6,7 +6,6 @@ import {
   Stories,
   ArgTypes,
   Description,
-  Subtitle,
   useOf,
 } from '@storybook/addon-docs/blocks';
 import {
@@ -15,6 +14,7 @@ import {
   SpectrumStories,
   OverviewStory,
   StatusBadge,
+  Subtitle,
 } from './blocks';
 
 export const checkIsSingleStory = () => {

--- a/2nd-gen/packages/swc/.storybook/blocks/CssPartsTable.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/CssPartsTable.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+
+import { scrollStyle, tableStyle, useStoryComponent } from './cem-helpers';
+
+/**
+ * Standalone CSS Parts table for MDX composition. Reads the current
+ * story's `meta.component` tag, looks up its CEM declaration, and
+ * renders a row per `@csspart`. Renders nothing when there are no
+ * parts — safe to drop into any component's `README.mdx`.
+ */
+export function CssPartsTable() {
+  const component = useStoryComponent();
+  const cssParts = component?.cssParts ?? [];
+  if (cssParts.length === 0) return null;
+
+  return (
+    <>
+      <h3>CSS parts</h3>
+      <div style={scrollStyle}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cssParts.map((part) => (
+              <tr key={part.name}>
+                <td>
+                  <code>{part.name}</code>
+                </td>
+                <td>{part.description ?? ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/2nd-gen/packages/swc/.storybook/blocks/CssPropsTable.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/CssPropsTable.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+
+import { scrollStyle, tableStyle, useStoryComponent } from './cem-helpers';
+
+/**
+ * Standalone CSS custom properties table for MDX composition. Reads the
+ * current story's `meta.component` tag, looks up its CEM declaration,
+ * and renders a row per `@cssprop`. Renders nothing when there are no
+ * custom properties.
+ *
+ * Per the 2nd-gen styling contract, every exposed custom property name
+ * is expected to begin with `--swc-` — `--mod-*` and `--spectrum-*` are
+ * 1st-gen-only and should not be surfaced here.
+ */
+export function CssPropsTable() {
+  const component = useStoryComponent();
+  const cssProps = component?.cssProperties ?? [];
+  if (cssProps.length === 0) return null;
+
+  return (
+    <>
+      <h3>CSS custom properties</h3>
+      <div style={scrollStyle}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Default</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cssProps.map((prop) => (
+              <tr key={prop.name}>
+                <td>
+                  <code>{prop.name}</code>
+                </td>
+                <td>
+                  {prop.default != null ? <code>{prop.default}</code> : '-'}
+                </td>
+                <td>{prop.description ?? ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/2nd-gen/packages/swc/.storybook/blocks/EmbedStory.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/EmbedStory.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Canvas, Source } from '@storybook/addon-docs/blocks';
+import React from 'react';
+
+interface EmbedStoryProps {
+  /**
+   * A Storybook story reference — the same value accepted by
+   * `<Canvas of={...} />`. In MDX, this is typically an identifier
+   * imported from the component's `*.stories.ts` file.
+   */
+  of: unknown;
+  /**
+   * When `true`, hide the source panel under the canvas. Default: `false`.
+   */
+  hideSource?: boolean;
+}
+
+/**
+ * Embed a single story's canvas (and optional source) inside a
+ * narrative `README.mdx`, decoupling executable examples from the
+ * sidebar-browsable story set. The `of` prop accepts the same values as
+ * Storybook's built-in `<Canvas of={…} />`.
+ *
+ * Intended usage in a component README:
+ *
+ * ```mdx
+ * import * as Stories from './stories/badge.stories';
+ *
+ * ### Status display
+ * A short paragraph of per-example prose (≤ 3 sentences).
+ *
+ * <EmbedStory of={Stories.StatusDisplay} />
+ * ```
+ *
+ * Scaffolded in MVP-5; the styling contract (spacing, border, source
+ * panel defaults) is intentionally minimal here and will be hardened as
+ * more component `README.mdx` files adopt the composed template.
+ */
+export function EmbedStory({ of, hideSource = false }: EmbedStoryProps) {
+  return (
+    <>
+      {/* Cast preserves the flexible `of` contract from Storybook without
+          pulling its internal types into our public block surface. */}
+      <Canvas of={of as never} />
+      {!hideSource && <Source of={of as never} />}
+    </>
+  );
+}

--- a/2nd-gen/packages/swc/.storybook/blocks/EventsTable.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/EventsTable.tsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+
+import { scrollStyle, tableStyle, useStoryComponent } from './cem-helpers';
+
+/**
+ * Standalone Events table for MDX composition. Reads the current story's
+ * `meta.component` tag, looks up its CEM declaration, and renders a row
+ * per `@fires` event. Renders nothing when there are no events — safe to
+ * drop into any component's `README.mdx`.
+ *
+ * Mirrors the per-section tables inside `<ApiTable />` but can be
+ * imported and placed independently next to narrative prose.
+ */
+export function EventsTable() {
+  const component = useStoryComponent();
+  const events = component?.events ?? [];
+  if (events.length === 0) return null;
+
+  return (
+    <>
+      <h3>Events</h3>
+      <div style={scrollStyle}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((event) => (
+              <tr key={event.name}>
+                <td>
+                  <code>{event.name}</code>
+                </td>
+                <td>
+                  {event.type?.text ? <code>{event.type.text}</code> : '-'}
+                </td>
+                <td>{event.description ?? ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/2nd-gen/packages/swc/.storybook/blocks/RelatedEntities.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/RelatedEntities.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+
+import { useStoryComponent } from './cem-helpers';
+
+/**
+ * Render a list of sibling-entity cross-links, sourced from the current
+ * component's `@related` JSDoc tag (a comma-separated list of element
+ * tag names). Each entry links to the sibling's Storybook docs page.
+ *
+ * Example JSDoc:
+ *
+ * ```ts
+ * /**
+ *  * @element swc-badge
+ *  * @related status-light,tag
+ *  *\/
+ * ```
+ *
+ * Renders nothing when `@related` is absent.
+ */
+export function RelatedEntities() {
+  const component = useStoryComponent();
+  const related = component?.related ?? [];
+  if (related.length === 0) return null;
+
+  return (
+    <>
+      <h3>Related</h3>
+      <ul>
+        {related.map((name) => {
+          const slug = name.startsWith('swc-') ? name.slice(4) : name;
+          const label = slug
+            .split('-')
+            .map((p) => (p.length > 0 ? p[0].toUpperCase() + p.slice(1) : p))
+            .join(' ');
+          return (
+            <li key={name}>
+              <a href={`../?path=/docs/components-${slug}--readme`}>{label}</a>
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+}

--- a/2nd-gen/packages/swc/.storybook/blocks/Subtitle.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/Subtitle.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Subtitle as StorybookSubtitle } from '@storybook/addon-docs/blocks';
+import React from 'react';
+
+import { useStoryComponent } from './cem-helpers';
+
+/**
+ * One-sentence subtitle rendered below the component title on its
+ * Storybook docs page. Sourced from the class JSDoc `@summary` tag, parsed
+ * into CEM by `swcJsdocTagsPlugin` (see `cem.config.js`).
+ *
+ * Fallback: if `@summary` isn't set on the class, defer to Storybook's
+ * built-in `<Subtitle />` block, which reads `parameters.docs.subtitle`
+ * (legacy path kept for transitional compatibility — new components
+ * should use `@summary` and omit `parameters.docs.subtitle`).
+ */
+export function Subtitle() {
+  const component = useStoryComponent();
+  const summary = component?.summary?.trim();
+
+  if (summary) {
+    return <p className="sbdocs-subtitle">{summary}</p>;
+  }
+
+  return <StorybookSubtitle />;
+}

--- a/2nd-gen/packages/swc/.storybook/blocks/cem-helpers.ts
+++ b/2nd-gen/packages/swc/.storybook/blocks/cem-helpers.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { useOf } from '@storybook/addon-docs/blocks';
+import type {
+  CustomElement,
+  Declaration,
+  Package,
+} from 'custom-elements-manifest/schema';
+import type React from 'react';
+
+// ────────────────────────────
+//   CEM types + globals
+// ────────────────────────────
+
+declare global {
+  interface Window {
+    __STORYBOOK_CUSTOM_ELEMENTS_MANIFEST__?: Package;
+  }
+}
+
+/**
+ * Subset of the CEM declaration fields we add via `swcJsdocTagsPlugin`
+ * in `cem.config.js`. Narrowly typed so blocks get autocomplete without
+ * re-declaring the plugin's shape inline.
+ */
+export interface SwcExtendedDeclaration {
+  summary?: string;
+  genre?: string;
+  category?: string;
+  related?: string[];
+  RSPparity?: string;
+  a11yPattern?: string;
+  deprecated?: DeprecatedInfo | string | boolean;
+}
+
+export interface DeprecatedInfo {
+  reason: string;
+  since?: string;
+  replacedBy?: string;
+}
+
+export type SwcCustomElement = Declaration &
+  CustomElement &
+  SwcExtendedDeclaration;
+
+// ────────────────────────────
+//   CEM lookup
+// ────────────────────────────
+
+export function findComponent(
+  cem: Package,
+  tagName: string
+): SwcCustomElement | undefined {
+  for (const mod of cem.modules) {
+    for (const decl of mod.declarations ?? []) {
+      if ('tagName' in decl && decl.tagName === tagName) {
+        return decl as SwcCustomElement;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the CEM declaration that corresponds to the current story's
+ * `meta.component` tag name. Returns `undefined` if the CEM hasn't been
+ * set on `window` (dev-mode transient) or the tag name isn't in the
+ * manifest.
+ */
+export function useStoryComponent(): SwcCustomElement | undefined {
+  const resolvedOf = useOf('meta', ['meta']);
+  const meta = resolvedOf.csfFile?.meta as { component?: string } | undefined;
+  const tagName = meta?.component;
+
+  const cem = window.__STORYBOOK_CUSTOM_ELEMENTS_MANIFEST__;
+  if (!cem || !tagName) {
+    return undefined;
+  }
+
+  return findComponent(cem, tagName);
+}
+
+// ────────────────────────────
+//   Shared table styles
+// ────────────────────────────
+
+export const scrollStyle: React.CSSProperties = {
+  overflowX: 'auto',
+  width: '100%',
+};
+
+export const tableStyle: React.CSSProperties = {
+  width: '100%',
+};

--- a/2nd-gen/packages/swc/.storybook/blocks/index.ts
+++ b/2nd-gen/packages/swc/.storybook/blocks/index.ts
@@ -10,8 +10,14 @@
  * governing permissions and limitations under the License.
  */
 export * from './ApiTable';
+export * from './CssPartsTable';
+export * from './CssPropsTable';
+export * from './EmbedStory';
+export * from './EventsTable';
 export * from './GettingStarted';
 export * from './OverviewStory';
+export * from './RelatedEntities';
 export * from './SpectrumDocs';
 export * from './SpectrumStories';
 export * from './StatusBadge';
+export * from './Subtitle';

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -269,7 +269,10 @@ const preview = {
               '2nd-gen testing',
               'Accessibility testing',
               'Authoring contributor docs',
-              ['Templates', ['Consumer quickstart']],
+              [
+                'Templates',
+                ['Consumer quickstart'],
+              ],
               'Focus management',
               'Getting involved',
               'Making a pull request',

--- a/2nd-gen/packages/swc/cem.config.js
+++ b/2nd-gen/packages/swc/cem.config.js
@@ -11,24 +11,147 @@
  */
 
 /**
- * CEM plugin that extracts `@status` and `@since` JSDoc tags from class
- * declarations and attaches them to the corresponding CEM declaration.
+ * Extract the string value of a JSDoc tag's comment, handling both the
+ * plain-string and mixed-content (`JSDocText[]`) shapes the TS compiler emits.
+ */
+function readTagComment(tag) {
+  if (!tag) return '';
+  if (typeof tag.comment === 'string') {
+    return tag.comment.trim();
+  }
+  if (Array.isArray(tag.comment)) {
+    return tag.comment
+      .map((c) => c.text ?? '')
+      .join('')
+      .trim();
+  }
+  return '';
+}
+
+/**
+ * Try to coerce a `@deprecated` JSDoc tag body into a structured record.
+ * Accepts any of these shapes, in order of preference:
  *
- * Usage in component source:
+ *   @deprecated { "reason": "…", "since": "1.2.0", "replacedBy": "…" }
+ *   @deprecated reason: …; since: …; replacedBy: …
+ *   @deprecated free-form prose
+ *
+ * Returns either a `{ reason, since, replacedBy }` object (when any field
+ * was parseable) or the original string (so downstream callers can fall
+ * back to rendering it verbatim).
+ */
+function parseDeprecatedComment(raw) {
+  if (!raw) return { reason: '' };
+
+  // JSON form: `{ "reason": "…", "since": "…" }`
+  if (raw.startsWith('{') && raw.endsWith('}')) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object') {
+        return {
+          reason: typeof parsed.reason === 'string' ? parsed.reason : '',
+          since: typeof parsed.since === 'string' ? parsed.since : undefined,
+          replacedBy:
+            typeof parsed.replacedBy === 'string'
+              ? parsed.replacedBy
+              : undefined,
+        };
+      }
+    } catch {
+      // fall through to key-value parsing
+    }
+  }
+
+  // Key-value form: `reason: …; since: …; replacedBy: …`
+  if (raw.includes(':')) {
+    const parts = raw
+      .split(';')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const out = {};
+    let matched = 0;
+    for (const part of parts) {
+      const match = part.match(/^(reason|since|replacedBy)\s*:\s*(.+)$/i);
+      if (match) {
+        const key =
+          match[1].toLowerCase() === 'reason'
+            ? 'reason'
+            : match[1].toLowerCase() === 'since'
+              ? 'since'
+              : 'replacedBy';
+        out[key] = match[2].trim();
+        matched++;
+      }
+    }
+    if (matched > 0) {
+      return {
+        reason: out.reason ?? '',
+        since: out.since,
+        replacedBy: out.replacedBy,
+      };
+    }
+  }
+
+  // Fall through: treat as free-form prose attached to `reason`.
+  return { reason: raw };
+}
+
+/**
+ * CEM plugin that extracts SWC-authored JSDoc tags from class declarations
+ * and attaches them to the corresponding CEM declaration.
+ *
+ * Tags handled:
+ *
+ * - `@status preview|beta|stable|deprecated` — lifecycle
+ * - `@since 0.1.0` — first-released version
+ * - `@summary …` — one-sentence description surfaced as Storybook subtitle
+ *   (supersedes `parameters.docs.subtitle` in stories)
+ * - `@genre component|controller|pattern|token-family|…` — top-level
+ *   entity type; drives which blocks render in the composed README.mdx
+ * - `@category status-display|…` — taxonomy string used for sidebar
+ *   grouping and cross-references
+ * - `@related tag-name,other-tag-name` — sibling entity names (comma-
+ *   separated list) consumed by `<RelatedEntities>`
+ * - `@RSPparity full|partial|none|<note>` — React Spectrum 2 parity;
+ *   consumed by the component status matrix (MVP-6a)
+ * - `@a11yPattern …` — accessibility pattern label; consumed by
+ *   narrative + `<ApiTable>` extensions
+ * - `@deprecated …` — free-form OR structured `{ reason, since,
+ *   replacedBy }` (JSON or `key: value; …`), emitted as
+ *   `declaration.deprecated = { reason, since?, replacedBy? }`
+ *
+ * Example:
+ *
  * ```ts
  * /**
- *  * @element swc-my-component
+ *  * @element swc-badge
  *  * @status preview
- *  * @since 1.0.0
+ *  * @since 0.1.0
+ *  * @summary A non-interactive label that communicates status or category.
+ *  * @genre component
+ *  * @category status-display
+ *  * @related status-light,tag
+ *  * @RSPparity partial
+ *  * @a11yPattern aria-describedby-owner
  *  *\/
- * export class MyComponent extends … { … }
+ * export class Badge extends BadgeBase {}
  * ```
- *
- * Produces CEM entries with `"status": "preview"` and `"since": "1.0.0"`.
  */
-function statusPlugin() {
+function swcJsdocTagsPlugin() {
+  // Scalar tags whose value is stored verbatim on the declaration under the
+  // same key. Extend this set as new tags are introduced.
+  const SCALAR_TAGS = new Set([
+    'status',
+    'since',
+    'summary',
+    'genre',
+    'category',
+    'RSPparity',
+    'a11yPattern',
+  ]);
+
   return {
-    name: 'cem-plugin-component-status',
+    name: 'cem-plugin-swc-jsdoc-tags',
     analyzePhase({ ts, node, moduleDoc }) {
       if (!ts.isClassDeclaration(node)) return;
 
@@ -48,19 +171,25 @@ function statusPlugin() {
 
       for (const tag of jsDoc.tags) {
         const tagName = tag.tagName.getText();
+        const value = readTagComment(tag);
+        if (!value) continue;
 
-        if (tagName === 'status' || tagName === 'since') {
-          const value =
-            typeof tag.comment === 'string'
-              ? tag.comment.trim()
-              : tag.comment
-                  ?.map((c) => c.text)
-                  .join('')
-                  .trim();
+        if (SCALAR_TAGS.has(tagName)) {
+          declaration[tagName] = value;
+          continue;
+        }
 
-          if (value) {
-            declaration[tagName] = value;
-          }
+        if (tagName === 'related') {
+          declaration.related = value
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+          continue;
+        }
+
+        if (tagName === 'deprecated') {
+          declaration.deprecated = parseDeprecatedComment(value);
+          continue;
         }
       }
     },
@@ -88,5 +217,5 @@ export default {
   outdir: '.storybook',
   litelement: true,
   dev: false,
-  plugins: [statusPlugin()],
+  plugins: [swcJsdocTagsPlugin()],
 };


### PR DESCRIPTION
## Description

Extends the CEM pipeline with custom JSDoc tags and scaffolds a composable block library so component docs can render directly from CEM rather than per-component metadata files. This is the documentation-pipeline groundwork that MVP-7 (Badge pilot) and the broader entity-readme rollout (Phase 2) depend on.

Two changes, one PR:

1. **CEM extension** — `cem.config.js` swaps `statusPlugin` for `swcJsdocTagsPlugin`, which parses additional JSDoc tags into the manifest:
   - `@summary` — one-line subtitle (consumed by the new `<Subtitle />` block)
   - `@genre` / `@category` — taxonomy fields used by future doc routing
   - `@related` — comma-split list of sibling entity tag names
   - `@RSPparity` — React Spectrum 2 parity status (`full | partial | none | <note>`)
   - `@a11yPattern` — short pattern reference (e.g. `aria-describedby-owner`)
   - structured `@deprecated` — JSON `{ reason, since, replacedBy }`, key-value, or free-form prose; emitted as a structured object on the declaration
   
   Existing `@status` / `@since` behaviour is preserved (Badge still emits `status: "preview"`, `since: "0.0.1"`).

2. **Block library scaffold** — six new React blocks under `.storybook/blocks/`, each reading from CEM via a shared `cem-helpers.ts` module:
   - `EventsTable` — renders `events[]` (from `@fires`)
   - `CssPartsTable` — renders `cssParts[]` (from `@csspart`)
   - `CssPropsTable` — renders `cssProperties[]` (from `@cssprop`); the `--swc-*` contract is documented in the block's JSDoc
   - `EmbedStory` — thin wrapper around `<Canvas of={…} />` + optional `<Source of={…} />`, for embedding executable examples in narrative MDX
   - `RelatedEntities` — renders cross-links from `@related`
   - `Subtitle` — reads `@summary` from CEM, falls back to Storybook's built-in subtitle block for transitional compatibility
   
   `DocumentTemplate.mdx` is updated to import the new local `Subtitle` block; the existing scaffolding is otherwise unchanged.

## Motivation and context

Per the docs-overhaul v2 plan ([CONTRIBUTOR-DOCS RFC](https://github.com/adobe/spectrum-web-components/blob/caseyisonit/docs-mvp/CONTRIBUTOR-DOCS/project-planning/decisions-and-rfcs/docs-overhaul-v2.md)), the per-entity authoring shape is **class JSDoc + `README.mdx` + optional executable-only stories**. For the MDX layer to render API surface (events, parts, props) without hand-maintained tables, every block needs to read from CEM — and CEM needs to carry the full surface.

This PR builds the CEM-side parsing and the block-side rendering. It changes no public API surface and adds no new authoring requirements; existing components keep working unchanged.

## Related issue(s)

Stacks on #6205 (MVP-3 persona sidebar). Unblocks MVP-7 (Badge pilot), which exercises every new block end-to-end.

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have reviewed the Accessibility Practices for this feature.
- [x] I have added automated tests to cover my changes. *(N/A — pure tooling/scaffolding; first end-to-end exercise lands in MVP-7 Badge pilot)*
- [x] I have included a well-written changeset if my change needs to be published. *(N/A — no public package surface change)*
- [x] I have included updated documentation if my change required it.

### Manual review test cases

- [ ] *CEM regenerates with new tags.*
  1. Check out the branch
  2. From `2nd-gen/packages/swc`, run `yarn analyze`
  3. Open `2nd-gen/packages/swc/.storybook/custom-elements.json`
  4. Verify Badge's class entry still has `status: "preview"` and `since: "0.0.1"` (backward-compat preserved)
  5. Verify no new errors or warnings in the analyzer output

- [ ] *Storybook still renders.*
  1. From `2nd-gen/packages/swc`, run `yarn storybook`
  2. Verify the sidebar loads with all sections (Get started, Components, Reference, etc.)
  3. Open the Badge docs page
  4. Verify the subtitle area still renders (currently from `parameters.docs.subtitle` until MVP-7 sets `@summary`)
  5. Verify the API table, examples, and existing scaffolding all render unchanged

- [ ] *Type-check passes.*
  1. From repo root, run `npx tsc --noEmit -p 2nd-gen/packages/swc/tsconfig.json`
  2. Confirm no new type errors from the new block files (a pre-existing `@vitest/browser/providers/playwright` error is unrelated)

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

**Required:** Complete each applicable item and document your testing steps.

- [ ] **Keyboard** (required — document steps below)
  
  No new interactive surface — all six new blocks render static HTML (tables, links). The only links are in `<RelatedEntities />`, which uses native `<a href>` elements with no custom focus handling. Confirm no regressions in surrounding examples.
  
  1. Open the Badge docs page in Storybook
  2. <kbd>Tab</kbd> through the page
  3. Expect: focus order is unchanged from the pre-PR baseline; no new focus traps; native link focus indicators are visible

- [ ] **Screen reader** (required — document steps below)
  
  Tables and links use semantic HTML (`<table>`, `<thead>`, `<tbody>`, `<a>`); no custom ARIA. The `<Subtitle />` block emits a `<p class="sbdocs-subtitle">` matching Storybook's built-in subtitle markup.
  
  1. Open the Badge docs page in Storybook with VoiceOver active
  2. Navigate through the page
  3. Expect: subtitle is announced as a paragraph; tables (when populated by MVP-7) are announced with row/column structure; cross-links (when populated) are announced as links with their slug-derived label