### PR TITLE
docs(badge, divider, progresscircle): improve Chromatic coverage

### DIFF
--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -277,22 +277,53 @@ export const Anatomy: Story = {
  *
  * The `s` size is the default. Use larger sizes sparingly to create a hierarchy of importance on a page.
  */
-
-// @todo - We should make sure to capture icon-only badges in all sizes for VRTs: SWC-1852
 export const Sizes: Story = {
   render: (args) => html`
-    ${BADGE_VALID_SIZES.map(
-      (size) => html`
-        <swc-badge variant=${args.variant} size=${size}>
-          <swc-icon size=${size} slot="icon">
-            ${checkmarkIconForSize(size)}
-          </swc-icon>
-          ${sizeLabels[size]}
-        </swc-badge>
-      `
-    )}
+    <div
+      style="display: flex; flex-wrap: wrap; gap: var(--swc-spacing-200); align-items: center;"
+    >
+      ${BADGE_VALID_SIZES.map(
+        (size) => html`
+          <swc-badge variant=${args.variant} size=${size}>
+            <swc-icon size=${size} slot="icon">
+              ${checkmarkIconForSize(size)}
+            </swc-icon>
+            ${sizeLabels[size]}
+          </swc-badge>
+        `
+      )}
+    </div>
+    <div
+      style="display: flex; flex-wrap: wrap; gap: var(--swc-spacing-200); align-items: center; margin-block-start: var(--swc-spacing-300);"
+    >
+      ${BADGE_VALID_SIZES.map(
+        (size) => html`
+          <swc-badge variant=${args.variant} size=${size}>
+            ${sizeLabels[size]}
+          </swc-badge>
+        `
+      )}
+    </div>
+    <div
+      style="display: flex; flex-wrap: wrap; gap: var(--swc-spacing-200); align-items: center; margin-block-start: var(--swc-spacing-300);"
+    >
+      ${BADGE_VALID_SIZES.map(
+        (size) => html`
+          <swc-badge
+            variant=${args.variant}
+            size=${size}
+            role="img"
+            aria-label=${sizeLabels[size]}
+          >
+            <swc-icon size=${size} slot="icon">
+              ${checkmarkIconForSize(size)}
+            </swc-icon>
+          </swc-badge>
+        `
+      )}
+    </div>
   `,
-  parameters: { 'section-order': 1 },
+  parameters: { 'section-order': 1, flexLayout: 'column-stretch' },
   tags: ['options'],
   args: {
     variant: 'neutral',

--- a/2nd-gen/packages/swc/components/badge/test/badge.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/badge/test/badge.a11y.spec.ts
@@ -62,7 +62,11 @@ test.describe('Badge - ARIA Snapshots', () => {
   test('should handle different sizes', async ({ page }) => {
     const root = await gotoStory(page, 'components-badge--sizes', 'swc-badge');
     await expect(root).toMatchAriaSnapshot(`
-      - text: Small Medium Large Extra-large
+      - text: Small Medium Large Extra-large Small Medium Large Extra-large
+      - img "Small"
+      - img "Medium"
+      - img "Large"
+      - img "Extra-large"
     `);
   });
 

--- a/2nd-gen/packages/swc/components/divider/Divider.ts
+++ b/2nd-gen/packages/swc/components/divider/Divider.ts
@@ -22,9 +22,6 @@ import styles from './divider.css';
  * @element swc-divider
  * @since 0.0.1
  *
- * Give horizontal dividers a definite **inline size** and vertical dividers a definite **block size**
- * when the surrounding layout leaves percentages unresolved (see divider CSS minimum tracks).
- *
  * @cssprop --swc-divider-background-color - Background color of the divider.
  * @cssprop --swc-divider-thickness - Thickness of the divider.
  */

--- a/2nd-gen/packages/swc/components/divider/divider.css
+++ b/2nd-gen/packages/swc/components/divider/divider.css
@@ -18,7 +18,6 @@
   box-sizing: border-box;
 }
 
-/* @todo capture visual regression tests for WHCM (forced-colors) and more static color sizes in Chromatic. SWC-1848 */
 .swc-Divider {
   --_swc-divider-thickness: var(--swc-divider-thickness, token("divider-thickness-medium"));
 

--- a/2nd-gen/packages/swc/components/divider/divider.css
+++ b/2nd-gen/packages/swc/components/divider/divider.css
@@ -36,6 +36,7 @@
   --swc-divider-background-color: token("gray-800");
 }
 
+/* Minimum tracks below cap percentage fill; when the basis does not resolve, set a definite inline size on :host for horizontal dividers or block size for vertical. */
 .swc-Divider:not(.swc-Divider--vertical) {
   min-inline-size: min(100%, token("divider-horizontal-minimum-width"));
 }

--- a/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
+++ b/2nd-gen/packages/swc/components/divider/stories/divider.stories.ts
@@ -11,6 +11,7 @@
  */
 
 import { html } from 'lit';
+import { styleMap } from 'lit/directives/style-map.js';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
@@ -230,32 +231,91 @@ export const Vertical: Story = {
   },
 };
 
+/** Same prose for each horizontal thickness so snapshots emphasize divider weight only. */
+const STATIC_COLORS_HORIZONTAL_COPY = {
+  headingBefore: 'Dashboard settings',
+  bodyBefore: 'Configure your dashboard preferences and layout options.',
+  headingAfter: 'Display options',
+  bodyAfter: 'Adjust your layout and theme settings.',
+} as const;
+
+const STATIC_COLORS_HORIZONTAL_SIZES = Divider.VALID_SIZES;
+
+/** Vertical rows: explicit `block-size` matches {@link Vertical}. */
+const STATIC_COLORS_VERTICAL_SAMPLES = [
+  { size: 's' as const, blockSize: 16 },
+  { size: 'm' as const, blockSize: 24 },
+  { size: 'l' as const, blockSize: 32 },
+];
+
 /**
  * Use the `static-color` attribute when displaying over images or colored backgrounds:
  *
  * - **white**: Use on dark or colored backgrounds for better contrast
  * - **black**: Use on light backgrounds for better contrast
+ *
+ * Each static color panel shows **horizontal** dividers at sizes `s`, `m`, and `l`, and **vertical**
+ * dividers at the same sizes (vertical rows use an explicit `block-size` so the line is visible).
  */
 export const StaticColors: Story = {
   render: (args) => html`
     ${['white', 'black'].map(
       (color) => html`
-        <div>
-          <h4>Dashboard settings</h4>
-          <p>Configure your dashboard preferences and layout options.</p>
-          ${template({ ...args, 'static-color': color })}
-          <h4>Display options</h4>
-          <p>Adjust your layout and theme settings.</p>
+        <div
+          style=${styleMap({
+            '--swc-detail-font-color': color === 'white' ? 'white' : 'black',
+          })}
+        >
+          ${STATIC_COLORS_HORIZONTAL_SIZES.map(
+            (size) => html`
+              <div
+                class="swc-Typography--emphasized swc-Detail swc-Detail--sizeS swc-Detail--margins"
+              >
+                Horizontal · size ${size}
+              </div>
+              <h4>${STATIC_COLORS_HORIZONTAL_COPY.headingBefore}</h4>
+              <p>${STATIC_COLORS_HORIZONTAL_COPY.bodyBefore}</p>
+              ${template({ ...args, 'static-color': color, size })}
+              <h4>${STATIC_COLORS_HORIZONTAL_COPY.headingAfter}</h4>
+              <p>${STATIC_COLORS_HORIZONTAL_COPY.bodyAfter}</p>
+            `
+          )}
+          ${STATIC_COLORS_VERTICAL_SAMPLES.map(
+            (row) => html`
+              <div
+                class="swc-Typography--emphasized swc-Detail swc-Detail--sizeS swc-Detail--margins"
+              >
+                Vertical · size ${row.size}
+              </div>
+              <div
+                style="display: flex; align-items: center; gap: 8px; block-size: ${row.blockSize}px;"
+              >
+                ${(['Cut', 'Copy', 'Paste'] as const).map(
+                  (label, index) => html`
+                    ${index === 0
+                      ? ''
+                      : template({
+                          ...args,
+                          'static-color': color,
+                          size: row.size,
+                          vertical: true,
+                        })}
+                    <span>${label}</span>
+                  `
+                )}
+              </div>
+            `
+          )}
         </div>
       `
     )}
   `,
-  args: {
-    size: 'm',
-  },
   parameters: {
     staticColorsDemo: true,
     'section-order': 3,
+    styles: {
+      'align-items': 'flex-start',
+    },
   },
   tags: ['options'],
 };

--- a/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-circle/stories/progress-circle.stories.ts
@@ -172,13 +172,23 @@ export const Sizes: Story = {
  *
  * - **white**: Use on dark or colored backgrounds for better contrast
  * - **black**: Use on light backgrounds for better contrast
+ *
+ * Each panel lists **small**, **medium**, and **large** in order so Chromatic can snapshot every
+ * static-color and size pairing with the same label text (stroke weight is what changes).
  */
-// @todo: capture the Chromatic VRTs for all sizes of progress circles for both static color options and WHCM. SWC-1848
 export const StaticColors: Story = {
   render: (args) => html`
     ${PROGRESS_CIRCLE_STATIC_COLORS.map(
       (color) => html`
-        ${template({ ...args, 'static-color': color })}
+        <div>
+          ${PROGRESS_CIRCLE_VALID_SIZES.map((size) =>
+            template({
+              ...args,
+              size,
+              'static-color': color,
+            })
+          )}
+        </div>
       `
     )}
   `,
@@ -189,6 +199,9 @@ export const StaticColors: Story = {
   parameters: {
     staticColorsDemo: true,
     'section-order': 2,
+    styles: {
+      'align-items': 'flex-start',
+    },
   },
 };
 


### PR DESCRIPTION
## Description

Expands variants of components captured in stories in **2nd-gen Storybook** so Chromatic can snapshot:

- **Divider**: now displays each size (s, m, l), each variant (horizontal, vertical) at each static color (white, black)
- **Progress circle**: now displays each size (s, m, l) at each static color (white, black)
- **Badge**: now displays each size (s, m, l, xl) for icon-only _and_ text-only variants along with text + icon variant that was displayed before

## Motivation and context

- **SWC-1848**: Chromatic should capture static-color size (and Divider orientation) combinations; WHCM / `forced-colors` may remain separate follow-up per ticket.
- **SWC-1852**: Icon-only badge geometry can differ from icon + text; snapshot every size in Storybook.

## Related issue(s)

- Addresses **SWC-1848** (Storybook / static-color coverage for Divider and Progress circle).
- Addresses **SWC-1852** (icon-only badge coverage across sizes, folded into **Sizes**).

## Screenshots (if appropriate)

- **Divider** 
<img width="734" height="865" alt="image" src="https://github.com/user-attachments/assets/c2af5bad-0774-41e8-8590-49d471eaf670" />

- **Progress circle** 
<img width="732" height="193" alt="image" src="https://github.com/user-attachments/assets/a5b990a5-8151-40ee-8fa5-78d6602aebaf" />

- **Badge** 
<img width="733" height="273" alt="image" src="https://github.com/user-attachments/assets/6e979368-ba00-4ab0-9e69-88fe7fa28a87" />


---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes. _(Storybook-focused; add or extend tests only if you changed behavior outside stories.)_
- [ ] I have included a well-written **changeset** if my change needs to be published. _(Confirm with maintainers.)_
- [ ] I have included updated documentation if my change required it.
- [ ] Add `run_vrt` label to run Chromatic

---

## Reviewer's checklist

### Manual review test cases

- [ ] **Divider — Static colors** — Both gradient panels; horizontal **s/m/l**; vertical rows; meta labels readable.
- [ ] **Progress circle — Static colors** — Both panels; three sizes; shared label; rings visible.
- [ ] **Badge — Sizes** — Row 1 icon + label, row 2 text only, row 3 icon only; all four sizes; **`flexLayout`** column reads cleanly.
- [ ] **Chromatic** — PR has **`run_vrt`** (or team equivalent); review **Static colors** / **Sizes** snapshots.

## Acceptance criteria (Given / When / Then)

1. **Given** a Chromatic build of 2nd-gen Storybook, **when** Divider **Static colors** is snapshotted, **then** both static-color panels include horizontal **s/m/l** and vertical rows per size as in the story.

2. **Given** the same build, **when** Progress circle **Static colors** is snapshotted, **then** each static-color panel includes all **valid sizes** with stable **`label`** text.

3. **Given** Divider **Static colors** on static-color demo backgrounds, **when** viewing meta lines, **then** **`--swc-detail-font-color`** keeps detail text readable against each panel foreground.

4. **Given** Badge **Sizes**, **when** Chromatic snapshots the story, **then** icon-only instances exist for **every** **`BADGE_VALID_SIZES`** entry (**SWC-1852**).
