### PR TITLE
fix(test-runner): exclude addon-a11y from ci-a11y build to eliminate axe conflict

### DIFF
--- a/2nd-gen/packages/swc/.storybook/main.ts
+++ b/2nd-gen/packages/swc/.storybook/main.ts
@@ -143,8 +143,9 @@ if (storybookMode === 'dev') {
 }
 
 /**
- * ci-a11y mode needs docs (for MDX parsing) and a11y; everything else
- * (designs, vitest, chromatic, screen-reader) is unnecessary overhead.
+ * ci-a11y mode needs docs (for MDX parsing); addon-a11y is excluded because
+ * the test-runner handles axe analysis directly. Everything else (designs,
+ * vitest, chromatic, screen-reader) is unnecessary overhead.
  */
 const addons: StorybookConfig['addons'] = [
   {
@@ -158,12 +159,12 @@ const addons: StorybookConfig['addons'] = [
       },
     },
   },
-  '@storybook/addon-a11y',
   '@github-ui/storybook-addon-performance-panel/universal',
 ];
 
 if (storybookMode !== 'ci-a11y') {
   addons.push(
+    '@storybook/addon-a11y',
     '@storybook/addon-designs',
     '@storybook/addon-vitest',
     '@chromatic-com/storybook',

--- a/2nd-gen/packages/swc/.storybook/test-runner.ts
+++ b/2nd-gen/packages/swc/.storybook/test-runner.ts
@@ -41,8 +41,6 @@ const config: TestRunnerConfig = {
       targetPage: typeof page,
       viewLabel: 'story' | 'docs'
     ): Promise<string | null> => {
-      await targetPage.waitForFunction(() => !(window as any).axe?.running);
-
       const axeBuilder = new AxeBuilder({ page: targetPage })
         .include('#storybook-root')
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']);
@@ -54,23 +52,7 @@ const config: TestRunnerConfig = {
         axeBuilder.disableRules(a11yConfig.disabledRules);
       }
 
-      // Both addon-a11y and the test-runner run axe in the same preview iframe.
-      // The waitForFunction above can resolve just before the addon starts a new run,
-      // so analyze() may find axe already running. Retry once after waiting.
-      let results;
-      try {
-        results = await axeBuilder.analyze();
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes('Axe is already running')
-        ) {
-          await targetPage.waitForFunction(() => !(window as any).axe?.running);
-          results = await axeBuilder.analyze();
-        } else {
-          throw error;
-        }
-      }
+      const results = await axeBuilder.analyze();
 
       // Filter violations using rule-specific exclusions from story parameters.
       // parameters.a11y.exclude: { 'rule-id': ['selector1', 'selector2'] }


### PR DESCRIPTION
## Description

Both `addon-a11y` and the test-runner inject axe into the same preview iframe. `addon-a11y` triggers its own analysis on every story render, which races with the test-runner's `axeBuilder.analyze()` call and produces `"Axe is already running"` errors.

The previous workaround retried `analyze()` on conflict. The race window between checking `!axe.running` and calling `analyze()` still exists; the addon can slip in between the two calls.

## Motivation and context

The root cause is two axe runners competing in the same iframe. `addon-a11y` is only useful for the interactive Storybook panel — in the `ci-a11y` build, nobody is looking at the panel, and the test-runner already owns all axe analysis. Excluding the addon from that build removes the conflict entirely.

## Related issue(s)

- Follows up on #6279

## Screenshots (if appropriate)

N/A

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _CI axe tests pass without "Axe is already running" errors_
  1. Trigger the CI `ci-a11y` job
  2. Confirm no `Axe is already running` errors appear in the test-runner output
  3. Confirm axe violations are still reported correctly when present

- [ ] _Local Storybook still shows the accessibility panel_
  1. Run `yarn storybook` locally (dev mode)
  2. Open any component story
  3. Confirm the Accessibility panel in the Storybook toolbar is present and functional

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

This PR changes CI test infrastructure only — no component rendering or interactive behavior is modified.

- [ ] **Keyboard** (required — document steps below)
  No focusable parts changed; confirm no regressions in surrounding Storybook examples by running the test suite.

- [ ] **Screen reader** (required — document steps below)
  No component markup changed; screen reader behavior is unaffected.