### PR TITLE
fix(test-runner): retry axe analysis on conflict with addon-a11y in test-runner

### DIFF
--- a/2nd-gen/packages/swc/.storybook/test-runner.ts
+++ b/2nd-gen/packages/swc/.storybook/test-runner.ts
@@ -54,7 +54,23 @@ const config: TestRunnerConfig = {
         axeBuilder.disableRules(a11yConfig.disabledRules);
       }
 
-      const results = await axeBuilder.analyze();
+      // Both addon-a11y and the test-runner run axe in the same preview iframe.
+      // The waitForFunction above can resolve just before the addon starts a new run,
+      // so analyze() may find axe already running. Retry once after waiting.
+      let results;
+      try {
+        results = await axeBuilder.analyze();
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes('Axe is already running')
+        ) {
+          await targetPage.waitForFunction(() => !(window as any).axe?.running);
+          results = await axeBuilder.analyze();
+        } else {
+          throw error;
+        }
+      }
 
       // Filter violations using rule-specific exclusions from story parameters.
       // parameters.a11y.exclude: { 'rule-id': ['selector1', 'selector2'] }


### PR DESCRIPTION
## Description

In `test-runner.ts`, wrap `axeBuilder.analyze()` in a try/catch that retries once when axe-core throws `"Axe is already running"`. On conflict, the handler re-polls `window.axe.running` via the existing `waitForFunction` pattern,
then retries the analysis.

## Motivation and context

`@storybook/addon-a11y` and `@axe-core/playwright` both run axe in the same preview iframe. The existing `waitForFunction(() => !axe?.running)` guard reduces the window for conflict but cannot eliminate it entirely: the poll can
resolve, then the addon begins a new run triggered by a re-render before `analyze()` can claim axe, causing axe-core to throw `"Axe is already running"`. The failure was timing-dependent, which is why re-running the job resolved
it.

## Related issue(s)

- fixes SWC-2070

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [[Aria Practices](https://www.w3.org/TR/wai-aria-practices/)](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Confirm the `test-2ndgen-axe` CircleCI job passes without re-runs across several main-branch merges.

### Device review

N/A — CI configuration change only.

## Accessibility testing checklist

N/A — this change fixes the test infrastructure, not a component.