### PR TITLE
feat(ai|docs): update styling skills, docs

### DIFF
--- a/.ai/skills/migration-documentation/SKILL.md
+++ b/.ai/skills/migration-documentation/SKILL.md
@@ -37,6 +37,14 @@ Read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[
 
 ## Workflow
 
+**Check for a Phase 4 stories scaffold first.** If Phase 4 (migration-styling) was completed, `2nd-gen/packages/swc/components/[component]/stories/[component].stories.ts` likely already exists with Playground, Overview, Anatomy, Options, States, and Behaviors stories — all structurally correct but without JSDoc prose. Phase 7's job is to:
+
+1. Add JSDoc comments to every story (except Playground and Overview, which have none by convention).
+2. Complete the Accessibility story body — it was left as a `// TODO` comment in Phase 4.
+3. Add any stories that were deferred or were not CSS-visible enough to include in Phase 4.
+
+If the stories document already exists, do **not** recreate the file from scratch. Augment what is already there.
+
 Follow **[Phase 7: Documentation](../../../CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#phase-7-documentation)** in the washing machine workflow doc — it covers what to do, what to check, common problems, and the quality gate for this phase.
 
 If the docs need to describe behavior or migration guidance that differs from the approved migration plan, follow [`migration-plan-contract`](../migration-prep/references/migration-plan-contract.md).

--- a/.ai/skills/migration-prep/assets/migration-prep-template.md
+++ b/.ai/skills/migration-prep/assets/migration-prep-template.md
@@ -269,6 +269,8 @@ Example content for this section
 
 No `--mod-*` properties will be exposed. New `--swc-*` component-level properties may be introduced where needed — these are additive and not breaking. See [Component Custom Property Exposure](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md#component-custom-property-exposure) for what to expose and how.
 
+Each exposed `--swc-*` property must be documented with a `@cssprop` JSDoc tag on the primary SWC component class. Storybook picks these up and surfaces them in the API docs panel automatically.
+
 Initial expectation for [Component] is a small reviewed set.
 
 ### Behavioral semantics
@@ -347,6 +349,7 @@ Planned rendering shape:
 <!-- Most components will need these items; add others as needed -->
 
 - [ ] Verify i18n size modifiers (`:lang(ja)`, `:lang(ko)`, `:lang(zh)`) if present in S2 source
+- [ ] Add `@cssprop` JSDoc tag to the primary SWC component class for every exposed `--swc-*` property (e.g. `@cssprop --swc-[component]-height - Block size of the [component].`)
 - [ ] Pass stylelint (property order, `no-descending-specificity`, token validation)
 
 ### Accessibility

--- a/.ai/skills/migration-styling/SKILL.md
+++ b/.ai/skills/migration-styling/SKILL.md
@@ -9,9 +9,20 @@ description: Phase 4 of 1st-gen to 2nd-gen component migration. Use to migrate C
 
 ## Mindset
 
-You are translating, not redesigning. Your job is not to invent new visual decisions. Use the `rendering-and-styling-migration-analysis.md` file that corresponds to the component you are migrating. When the token you need does not exist, use the `ask-questions` skill to flag it with the user. Refer to the CSS styling guides in `CONTRIBUTOR-DOCS/02_style-guide/` when refactoring the CSS (i.e. change `--spectrum` prefixes to `--swc`; `.spectrum*` classes to `.swc*`; `--mod` prefixes should not exist). The CSS style guides are the preferred way to write the CSS, as opposed to any recommendations you find in the rendering analysis doc.
+You are translating, not redesigning. Your job is not to invent new visual decisions.
 
-Also read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[component]/migration-plan.md` when available for approved visual scope, intentional divergences, custom-property decisions, and any planned reduction or split in the supported surface area. If it is missing, stale, or intentionally incomplete, derive the needed context from source material and call out the missing plan as a risk. See also [`migration-plan-contract`](../migration-prep/references/migration-plan-contract.md).
+**Before writing any CSS**, read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[component]/migration-plan.md`. It is the scope authority for this phase. For Phase 4, extract:
+
+- **Visual scope** — what visual changes are approved vs. out of scope
+- **Custom-property decisions** — which custom properties to keep, rename, or remove
+- **Intentional divergences** — places where 2nd-gen deliberately differs from 1st-gen
+- **Planned surface-area reductions or splits** — variants, sizes, or features that are being dropped or deferred
+
+If the plan is missing, stale, or intentionally incomplete, derive the needed context from source material, call out the missing plan as a risk, and proceed only for the fields you can resolve confidently. See [`migration-plan-contract`](../migration-prep/references/migration-plan-contract.md) for the full drift rule and when to pause.
+
+With that context established, read [`references/tldr-component-css-guidelines.md`](references/tldr-component-css-guidelines.md) — a TL;DR of the most critical rules from `CONTRIBUTOR-DOCS/02_style-guide/` with correct/incorrect code examples and links to the full docs for each rule. This is the CSS rules authority for this phase; follow it in preference to any conflicting guidance in the rendering analysis doc.
+
+Then use the `rendering-and-styling-migration-analysis.md` file for the component-specific technical detail of what to migrate. When a token you need does not exist, use the `ask-questions` skill to flag it with the user.
 
 ## When to use this skill
 
@@ -35,6 +46,24 @@ Also read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_compone
 
 ## Workflow
 
-Follow **[Phase 4: Styling](../../../CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#phase-4-styling)** in the washing machine workflow doc — it covers what to do, what to check, common problems, and the quality gate for this phase.
+**Step 0 — Read the migration plan first.** Before touching any CSS, open `CONTRIBUTOR-DOCS/03_project-planning/03_components/[component]/migration-plan.md` and extract the four Phase 4 fields listed in the Mindset section above. Note any open questions or intentional divergences so you can surface them proactively rather than discovering drift mid-work.
 
-If styling work would diverge from the migration plan's approved visual scope or custom-property decisions, follow [`migration-plan-contract`](../migration-prep/references/migration-plan-contract.md).
+**Step 1 — Check for drift before committing to an approach.** If your planned CSS changes would exceed the migration plan's approved visual scope or contradict its custom-property decisions, call out the drift explicitly and follow [`migration-plan-contract`](../migration-prep/references/migration-plan-contract.md) before writing any code. Do not silently resolve open questions in CSS.
+
+**Step 2 — Verify or create the stories file.** The Phase 4 quality gate requires visual verification in Storybook, which needs a stories file. Check whether `2nd-gen/packages/swc/components/[component]/stories/[component].stories.ts` exists.
+
+- **If it exists**, confirm it renders the component in Storybook with no console errors before touching CSS.
+- **If it does not exist**, create it now using [`assets/stories-template.md`](assets/stories-template.md) before starting CSS work. Follow the template's "Decisions to make" section and its checklist.
+
+**Phase 4 stories scope** — the stories file at this phase should contain: Playground, Overview, Anatomy, Options (one story per constant array in the types file), States, and any Behaviors that exercise CSS-visible properties. Do **not** add JSDoc prose to stories (deferred to Phase 7) and do **not** write the Accessibility story body (deferred to the accessibility phase) — leave it as a `// TODO` comment.
+
+**Step 3 — Align render template class names with CSS selectors.** Before writing CSS, read the component's `render()` method and note every class name emitted. The CSS you write must use those exact names. Mismatches cause styles to silently not apply — there is no error.
+
+Common case: migrating from 1st-gen CSS that used single-hyphen separators (e.g. `.swc-Button-label`) to 2nd-gen BEM double-underscore notation (e.g. `.swc-Button__label`). If the CSS target changes, update the class name in `render()` at the same time. Check both directions:
+
+- CSS selector → does `render()` emit this class?
+- `render()` class name → does the CSS have a matching selector?
+
+If a rename is needed, make the template change first, confirm the component still renders correctly in Storybook, then write the CSS.
+
+**Step 4 — Execute the phase.** Follow **[Phase 4: Styling](../../../CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#phase-4-styling)** in the washing machine workflow doc — it covers what to do, what to check, common problems, and the quality gate for this phase.

--- a/.ai/skills/migration-styling/SKILL.md
+++ b/.ai/skills/migration-styling/SKILL.md
@@ -55,7 +55,7 @@ Then use the `rendering-and-styling-migration-analysis.md` file for the componen
 - **If it exists**, confirm it renders the component in Storybook with no console errors before touching CSS.
 - **If it does not exist**, create it now using [`assets/stories-template.md`](assets/stories-template.md) before starting CSS work. Follow the template's "Decisions to make" section and its checklist.
 
-**Phase 4 stories scope** — the stories file at this phase should contain: Playground, Overview, Anatomy, Options (one story per constant array in the types file), States, and any Behaviors that exercise CSS-visible properties. Do **not** add JSDoc prose to stories (deferred to Phase 7) and do **not** write the Accessibility story body (deferred to the accessibility phase) — leave it as a `// TODO` comment.
+**Phase 4 stories scope** — the stories file at this phase should contain: Playground, Overview, Anatomy, Options (one story per constant array in the types file), States, and any Behaviors that exercise CSS-visible properties. Do **not** add JSDoc prose to stories (deferred to Phase 7) and do **not** write the Accessibility story body (deferred to the accessibility phase) — leave it as a `// TODO` comment referencing that phase.
 
 **Step 3 — Align render template class names with CSS selectors.** Before writing CSS, read the component's `render()` method and note every class name emitted. The CSS you write must use those exact names. Mismatches cause styles to silently not apply — there is no error.
 

--- a/.ai/skills/migration-styling/SKILL.md
+++ b/.ai/skills/migration-styling/SKILL.md
@@ -59,7 +59,7 @@ Then use the `rendering-and-styling-migration-analysis.md` file for the componen
 
 **Step 3 — Align render template class names with CSS selectors.** Before writing CSS, read the component's `render()` method and note every class name emitted. The CSS you write must use those exact names. Mismatches cause styles to silently not apply — there is no error.
 
-Common case: migrating from 1st-gen CSS that used single-hyphen separators (e.g. `.swc-Button-label`) to 2nd-gen BEM double-underscore notation (e.g. `.swc-Button__label`). If the CSS target changes, update the class name in `render()` at the same time. Check both directions:
+Common case: confirming that subcomponent class names follow the single-hyphen separator convention (e.g. `.swc-Button-label`, `.swc-Badge-label`) — not BEM double-underscore. If any class name in `render()` uses `__`, rename it to `-` in both the template and the CSS at the same time. Check both directions:
 
 - CSS selector → does `render()` emit this class?
 - `render()` class name → does the CSS have a matching selector?

--- a/.ai/skills/migration-styling/assets/stories-template.md
+++ b/.ai/skills/migration-styling/assets/stories-template.md
@@ -1,0 +1,241 @@
+# Phase 4 stories template
+
+A minimal `[component].stories.ts` file for visual verification of 2nd-gen CSS during Phase 4. Full JSDoc and the Accessibility story are deferred — JSDoc belongs to Phase 7 (Documentation); the Accessibility story belongs to the accessibility phase.
+
+## What to replace
+
+| Placeholder       | Meaning                              | Example      |
+| ----------------- | ------------------------------------ | ------------ |
+| `[Component]`     | PascalCase element name              | `Button`     |
+| `[component]`     | kebab-case element name              | `button`     |
+| `swc-[component]` | Custom element tag                   | `swc-button` |
+| `[COMPONENT]`     | SCREAMING_SNAKE_CASE constant prefix | `BUTTON`     |
+
+## Decisions to make before writing
+
+**From the component's types file** (`Button.types.ts`), identify which constant arrays exist:
+
+- `[COMPONENT]_VALID_SIZES` → add a `Sizes` story and a `sizeLabels` helper
+- `[COMPONENT]_VARIANTS` → add a `Variants` story and a `variantLabels` helper; if variants split into semantic/non-semantic, add two stories
+- `[COMPONENT]_FILL_STYLES` or similar → add a fill-style story (e.g. `Outline`) and a `fillStyleLabels` helper
+- `[COMPONENT]_STATIC_COLORS` → add a `StaticColors` story with `staticColorsDemo: true` and `'!test'` tag
+
+**Add a `storyName` assignment** for any export whose PascalCase would not render in sentence case (e.g. `StaticColors` → `'Static colors'`, `IconOnly` → `'Icon only'`).
+
+**Anatomy** should show every meaningful slot combination (e.g. label-only, icon + label). Icon-only buttons belong in Behaviors (they depend on a property, not just a slot).
+
+**Behaviors** covers properties that change rendering in a non-obvious way: `icon-only`, `truncate`, text-wrapping constraints, etc. Prefer `template({ ...args, propName: value })` over raw `html\`\``— raw html is acceptable only when slot content (e.g. inline SVG with`slot="icon"`) cannot cleanly flow through `template()`.
+
+**States** covers interactive states the CSS must style: default, disabled, pending (or selected, invalid, etc.) — whatever the component declares.
+
+---
+
+## Template
+
+```typescript
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+
+import '@adobe/spectrum-wc/[component]';
+
+import {
+  [COMPONENT]_VALID_SIZES,
+  [COMPONENT]_VARIANTS,
+  // …add other constant arrays that have corresponding stories
+  type [Component]Size,
+  type [Component]Variant,
+  // …add other types used in satisfies constraints below
+} from '../../../../core/components/[component]/[Component].types.js';
+
+// ────────────────
+//    METADATA
+// ────────────────
+
+const { args, argTypes, template } = getStorybookHelpers('swc-[component]');
+
+// Override argTypes for any attribute that needs explicit options or a control type.
+// Use the constant array from the types file — not a hand-written list.
+argTypes.variant = {
+  ...argTypes.variant,
+  control: { type: 'select' },
+  options: [COMPONENT]_VARIANTS,
+};
+
+argTypes.size = {
+  ...argTypes.size,
+  control: { type: 'select' },
+  options: [COMPONENT]_VALID_SIZES,
+};
+
+// Set defaults that match the most common real-world usage.
+args['default-slot'] = '[Component]';
+args.variant = '[first-variant]';
+args.size = 'm';
+
+/**
+ * [One or two sentences describing what the component does and when to use it.
+ * Keep this brief — detailed usage guidance belongs in Phase 7 docs.]
+ */
+export const meta: Meta = {
+  title: '[Component]',
+  component: 'swc-[component]',
+  parameters: {
+    docs: {
+      subtitle: `[Plain-text one-liner displayed as the subtitle — no links, no markdown.]`,
+    },
+  },
+  args,
+  argTypes,
+  render: (args) => template(args),
+  tags: ['migrated'],
+};
+
+export default {
+  ...meta,
+  title: '[Component]',
+  excludeStories: ['meta'],
+} as Meta;
+
+// ────────────────────
+//    HELPERS
+// ────────────────────
+
+// Add one label map per constant array that has a corresponding story.
+// Use `as const satisfies Record<Type, string>` for type safety.
+const sizeLabels = {
+  s: 'Small',
+  m: 'Medium',
+  l: 'Large',
+  xl: 'Extra-large',
+} as const satisfies Record<[Component]Size, string>;
+
+const variantLabels = {
+  // [first-variant]: '[Label]',
+  // …one entry per variant
+} as const satisfies Record<[Component]Variant, string>;
+
+// ────────────────────
+//    AUTODOCS STORY
+// ────────────────────
+
+export const Playground: Story = {
+  tags: ['autodocs', 'dev'],
+  args: {
+    // Most common real-world configuration
+    variant: '[first-variant]',
+    size: 'm',
+    'default-slot': '[Component]',
+  },
+};
+
+// ──────────────────────────────
+//    OVERVIEW STORIES
+// ──────────────────────────────
+
+export const Overview: Story = {
+  tags: ['overview'],
+  args: {
+    variant: '[first-variant]',
+    size: 'm',
+    'default-slot': '[Realistic label]', // Use a real word, not the component name
+  },
+};
+
+// ──────────────────────────
+//    ANATOMY STORIES
+// ──────────────────────────
+
+export const Anatomy: Story = {
+  render: (args) => html`
+    ${template({ ...args, 'default-slot': 'Label only' })}
+    ${template({ ...args, 'default-slot': 'Icon and label', 'icon-slot': '…' })}
+    ${/* Add or remove combinations to match this component's actual slots */}
+  `,
+  tags: ['anatomy'],
+  parameters: { flexLayout: true },
+  args: {
+    variant: '[first-variant]',
+    size: 'm',
+  },
+};
+
+// ──────────────────────────
+//    OPTIONS STORIES
+// ──────────────────────────
+
+// One story per distinct constant array in the types file (sizes, variants,
+// fill styles, static colors, etc.). Add section-order to control display order.
+
+export const Sizes: Story = {
+  render: (args) => html`
+    ${[COMPONENT]_VALID_SIZES.map((size) =>
+      template({ ...args, size, 'default-slot': sizeLabels[size] })
+    )}
+  `,
+  parameters: { flexLayout: true, 'section-order': 1 },
+  tags: ['options'],
+};
+
+export const Variants: Story = {
+  render: (args) => html`
+    ${[COMPONENT]_VARIANTS.map((variant) =>
+      template({ ...args, variant, 'default-slot': variantLabels[variant] })
+    )}
+  `,
+  parameters: { flexLayout: true, 'section-order': 2 },
+  tags: ['options'],
+};
+
+// Add additional Options stories here (Outline, StaticColors, etc.)
+// For StaticColors, use: tags: ['options', '!test'] and parameters: { staticColorsDemo: true }
+
+// ──────────────────────────
+//    STATES STORIES
+// ──────────────────────────
+
+export const States: Story = {
+  render: (args) => html`
+    ${template({ ...args, 'default-slot': 'Default' })}
+    ${template({ ...args, disabled: true, 'default-slot': 'Disabled' })}
+    ${/* Add pending, selected, invalid, or other states as applicable */}
+  `,
+  parameters: { flexLayout: true },
+  tags: ['states'],
+};
+
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+// Add stories for properties that change rendering in non-obvious ways
+// (icon-only, truncate, text-wrapping, etc.). Prefer template() over raw html``.
+
+// ────────────────────────────────
+//    ACCESSIBILITY STORIES
+// ────────────────────────────────
+
+// TODO: will complete in separate accessibility phase
+```
+
+## Checklist before moving to CSS work
+
+- [ ] File exists at `2nd-gen/packages/swc/components/[component]/stories/[component].stories.ts`
+- [ ] `Playground` renders with correct defaults
+- [ ] `Anatomy` shows all meaningful slot combinations
+- [ ] Every constant array in the types file has a corresponding Options story
+- [ ] `StaticColors` story (if applicable) has `staticColorsDemo: true` and `'!test'` tag
+- [ ] `storyName` added for any PascalCase export that doesn't read as sentence case
+- [ ] Component renders in Storybook with no console errors before touching CSS

--- a/.ai/skills/migration-styling/assets/stories-template.md
+++ b/.ai/skills/migration-styling/assets/stories-template.md
@@ -252,7 +252,7 @@ export const States: Story = {
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────
 
-// TODO: will complete in separate accessibility phase
+// TODO: will complete in separate accessibility pass of phase 5
 ```
 
 ## Checklist before moving to CSS work

--- a/.ai/skills/migration-styling/assets/stories-template.md
+++ b/.ai/skills/migration-styling/assets/stories-template.md
@@ -13,7 +13,7 @@ A minimal `[component].stories.ts` file for visual verification of 2nd-gen CSS d
 
 ## Decisions to make before writing
 
-**From the component's types file** (`Button.types.ts`), identify which constant arrays exist:
+**From the component's types file** (`[Component].types.ts`), identify which constant arrays exist:
 
 - `[COMPONENT]_VALID_SIZES` → add a `Sizes` story and a `sizeLabels` helper
 - `[COMPONENT]_VARIANTS` → add a `Variants` story and a `variantLabels` helper; if variants split into semantic/non-semantic, add two stories
@@ -96,6 +96,9 @@ export const meta: Meta = {
     docs: {
       subtitle: `[Plain-text one-liner displayed as the subtitle — no links, no markdown.]`,
     },
+    // design: { type: 'figma', url: 'https://www.figma.com/...' },
+    // stackblitz: { url: 'https://stackblitz.com/...' },
+    // flexLayout: true, // set here to apply to all stories; use 'row-wrap' if items should wrap
   },
   args,
   argTypes,
@@ -122,10 +125,23 @@ const sizeLabels = {
   xl: 'Extra-large',
 } as const satisfies Record<[Component]Size, string>;
 
+// If variants split into semantic and non-semantic groups, use two maps and combine:
 const variantLabels = {
   // [first-variant]: '[Label]',
   // …one entry per variant
 } as const satisfies Record<[Component]Variant, string>;
+
+// Example split pattern (delete if not applicable):
+// const semanticLabels = {
+//   positive: 'Approved', informative: 'Active', neutral: 'Archived',
+//   notice: 'Pending', negative: 'Rejected',
+// } as const satisfies Record<[Component]SemanticVariant, string>;
+//
+// const nonSemanticLabels = {
+//   indigo: 'Engineering', magenta: 'Design', // …
+// } as const satisfies Record<[Component]ColorVariant, string>;
+//
+// const allVariantLabels = { ...semanticLabels, ...nonSemanticLabels };
 
 // ────────────────────
 //    AUTODOCS STORY
@@ -165,7 +181,6 @@ export const Anatomy: Story = {
     ${/* Add or remove combinations to match this component's actual slots */}
   `,
   tags: ['anatomy'],
-  parameters: { flexLayout: true },
   args: {
     variant: '[first-variant]',
     size: 'm',
@@ -185,7 +200,7 @@ export const Sizes: Story = {
       template({ ...args, size, 'default-slot': sizeLabels[size] })
     )}
   `,
-  parameters: { flexLayout: true, 'section-order': 1 },
+  parameters: { 'section-order': 1 },
   tags: ['options'],
 };
 
@@ -195,9 +210,10 @@ export const Variants: Story = {
       template({ ...args, variant, 'default-slot': variantLabels[variant] })
     )}
   `,
-  parameters: { flexLayout: true, 'section-order': 2 },
+  parameters: { 'section-order': 2 },
   tags: ['options'],
 };
+Variants.storyName = 'Variants'; // rename if PascalCase doesn't read as sentence case (e.g. 'Semantic variants', 'Non-semantic variants')
 
 // Add additional Options stories here (Outline, StaticColors, etc.)
 // For StaticColors, use: tags: ['options', '!test'] and parameters: { staticColorsDemo: true }
@@ -212,7 +228,6 @@ export const States: Story = {
     ${template({ ...args, disabled: true, 'default-slot': 'Disabled' })}
     ${/* Add pending, selected, invalid, or other states as applicable */}
   `,
-  parameters: { flexLayout: true },
   tags: ['states'],
 };
 
@@ -220,8 +235,18 @@ export const States: Story = {
 //    BEHAVIORS STORIES
 // ──────────────────────────────
 
-// Add stories for properties that change rendering in non-obvious ways
-// (icon-only, truncate, text-wrapping, etc.). Prefer template() over raw html``.
+// Add one story per behavior that changes rendering in a non-obvious way
+// (text wrapping, truncation, icon-only layout, etc.).
+// Prefer template({ ...args, prop: value }) over raw html`` where possible.
+
+// Example — text wrapping (common for text-bearing components):
+// export const TextWrapping: Story = {
+//   render: (args) => html`
+//     ${template({ ...args, 'default-slot': 'A label long enough to demonstrate wrapping behavior', style: 'max-inline-size: 120px' })}
+//   `,
+//   tags: ['behaviors'],
+// };
+// TextWrapping.storyName = 'Text wrapping';
 
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES

--- a/.ai/skills/migration-styling/assets/stories-template.md
+++ b/.ai/skills/migration-styling/assets/stories-template.md
@@ -80,11 +80,6 @@ argTypes.size = {
   options: [COMPONENT]_VALID_SIZES,
 };
 
-// Set defaults that match the most common real-world usage.
-args['default-slot'] = '[Component]';
-args.variant = '[first-variant]';
-args.size = 'm';
-
 /**
  * [One or two sentences describing what the component does and when to use it.
  * Keep this brief — detailed usage guidance belongs in Phase 7 docs.]

--- a/.ai/skills/migration-styling/references/tldr-component-css-guidelines.md
+++ b/.ai/skills/migration-styling/references/tldr-component-css-guidelines.md
@@ -83,6 +83,17 @@ Follow the prescribed stylesheet order to manage specificity and reduce selector
 ### 3. Custom Properties
 
 Use `token()` for design token values. Use `--swc-*` only for intentionally exposed override points, and `--_swc-*` for internal/private properties. Do not keep old `--mod-*` chains.
+
+Every exposed `--swc-*` property must be documented with a `@cssprop` JSDoc tag on the primary component class export (the SWC layer class, not the core base). Storybook picks these up automatically and surfaces them in the API docs panel.
+
+```ts
+/**
+ * @cssprop --swc-button-height - Block size of the button. Defaults to the medium component height token.
+ * @cssprop --swc-button-border-radius - Corner radius. Defaults to half the component height (pill shape).
+ */
+export class Button extends ButtonBase { … }
+```
+
 → See [02_custom-properties](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md)
 
 ### 4. Attribute Selectors vs Modifier Classes

--- a/.ai/skills/migration-styling/references/tldr-component-css-guidelines.md
+++ b/.ai/skills/migration-styling/references/tldr-component-css-guidelines.md
@@ -1,0 +1,116 @@
+# TL;DR of Component CSS Guidelines
+
+## Reference Documents
+
+- **Working examples:** [badge.css](../../../../2nd-gen/packages/swc/components/badge/badge.css), [status-light.css](../../../../2nd-gen/packages/swc/components/status-light)
+- **Main rules:** [01_component-css](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md)
+- **Custom property decisions:** [02_custom-properties](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md)
+- **PR self-check:** [03_component-css-pr-checklist](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/03_component-css-pr-checklist.md)
+
+---
+
+## ✅ Correct Pattern
+
+```css
+:host {
+  display: inline-block;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.swc-Badge {
+  --_swc-badge-border-width: token('border-width-200');
+
+  min-block-size: var(--swc-badge-height, token('component-height-100'));
+  background: var(
+    --swc-badge-background-color,
+    token('accent-background-color-default')
+  );
+}
+
+:host([size='s']) {
+  --swc-badge-height: token('component-height-75');
+}
+
+:host([variant='positive']) {
+  --swc-badge-background-color: token('positive-background-color-default');
+}
+
+.swc-Badge--magenta:where(.swc-Badge--subtle) {
+  --swc-badge-background-color: token('magenta-background-color-default');
+}
+```
+
+---
+
+## ❌ Anti-Patterns
+
+```css
+/*
+- visual styles are incorrectly on :host
+- legacy --mod-* indirection is preserved
+- hardcoded values instead of token()
+- selector specificity is too high
+*/
+:host {
+  padding: 8px;
+  background: var(--mod-badge-background, var(--swc-badge-background-color));
+}
+
+.swc-Badge.swc-Badge--large.swc-Badge--primary {
+  padding: 16px;
+}
+```
+
+> **[Review all Anti-Patterns](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/05_anti-patterns.md)**
+
+---
+
+## Rules Summary
+
+### 1. `:host` vs Component Class
+
+Put only layout-participation styles on `:host`. Put actual visuals on `.swcComponentName` or internal parts.
+→ See [01_component-css](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md)
+
+### 2. Stylesheet Order
+
+Follow the prescribed stylesheet order to manage specificity and reduce selector conflicts.
+→ See [01_component-css#rule-order](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md#rule-order)
+
+### 3. Custom Properties
+
+Use `token()` for design token values. Use `--swc-*` only for intentionally exposed override points, and `--_swc-*` for internal/private properties. Do not keep old `--mod-*` chains.
+→ See [02_custom-properties](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md)
+
+### 4. Attribute Selectors vs Modifier Classes
+
+Use `:host([size="..."])` and `:host([variant="..."])` for consumer-settable attributes that should expose a customization surface. Use `.swc-ComponentName--modifier` for:
+
+- Implementation details that should not expose overrides (non-semantic color variants, static color, geometric modifiers)
+- **Derived states** — visual modes computed from slot content or internal logic, not set by consumers (e.g. icon-only layout derived from `hasIcon && !hasLabel`). These must never appear as a host attribute; apply them via `classMap` in the template.
+
+```typescript
+// ✅ Derived state as a class modifier — not a consumer attribute
+class=${classMap({ 'swc-Button': true, 'swc-Button--iconOnly': this.hasIcon && !this.hasLabel })}
+```
+
+→ See [01_component-css#when-to-use-classes-vs-attributes](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md#when-to-use-classes-vs-attributes)
+
+### 5. Vertical spacing tokens
+
+When migrating block padding, use `component-padding-vertical-{scale}` (S2). **Do not carry forward** `component-top-to-text-{scale}` or `component-bottom-to-text-{scale}` from S1/Spectrum CSS — those were offset hacks to compensate for glyph positioning in the old typeface. Adobe Clean VF corrected the glyph position, so the offsets no longer produce visually centered text in S2 components.
+
+→ See [01_component-css#vertical-spacing-tokens](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md#vertical-spacing-tokens-component-padding-vertical--vs-component-top-to-text-)
+
+### 6. Selector specificity
+
+Keep selector specificity at or below `(0,1,0)`. If you need a compounded selector, use `:where()` on the extra class instead of stacking specificity. Don't use higher-specificity selectors to "win."
+→ See [01_component-css#managing-specificity](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md#managing-specificity) and [05_anti-patterns](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/05_anti-patterns.md)
+
+### 7. Forced colors
+
+Only add `@media (forced-colors: active)` if browser defaults are not conveying correct semantic intent, and always put it at the end of the component stylesheet.
+→ See [01_component-css#forced-colors-requirements](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css#forced-colors-requirements.md)

--- a/.ai/skills/migration-styling/references/tldr-component-css-guidelines.md
+++ b/.ai/skills/migration-styling/references/tldr-component-css-guidelines.md
@@ -124,4 +124,4 @@ Keep selector specificity at or below `(0,1,0)`. If you need a compounded select
 ### 7. Forced colors
 
 Only add `@media (forced-colors: active)` if browser defaults are not conveying correct semantic intent, and always put it at the end of the component stylesheet.
-→ See [01_component-css#forced-colors-requirements](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css#forced-colors-requirements.md)
+→ See [01_component-css#forced-colors-requirements](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md#forced-colors-requirements)

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md
@@ -24,12 +24,14 @@
 - [Variant implementation patterns](#variant-implementation-patterns)
 - [State implementation patterns](#state-implementation-patterns)
 - [Size variant patterns](#size-variant-patterns)
+- [Modifier overrides on inner elements](#modifier-overrides-on-inner-elements)
 - [Animation and transition patterns](#animation-and-transition-patterns)
 - [Forced colors requirements](#forced-colors-requirements)
 - [Managing Specificity](#managing-specificity)
     - [Shadow DOM Specificity and Custom Property Inheritance](#shadow-dom-specificity-and-custom-property-inheritance)
     - [Using Cascade Layers (`@layer`)](#using-cascade-layers-layer)
 - [Component Specs vs. Component Styles](#component-specs-vs-component-styles)
+    - [Vertical spacing tokens: `component-padding-vertical-*` vs `component-top-to-text-*`](#vertical-spacing-tokens-component-padding-vertical--vs-component-top-to-text-)
 - [Color Themes](#color-themes)
     - [Modifying Non-Color Properties](#modifying-non-color-properties)
 - [Closing Note for Contributors](#closing-note-for-contributors)
@@ -216,7 +218,20 @@ Use `:host([attribute])` when the variant or state should expose custom properti
 
 ### When to use classes vs attributes
 
-See [variant implementation patterns](#variant-implementation-patterns) for the full decision table. In short: `:host([attribute])` for exposed customization, `.swc-ComponentName--variant` for implementation details.
+See [variant implementation patterns](#variant-implementation-patterns) for the full decision table. In short:
+
+- `:host([attribute])` — consumer-settable attributes that should expose a customization surface (size, variant, disabled, pending)
+- `.swc-ComponentName--modifier` — implementation details not meant for consumer override, and any state *derived* from slot content or internal logic rather than set by the consumer
+
+Derived states are a key case to get right. If a visual mode is fully determinable from slot composition (e.g. icon present + no label text → icon-only layout), do not create a consumer-settable attribute for it. Compute it in the component class and apply it as a class modifier via `classMap`. This keeps the attribute API honest: every attribute on the host element is something a consumer intentionally set.
+
+```typescript
+// ✅ Derived state applied via classMap — not a consumer attribute
+class=${classMap({
+  'swc-Button': true,
+  'swc-Button--iconOnly': this.hasIcon && !this.hasLabel,
+})}
+```
 
 ### Managing specificity with `:where()`
 
@@ -226,13 +241,14 @@ See [Managing Specificity](#managing-specificity) for full guidance. In short: w
 
 Variants change how the component looks. Use the right selector based on customization intent of [custom property exposure](02_custom-properties.md#component-custom-property-exposure).
 
-| Variant type       | Selector                                 | Example                                |
-| ------------------ | ---------------------------------------- | -------------------------------------- |
-| Size               | `:host([size="s"])`                      | Exposes `--swc-badge-height`, etc.     |
-| Semantic color     | `:host([variant="positive"])`            | Exposes `--swc-badge-background-color` |
-| Non-semantic color | `.swc-ComponentName--magenta`            | No exposure; implementation detail     |
-| Static color       | `.swc-ComponentName--staticWhite`        | No exposure; ensures contrast          |
-| Geometric          | `.swc-ComponentName--fixed-inline-start` | No exposure; layout modifier           |
+| Variant type       | Selector                                 | Example                                       |
+| ------------------ | ---------------------------------------- | --------------------------------------------- |
+| Size               | `:host([size="s"])`                      | Exposes `--swc-badge-height`, etc.            |
+| Semantic color     | `:host([variant="positive"])`            | Exposes `--swc-badge-background-color`        |
+| Non-semantic color | `.swc-ComponentName--magenta`            | No exposure; implementation detail            |
+| Static color       | `.swc-ComponentName--staticWhite`        | No exposure; ensures contrast                 |
+| Geometric          | `.swc-ComponentName--fixed-inline-start` | No exposure; layout modifier                  |
+| Derived state      | `.swc-ComponentName--iconOnly`           | Computed from slots; not consumer-settable    |
 
 **Example from [Badge](../../../2nd-gen/packages/swc/components/badge/badge.css)**:
 
@@ -261,6 +277,8 @@ States reflect user interaction or component condition. Attach them to `:host` w
 
 **Note**: Badge and Status Light are non-interactive, so they do not define focus or disabled states. See interactive components (e.g. Button) for examples.
 
+**Derived states are not on `:host`**: If a state is computed from slot content (e.g. icon-only), it is not a consumer-settable attribute and must not appear in the state table above. Express it as a class modifier on the internal element via `classMap`. See [When to use classes vs attributes](#when-to-use-classes-vs-attributes).
+
 ## Size variant patterns
 
 Size variants (s, m, l, xl) use `:host([size="..."])` and update custom properties. Do not add size classes to `render()`.
@@ -277,6 +295,40 @@ Size variants (s, m, l, xl) use `:host([size="..."])` and update custom properti
 ```
 
 **Why**: Size is part of the customization surface. Consumers can override `swc-badge[size="l"] { --swc-badge-height: 48px; }`.
+
+## Modifier overrides on inner elements
+
+When a structural modifier needs to change inner-element spacing or positioning, set the relevant custom properties in the modifier rule rather than writing a compound selector that re-states individual properties directly.
+
+For **derived state modifiers** (computed in the component class, not consumer-settable), use the class form:
+
+```css
+/* ❌ Compound selector re-asserts individual properties */
+.swc-Button--iconOnly slot[name="icon"]::slotted(*) {
+  margin-block-start: 0;
+  margin-inline-start: 0;
+}
+
+/* ✅ Override the custom properties the element already reads */
+.swc-Button--iconOnly slot[name="icon"]::slotted(*) {
+  --swc-button-edge-to-visual: 0;
+}
+```
+
+For **consumer-set state modifiers** expressed as host attributes (e.g. `pending`, `disabled`), the same principle applies using `:host([attr])`:
+
+```css
+/* ✅ Use the custom property override pattern on host attribute selectors too */
+:host([pending]) .swc-Button__icon {
+  --swc-button-icon-opacity: 0;
+}
+```
+
+The inner element's base `calc()` expressions already consume the custom property through their `var()` chains, so resetting the variable is sufficient — no additional override rules needed.
+
+**Why**: Layout logic stays consolidated in the base rule. Modifier states only update values; they do not restate structure. This avoids compound selectors that would need to grow in step with any future changes to the inner element's base rule.
+
+📖 See: [Custom properties → Selector conventions](02_custom-properties.md#selector-conventions)
 
 ## Animation and transition patterns
 
@@ -513,6 +565,19 @@ For example:
     - Badge also uses `:has()` to conditionally adjust padding when icons are present; this replaces Spectrum-era spacing rules.
 
 The ultimate intent here is to prioritize working with the grain of CSS layout models.
+
+### Vertical spacing tokens: `component-padding-vertical-*` vs `component-top-to-text-*`
+
+When setting block padding on a component, choose the token family based on the design intent and which generation of Spectrum the component targets.
+
+| Token family | Generation | Intent |
+| --- | --- | --- |
+| `component-padding-vertical-{scale}` | S2 (2nd-gen) | True block padding; produces visually centered text with Adobe Clean VF |
+| `component-top-to-text-{scale}` / `component-bottom-to-text-{scale}` | S1 / legacy S2 | Offset values that compensated for glyph positioning in the old typeface |
+
+The distinction exists because Adobe Clean VF improved glyph positioning within the text box. In S1 and early S2 Spectrum CSS, `component-top-to-text-*` and `component-bottom-to-text-*` were offset values applied to balance out the extra space above/below glyphs and achieve visual centering. With the improved typeface, that offset is no longer needed — `component-padding-vertical-*` represents the actual design intent.
+
+**Rule**: Use `component-padding-vertical-*` in 2nd-gen components. If you encounter `component-top-to-text-*` or `component-bottom-to-text-*` in a source file being migrated, replace them with `component-padding-vertical-*` at the same scale index — do not carry the offset tokens forward.
 
 ## Color Themes
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md
@@ -319,7 +319,7 @@ For **consumer-set state modifiers** expressed as host attributes (e.g. `pending
 
 ```css
 /* ✅ Use the custom property override pattern on host attribute selectors too */
-:host([pending]) .swc-Button__icon {
+:host([pending]) .swc-Button-icon {
   --swc-button-icon-opacity: 0;
 }
 ```

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md
@@ -13,6 +13,7 @@
 
 - [Naming Conventions](#naming-conventions)
 - [Private Properties](#private-properties)
+    - [Reusing private properties](#reusing-private-properties)
 - [Component Custom Property Exposure](#component-custom-property-exposure)
     - [Internal vs. Exposed vs. Static](#internal-vs-exposed-vs-static)
     - [Decision Tree for Exposure](#decision-tree-for-exposure)
@@ -81,6 +82,31 @@ CSS custom properties *normally* can't actually be "private". However, due to sh
 ```
 
 _*"partially" due to possible eventual exposure when we introduce parts_
+
+### Reusing private properties
+
+When a private property captures a token value, reference the private property in all subsequent expressions. Do not call `token()` again for the same value.
+
+```css
+.swc-Button {
+  --_swc-button-border-width: token("border-width-200");
+
+  /* ✅ References the private var — all derived values update together */
+  padding-inline: calc(var(--swc-button-edge-to-text, ...) - var(--_swc-button-border-width));
+  border-width: var(--_swc-button-border-width);
+}
+```
+
+```css
+.swc-Button {
+  --_swc-button-border-width: token("border-width-200");
+
+  /* ❌ Repeating token() breaks the single-source relationship */
+  padding-inline: calc(var(--swc-button-edge-to-text, ...) - token("border-width-200"));
+}
+```
+
+This keeps all overrides and derived calculations linked to the private property. If the definition ever changes, every downstream call updates automatically.
 
 ## Component Custom Property Exposure
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/09_rendering-patterns.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/02_typescript/09_rendering-patterns.md
@@ -15,12 +15,13 @@
 - [Size modifier pattern](#size-modifier-pattern)
 - [Inline SVG](#inline-svg)
 - [classMap patterns](#classmap-patterns)
+- [Shadow root customization](#shadow-root-customization)
 
 </details>
 
 <!-- Document content (editable) -->
 
-This guide covers rendering-specific patterns for 2nd-gen component templates, including helper functions, size transformations, inline SVG accessibility, and classMap usage.
+This guide covers rendering-specific patterns for 2nd-gen component templates, including helper functions, size transformations, inline SVG accessibility, classMap usage, and shadow root customization.
 
 ## Helper functions
 
@@ -218,3 +219,52 @@ class=${classMap({
   [`swc-Badge--${this.variant}`]: true, // Bracketed
 })}
 ```
+
+## Shadow root customization
+
+To customize shadow root options (e.g., enabling `delegatesFocus`), always use the static `shadowRootOptions` property. **Never override `createRenderRoot()`** to set shadow root options.
+
+**Why this matters:** Lit's default `createRenderRoot()` calls `adoptStyles()` to inject the component's CSS into the shadow DOM via `adoptedStylesheets`. Any `createRenderRoot()` override that does not call `super.createRenderRoot()` silently bypasses this step — the component renders, but no styles are applied and no error is thrown.
+
+**Correct pattern:**
+
+```ts
+// ✅ Good — uses the documented Lit API; default createRenderRoot() runs adoptStyles()
+export abstract class ButtonBase extends SizedMixin(SpectrumElement, {
+  validSizes: BUTTON_VALID_SIZES,
+}) {
+  static override shadowRootOptions: ShadowRootInit = {
+    ...SpectrumElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+}
+```
+
+**Anti-pattern:**
+
+```ts
+// ❌ Bad — bypasses adoptStyles(); all component CSS is silently ignored
+export abstract class ButtonBase extends SpectrumElement {
+  protected override createRenderRoot(): ShadowRoot {
+    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+  }
+}
+```
+
+The spreading of `...SpectrumElement.shadowRootOptions` (or the parent class's `shadowRootOptions`) preserves any options set by the base class, such as `mode: 'open'`.
+
+**When `createRenderRoot()` is appropriate:**
+
+Override `createRenderRoot()` only when you need to change the render target itself (e.g., rendering into the light DOM instead of a shadow root). In those cases, call `super.createRenderRoot()` or manually call `adoptStyles()` to preserve style injection:
+
+```ts
+// ✅ Acceptable — light DOM render target, adoptStyles called manually
+import { adoptStyles, unsafeCSS } from 'lit';
+
+protected override createRenderRoot(): Element {
+  adoptStyles(this, (this.constructor as typeof LitElement).elementStyles);
+  return this;
+}
+```
+
+This scenario is rare in SWC components. If you find yourself considering it, discuss with the team first.

--- a/CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md
@@ -376,6 +376,7 @@ For troubleshooting and detailed patterns (e.g. 1st-gen Constructable Stylesheet
 
 - [ ] Stories file exists; component renders correctly in Storybook.
 - [ ] Render template class names match CSS selectors (no stale names from 1st-gen).
+- [ ] Every exposed `--swc-*` custom property has a `@cssprop` JSDoc tag on the primary SWC component class (e.g. `@cssprop --swc-button-height - Block size of the button.`). Storybook surfaces these automatically in the API docs panel.
 - [ ] Follows the [full migration steps](../../../../02_style-guide/01_css/04_spectrum-swc-migration.md).
 - [ ] Adheres to the [component styling guidelines](../../../../02_style-guide/01_css/01_component-css.md).
 - [ ] Stylelint passes for the component’s CSS (no 2nd-gen CSS lint errors).

--- a/CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md
@@ -342,14 +342,18 @@ If you are renaming or removing a public prop or attribute, confirm with the tea
 
 ### What to do
 
-1. **Follow the migration steps** — [Step 6](06_migrate-rendering-and-styles.md) and the [full migration steps](../../../../02_style-guide/01_css/04_spectrum-swc-migration.md). Use [03_components/](../../../03_components/) for spectrum-two alignment. Copy S2 styles from your **spectrum-css** clone, **`spectrum-two`** branch, component `index.css` (not `dist`).
-2. **Use tokens** — Replace hard-coded values with `token(...)`. Follow [component CSS](../../../../02_style-guide/01_css/01_component-css.md) and [custom properties](../../../../02_style-guide/01_css/02_custom-properties.md).
-3. **Run stylelint** — After updating CSS, run `nx run swc:lint`. Fix all errors. The 2nd-gen config enforces: **property order** (see `linters/stylelint-property-order.js`); **no descending specificity** (e.g. `:host([disabled])` before `:host([checked][disabled])`); **declaration empty line** (empty line between groups); **token usage** (`token("...")` for color, font-size, etc.).
+1. **Verify or create the stories file** — Visual verification requires a stories file. If `stories/[component].stories.ts` does not exist, create it before writing CSS using the `migration-styling` skill’s Phase 4 stories template. The stories file at this phase should have Playground, Overview, Anatomy, Options, States, and CSS-visible Behaviors — no JSDoc prose, and the Accessibility story left as a `// TODO` comment. Confirm the component renders in Storybook with no console errors before touching CSS.
+2. **Align render template class names with CSS selectors** — Read the component’s `render()` method and note every class name emitted. The CSS you write must use those exact names; mismatches cause styles to silently not apply. When migrating from 1st-gen single-hyphen naming (e.g. `.swc-Button-label`) to 2nd-gen BEM double-underscore notation (e.g. `.swc-Button__label`), update `render()` first, confirm the component still renders, then write the CSS.
+3. **Follow the migration steps** — [Step 6](06_migrate-rendering-and-styles.md) and the [full migration steps](../../../../02_style-guide/01_css/04_spectrum-swc-migration.md). Use [03_components/](../../../03_components/) for spectrum-two alignment. Copy S2 styles from your **spectrum-css** clone, **`spectrum-two`** branch, component `index.css` (not `dist`).
+4. **Use tokens** — Replace hard-coded values with `token(...)`. Follow [component CSS](../../../../02_style-guide/01_css/01_component-css.md) and [custom properties](../../../../02_style-guide/01_css/02_custom-properties.md).
+5. **Run stylelint** — After updating CSS, run `nx run swc:lint`. Fix all errors. The 2nd-gen config enforces: **property order** (see `linters/stylelint-property-order.js`); **no descending specificity** (e.g. `:host([disabled])` before `:host([checked][disabled])`); **declaration empty line** (empty line between groups); **token usage** (`token("...")` for color, font-size, etc.).
 
 For templates, `render()`, icons (inline SVG), and detailed examples, see [Step 6](06_migrate-rendering-and-styles.md) and the [full migration steps](../../../../02_style-guide/01_css/04_spectrum-swc-migration.md).
 
 ### What to check
 
+- [ ] Stories file exists and component renders in Storybook with no console errors.
+- [ ] Class names emitted by `render()` match the selectors in the component CSS (no stale 1st-gen names).
 - [ ] No inline styles for theme/size; use CSS and classes.
 - [ ] Tokens and custom properties align with Spectrum 2.
 - [ ] Follows the [full migration steps](../../../../02_style-guide/01_css/04_spectrum-swc-migration.md).
@@ -362,12 +366,16 @@ For troubleshooting and detailed patterns (e.g. 1st-gen Constructable Stylesheet
 
 | Problem | Solution |
 |--------|----------|
+| Styles not applied; `adoptedStylesheets` empty | Never override `createRenderRoot()` to set shadow root options; use `static override shadowRootOptions = { ...ParentClass.shadowRootOptions, delegatesFocus: true }` instead. Overriding `createRenderRoot()` without calling `super` bypasses Lit’s `adoptStyles()`, silently dropping all component CSS. |
+| CSS selector targets wrong element | Class name in CSS (e.g. `.swc-Button__label`) does not match what `render()` emits. Grep the render template for the old name and update it before blaming the CSS. |
 | `order/properties-order` errors | Reorder declarations to match `linters/stylelint-property-order.js` (e.g. display → position → flex → box sizing → margin → font → overflow → pointer-events → content → opacity → transition). |
 | `no-descending-specificity` errors | Place lower-specificity selectors before higher-specificity ones (e.g. `:host([disabled])` before `:host([checked][disabled])`; single-attribute or single-pseudo before compound selectors). Split rule blocks if needed so order is consistent. |
 | Token / `declaration-strict-value` | Replace hard-coded colors, font-size, etc. with `token("...")`. |
 
 ### Quality gate
 
+- [ ] Stories file exists; component renders correctly in Storybook.
+- [ ] Render template class names match CSS selectors (no stale names from 1st-gen).
 - [ ] Follows the [full migration steps](../../../../02_style-guide/01_css/04_spectrum-swc-migration.md).
 - [ ] Adheres to the [component styling guidelines](../../../../02_style-guide/01_css/01_component-css.md).
 - [ ] Stylelint passes for the component’s CSS (no 2nd-gen CSS lint errors).
@@ -385,7 +393,7 @@ For troubleshooting and detailed patterns (e.g. 1st-gen Constructable Stylesheet
 3. **Identify the APG pattern** for your component type (e.g. button, combobox) — [WCAG ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/patterns/).
 4. **Implement:** Semantics (prefer native HTML), ARIA where needed, keyboard support, focus management (trap in overlays), screen reader exposure. Test with assistive tech; document in JSDoc.
 5. **Native vs custom controls:** Native form control (e.g. Checkbox) → `delegatesFocus: true`. Custom control (e.g. Radio) → `role` and `aria-*` on host, manage focus/keyboard. See Checkbox and Radio as references.
-6. **Focus delegation on internal control:** When a component wraps a native form control inside its shadow DOM, `delegatesFocus: true` should be set in `createRenderRoot()` so that focus lands on the internal control, not the host. This belongs in the base class if all subclasses share the same host-wraps-native-control structure.
+6. **Focus delegation on internal control:** When a component wraps a native form control inside its shadow DOM, set `delegatesFocus: true` via `static override shadowRootOptions = { ...ParentClass.shadowRootOptions, delegatesFocus: true }` so that focus lands on the internal control, not the host. This belongs in the base class if all subclasses share the same host-wraps-native-control structure. **Do not** override `createRenderRoot()` to set this option — doing so bypasses Lit's `adoptStyles()`, silently preventing all component CSS from being injected into the shadow DOM. See [Rendering patterns: Shadow root customization](../../../../02_style-guide/02_typescript/09_rendering-patterns.md#shadow-root-customization).
 7. **Accessible name forwarding:** Attributes like `aria-label` on the host do not automatically apply to the internal control — either bind them explicitly in the render template (e.g. `aria-label=${this.getAttribute('aria-label')}`) or derive the accessible name in a protected helper and forward it. See `ButtonBase.getResolvedAccessibleName()` as a reference. Note that implementing these patterns may require adding methods or modifying the render template, so Phase 5 often touches component class files, not only Storybook or docs.
 
 ### What to check
@@ -459,7 +467,7 @@ Follow the two-file layout (`test/<component>.test.ts`, `test/<component>.a11y.s
 ### What to do
 
 1. **JSDoc:** Every public prop, slot, event, and the element itself. Use `@element`, `@example`, `@internal` for non-public.
-2. **Storybook stories:** Use `getStorybookHelpers`, METADATA (args, argTypes, meta), stories for variants/sizes. Reference `badge/stories/badge.stories.ts`, `divider/stories/divider.stories.ts`.
+2. **Storybook stories:** If Phase 4 was completed, `stories/[component].stories.ts` may already exist with Playground, Overview, Anatomy, Options, States, and Behaviors stories — all correctly structured but without JSDoc prose. Phase 7 augments that file: add JSDoc comments to every story (except Playground and Overview, which have none by convention), complete the Accessibility story body (left as `// TODO` in Phase 4), and add any stories deferred from earlier phases. Do not recreate the file from scratch. If no Phase 4 scaffold exists, create it from the `migration-styling` skill's stories template and then fill in the Phase 7 content. Reference `badge/stories/badge.stories.ts` and `divider/stories/divider.stories.ts` for complete examples.
 3. **Size/variant controls:** Ensure controls drive the component. If the attribute comes from a mixin (e.g. `SizedMixin`), declare it on the SWC class with `@property({ reflect: true })` so the CEM includes it; run `yarn analyze` to regenerate the manifest.
 4. **Review, usage docs, migration notes:** Confirm stories; add usage docs; document API changes from 1st-gen.
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/07_add-stories-for-2nd-gen-component.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/07_add-stories-for-2nd-gen-component.md
@@ -6,19 +6,106 @@
 
 # Add stories for 2nd-gen component
 
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [When is the stories file created?](#when-is-the-stories-file-created)
+- [Phase 4: stories scaffold](#phase-4-stories-scaffold)
+- [Phase 7: completing the stories](#phase-7-completing-the-stories)
+- [File structure](#file-structure)
+- [Key patterns](#key-patterns)
+
+</details>
+
 <!-- Document content (editable) -->
 
-- Create `stories/[component].stories.ts` file
-- Add section headers: METADATA, STORIES, HELPER FUNCTIONS (if needed)
-- In METADATA section:
-    - Import `StoryObj as Story` for consistency
-    - Set up Storybook helpers with `getStorybookHelpers()`
-    - Configure argTypes for component-specific controls
-    - Define and export the meta object
-- In STORIES section:
-    - Create Default story (without `tags: ['!dev']`)
-    - Create additional stories showcasing variants, sizes, states
-    - Add `tags: ['!dev']` to all non-default stories
-- In HELPER FUNCTIONS section (if needed):
-    - Add any utility functions or template helpers
-    - Convert arrow functions to standard function declarations where appropriate
+## When is the stories file created?
+
+The stories file has two distinct phases of work:
+
+- **Phase 4 (Styling):** A minimal scaffold is created to enable visual verification of CSS in Storybook. It contains the correct structure — HELPERS, Playground, Overview, Anatomy, Options, States, and Behaviors — but no JSDoc prose, and the Accessibility story is left as a `// TODO` comment.
+- **Phase 7 (Documentation):** The scaffold is completed with JSDoc on every story (except Playground and Overview), the Accessibility story body is filled in, and any deferred stories are added.
+
+If Phase 4 has been completed, **do not recreate the file** — augment the existing scaffold.
+
+## Phase 4: stories scaffold
+
+Use the `migration-styling` skill's [`assets/stories-template.md`](../../../../../.ai/skills/migration-styling/assets/stories-template.md) to generate the file. The template documents the section order, required stories per type, and the Phase 4 scope boundary.
+
+**Phase 4 scope:**
+
+- Playground (`tags: ['autodocs', 'dev']`)
+- Overview (`tags: ['overview']`)
+- Anatomy — shows all meaningful slot combinations (`tags: ['anatomy']`)
+- Options — one story per constant array in the types file (`tags: ['options']`), with `section-order`, `storyName` where needed, and `staticColorsDemo: true` + `'!test'` for static colors
+- States — all interactive states (`tags: ['states']`)
+- Behaviors — properties that produce CSS-visible differences (`tags: ['behaviors']`)
+- Accessibility section — `// TODO` comment only
+
+## Phase 7: completing the stories
+
+With the Phase 4 scaffold in place:
+
+1. **Add JSDoc to every story except Playground and Overview.** See the [stories documentation standards](../../../../../.ai/rules/stories-documentation.md) for structure and examples.
+2. **Complete the Accessibility story body.** Document built-in accessibility features (keyboard, ARIA, focus) and best practices for consumers.
+3. **Add any deferred stories** — anatomy combinations that require interaction, behavior stories not visible through CSS alone, etc.
+
+Reference examples: `badge/stories/badge.stories.ts`, `divider/stories/divider.stories.ts`.
+
+## File structure
+
+```text
+stories/
+  [component].stories.ts   ← single file; no .usage.mdx needed
+```
+
+Section order within the file:
+
+```typescript
+// ────────────────
+//    METADATA
+// ────────────────
+
+// ────────────────────
+//    HELPERS
+// ────────────────────
+
+// ────────────────────
+//    AUTODOCS STORY
+// ────────────────────
+
+// ──────────────────────────────
+//    OVERVIEW STORIES
+// ──────────────────────────────
+
+// ──────────────────────────
+//    ANATOMY STORIES
+// ──────────────────────────
+
+// ──────────────────────────
+//    OPTIONS STORIES
+// ──────────────────────────
+
+// ──────────────────────────
+//    STATES STORIES
+// ──────────────────────────
+
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+// ────────────────────────────────
+//    ACCESSIBILITY STORIES
+// ────────────────────────────────
+```
+
+## Key patterns
+
+- Use `getStorybookHelpers('swc-[component]')` for args, argTypes, and template.
+- Override `argTypes` for any attribute that needs explicit options or a control type; source options from the constant array in the types file, not a hand-written list.
+- Define label maps in HELPERS using `as const satisfies Record<Type, string>` for type safety.
+- Prefer `template({ ...args, propName: value })` over raw `html` tagged template literals — use raw html only when slot content (e.g. inline SVG with `slot="icon"`) cannot flow through `template()`.
+- Add `storyName` for any PascalCase export that would not render as sentence case (e.g. `StaticColors.storyName = 'Static colors'`).
+- `StaticColors` stories use `parameters: { staticColorsDemo: true }` and `tags: ['options', '!test']`.


### PR DESCRIPTION
## Description / Motivation

Improves Phase 4 migration tooling across the `migration-styling` skill, reference docs, and contributor style guides — all driven by lessons from the button migration.

- **`migration-prep-template.md`** - Added description and checklist item about requirement of adding `@cssprop` doc comments for exposed custom properties.

- **`migration-styling` SKILL.md** — Expanded from a single paragraph into a structured 4-step workflow: read the migration plan first, check for scope drift, verify/create the stories file, align class names between `render()` and CSS before writing styles.

- **`tldr-component-css-guidelines.md`** (new) — A compact reference with correct/incorrect examples covering the 7 most critical CSS rules (`:host` vs component class, token usage, attribute vs class selectors, derived states, vertical spacing tokens, specificity, forced colors).

- **`stories-template.md`** (new) — A Phase 4 stories scaffold with placeholder substitution table, a "decisions to make" guide keyed to the types file, and a full template covering Playground through Accessibility.

- **`01_component-css.md`** — Added sections on derived state modifiers, modifier overrides on inner elements (custom property override pattern), and vertical spacing tokens (`component-padding-vertical-*` vs the deprecated `component-top-to-text-*` offsets).

- **`02_custom-properties.md`** — Added guidance on reusing private properties: capture a token value once as `--_swc-*` and reference the variable in all downstream `calc()` expressions.

- **`09_rendering-patterns.md`** — New shadow root customization section documenting why `static shadowRootOptions` must be used instead of overriding `createRenderRoot()`, and when the override is actually appropriate.

- **`01_washing-machine-workflow.md`** — Added stories verification and class-name alignment as explicit steps in Phase 4; added two new common-problem rows (`adoptedStylesheets` empty, CSS selector mismatch); updated Phase 7 to describe the Phase 4 scaffold handoff.

- **`07_add-stories-for-2nd-gen-component.md`** — Expanded with Phase 4 vs Phase 7 scope split, decisions guide, and template usage instructions.

---

## Reviewer's checklist

- Read through each new doc or doc update
- Provide feedback on the updated guidance, especially:
    1. **Accuracy of the CSS rules in `tldr-component-css-guidelines.md`** — especially Rule 5 (vertical spacing tokens) and Rule 4 (derived states via `classMap`). These are new guidance that future migrations will follow, so any wrong claim becomes a repeating mistake.
    2. **The `stories-template.md` "decisions to make" section** — verify the logic for when to add each story type (Sizes, Variants, StaticColors, etc.) matches what was actually done in the button migration and what reviewers would expect for future components.
    3. **The `shadowRootOptions` guidance in `09_rendering-patterns.md`** — confirm the anti-pattern description accurately describes the failure mode (styles silently not applied, no error thrown) and that the "when `createRenderRoot()` is appropriate" exception case is correctly scoped.
