### PR TITLE
ci(publish): replace --refresh-lockfile with yarn install to fix constraints assertion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Refresh lockfile and rebuild
         run: |
-          yarn install --refresh-lockfile
+          yarn install
           yarn build
 
       - name: Publish all packages
@@ -298,7 +298,7 @@ jobs:
         if: steps.extract-tag.outputs.tag == 'latest'
         run: |
           git add .
-          HUSKY=0 git commit -m "chore: release packages #publish" || echo "No changes to commit"
+          git commit -m "chore: release packages #publish" || echo "No changes to commit"
           git push
 
       - name: Create git tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -298,7 +298,7 @@ jobs:
         if: steps.extract-tag.outputs.tag == 'latest'
         run: |
           git add .
-          git commit -m "chore: release packages #publish" || echo "No changes to commit"
+          HUSKY=0 git commit -m "chore: release packages #publish" || echo "No changes to commit"
           git push
 
       - name: Create git tag


### PR DESCRIPTION
## Description

Replaces `yarn install --refresh-lockfile` with plain `yarn install` in the publish workflow's "Refresh lockfile and rebuild" step to prevent a Yarn 4.9.2 bug from breaking the post-publish commit.

```diff
- yarn install --refresh-lockfile
+ yarn install
```

## Root cause

After tracing through the Yarn 4.9.2 minified source, the assertion fires inside `createEnvironment` (the constraint system's Prolog environment builder). It triggers when a stored package has a dependency whose descriptor resolves to a locator hash that is not in `storedPackages` — meaning `storedResolutions` and `storedPackages` are out of sync.

In a fresh CI environment, `--refresh-lockfile` aggressively prunes stale resolution entries after `yarn changeset version` bumps package versions. This can leave dangling entries in `storedResolutions` without a corresponding entry in `storedPackages`. Locally the Yarn cache is warm so the pruning is a no-op and the inconsistency is never introduced.

Plain `yarn install` (already unlocked by `YARN_ENABLE_IMMUTABLE_INSTALLS: false`) adds new resolutions without aggressively pruning old ones, keeping both maps consistent. The lockfile may carry a few extra stale version aliases from the previous release, which is harmless.

## Motivation and context

The publish workflow published all packages to npm for the 1.12.0 / 0.1.0 release, but the post-publish commit failed because `yarn constraints --fix` (run by lint-staged in the pre-commit hook) crashed with this Yarn internal assertion. The version-bump commit was recovered manually in #6277.

## Related issue(s)

- Recovers #6277

## Screenshots (if appropriate)

N/A

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers

### Manual review test cases

- [ ] Trigger the publish workflow after merging; confirm the "Refresh lockfile and rebuild" and "Commit and push changes" steps both succeed

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

N/A — CI workflow change only.