### PR TITLE
fix(test-a11y): stabilize 2nd-gen ARIA snapshot tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,13 +399,20 @@ jobs:
                 path: 2nd-gen/packages/swc/coverage
 
   # 2nd-gen ARIA snapshot tests (Playwright)
+  # NOTE: Uses full `downstream` because Storybook build has 1st-gen references
+  # (contributor-docs generation, CEM analysis). The tests run against the
+  # built static Storybook to avoid Vite dev-server cold-start flakiness.
   test-2ndgen-a11y:
     executor: node
 
     steps:
       - halt-if-not-affected:
           gen: 2nd-gen
-      - downstream-2ndgen
+      - downstream
+      - run:
+          name: Build 2nd-gen Storybook (ci-a11y mode)
+          command: |
+            NODE_ENV=production SWC_STORYBOOK_MODE=ci-a11y yarn workspace @adobe/spectrum-wc storybook:build
       - run:
           name: Run 2nd-gen ARIA snapshot tests
           command: |

--- a/2nd-gen/packages/swc/utils/a11y-helpers.ts
+++ b/2nd-gen/packages/swc/utils/a11y-helpers.ts
@@ -115,5 +115,11 @@ export async function gotoStory(
     waitUntil: 'domcontentloaded',
   });
 
+  // Wait for Storybook's JS modules to finish loading before checking for
+  // custom-element registration. `domcontentloaded` only signals that the
+  // HTML shell is parsed; the story's <script type="module"> tags may
+  // still be in flight, which is when `customElements.whenDefined` hangs.
+  await page.waitForLoadState('networkidle');
+
   return waitForStoryReady(page, elementSelector);
 }

--- a/playwright.a11y.2ndgen.config.ts
+++ b/playwright.a11y.2ndgen.config.ts
@@ -19,10 +19,10 @@ import {
 } from './playwright.a11y.shared.config';
 
 const config: PlaywrightTestConfig = {
-  timeout: 30 * 1000,
+  timeout: 90 * 1000,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 2 : 1,
   reporter: a11yReporter(!!process.env.CI),
 
   use: a11yUse,

--- a/playwright.a11y.shared.config.ts
+++ b/playwright.a11y.shared.config.ts
@@ -10,7 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import { devices, type PlaywrightTestConfig } from '@playwright/test';
+import {
+  devices,
+  PlaywrightTestProject,
+  type PlaywrightTestConfig,
+} from '@playwright/test';
 
 const reportOutputFolder = '2nd-gen/test/playwright-a11y/report';
 const junitOutputFile = '2nd-gen/test/playwright-a11y/results/junit.xml';
@@ -31,7 +35,7 @@ export const a11yUse: PlaywrightTestConfig['use'] = {
   screenshot: 'only-on-failure',
 };
 
-export const firstGenA11yProject: PlaywrightTestConfig['projects'][number] = {
+export const firstGenA11yProject: PlaywrightTestProject = {
   name: '1st-gen',
   testDir: './1st-gen/',
   testMatch: '**/packages/*/test/**/*.a11y.spec.ts',
@@ -41,7 +45,7 @@ export const firstGenA11yProject: PlaywrightTestConfig['projects'][number] = {
   },
 };
 
-export const secondGenA11yProject: PlaywrightTestConfig['projects'][number] = {
+export const secondGenA11yProject: PlaywrightTestProject = {
   name: '2nd-gen',
   testDir: './2nd-gen/',
   testMatch: [
@@ -54,18 +58,24 @@ export const secondGenA11yProject: PlaywrightTestConfig['projects'][number] = {
   },
 };
 
-export const firstGenStorybookServer: PlaywrightTestConfig['webServer'][number] =
-  {
-    command: 'cd 1st-gen && yarn storybook',
-    port: 8080,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  };
+export const firstGenStorybookServer: PlaywrightTestConfig['webServer'] = {
+  command: 'cd 1st-gen && yarn storybook',
+  port: 8080,
+  reuseExistingServer: !process.env.CI,
+  timeout: 120 * 1000,
+};
 
-export const secondGenComponentsOnlyStorybookServer: PlaywrightTestConfig['webServer'][number] =
+// In CI, serve a prebuilt Storybook so test workers hit static assets instead
+// of a Vite dev server. The dev server's lazy compilation + WebSocket reloads
+// caused 30s timeouts on `customElements.whenDefined` when 8 workers hit cold
+// modules in parallel. CI jobs must run `storybook:build` before invoking
+// Playwright (see `.circleci/config.yml`). Locally we keep the dev server for
+// fast iteration.
+export const secondGenComponentsOnlyStorybookServer: PlaywrightTestConfig['webServer'] =
   {
-    command:
-      'cd 2nd-gen/packages/swc && SWC_STORYBOOK_MODE=ci-a11y yarn storybook',
+    command: process.env.CI
+      ? 'npx http-server 2nd-gen/packages/swc/storybook-static -p 6006 --silent'
+      : 'cd 2nd-gen/packages/swc && SWC_STORYBOOK_MODE=ci-a11y yarn storybook',
     port: 6006,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,


### PR DESCRIPTION
## Description

Stabilize the 2nd-gen ARIA snapshot Playwright tests (`yarn test:a11y:2nd`), which had begun consistently timing out on `swc-asset` and `swc-avatar` stories both locally and in CircleCI. Every failure landed on the same line — `page.evaluate(() => customElements.whenDefined(tag))` hitting the 30s global timeout.

## Motivation and context

Root cause: the test suite drives a Vite **dev server** (via `SWC_STORYBOOK_MODE=ci-a11y yarn storybook`) while 8 parallel Playwright workers each navigate to a different story URL on a cold cache. Vite has to TS-transpile and pre-bundle every story's import graph on first hit, and the WebSocket reloads it broadcasts mid-compile keep destroying the page execution context. With a 30s budget, the asset stories (which live in `.internal.stories.ts` and may never have been pre-bundled) and the avatar stories with many remote `picsum.photos` images (anatomy, accessibility, sizes — sizes alone renders 17 instances) never got the custom element registered in time.

This PR addresses the root cause by switching CI to a prebuilt static Storybook, plus three smaller mitigations to harden the helper code itself.

## What changed

- **`a11y-helpers.ts`** — `gotoStory` now waits for `networkidle` after `page.goto`, so the story's `<script type=\"module\">` chunks finish loading before `customElements.whenDefined` is queried. `domcontentloaded` alone only signals HTML parse.
- **`playwright.a11y.2ndgen.config.ts`** — per-test timeout `30s → 90s`; local `retries: 0 → 1`. One Vite reload no longer hard-fails locally; CI retries unchanged at 2.
- **`playwright.a11y.shared.config.ts`** — `secondGenComponentsOnlyStorybookServer.command` is now CI-aware: locally still launches the Vite dev server (fast iteration); in CI runs `npx http-server 2nd-gen/packages/swc/storybook-static` against a prebuilt Storybook. Eliminates the Vite cold-start class of bugs entirely.
- **`.circleci/config.yml`** — `test-2ndgen-a11y` now runs `storybook:build` (ci-a11y mode) before invoking Playwright. Switched from `downstream-2ndgen` to full `downstream` because the Storybook build's `generate:contributor-docs` and `analyze` steps reference 1st-gen artifacts (matches `test-2ndgen-axe`).

## Related issue(s)

Internal: SWC-flaky-a11y-tests (no GH issue filed).

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published. (Not needed; CI/test infra only, nothing ships to consumers.)
- [ ] I have included updated documentation if my change required it. (Not needed.)

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Local test run is clean_
  1. Run `yarn test:a11y:2nd` from a fresh checkout (no warm Storybook server).
  2. Expect all 75 tests to pass within a few minutes. Previously, ~7 asset/avatar tests timed out at 30s.

- [ ] _CircleCI `test-2ndgen-a11y` job passes_
  1. Inspect the job log on this PR.
  2. Verify a `Build 2nd-gen Storybook (ci-a11y mode)` step runs before `Run 2nd-gen ARIA snapshot tests`.
  3. Verify all ARIA snapshot tests pass with no retries.

- [ ] _Local dev workflow unchanged_
  1. Run `yarn test:a11y:2nd` locally a second time.
  2. Verify the Vite dev server (not http-server) is what launches — confirms the CI/local split is correct.

### Device review

- [ ] Did it pass in Desktop?  (N/A — no UI changes, tests only.)
- [ ] Did it pass in (emulated) Mobile?  (N/A.)
- [ ] Did it pass in (emulated) iPad?  (N/A.)

## Accessibility testing checklist

This PR contains **no user-facing changes** — it only modifies test infrastructure and CI orchestration. The accessibility behavior of the components themselves is unchanged. The ARIA snapshot tests that this PR stabilizes are themselves the accessibility coverage; if those tests pass on this branch, accessibility is preserved.

- [ ] **Keyboard** — N/A; no interactive behavior introduced or modified. The existing keyboard-focus test (`avatar.a11y.spec.ts:132`) continues to run and pass under the new timeout/retry settings.
- [ ] **Screen reader** — N/A; no DOM, ARIA, or role changes. The 75 existing ARIA snapshot assertions act as the screen-reader regression gate.