### PR TITLE
fix(build): replace process.env.NODE_ENV in 1st-gen and 2nd-gen builds

### DIFF
--- a/1st-gen/scripts/ts-tools.js
+++ b/1st-gen/scripts/ts-tools.js
@@ -83,7 +83,10 @@ export const buildPackage = async (paths) => {
       build({
         ...config,
         entryPoints: devPaths,
-        define: { 'window.__swc.DEBUG': 'true' },
+        define: {
+          'window.__swc.DEBUG': 'true',
+          'process.env.NODE_ENV': '"development"',
+        },
         outExtension: { '.js': '.dev.js' },
         plugins: devPlugins,
       }).catch(() => process.exit(1))
@@ -91,7 +94,10 @@ export const buildPackage = async (paths) => {
   }
   const prodConfig = {
     ...config,
-    define: { 'window.__swc.DEBUG': 'false' },
+    define: {
+      'window.__swc.DEBUG': 'false',
+      'process.env.NODE_ENV': '"production"',
+    },
     plugins: paths.length === 1 ? [] : prodPlugins,
   };
   if (prodPath.length) {

--- a/2nd-gen/packages/core/vite.config.js
+++ b/2nd-gen/packages/core/vite.config.js
@@ -86,7 +86,12 @@ function getEntries() {
   return entries;
 }
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  define: {
+    'process.env.NODE_ENV': JSON.stringify(
+      mode === 'development' ? 'development' : 'production'
+    ),
+  },
   plugins: [
     dts({
       include: ['**/*.ts'],
@@ -125,4 +130,4 @@ export default defineConfig({
   esbuild: {
     target: 'es2018',
   },
-});
+}));

--- a/2nd-gen/packages/swc/vite.config.ts
+++ b/2nd-gen/packages/swc/vite.config.ts
@@ -60,7 +60,12 @@ function processStylesheets(): Plugin {
   };
 }
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  define: {
+    'process.env.NODE_ENV': JSON.stringify(
+      mode === 'development' ? 'development' : 'production'
+    ),
+  },
   plugins: [
     litCss({ exclude: ['./stylesheets/**/*.css'] }),
     processStylesheets(),
@@ -147,4 +152,4 @@ export default defineConfig({
   esbuild: {
     target: 'es2018',
   },
-});
+}));


### PR DESCRIPTION
## Description

Ensures built artifacts in both 1st-gen and 2nd-gen never contain raw `process.env.NODE_ENV` references, so downstream consumers (e.g. Sass playground) loading SWC packages in a browser without a bundler don't hit `ReferenceError: process is not defined`.

- **1st-gen** (`ts-tools.js`): adds an explicit `define` for `process.env.NODE_ENV` in the esbuild config. esbuild's `build()` API auto-replaces this by default, but making it explicit is defensive and self-documenting.
- **2nd-gen** (`vite.config.js` / `vite.config.ts`): adds a `define` to the Vite config. Vite's library mode (`build.lib`) does **not** auto-replace `process.env.NODE_ENV`, which is why the published 2nd-gen `dist/element/spectrum-element.js` was shipping with the raw expression — this is the actual customer-facing bug.

## Motivation and context

PR #6250 fixes `ReferenceError: process is not defined` for downstream consumers by adding a `typeof process !== 'undefined'` runtime guard in `Base.ts` and `spectrum-element.ts`. That approach fixes the symptom but breaks 1st-gen CI tests: esbuild doesn't replace `typeof process`, so the guard evaluates to `false` in the browser test environment, `window.__swc` is never initialized, and `window.__swc.warn()` crashes in components like `DialogBase`.

**Verification** — built dist files no longer contain any `process.X` or `typeof process` references:

```
$ grep -rEn '\bprocess\.|typeof process\b' \
    1st-gen/packages/*/src/*.dev.js 1st-gen/packages/*/src/*.js \
    1st-gen/tools/*/src/*.dev.js 1st-gen/tools/*/src/*.js \
    2nd-gen/packages/core/dist 2nd-gen/packages/swc/dist
# (no matches)
```

In the rebuilt 2nd-gen `spectrum-element.js`, the entire dev-mode setup block is dead-code eliminated because `"production" === 'development'` is `false`.

**Important:** PR #6250 must also **revert** its `typeof process !== 'undefined'` source-level guards in `Base.ts` and `spectrum-element.ts`. With `process.env.NODE_ENV` replaced at build time in both build systems, the guards are unnecessary, and keeping them would still break 1st-gen tests (the built output becomes `if (typeof process !== 'undefined' && true)`, still `false` in the browser).

## Related issue(s)

- Fixes the CI breakage introduced by #6250
- fixes [#6242](https://github.com/adobe/spectrum-web-components/issues/6242)

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [n/a] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [n/a] I have added automated tests to cover my changes.
- [n/a] I have included a well-written changeset if my change needs to be published.
- [n/a] I have included updated documentation if my change required it.

## Accessibility testing checklist

N/A — build configuration change only.