### PR TITLE
Upcoming features section and Illustrated Message storybook update

### DIFF
--- a/.ai/rules/stories-format.md
+++ b/.ai/rules/stories-format.md
@@ -267,6 +267,11 @@ export const StaticColors: Story = {
 | `'a11y'`              | Accessibility story                           |
 | `'migrated'`          | On meta object                                |
 
+### Optional tags
+
+- `'description-only'` - Story contains only descriptive content (no interactive component rendered)
+- `'upcoming'` - Story demonstrates a feature or variant that is not yet available
+
 ### Exclusion tags
 
 - `'!test'` - Exclude from test runs

--- a/.ai/scripts/validate-story-tags.js
+++ b/.ai/scripts/validate-story-tags.js
@@ -42,6 +42,8 @@ const ALLOWED_TAGS = new Set([
   'autodocs',
   'dev',
   'utility',
+  'upcoming',
+  'description-only',
   '!test',
   '!dev',
   '!autodocs',

--- a/.ai/skills/migration-documentation/SKILL.md
+++ b/.ai/skills/migration-documentation/SKILL.md
@@ -41,7 +41,9 @@ Read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[
 
 1. Add JSDoc comments to every story (except Playground and Overview, which have none by convention).
 2. Complete the Accessibility story body — it was left as a `// TODO` comment in Phase 4.
-3. Add any stories that were deferred or were not CSS-visible enough to include in Phase 4.
+3. Add any stories that were deferred or were not CSS-visible enough to include in Phase 4. For each item in the migration plan's Additive table:
+   - If the feature is implemented and has no story yet, add it as a normal story in the relevant section (Options, Behaviors, etc.).
+   - If the feature is not yet implemented, add it to an `UpcomingFeatures` story (tag: `['upcoming', 'description-only']`). Write from a consumer's perspective — what the feature does for them, not how it's built.
 
 If the stories document already exists, do **not** recreate the file from scratch. Augment what is already there.
 

--- a/.ai/skills/migration-documentation/SKILL.md
+++ b/.ai/skills/migration-documentation/SKILL.md
@@ -41,7 +41,7 @@ Read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[
 
 1. Add JSDoc comments to every story (except Playground and Overview, which have none by convention).
 2. Complete the Accessibility story body — it was left as a `// TODO` comment in Phase 4.
-3. Add any stories that were deferred or were not CSS-visible enough to include in Phase 4. 
+3. Add any stories that were deferred or were not CSS-visible enough to include in Phase 4.
 4. For each item in the migration plan's Additive table:
    - If the feature is implemented and has no story yet, add it as a normal story in the relevant section (Options, Behaviors, etc.).
    - If the feature is not yet implemented, add it to an `UpcomingFeatures` story (tag: `['upcoming', 'description-only']`). Write from a consumer's perspective — what the feature does for them, not how it's built.

--- a/.ai/skills/migration-documentation/SKILL.md
+++ b/.ai/skills/migration-documentation/SKILL.md
@@ -41,7 +41,8 @@ Read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[
 
 1. Add JSDoc comments to every story (except Playground and Overview, which have none by convention).
 2. Complete the Accessibility story body — it was left as a `// TODO` comment in Phase 4.
-3. Add any stories that were deferred or were not CSS-visible enough to include in Phase 4. For each item in the migration plan's Additive table:
+3. Add any stories that were deferred or were not CSS-visible enough to include in Phase 4. 
+4. For each item in the migration plan's Additive table:
    - If the feature is implemented and has no story yet, add it as a normal story in the relevant section (Options, Behaviors, etc.).
    - If the feature is not yet implemented, add it to an `UpcomingFeatures` story (tag: `['upcoming', 'description-only']`). Write from a consumer's perspective — what the feature does for them, not how it's built.
 

--- a/2nd-gen/packages/swc/.storybook/DocumentTemplate.mdx
+++ b/2nd-gen/packages/swc/.storybook/DocumentTemplate.mdx
@@ -51,10 +51,10 @@ export const ConditionalSection = ({ tag, title, hideTitle = false }) => {
     }
 
     return (
-        <>
+        <div data-section={tag}>
             {title && <h2>{title}</h2>}
             <SpectrumStories tag={tag} hideTitle={hideTitle} />
-        </>
+        </div>
     );
 
 };
@@ -109,13 +109,7 @@ export const ConditionalGettingStarted = () => {
 <ConditionalGettingStarted />
 
 <ConditionalSection tag="anatomy" title="Anatomy" hideTitle={true} />
-<div data-section="upcoming">
-  <ConditionalSection
-    tag="upcoming"
-    title="Upcoming features"
-    hideTitle={true}
-  />
-</div>
+<ConditionalSection tag="upcoming" title="Upcoming features" hideTitle={true} />
 <ConditionalSection tag="usage" hideTitle={true} />
 <ConditionalSection tag="options" title="Options" />
 <ConditionalSection tag="states" title="States" />

--- a/2nd-gen/packages/swc/.storybook/DocumentTemplate.mdx
+++ b/2nd-gen/packages/swc/.storybook/DocumentTemplate.mdx
@@ -109,6 +109,7 @@ export const ConditionalGettingStarted = () => {
 <ConditionalGettingStarted />
 
 <ConditionalSection tag="anatomy" title="Anatomy" hideTitle={true} />
+<ConditionalSection tag="upcoming" title="Upcoming features" hideTitle={true} />
 <ConditionalSection tag="usage" hideTitle={true} />
 <ConditionalSection tag="options" title="Options" />
 <ConditionalSection tag="states" title="States" />

--- a/2nd-gen/packages/swc/.storybook/DocumentTemplate.mdx
+++ b/2nd-gen/packages/swc/.storybook/DocumentTemplate.mdx
@@ -109,7 +109,13 @@ export const ConditionalGettingStarted = () => {
 <ConditionalGettingStarted />
 
 <ConditionalSection tag="anatomy" title="Anatomy" hideTitle={true} />
-<ConditionalSection tag="upcoming" title="Upcoming features" hideTitle={true} />
+<div data-section="upcoming">
+  <ConditionalSection
+    tag="upcoming"
+    title="Upcoming features"
+    hideTitle={true}
+  />
+</div>
 <ConditionalSection tag="usage" hideTitle={true} />
 <ConditionalSection tag="options" title="Options" />
 <ConditionalSection tag="states" title="States" />

--- a/2nd-gen/packages/swc/.storybook/blocks/StatusBadge.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/StatusBadge.tsx
@@ -17,7 +17,7 @@ import customElements from '../custom-elements.json' with { type: 'json' };
 // Register the badge component for use in the docs iframe
 import '../../components/badge/index.js';
 
-type Status = 'preview' | 'deprecated' | 'internal' | 'unsupported';
+type Status = 'preview' | 'deprecated' | 'internal';
 
 const STATUS_CONFIG: Record<
   Status,
@@ -26,7 +26,6 @@ const STATUS_CONFIG: Record<
   preview: { label: 'Preview', variant: 'fuchsia' },
   deprecated: { label: 'Deprecated', variant: 'negative', outline: true },
   internal: { label: 'Internal', variant: 'neutral', outline: true },
-  unsupported: { label: 'Unsupported', variant: 'negative' },
 };
 
 /**

--- a/2nd-gen/packages/swc/.storybook/preview-head.html
+++ b/2nd-gen/packages/swc/.storybook/preview-head.html
@@ -151,6 +151,10 @@
     table code {
       font-size: 0.75rem !important;
     }
+
+    [data-section='upcoming'] {
+      margin-block-end: 3.5rem;
+    }
   }
 
   /* Ensure an adaptive-capable background */

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -377,6 +377,7 @@ const preview = {
                 'Illustrated message',
                 [
                   'Accessibility migration analysis',
+                  'Migration plan',
                   'Rendering and styling migration analysis',
                 ],
                 'Infield button',
@@ -388,6 +389,17 @@ const preview = {
                   'Accessibility migration analysis',
                   'Rendering and styling migration analysis',
                 ],
+                'Menu',
+                [
+                  'Accessibility migration analysis',
+                  'Rendering and styling migration analysis',
+                ],
+                'Menu group',
+                ['Accessibility migration analysis'],
+                'Menu item',
+                ['Accessibility migration analysis'],
+                'Menu separator',
+                ['Accessibility migration analysis'],
                 'Meter',
                 [
                   'Accessibility migration analysis',

--- a/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
@@ -18,7 +18,6 @@ import styles from './illustrated-message.css';
 
 /**
  * @element swc-illustrated-message
- * @status unsupported
  * @since 0.0.1
  *
  * @example

--- a/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
@@ -314,7 +314,7 @@ DescriptionWithLink.storyName = 'Description with link';
 /**
  * ### Button group slot
  *
- * A button group slot is coming to place a button or button group alongside the heading and description.
+ * An upcoming button group slot will let you add action buttons alongside the heading and description.
  */
 export const UpcomingFeatures: Story = {
   tags: ['upcoming', 'description-only'],

--- a/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
@@ -308,6 +308,20 @@ export const DescriptionWithLink: Story = {
 DescriptionWithLink.storyName = 'Description with link';
 
 // ────────────────────────────────
+//    UPCOMING FEATURES STORIES
+// ────────────────────────────────
+
+/**
+ * ### Button group slot
+ *
+ * A button group slot is coming to place a button or button group alongside the heading and description.
+ */
+export const UpcomingFeatures: Story = {
+  tags: ['upcoming', 'description-only'],
+};
+UpcomingFeatures.storyName = 'Upcoming features';
+
+// ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/illustrated-message/accessibility-migration-analysis.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/illustrated-message/accessibility-migration-analysis.md
@@ -101,7 +101,7 @@ Bottom line: Authors choose `heading-level` (`2`–`6`, i.e. `h2`–`h6`) to mat
 |-------|------------|
 | Illustration (default slot) | If purely decorative, `aria-hidden="true"` on the SVG (or equivalent). If meaningful, `role="img"` and `aria-label` / `<title>` (see icon and SVG accessibility patterns). |
 | Description | Body text; links inside description must be real `<a>` or link components with visible names. |
-| Actions (Spectrum 2) | Slotted buttons follow button and action group labeling; order matches visual reading order. |
+| `button-group` slot (Spectrum 2) | Slotted buttons follow button and action group labeling; order matches visual reading order. |
 
 ### Shadow DOM and cross-root ARIA issues
 
@@ -147,7 +147,7 @@ Typical open state
 - [ ] Storybook examples vary `heading-level` by context (not always `2`).
 - [ ] 1st-gen fixed `h2` called out as migration motivation; link SWC-1466 / accordion for “configurable level” precedent only (different slot rules).
 - [ ] Decorative vs meaningful illustration documented for SVG slot.
-- [ ] Actions slot meets button label requirements.
+- [ ] `button-group` slot meets button label requirements.
 
 ---
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/illustrated-message/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/illustrated-message/migration-plan.md
@@ -142,7 +142,7 @@ No mixins, no shared utilities, no other SWC components composed inside. No depe
 |---|---|---|
 | **A1** | `size` attribute (`s` \| `m` \| `l`, default `m`) | Net-new t-shirt sizing. `m` is the base style, no extra ruleset needed. Implemented via `:host([size="..."])` attribute selectors, not modifier classes. |
 | **A2** | `orientation` string attribute (`'vertical'` \| `'horizontal'`, default `'vertical'`) | Net-new layout variant. Consumers not using it are unaffected. |
-| **A3** | `actions` slot | Net-new. Leave untyped — a focus group navigation controller will be needed in a future follow-up. |
+| **A3** | `button-group` slot | Net-new. Leave untyped — a focus group navigation controller will be needed in a future follow-up. |
 
 ---
 
@@ -165,7 +165,7 @@ These are derived from the a11y analysis and rendering roadmap. Confirmed items 
 | *(default)* | Decorative or informative SVG | Decorative SVGs should have `aria-hidden="true"`; informative need `role="img"` + `aria-label` |
 | `heading` | Single `<span>` | Restriction is semantic contract; dev-mode warning for non-`span` root nodes |
 | `description` | Phrasing content | Links must be real `<a>` or link components with visible names |
-| `actions` | **New.** Button group (untyped) | Leave untyped. Focus group navigation controller to be implemented in a future follow-up. |
+| `button-group` | **New.** Button group (untyped) | Leave untyped. Focus group navigation controller to be implemented in a future follow-up. |
 
 ### CSS custom properties (2nd-gen)
 
@@ -229,7 +229,7 @@ Follow the [Badge migration reference](../../02_workstreams/02_2nd-gen-component
 - [ ] Dev-mode `__swc.warn()` if heading slot root is not a `span`
 - [ ] Heading slot restricted to `<span>` only; shadow DOM owns the heading tag
 - [ ] Decorative illustration guidance documented (`aria-hidden="true"` on SVG); informative illustration guidance documented (`role="img"` + `aria-label`)
-- [ ] Actions slot button labels documented
+- [ ] `button-group` slot button labels documented
 
 ### Testing
 
@@ -242,7 +242,7 @@ Follow the [Badge migration reference](../../02_workstreams/02_2nd-gen-component
 
 - [ ] JSDoc on all public props, slots, and CSS custom properties
 - [ ] Storybook argTypes driven by `ILLUSTRATED_MESSAGE_VALID_SIZES` and `ILLUSTRATED_MESSAGE_VALID_HEADING_LEVELS` static arrays
-- [ ] Migration notes: `heading-level` replaces hard-coded `h2`; heading slot now `span`-only; new `size`, `orientation`, `actions` slot
+- [ ] Migration notes: `heading-level` replaces hard-coded `h2`; heading slot now `span`-only; new `size`, `orientation`, `button-group` slot
 - [ ] Storybook examples vary `heading-level` by context (not always `2`)
 - [ ] Decorative vs meaningful illustration guidance in Storybook
 
@@ -261,7 +261,7 @@ Follow the [Badge migration reference](../../02_workstreams/02_2nd-gen-component
 |---|---|---|---|
 | **Q1** | **`heading` attribute + `heading` slot precedence:** Slot takes precedence via `<slot name="heading">${this.heading}</slot>` — attribute is the fallback, slot content overrides it when present. | **Resolved** |
 | **Q2** | **`heading-level` clamping vs type-error:** Silently clamp using `Math.max(2, Math.min(6, level))` — consistent with `AccordionItem.getHeadingLevel()` precedent in the codebase. | **Resolved** |
-| **Q3** | **Actions slot type:** Leave untyped — consumer slots any button group content. A focus group navigation controller will need to be implemented in a future follow-up. | **Resolved** |
+| **Q3** | **`button-group` slot type:** Leave untyped — consumer slots any button group content. A focus group navigation controller will need to be implemented in a future follow-up. | **Resolved** |
 | **Q4** | **Typography styles dependency (SWC-1545):** 2nd-gen has typography classes but whether they will be importable in the same way as S1's `bodyStyles`/`headingStyles` is TBD. Tracked in SWC-1545. | Open | SWC-1545 |
 
 ---

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/illustrated-message/rendering-and-styling-migration-analysis.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/illustrated-message/rendering-and-styling-migration-analysis.md
@@ -280,7 +280,7 @@ For heading semantics, WCAG outline behavior, and the 2nd-gen API (`heading-leve
 | `.spectrum-IllustratedMessage-heading`      | `heading` attribute/slot     | Implemented                  |
 | `.spectrum-IllustratedMessage-description`  | `description` attribute/slot | Implemented                  |
 | `.spectrum-IllustratedMessage-content`      | Content container            | Missing from WC (new for S2) |
-| `.spectrum-IllustratedMessage-actions`      | Actions container            | Missing from WC (new for S2) |
+| `.spectrum-IllustratedMessage-actions`      | `button-group` slot          | Missing from WC (new for S2) |
 
 ## Summary of changes
 


### PR DESCRIPTION
## Description

- Creates a **Upcoming features** section in Storybook. Was added in `DocumentTemplate.mdx` to render immediately after Anatomy. 

- Removes the `unsupported` status from `StatusBadge.tsx` and drops `@status unsupported` from `IllustratedMessage.ts` — it was the only consumer and the status label is no longer needed

- Updates the `migration-documentation` skill (Phase 7) to clarify how to handle items from the migration plan's Additive table: write a normal story if the feature is already implemented; add an `['upcoming', 'description-only']` entry if it isn't, written from a consumer perspective

## Motivation and context

The `unsupported` status had no active use after the illustrated message migration completed. Placing upcoming features after anatomy makes them easier to find when reviewing a component's documentation. The skill update removes ambiguity around when to write upcoming vs. normal stories.

## Related issue(s)

- SWC-1841

## Screenshots (if appropriate)

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Upcoming features section renders after Anatomy in Storybook
  1. Open the illustrated message component in Storybook
  2. Navigate to the docs page
  3. Confirm the Upcoming features section appears after Anatomy and before Options

- [ ] Unsupported status badge no longer appears
  1. Open the illustrated message component in Storybook
  2. Confirm no "Unsupported" badge appears in the header

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  1. Open the illustrated message docs page in Storybook
  2. Tab through the page
  3. Confirm focus order is logical and no regressions in surrounding content

- [ ] **Screen reader** (required — document steps below)
  1. Open the illustrated message docs page in Storybook with a screen reader
  2. Navigate through the page headings
  3. Confirm section headings and content are announced correctly with no duplicate or unexpected announcements
