### PR TITLE
chore: remove platform scale toggle from Storybook UI

### DIFF
--- a/2nd-gen/packages/swc/.storybook/decorators/contexts.ts
+++ b/2nd-gen/packages/swc/.storybook/decorators/contexts.ts
@@ -14,11 +14,10 @@ import { html } from 'lit';
 import type { DecoratorFunction } from '@storybook/types';
 
 /**
- * Decorator that applies selected theme and scale
+ * Decorator that applies selected theme context.
  */
 export const withContext: DecoratorFunction = (Story, context) => {
   const theme = context.globals.theme;
-  const scale = context.globals.scale;
 
   document.documentElement.classList.remove(
     'swc-theme--light',
@@ -26,12 +25,6 @@ export const withContext: DecoratorFunction = (Story, context) => {
     'swc-theme--adaptive'
   );
   document.documentElement.classList.add(`swc-theme--${theme}`);
-
-  if (scale === 'large') {
-    document.documentElement.classList.add('swc-theme--sizeL');
-  } else {
-    document.documentElement.classList.remove('swc-theme--sizeL');
-  }
 
   return html`
     ${Story(context)}

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -67,20 +67,6 @@ const preview = {
         dynamicTitle: true,
       },
     },
-    scale: {
-      name: 'Scale',
-      description: 'Global scale for components',
-      defaultValue: 'medium',
-      type: 'string',
-      toolbar: {
-        title: 'Scale',
-        items: [
-          { value: 'medium', title: 'Medium' },
-          { value: 'large', title: 'Large' },
-        ],
-        dynamicTitle: true,
-      },
-    },
     lang: {
       name: 'Language',
       description:

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -123,7 +123,6 @@ const preview = {
   },
   initialGlobals: {
     theme: 'light',
-    scale: 'medium',
     lang: 'en-US',
     textDirection: 'auto',
   },


### PR DESCRIPTION
This removes the medium/large platform scale toggle option from the Storybook UI



## Screenshots (if appropriate)
**before:**
<img width="381" height="137" alt="Screenshot 2026-05-04 at 2 01 31 PM" src="https://github.com/user-attachments/assets/9ed0edd6-52c1-418c-b81a-a9be446c5419" />

**after:**
<img width="266" height="62" alt="Screenshot 2026-05-04 at 3 57 02 PM" src="https://github.com/user-attachments/assets/06a7e483-5027-47d4-8233-59d341c2dd71" />

---

## Reviewer's checklist

[ ] Gen2: hit the deploy URL in this PR and check to see that the platform scale toggle has been removed