### PR TITLE
fix(test-runner): refactor axe retry test logic into a loop for resilience

### DIFF
--- a/2nd-gen/packages/swc/.storybook/test-runner.ts
+++ b/2nd-gen/packages/swc/.storybook/test-runner.ts
@@ -52,14 +52,19 @@ const config: TestRunnerConfig = {
         axeBuilder.disableRules(a11yConfig.disabledRules);
       }
 
-      // Both addon-a11y and the test-runner run axe in the same preview iframe.
-      // waitForFunction can resolve just before the addon starts a new run, so
-      // analyze() may still find axe running. Retry up to 5 times with backoff.
-      let results;
+      // On the docs page the preview runs in a nested iframe; wait on that
+      // frame's window, not the shell's, which has no axe instance.
+      const previewFrame =
+        targetPage.frames().find((f) => f.url().includes('/iframe.html')) ??
+        targetPage.mainFrame();
+
+      let results!: Awaited<ReturnType<typeof axeBuilder.analyze>>;
       let lastError: Error | null = null;
       for (let attempt = 0; attempt < 5; attempt++) {
         try {
-          await targetPage.waitForFunction(() => !(window as any).axe?.running);
+          await previewFrame.waitForFunction(
+            () => !(window as any).axe?.running
+          );
           results = await axeBuilder.analyze();
           lastError = null;
           break;

--- a/2nd-gen/packages/swc/.storybook/test-runner.ts
+++ b/2nd-gen/packages/swc/.storybook/test-runner.ts
@@ -41,8 +41,6 @@ const config: TestRunnerConfig = {
       targetPage: typeof page,
       viewLabel: 'story' | 'docs'
     ): Promise<string | null> => {
-      await targetPage.waitForFunction(() => !(window as any).axe?.running);
-
       const axeBuilder = new AxeBuilder({ page: targetPage })
         .include('#storybook-root')
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']);
@@ -55,21 +53,30 @@ const config: TestRunnerConfig = {
       }
 
       // Both addon-a11y and the test-runner run axe in the same preview iframe.
-      // The waitForFunction above can resolve just before the addon starts a new run,
-      // so analyze() may find axe already running. Retry once after waiting.
+      // waitForFunction can resolve just before the addon starts a new run, so
+      // analyze() may still find axe running. Retry up to 5 times with backoff.
       let results;
-      try {
-        results = await axeBuilder.analyze();
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes('Axe is already running')
-        ) {
+      let lastError: Error | null = null;
+      for (let attempt = 0; attempt < 5; attempt++) {
+        try {
           await targetPage.waitForFunction(() => !(window as any).axe?.running);
           results = await axeBuilder.analyze();
-        } else {
-          throw error;
+          lastError = null;
+          break;
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes('Axe is already running')
+          ) {
+            lastError = error;
+            await targetPage.waitForTimeout(100 * (attempt + 1));
+          } else {
+            throw error;
+          }
         }
+      }
+      if (lastError) {
+        throw lastError;
       }
 
       // Filter violations using rule-specific exclusions from story parameters.


### PR DESCRIPTION
## Description

Upgrades the axe retry logic in the Storybook test-runner from a single retry to a loop of up to 5 attempts with incremental backoff (100 ms × attempt). The `waitForFunction` check is now inside the loop so it runs before every
attempt rather than only before the first.

## Motivation and context

`addon-a11y` and the test-runner both run axe inside the same preview iframe. The previous fix (#6279) caught the `"Axe is already running"` error and retried once, but a single retry is not enough: the race window between
`waitForFunction` resolving and `addon-a11y` starting a new run means the retry itself can fail with the same error. Stories like `Components/Icon › Playground` and `Patterns/Conversational AI/Suggestion group/Suggestion item ›
Playground` were flaking consistently in CI because of this.

## Related issue(s)

- follow-up to #6279

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.
> No changeset needed — this change is scoped to internal test infrastructure and does not affect any published package API.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Run the full Storybook test suite and confirm the previously flaking stories pass
1. Start the 2nd-gen Storybook: `yarn workspace @adobe/spectrum-wc storybook`
2. In a second terminal: `yarn workspace @adobe/spectrum-wc test:storybook`
3. Confirm `Components/Icon › Playground` and `Patterns/Conversational AI/Suggestion group/Suggestion item › Playground` pass without the `"Axe is already running"` error

## Accessibility testing checklist

This change is scoped entirely to test-runner infrastructure (`test-runner.ts`). No rendered UI, interactive component, or user-facing behavior was modified.

- [x] **Keyboard** — not applicable; no UI changes
- [x] **Screen reader** — not applicable; no UI changes