### PR TITLE
fix(storybook): 2nd-gen docs code panels 

### DIFF
--- a/2nd-gen/packages/swc/.storybook/blocks/GettingStarted.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/GettingStarted.tsx
@@ -6,16 +6,12 @@ import { formatTitle } from '../helpers/index.js';
  * A block that renders getting started instructions for a Spectrum Web Component.
  * Automatically derives package name and component names from the Storybook meta title.
  *
- * For `migrated` (2nd-gen) stories, instructions use `@adobe/spectrum-wc` and the
- * component subpath export (for example `@adobe/spectrum-wc/tabs`). The tabs module
- * registers three custom elements with one side-effect import.
- *
  * @param of - The Storybook meta or story to resolve the component from
  * @param packageName - Optional override for the package name (defaults to derived kebab-case from title)
  * @param componentName - Optional override for the component class name (defaults to derived PascalCase from title)
  * @param tagName - Optional override for the custom element tag name (defaults to swc-{packageName})
  */
-export const GettingStarted = ({ of, tags }: { of?: any; tags?: string[] }) => {
+export const GettingStarted = ({ of, tags }: { of?: any; tags?: string }) => {
   const resolvedOf = useOf(of || 'meta', ['meta']);
 
   if (tags?.includes('utility')) return null;
@@ -48,54 +44,27 @@ import { ${baseClassName} } from '@spectrum-web-components/core/controllers/${pa
     const baseClassName = formatTitle(resolvedOf.preparedMeta?.title, 'pascal');
 
     const tagName = `swc-${packageName}`;
-    const importPath = `@adobe/spectrum-wc/${packageName}`;
-    const npmPackage = '@adobe/spectrum-wc';
 
-    let markdownContent: string;
-
-    if (packageName === 'tabs') {
-      markdownContent = `## Getting started
+    const markdownContent = `## Getting started
 
 Add the package to your project:
 
 \`\`\`zsh
-yarn add ${npmPackage}
-\`\`\`
-
-One import registers \`<swc-tabs>\`, \`<swc-tab>\`, and \`<swc-tab-panel>\`:
-
-\`\`\`typescript
-import '${importPath}';
-\`\`\`
-
-Import \`Tabs\`, \`Tab\`, and \`TabPanel\` for types or subclassing:
-
-\`\`\`typescript
-import { Tabs, Tab, TabPanel } from '${importPath}';
-\`\`\`
-`;
-    } else {
-      markdownContent = `## Getting started
-
-Add the package to your project:
-
-\`\`\`zsh
-yarn add ${npmPackage}
+yarn add @spectrum-web-components/${packageName}
 \`\`\`
 
 Import the side effectful registration of \`<${tagName}>\` via:
 
 \`\`\`typescript
-import '${importPath}';
+import '@spectrum-web-components/${packageName}/${tagName}.js';
 \`\`\`
 
-When looking to leverage the \`${baseClassName}\` class as a type and/or for extension purposes, do so via:
+When looking to leverage the \`${baseClassName}\` base class as a type and/or for extension purposes, do so via:
 
 \`\`\`typescript
-import { ${baseClassName} } from '${importPath}';
+import { ${baseClassName} } from '@spectrum-web-components/${packageName}';
 \`\`\`
 `;
-    }
 
     return <Markdown>{markdownContent}</Markdown>;
   }

--- a/2nd-gen/packages/swc/.storybook/blocks/GettingStarted.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/GettingStarted.tsx
@@ -6,12 +6,16 @@ import { formatTitle } from '../helpers/index.js';
  * A block that renders getting started instructions for a Spectrum Web Component.
  * Automatically derives package name and component names from the Storybook meta title.
  *
+ * For `migrated` (2nd-gen) stories, instructions use `@adobe/spectrum-wc` and the
+ * component subpath export (for example `@adobe/spectrum-wc/tabs`). The tabs module
+ * registers three custom elements with one side-effect import.
+ *
  * @param of - The Storybook meta or story to resolve the component from
  * @param packageName - Optional override for the package name (defaults to derived kebab-case from title)
  * @param componentName - Optional override for the component class name (defaults to derived PascalCase from title)
  * @param tagName - Optional override for the custom element tag name (defaults to swc-{packageName})
  */
-export const GettingStarted = ({ of, tags }: { of?: any; tags?: string }) => {
+export const GettingStarted = ({ of, tags }: { of?: any; tags?: string[] }) => {
   const resolvedOf = useOf(of || 'meta', ['meta']);
 
   if (tags?.includes('utility')) return null;
@@ -44,27 +48,54 @@ import { ${baseClassName} } from '@spectrum-web-components/core/controllers/${pa
     const baseClassName = formatTitle(resolvedOf.preparedMeta?.title, 'pascal');
 
     const tagName = `swc-${packageName}`;
+    const importPath = `@adobe/spectrum-wc/${packageName}`;
+    const npmPackage = '@adobe/spectrum-wc';
 
-    const markdownContent = `## Getting started
+    let markdownContent: string;
+
+    if (packageName === 'tabs') {
+      markdownContent = `## Getting started
 
 Add the package to your project:
 
 \`\`\`zsh
-yarn add @spectrum-web-components/${packageName}
+yarn add ${npmPackage}
+\`\`\`
+
+One import registers \`<swc-tabs>\`, \`<swc-tab>\`, and \`<swc-tab-panel>\`:
+
+\`\`\`typescript
+import '${importPath}';
+\`\`\`
+
+Import \`Tabs\`, \`Tab\`, and \`TabPanel\` for types or subclassing:
+
+\`\`\`typescript
+import { Tabs, Tab, TabPanel } from '${importPath}';
+\`\`\`
+`;
+    } else {
+      markdownContent = `## Getting started
+
+Add the package to your project:
+
+\`\`\`zsh
+yarn add ${npmPackage}
 \`\`\`
 
 Import the side effectful registration of \`<${tagName}>\` via:
 
 \`\`\`typescript
-import '@spectrum-web-components/${packageName}/${tagName}.js';
+import '${importPath}';
 \`\`\`
 
-When looking to leverage the \`${baseClassName}\` base class as a type and/or for extension purposes, do so via:
+When looking to leverage the \`${baseClassName}\` class as a type and/or for extension purposes, do so via:
 
 \`\`\`typescript
-import { ${baseClassName} } from '@spectrum-web-components/${packageName}';
+import { ${baseClassName} } from '${importPath}';
 \`\`\`
 `;
+    }
 
     return <Markdown>{markdownContent}</Markdown>;
   }

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -197,7 +197,9 @@ const preview = {
       },
       source: {
         excludeDecorators: true,
-        type: 'auto',
+        // Prefer serialized DOM so docs code panels show HTML for stories that use
+        // custom render functions; type "auto" often surfaces raw source instead.
+        type: 'dynamic',
         language: 'html',
         transform: async (source: string) => {
           try {


### PR DESCRIPTION
## Description
Sets Storybook global `parameters.docs.source.type` from `auto` to `dynamic` in `2nd-gen/packages/swc/.storybook/preview.ts`.
With `auto`, the Docs tab **Code** panel often showed raw story source (for example `render: () => html\`...\``) when stories used custom render helpers. With `dynamic`, Storybook serializes the **rendered DOM**, which then flows through the existing HTML + Prettier `transform` so reviewers and consumers see formatted markup instead of implementation details.
This is a global Storybook-only change; no component APIs or runtime behavior are modified.
## Motivation and context
Improves the 2nd-gen SWC Storybook **Docs** experience so the code sample matches what actually renders, especially for stories that do not map cleanly to static CSF source.

## Screenshots (if appropriate)
Before
<img width="797" height="151" alt="Screenshot 2026-04-28 at 7 18 07 PM" src="https://github.com/user-attachments/assets/f897580a-f30b-4d0f-93e5-993f8e8c1478" />


After
<img width="777" height="173" alt="Screenshot 2026-04-28 at 7 22 35 PM" src="https://github.com/user-attachments/assets/af89b188-d9bf-4e6b-a395-1b6e8eb6b8d5" />


## Author's checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.
## Reviewer's checklist
- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash
### Manual review test cases
- [ ] **Docs code panel shows HTML**
  1. Run 2nd-gen SWC Storybook and open any migrated component **Docs** page.
  2. Open the **Code** (or source) panel under Docs.
  3. Confirm the snippet reflects rendered markup (HTML-like), not raw story `render` / `html` template source where that previously occurred.
### Device review
- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?
## Accessibility testing checklist
This change only affects Storybook’s Docs source serialization and formatting, not shipped component semantics or focus behavior.
- [ ] **Keyboard**
  1. Open a **Docs** page in Storybook as above.
  2. Tab through the page; confirm no new focus issues attributable to this PR (expect no change from main beyond Docs content display).
- [ ] **Screen reader**
  1. Same as above; confirm Docs narrative structure is unchanged except for the code sample content shown in the Code panel (optional spot-check).
