### PR TITLE
feat(docs): update test docs for exclusions, internals, static colors

### DIFF
--- a/.ai/rules/stories-format.md
+++ b/.ai/rules/stories-format.md
@@ -269,8 +269,8 @@ export const StaticColors: Story = {
 
 ### Exclusion tags
 
-- `'!test'` - Exclude from test runs
-- `'!dev'` - Exclude from dev Storybook
+- `'!dev'` - Exclude from the development Storybook sidebar without affecting tests
+- `'!test'` - Exclude from **all three** automated test runners simultaneously: Vitest play functions, aXe WCAG compliance, and VRT snapshots. Use only when testing would produce false positives due to context the test runner cannot see — the canonical case is static-color stories, where axe evaluates contrast against the page background rather than the decorator gradient. **When you apply `'!test'` to a story, you must add a corresponding test story with a custom render and `parameters: { staticColorsDemo: true }` to restore behavioral coverage.** Do not apply `'!test'` because a story is complex, has no `play` function, or has a real accessibility issue. See [Excluding stories from tests](../../CONTRIBUTOR-DOCS/02_style-guide/04_testing/01_testing-overview.md#excluding-stories-from-tests).
 
 ## Story types
 

--- a/.ai/skills/migration-styling/assets/stories-template.md
+++ b/.ai/skills/migration-styling/assets/stories-template.md
@@ -58,7 +58,7 @@ import {
   type [Component]Size,
   type [Component]Variant,
   // …add other types used in satisfies constraints below
-} from '../../../../core/components/[component]/[Component].types.js';
+} from '@spectrum-web-components/core/components/[component]';
 
 // ────────────────
 //    METADATA
@@ -84,7 +84,7 @@ argTypes.size = {
  * [One or two sentences describing what the component does and when to use it.
  * Keep this brief — detailed usage guidance belongs in Phase 7 docs.]
  */
-export const meta: Meta = {
+const meta: Meta = {
   title: '[Component]',
   component: 'swc-[component]',
   parameters: {
@@ -101,11 +101,7 @@ export const meta: Meta = {
   tags: ['migrated'],
 };
 
-export default {
-  ...meta,
-  title: '[Component]',
-  excludeStories: ['meta'],
-} as Meta;
+export default meta;
 
 // ────────────────────
 //    HELPERS

--- a/CONTRIBUTOR-DOCS/02_style-guide/04_testing/01_testing-overview.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/04_testing/01_testing-overview.md
@@ -13,6 +13,7 @@
 
 - [What to test](#what-to-test)
 - [What not to test](#what-not-to-test)
+- [Excluding stories from tests](#excluding-stories-from-tests)
 
 </details>
 
@@ -44,3 +45,37 @@ Test things that users and developers depend on:
 - Framework internals (Lit rendering, Storybook internals)
 - Third-party library behavior
 - Every possible prop combination (test meaningful ones)
+
+## Excluding stories from tests
+
+The `'!test'` tag excludes a story from all three automated test runners at once:
+
+- **Vitest play functions** — the story's `play` function is not executed
+- **aXe WCAG compliance** (`test:a11y` via `test-runner.ts`) — axe does not analyze the story
+- **Visual regression tests** — the story is not captured in VRT snapshots
+
+Use `'!test'` only when automated testing would produce **false positives** — results that appear as failures but do not reflect real defects. The most common case is static-color stories: axe evaluates contrast against the page background, not the decorator's gradient, so a `static-color="white"` button fails contrast thresholds in isolation even though it passes in real usage on a dark background.
+
+```typescript
+export const StaticColors: Story = {
+  // axe reports false-positive contrast failures because it evaluates colors
+  // against the page background, not the staticColorsDemo gradient decorator.
+  tags: ['options', '!test'],
+  parameters: { staticColorsDemo: true },
+};
+```
+
+**Appropriate uses:**
+
+- A story depends on a background or layout context (e.g., a gradient decorator) that axe cannot account for when checking contrast
+- A story is a pure animation or motion demo with no stable DOM state to assert against
+
+**Inappropriate uses:**
+
+- The story is complex or hard to test — simplify or split it instead
+- The story has a real accessibility issue — fix the issue rather than excluding the story
+- The story simply lacks a `play` function — omitting `play` is fine; adding `!test` creates a gap in aXe and VRT coverage too
+
+Every `'!test'` story is a blind spot across all three test layers. Add a comment explaining the reason when you apply the tag, and add a corresponding test story with a custom render (see [Testing static color variants](02_storybook-testing.md#testing-static-color-variants)) to restore behavioral coverage.
+
+The `'!dev'` tag is separate: it removes a story from the development Storybook sidebar without affecting any test runner.

--- a/CONTRIBUTOR-DOCS/02_style-guide/04_testing/02_storybook-testing.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/04_testing/02_storybook-testing.md
@@ -27,6 +27,8 @@
     - [Testing defaults](#testing-defaults)
     - [Testing attribute reflection](#testing-attribute-reflection)
     - [Testing slots](#testing-slots)
+    - [Testing shadow DOM internals](#testing-shadow-dom-internals)
+    - [Testing static color variants](#testing-static-color-variants)
     - [Testing dev mode warnings](#testing-dev-mode-warnings)
     - [Testing composed components](#testing-composed-components)
 
@@ -150,14 +152,14 @@ Use this table to decide where a test belongs:
 | --- | --- |
 | Default values after first render | Defaults |
 | Setting or clearing a property or attribute | Properties / Attributes |
-| Size variations (s, m, l, xl) | Properties / Attributes |
-| Static color attribute | Properties / Attributes |
-| ARIA label, role override | Properties / Attributes |
+| ARIA label, role override, `delegatesFocus` behavior | Properties / Attributes |
 | Slot content rendering | Slots |
 | Label fallback from slot | Slots |
+| Size variations (s, m, l, xl) | Variants / States |
+| Static color attribute | Variants / States |
 | Semantic or non-semantic variant list | Variants / States |
 | Outline, subtle, fixed positioning | Variants / States |
-| Indeterminate, disabled, progress values | Variants / States |
+| Indeterminate, disabled, pending state transitions | Variants / States |
 | State transitions (e.g., determinate to indeterminate) | Variants / States |
 | Invalid value warnings | Dev mode warnings |
 | Unsupported attribute warnings | Dev mode warnings |
@@ -403,6 +405,67 @@ await step('renders default slot content', async () => {
   expect(badge.textContent?.trim(), 'default slot text').toBe('Approved');
 });
 ```
+
+### Testing shadow DOM internals
+
+When a component wraps a native element in its shadow DOM (e.g., a `<button>` or `<input>`), assert the internal element's attributes and state through `renderRoot`.
+
+Access the internal element with `querySelector`:
+
+```typescript
+const button = await getComponent<Button>(canvasElement, 'swc-button');
+const internalButton = button.renderRoot.querySelector('button');
+expect(internalButton, 'internal button exists in shadow root').toBeTruthy();
+expect(internalButton?.getAttribute('aria-label'), 'aria-label on internal button').toBe('Save');
+```
+
+**Testing `delegatesFocus`:**
+
+When a component uses `delegatesFocus: true`, programmatic focus on the host routes to the internal element. Verify this by calling `focus()` and reading `activeElement` from the shadow root. Lit types `renderRoot` as `HTMLElement | DocumentFragment`, so cast it to `ShadowRoot` first:
+
+```typescript
+button.focus();
+const activeElement = (button.renderRoot as ShadowRoot).activeElement;
+expect(activeElement?.tagName.toLowerCase(), 'delegatesFocus routes focus to internal button').toBe('button');
+```
+
+When a native `disabled` attribute is present, `delegatesFocus` does not fire — assert `activeElement` is `null`:
+
+```typescript
+button.focus();
+const activeElement = (button.renderRoot as ShadowRoot).activeElement;
+expect(activeElement, 'focus not delegated to disabled internal button').toBeNull();
+```
+
+### Testing static color variants
+
+When the source story is tagged `!test`, spreading it into the test file carries the exclusion tag and skips the story. Use a custom `render` instead. Include `parameters: { staticColorsDemo: true }` to preserve the split dark/light background that makes the variants visible:
+
+```typescript
+export const StaticColorsTest: Story = {
+  render: () => html`
+    ${COMPONENT_STATIC_COLORS.map(
+      (color) => html`<swc-component static-color=${color}>Label</swc-component>`
+    )}
+  `,
+  parameters: {
+    staticColorsDemo: true,
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('reflects static-color attribute for each valid value', async () => {
+      for (const color of COMPONENT_STATIC_COLORS) {
+        const el = canvasElement.querySelector(
+          `swc-component[static-color="${color}"]`
+        ) as ComponentClass;
+        await el.updateComplete;
+        expect(el.staticColor, `staticColor="${color}" is reflected`).toBe(color);
+      }
+    });
+  },
+};
+```
+
+If the source story is not tagged `!test`, spread it directly — it already carries `staticColorsDemo: true` in its `parameters`.
 
 ### Testing dev mode warnings
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/04_testing/04_visual-regresssion-testing.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/04_testing/04_visual-regresssion-testing.md
@@ -35,7 +35,7 @@ VRT covers things that are hard to test programmatically:
 
 Every story is a VRT test case. When you create a story in your `*.stories.ts` file, it automatically becomes part of VRT. No extra code is needed.
 
-Stories tagged with `'!test'` are excluded from VRT runs (useful for interactive-only demos like `StaticColors`).
+Stories tagged with `'!test'` are excluded from VRT runs. See [Excluding stories from tests](01_testing-overview.md#excluding-stories-from-tests) for when and why to use this tag.
 
 ## Tips for reliable VRT
 


### PR DESCRIPTION
## Description

**Testing style guide improvements** (derived from button migration learnings, applicable to all components):

- **`!test` tag documentation** (`01_testing-overview.md`) — New canonical section explaining what `!test` gates (Vitest play functions, aXe, and VRT simultaneously), when it is and is not appropriate, and that it always requires a companion test story with a custom render.
- **Shadow DOM internals testing pattern** (`02_storybook-testing.md`) — Documents `renderRoot.querySelector()` for asserting internal element attributes, and the `(component.renderRoot as ShadowRoot).activeElement` cast needed to test `delegatesFocus` routing (including the disabled-element case where `activeElement` should be `null`).
- **Static color variant testing pattern** (`02_storybook-testing.md`) — Documents the `!test` workaround: custom render + `parameters: { staticColorsDemo: true }` to restore behavioral coverage when the source story is excluded from test runners.
- **Section placement table fix** (`02_storybook-testing.md`) — Moves size and static-color tests from Properties/Attributes to Variants/States, matching how badge and button tests are actually organized.
- **VRT doc fix** (`04_visual-regresssion-testing.md`) — Replaces the incorrect "interactive-only demos" explanation for `!test` with a cross-reference to the canonical section.
- **`stories-format.md` rule update** — Expands the one-line `!test` entry to explain the three runners it gates, the false-positive rationale, and the requirement to add a companion test story.

## Motivation and context

The shadow DOM internals and `!test` patterns came up repeatedly during button migration testing work and were not previously documented. Without the `!test` guidance, an agent applying the tag has no signal that it must also add a companion test story — leaving behavioral coverage gaps across all three test runners. Without the shadow DOM pattern, testing `delegatesFocus` requires rediscovering the `ShadowRoot` cast each time.

## Manual review test cases

- [ ] Verify the `!test` explanation in `01_testing-overview.md` matches the actual behavior in `.storybook/test-runner.ts` (line 35 early-return on `!test` tag)
- [ ] Verify the shadow DOM internals pattern (the `ShadowRoot` cast) compiles without error in a new test story