### PR TITLE
refactor(upload-artifact): remove redundant data-preview-only mechanism

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
@@ -46,26 +46,8 @@ export class UploadArtifact extends SpectrumElement {
   @property({ type: String, attribute: 'dismiss-label' })
   public dismissLabel = 'Remove attachment';
 
-  /** Internal flag reflected for preview-only host styling hooks. */
-  @property({ type: Boolean, attribute: 'data-preview-only', reflect: true })
-  private _previewOnly = false;
-
   public static override get styles(): CSSResultArray {
     return [styles];
-  }
-
-  private _syncMode(): void {
-    this._previewOnly = this.type === 'media';
-  }
-
-  protected override updated(changed: Map<string, unknown>): void {
-    if (changed.has('type')) {
-      this._syncMode();
-    }
-  }
-
-  protected override firstUpdated(): void {
-    this._syncMode();
   }
 
   private _handleDismissClick(): void {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
@@ -44,7 +44,6 @@ export const OverviewTest: Story = {
         expect(el.type).toBe('card');
         expect(el.dismissible).toBe(true);
         expect(el.dismissLabel).toBe('Remove attachment');
-        expect(el.hasAttribute('data-preview-only')).toBe(false);
 
         const dismissButton = el.shadowRoot?.querySelector<HTMLButtonElement>(
           '.swc-UploadArtifact-dismiss'
@@ -148,29 +147,8 @@ export const MediaPreviewOnlyTest: Story = {
       'swc-upload-artifact'
     );
 
-    await step('media artifacts are always preview-only', async () => {
-      expect(el.hasAttribute('data-preview-only')).toBe(true);
+    await step('media artifact has type="media"', async () => {
+      expect(el.type).toBe('media');
     });
-
-    await step(
-      'adding title/subtitle does not change media preview-only behavior',
-      async () => {
-        el.innerHTML = `
-        <div
-          slot="thumbnail"
-          style="inline-size:100%;block-size:196px;background:linear-gradient(135deg,#a78bfa,#f472b6);"
-          role="img"
-          aria-label="Campaign preview"
-        ></div>
-        <span slot="title">Campaign preview</span>
-        <span slot="subtitle">Should be ignored</span>
-      `;
-
-        await el.updateComplete;
-        await Promise.resolve();
-
-        expect(el.hasAttribute('data-preview-only')).toBe(true);
-      }
-    );
   },
 };

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -144,12 +144,26 @@
   text-overflow: ellipsis;
 }
 
+:host([type="media"]) {
+  inline-size: var(--swc-upload-artifact-preview-size, 68px);
+  block-size: var(--swc-upload-artifact-preview-size, 68px);
+}
+
+:host([type="media"]) .swc-UploadArtifact {
+  inline-size: 100%;
+  block-size: 100%;
+}
+
 :host([type="media"]) .swc-UploadArtifact-surface {
   flex-direction: column;
-  gap: token("spacing-100");
+  gap: 0;
+  inline-size: 100%;
+  block-size: 100%;
 }
 
 :host([type="media"]) .swc-UploadArtifact-thumbnail {
+  inline-size: 100%;
+  block-size: 100%;
   border-radius: token("corner-radius-200");
   overflow: hidden;
 }
@@ -159,6 +173,12 @@
   inline-size: 100%;
   block-size: auto;
   object-fit: cover;
+}
+
+:host([type="media"]) .swc-UploadArtifact-thumbnail ::slotted(*) {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
 }
 
 :host([type="media"]) .swc-UploadArtifact-meta {
@@ -182,32 +202,4 @@
 
 :host([type="media"]) .swc-UploadArtifact-subtitle {
   line-height: token("line-height-font-size-75");
-}
-
-/* Preview-only media (no title/subtitle) fills hosts like prompt-field tiles. */
-:host([type="media"][data-preview-only]) {
-  inline-size: var(--swc-upload-artifact-preview-size, 68px);
-  block-size: var(--swc-upload-artifact-preview-size, 68px);
-}
-
-:host([type="media"][data-preview-only]) .swc-UploadArtifact {
-  inline-size: 100%;
-  block-size: 100%;
-}
-
-:host([type="media"][data-preview-only]) .swc-UploadArtifact-surface {
-  gap: 0;
-  inline-size: 100%;
-  block-size: 100%;
-}
-
-:host([type="media"][data-preview-only]) .swc-UploadArtifact-thumbnail {
-  inline-size: 100%;
-  block-size: 100%;
-}
-
-:host([type="media"][data-preview-only]) .swc-UploadArtifact-thumbnail ::slotted(*) {
-  display: block;
-  inline-size: 100%;
-  block-size: 100%;
 }


### PR DESCRIPTION
## Description

While reviewing the `UploadArtifact` component I noticed a `_previewOnly` private property that didn't make sense to me, so I dug into it. It turned out to be entirely redundant and removing it had no visible effect.

The mechanism worked like this:

- `_previewOnly` was a `private` field decorated with `@property` (which is for public API), always set to `this.type === 'media'` via a `_syncMode` helper called from `firstUpdated` and `updated`
- It reflected to a `data-preview-only` attribute on the host solely for CSS targeting
- Every CSS rule that used `[data-preview-only]` also required `[type="media"]`, so the combined selector was functionally identical to `[type="media"]` alone

Removed `_previewOnly`, `_syncMode`, and the two lifecycle hooks. Collapsed the duplicate CSS selectors into the existing `[type="media"]` block and updated the test assertions that were checking the now-gone attribute.

## Motivation and context

The `@property` decorator on a `private` field is not idiomatic Lit — `@property` is for public reactive properties. The attribute it reflected was never set externally, was 100% derivable from `type`, and added a layer of indirection with no benefit.

## Related issue(s)

N/A

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Accessibility testing checklist

No interactive behavior changed. The dismiss button and slot structure are untouched.

- [x] **Keyboard**: No focusable parts were added or removed; no regressions expected.
- [x] **Screen reader**: No ARIA roles, labels, or state announcements changed.