### PR TITLE
fix(core): Check whether `process` is defined before trying to use it

### DIFF
--- a/1st-gen/tools/base/src/Base.ts
+++ b/1st-gen/tools/base/src/Base.ts
@@ -97,7 +97,7 @@ export class SpectrumElement extends SpectrumMixin(LitElement) {
   }
 }
 
-if (process.env.NODE_ENV === 'development') {
+if (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') {
   const ignoreWarningTypes = {
     default: false,
     accessibility: false,

--- a/2nd-gen/packages/core/element/spectrum-element.ts
+++ b/2nd-gen/packages/core/element/spectrum-element.ts
@@ -68,7 +68,7 @@ export class SpectrumElement extends SpectrumMixin(LitElement) {
   }
 }
 
-if (process.env.NODE_ENV === 'development') {
+if (typeof process !== 'undefined' && process.env.NODE_ENV === 'development') {
   const ignoreWarningTypes = {
     default: false,
     accessibility: false,


### PR DESCRIPTION
`process` does not exist in a browser

## Description

Checks for the ambient `process` being defined before attempting to use it. This is because `process` is not defined in a browser context.

## Motivation and context

This change broke Sass playground

## Related issue(s)

Fixes https://github.com/adobe/spectrum-web-components/issues/6242

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [n/a] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [n/a] I have added automated tests to cover my changes.
- [?] I have included a well-written changeset if my change needs to be published.
- [n/a] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

N/A

### Device review

N/A, but I patched it in the `sass-site` repo, and it solved the issue.

## Accessibility testing checklist

N/A