### PR TITLE
docs(storybook): add UpcomingFeatures stories to 2nd-gen components

### DIFF
--- a/.ai/skills/migration-documentation/SKILL.md
+++ b/.ai/skills/migration-documentation/SKILL.md
@@ -1,25 +1,45 @@
 ---
 name: migration-documentation
-description: Phase 7 of 1st-gen to 2nd-gen component migration. Use to write JSDoc, Storybook stories, and usage docs so the component is usable and understandable by others.
+description:
+  Phase 7 of 1st-gen to 2nd-gen component migration. Use to write JSDoc,
+  Storybook stories, and usage docs so the component is usable and
+  understandable by others.
 ---
 
 # Migration documentation ([Phase 7](../../../CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/README.md))
 
-[Phase 7](../../../CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/README.md) of the 1st-gen → 2nd-gen component migration. The goal is JSDoc on the public API, Storybook stories covering the main use cases, and migration notes where the API diverges from 1st-gen.
+[Phase 7](../../../CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/README.md)
+of the 1st-gen → 2nd-gen component migration. The goal is JSDoc on the public
+API, Storybook stories covering the main use cases, and migration notes where
+the API diverges from 1st-gen.
 
-See also: [`documentation`](../documentation/SKILL.md) for Adobe content writing standards to follow when writing usage docs and migration notes.
+See also: [`documentation`](../documentation/SKILL.md) for Adobe content writing
+standards to follow when writing usage docs and migration notes.
 
 ## Mindset
 
-You are writing for the next contributor, not for yourself. Every story, JSDoc line, and migration note should answer the question a new engineer would ask six months from now. Avoid restating the implementation. Explain the intent, the constraints, and why the decisions were made. Be sure to follow the `documentation` skill for writing style and content expectations.
+You are writing for the next contributor, not for yourself. Every story, JSDoc
+line, and migration note should answer the question a new engineer would ask six
+months from now. Avoid restating the implementation. Explain the intent, the
+constraints, and why the decisions were made. Be sure to follow the
+`documentation` skill for writing style and content expectations.
 
-Read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[component]/migration-plan.md` when available before documenting the component. Use it as the source for migration notes, consumer-facing breaking-change explanations, rationale behind naming or behavior differences, and the main scenarios the stories should emphasize. If it is missing, stale, or intentionally incomplete, derive the needed context from the implemented component and source material and call out the missing plan as a risk. See also [`migration-plan-contract`](../migration-prep/references/migration-plan-contract.md).
+Read the migration plan at
+`CONTRIBUTOR-DOCS/03_project-planning/03_components/[component]/migration-plan.md`
+when available before documenting the component. Use it as the source for
+migration notes, consumer-facing breaking-change explanations, rationale behind
+naming or behavior differences, and the main scenarios the stories should
+emphasize. If it is missing, stale, or intentionally incomplete, derive the
+needed context from the implemented component and source material and call out
+the missing plan as a risk. See also
+[`migration-plan-contract`](../migration-prep/references/migration-plan-contract.md).
 
 ## When to use this skill
 
 - Phase 6 (migration-testing) is complete
 - The user asks to "document [component]" or "add stories for [component]"
-- The user asks to write JSDoc, add Storybook stories, or document migration notes
+- The user asks to write JSDoc, add Storybook stories, or document migration
+  notes
 - The user refers to "Phase 7" of the 2nd-gen component migration workstream
 
 ## When NOT to use
@@ -37,17 +57,38 @@ Read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[
 
 ## Workflow
 
-**Check for a Phase 4 stories scaffold first.** If Phase 4 (migration-styling) was completed, `2nd-gen/packages/swc/components/[component]/stories/[component].stories.ts` likely already exists with Playground, Overview, Anatomy, Options, States, and Behaviors stories — all structurally correct but without JSDoc prose. Phase 7's job is to:
+**Check for a Phase 4 stories scaffold first.** If Phase 4 (migration-styling)
+was completed,
+`2nd-gen/packages/swc/components/[component]/stories/[component].stories.ts`
+likely already exists with Playground, Overview, Anatomy, Options, States, and
+Behaviors stories — all structurally correct but without JSDoc prose. Phase 7's
+job is to:
 
-1. Add JSDoc comments to every story (except Playground and Overview, which have none by convention).
-2. Complete the Accessibility story body — it was left as a `// TODO` comment in Phase 4.
-3. Add any stories that were deferred or were not CSS-visible enough to include in Phase 4.
+1. Add JSDoc comments to every story (except Playground and Overview, which have
+   none by convention).
+2. Complete the Accessibility story body — it was left as a `// TODO` comment in
+   Phase 4.
+3. Add any stories that were deferred or were not CSS-visible enough to include
+   in Phase 4.
 4. For each item in the migration plan's Additive table:
-   - If the feature is implemented and has no story yet, add it as a normal story in the relevant section (Options, Behaviors, etc.).
-   - If the feature is not yet implemented, add it to an `UpcomingFeatures` story (tag: `['upcoming', 'description-only']`). Keep it brief and bullet-point style — the goal is to signal roadmap intent, not explain scope decisions. Write from a consumer's perspective (what it does for them) and omit internal framing like "not part of the initial scope" or "deferred pending a decision". Do not include ticket numbers (e.g. SWC-1234) or TODO language.
+   - If the feature is implemented and has no story yet, add it as a normal
+     story in the relevant section (Options, Behaviors, etc.).
+   - If the feature is not yet implemented, add it to an `UpcomingFeatures`
+     story (tag: `['upcoming', 'description-only']`). Keep it brief and
+     bullet-point style — the goal is to signal roadmap intent, not explain
+     scope decisions. Write from a consumer's perspective (what it does for
+     them) and omit internal framing like "not part of the initial scope" or
+     "deferred pending a decision". Do not include ticket numbers or TODO
+     language.
 
-If the stories document already exists, do **not** recreate the file from scratch. Augment what is already there.
+If the stories document already exists, do **not** recreate the file from
+scratch. Augment what is already there.
 
-Follow **[Phase 7: Documentation](../../../CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#phase-7-documentation)** in the washing machine workflow doc — it covers what to do, what to check, common problems, and the quality gate for this phase.
+Follow
+**[Phase 7: Documentation](../../../CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#phase-7-documentation)**
+in the washing machine workflow doc — it covers what to do, what to check,
+common problems, and the quality gate for this phase.
 
-If the docs need to describe behavior or migration guidance that differs from the approved migration plan, follow [`migration-plan-contract`](../migration-prep/references/migration-plan-contract.md).
+If the docs need to describe behavior or migration guidance that differs from
+the approved migration plan, follow
+[`migration-plan-contract`](../migration-prep/references/migration-plan-contract.md).

--- a/.ai/skills/migration-documentation/SKILL.md
+++ b/.ai/skills/migration-documentation/SKILL.md
@@ -44,7 +44,7 @@ Read the migration plan at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[
 3. Add any stories that were deferred or were not CSS-visible enough to include in Phase 4.
 4. For each item in the migration plan's Additive table:
    - If the feature is implemented and has no story yet, add it as a normal story in the relevant section (Options, Behaviors, etc.).
-   - If the feature is not yet implemented, add it to an `UpcomingFeatures` story (tag: `['upcoming', 'description-only']`). Write from a consumer's perspective — what the feature does for them, not how it's built.
+   - If the feature is not yet implemented, add it to an `UpcomingFeatures` story (tag: `['upcoming', 'description-only']`). Keep it brief and bullet-point style — the goal is to signal roadmap intent, not explain scope decisions. Write from a consumer's perspective (what it does for them) and omit internal framing like "not part of the initial scope" or "deferred pending a decision". Do not include ticket numbers (e.g. SWC-1234) or TODO language.
 
 If the stories document already exists, do **not** recreate the file from scratch. Augment what is already there.
 

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -458,7 +458,10 @@ const preview = {
                 'Thumbnail',
                 ['Rendering and styling migration analysis'],
                 'Tooltip',
-                ['Rendering and styling migration analysis'],
+                [
+                  'Accessibility migration analysis',
+                  'Rendering and styling migration analysis',
+                ],
               ],
               'Milestones',
               'Strategies',

--- a/2nd-gen/packages/swc/components/avatar/stories/avatar.stories.ts
+++ b/2nd-gen/packages/swc/components/avatar/stories/avatar.stories.ts
@@ -295,6 +295,26 @@ export const Disabled: Story = {
   tags: ['options'],
 };
 
+// ──────────────────────────────────
+//    UPCOMING FEATURES STORIES
+// ──────────────────────────────────
+
+/**
+ * ### Additional avatar types
+ *
+ * - **Gradient image**: Shows a generated colorful gradient when no photo is available
+ * - **Initials**: Shows the user's initials inside the avatar circle as a photo fallback
+ * - **Guest**: Shows a default guest icon when no user identity is known
+ *
+ * ### Avatar Group
+ *
+ * - Display a collection of avatars in a stacked layout with configurable overlap and overflow
+ */
+export const UpcomingFeatures: Story = {
+  tags: ['upcoming', 'description-only'],
+};
+UpcomingFeatures.storyName = 'Upcoming features';
+
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────

--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -525,6 +525,21 @@ export const Inline: Story = {
   tags: ['behaviors'],
 };
 
+// ──────────────────────────────────
+//    UPCOMING FEATURES STORIES
+// ──────────────────────────────────
+
+/**
+ * ### Notification and indicator badge types
+ *
+ * - **Notification**: Displays a numeric count to signal unread or pending items, such as a message counter on an icon
+ * - **Indicator**: A dot-only badge that signals activity or updated content without showing a count
+ */
+export const UpcomingFeatures: Story = {
+  tags: ['upcoming', 'description-only'],
+};
+UpcomingFeatures.storyName = 'Upcoming features';
+
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────

--- a/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/stories/illustrated-message.stories.ts
@@ -314,7 +314,7 @@ DescriptionWithLink.storyName = 'Description with link';
 /**
  * ### Button group slot
  *
- * An upcoming button group slot will let you add action buttons alongside the heading and description.
+ * - Add a group of action buttons alongside the heading and description using the `button-group` slot
  */
 export const UpcomingFeatures: Story = {
   tags: ['upcoming', 'description-only'],

--- a/2nd-gen/packages/swc/components/tabs/stories/tabs.stories.ts
+++ b/2nd-gen/packages/swc/components/tabs/stories/tabs.stories.ts
@@ -432,6 +432,20 @@ export const ActivationModes: Story = {
   tags: ['behaviors'],
 };
 
+// ──────────────────────────────────
+//    UPCOMING FEATURES STORIES
+// ──────────────────────────────────
+
+/**
+ * ### Overflow
+ *
+ * - When tabs exceed the container width, overflowing tabs will collapse into a `<swc-picker>` dropdown
+ */
+export const UpcomingFeatures: Story = {
+  tags: ['upcoming', 'description-only'],
+};
+UpcomingFeatures.storyName = 'Upcoming features';
+
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────


### PR DESCRIPTION
## Description

Adds an `UpcomingFeatures` Storybook story to four 2nd-gen components — `swc-avatar`, `swc-badge`, `swc-tabs`, and `swc-illustrated-message` — to surface planned roadmap features in the component documentation. Also updates the `migration-documentation` skill with explicit authoring guidance for this story type.

Each `UpcomingFeatures` story uses `tags: ['upcoming', 'description-only']` and contains a brief, bullet-point JSDoc written from a consumer perspective. No interactive component is rendered.

## Motivation and context

The `migration-documentation` skill was updated to include a step for documenting unimplemented Additive features from migration plans. Illustrated Message was the only component with this section before this change. This applies the pattern consistently across the remaining migrated 2nd-gen components that have known upcoming features.

The skill guidance was also tightened to require bullet-point style and consumer-facing language, and to prohibit internal framing (e.g. "deferred", "phase 2") and ticket numbers in story copy.

## Related issue(s)

- No issue — documentation-only change to the 2nd-gen Storybook

## Screenshots (if appropriate)

N/A — stories are `description-only` and render no visual component.

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

> **Notes:** No automated tests are applicable — `description-only` stories render no component. No changeset is needed — this is a documentation-only change with no published package impact.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _UpcomingFeatures story renders correctly in Storybook for each component_
  1. Open the 2nd-gen Storybook
  2. Navigate to each of: Avatar, Badge, Tabs, Illustrated Message
  3. Select the **Upcoming features** entry in the sidebar
  4. Expect a description-only page with the feature bullet points — no interactive component rendered

- [ ] _Skill guidance is reflected in the migration-documentation skill file_
  1. Open `.ai/skills/migration-documentation/SKILL.md`
  2. Locate step 4 of the Workflow section
  3. Expect the UpcomingFeatures guidance to read: brief, bullet-point style, consumer perspective, no internal framing, no ticket numbers

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)

  The `UpcomingFeatures` stories use `tags: ['description-only']` and render no interactive elements. There are no focusable parts. Confirm no regressions in surrounding Storybook navigation.

