### PR TITLE
docs(typography): fix incorrect import path in migration guide

### DIFF
--- a/2nd-gen/packages/swc/components/typography/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/typography/migration-guide.mdx
@@ -23,19 +23,19 @@ Update your import:
 import '@spectrum-web-components/styles/typography.css';
 
 // After
-import '@adobe/spectrum-wc/components/typography/typography.css';
+import '@adobe/spectrum-wc/typography.css';
 ```
 
-> `@adobe/spectrum-wc` is a monolithic package. Importing via subpath (e.g. `@adobe/spectrum-wc/components/typography/typography.css`) loads only that component's stylesheet.
+> `@adobe/spectrum-wc` is a monolithic package. Importing via subpath (e.g. `@adobe/spectrum-wc/typography.css`) loads only that stylesheet.
 
 ## What changed
 
 ### Renamed
 
-| Area         | Spectrum 1                                       | Spectrum 2                                                |
-| ------------ | ------------------------------------------------ | --------------------------------------------------------- |
-| Import path  | `@spectrum-web-components/styles/typography.css` | `@adobe/spectrum-wc/components/typography/typography.css` |
-| Class prefix | `.spectrum-Heading`, `.spectrum-Body`, etc.      | `.swc-Heading`, `.swc-Body`, etc.                         |
+| Area         | Spectrum 1                                       | Spectrum 2                          |
+| ------------ | ------------------------------------------------ | ----------------------------------- |
+| Import path  | `@spectrum-web-components/styles/typography.css` | `@adobe/spectrum-wc/typography.css` |
+| Class prefix | `.spectrum-Heading`, `.spectrum-Body`, etc.      | `.swc-Heading`, `.swc-Body`, etc.   |
 
 ### Added in Spectrum 2
 


### PR DESCRIPTION
## Description

Fix the typography migration guide to use the correct `@adobe/spectrum-wc` import path for `typography.css`. The documented path (`@adobe/spectrum-wc/components/typography/typography.css`) does not match the package's `exports` map or Vite build output, causing a "Failed to resolve import" error in consumer projects.

The correct subpath is `@adobe/spectrum-wc/typography.css`, which matches the `./*.css` export pattern that resolves to `./dist/*.css`.

## Motivation and context

Consumers following the published migration guide at [Typography / Migration guide](https://spectrum-web-components.adobe.com/?path=/docs/components-typography-migration-guide--docs) encounter a Vite pre-transform error when using the documented import. This blocks adoption of the 2nd-gen typography utilities.

**Root cause:** The `exports` map in `@adobe/spectrum-wc/package.json` defines:

```json
"./*.css": {
  "default": "./dist/*.css"
}
```
## Related issue(s)

N/A (add ticket reference if applicable)

## Screenshots (if appropriate)

N/A — documentation-only change.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] **Verify the corrected import resolves**
  1. In a Vite project, run `yarn add @adobe/spectrum-wc`
  2. Add `import '@adobe/spectrum-wc/typography.css';` to a source file
  3. Expect the import to resolve without errors and typography utility classes (`.swc-Heading`, `.swc-Body`, etc.) to be available

- [ ] **Verify migration guide renders correctly in Storybook**
  1. Go to [Typography / Migration guide](https://spectrum-web-components.adobe.com/?path=/docs/components-typography-migration-guide--docs) (after deploy)
  2. Confirm the "After" import example reads `@adobe/spectrum-wc/typography.css`
  3. Confirm the "Renamed" table shows the same corrected path

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [x] **Keyboard**: No interactive elements changed; this is a documentation-only MDX file. No focusable parts to verify; confirm no regressions in surrounding Storybook navigation.
- [x] **Screen reader**: No ARIA or semantic changes; documentation content is rendered as standard prose by Storybook.