### PR TITLE
fix(build): enable stylelint for auto-generated global element stylesheets

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -34,4 +34,3 @@
 1st-gen/packages/iconset
 1st-gen/packages/icons-ui
 1st-gen/packages/icons-workflow
-2nd-gen/packages/swc/stylesheets/global

--- a/2nd-gen/packages/swc/components/color-loupe/stories/color-loupe.stories.ts
+++ b/2nd-gen/packages/swc/components/color-loupe/stories/color-loupe.stories.ts
@@ -30,7 +30,7 @@ const { events, args, argTypes, template } =
  * color slider, and color wheel — visibility is managed by the parent.
  */
 const meta: Meta = {
-  title: 'Color Components/Color Loupe',
+  title: 'Color components/Color Loupe',
   component: 'swc-color-loupe',
   args: {
     ...args,

--- a/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
@@ -13,7 +13,7 @@ import * as MessageSourcesStories from './message-sources/stories/message-source
 import * as SuggestionGroupStories from './suggestion/stories/suggestion-group.stories';
 import * as SuggestionItemStories from './suggestion-item/stories/suggestion-item.stories';
 
-<Meta title="Conversational AI/README" />
+<Meta title="Conversational AI/Pattern overview" />
 
 # Conversational AI
 

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -99,5 +99,11 @@ export default {
         'no-duplicate-selectors': null,
       },
     },
+    {
+      files: ['2nd-gen/packages/swc/stylesheets/global/**/*.css'],
+      rules: {
+        'no-descending-specificity': null,
+      },
+    },
   ],
 };


### PR DESCRIPTION
## Description

The `stylesheets/global` directory was listed in `.stylelintignore`, causing `runStylelintFix` inside `vite-global-elements-css` to silently skip every file it generated. As a result, generated global stylesheets (e.g. `global-button.css`) were always written with property-ordering and whitespace violations that were never auto-corrected.

Two changes fix this:

1. **`.stylelintignore`** — remove `2nd-gen/packages/swc/stylesheets/global` so stylelint processes generated files.
2. **`stylelint.config.js`** — add a `no-descending-specificity: null` override for the global directory. The generation pipeline concatenates `*-base.css` before the component CSS, so the base's intentionally inflated-specificity disabled rule (`.swc-Button:disabled:is(*, :hover)`) lands before the component's `:hover`/`:active` rules. That ordering is semantically correct and intentional, but the rule flags it as a false positive.

After these changes, `runStylelintFix` correctly auto-fixes the generated file on every dev-server start or build, and `yarn lint:css` will also catch any regressions.

## Motivation and context

Auto-generated files in `stylesheets/global` were silently exempt from linting, causing them to accumulate property-order and whitespace violations on every regeneration.

## Related issue(s)

N/A — internal tooling fix.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Accessibility testing checklist

**Keyboard** — no interactive changes; no keyboard testing required.

**Screen reader** — no markup changes; no screen reader testing required.