### PR TITLE
feat(ai): add rules for migration plan and code conformance adherence

### DIFF
--- a/.ai/rules/consistency-pass.md
+++ b/.ai/rules/consistency-pass.md
@@ -57,6 +57,8 @@ Read the plan sections covering the current phase and verify the implementation 
 
 Flag any divergence. If a change was confirmed in-session, update the plan and proceed to Check 2.
 
+Once implementation and plan are aligned, update the plan's checklists for the current phase to reflect the work completed. Mark off completed items, fill in any "to be determined" fields that were resolved during this phase, and note any decisions made. The plan checklists are the record that this phase was done and what was produced — keep them current.
+
 ### Check 2: Intra-plan consistency (cascading updates)
 
 When any part of the plan changes — whether from a session-confirmed decision or a correction — scan the entire plan for other sections affected by that change. Plans are multi-section documents where a single decision can appear in several places.
@@ -85,9 +87,11 @@ Code conformance:
 
 Plan validity:
 - ✅ Implementation matches plan for this phase
+- ✅ Phase checklist updated
 - ✅ No cascading inconsistencies found
 - ⚠️ [plan section] — [implementation diverges from plan; flagging for confirmation before updating]
 - ⚠️ [plan section] — [cascading effect of confirmed change X; updated]
+- ⚠️ Phase checklist — [items that could not be marked complete; reason]
 - ❌ [plan section] — [implementation diverges in a way that may require re-alignment]
 ```
 

--- a/.ai/rules/consistency-pass.md
+++ b/.ai/rules/consistency-pass.md
@@ -1,0 +1,98 @@
+---
+description: Defines when and how to run a consistency and validity self-audit on changed files and the migration plan. Apply before declaring any migration phase or significant implementation task complete.
+alwaysApply: false
+---
+
+# Consistency and validity pass
+
+A consistency and validity pass has two parts:
+
+1. **Code conformance** — are the changed files aligned with project style guides?
+2. **Plan validity** — does the migration plan still accurately reflect what was built?
+
+Run both proactively, not only when asked. The per-domain code checklist lives in `.ai/rules/code-conformance.md`. The plan validity check is defined here.
+
+## When to run
+
+Run a consistency and validity pass:
+
+1. **When explicitly asked** — "check my work", "consistency pass", "validity pass", "check this against the style guide"
+2. **Before declaring a migration phase complete** — especially Phases 3 (API), 5 (styling), 6 (testing), and 7 (documentation), where both code drift and plan staleness are most likely
+3. **After making implementation changes** to TypeScript, CSS, test, or stories files during a migration session, even if not completing a formal phase
+
+If you are in a migration session and a pass is due but the user has not asked for one, run it — do not wait to be asked.
+
+## Part 1: Code conformance
+
+Apply the full checklist from `.ai/rules/code-conformance.md` to the files changed in the current task or phase. Read that rule before starting. Scope the check to changed files only unless a broader audit was requested.
+
+Run automated linters first, then the manual review:
+
+```bash
+yarn lint
+yarn lint:css
+yarn prettier --check "path/to/changed/files"
+```
+
+Fix every automated error before doing the manual review. A manual review on top of failing linters is wasted effort.
+
+## Part 2: Plan validity
+
+If a migration plan exists at `CONTRIBUTOR-DOCS/03_project-planning/03_components/[component]/migration-plan.md`, read the full plan and check for two categories of issues.
+
+### The plan is authoritative
+
+The migration plan represents the agreed design. When the implementation diverges from the plan, the default assumption is that the implementation drifted — not that the plan should be updated to match. Flag implementation divergence to the user rather than silently updating the plan to reflect it.
+
+The only time the plan should be updated to reflect a change is when that change was explicitly confirmed during the current session — for example, a PR reviewer requested a rename, or the team decided during this session to remove a dependency. Session-confirmed changes should be written back to the plan.
+
+### Check 1: Implementation vs. plan
+
+Read the plan sections covering the current phase and verify the implementation matches:
+
+- API shape, attribute names, property types, and default values match the plan
+- Behavior and state handling match the plan
+- Breaking changes are implemented as the plan specifies (no additions or removals without confirmation)
+- Accessibility decisions match the plan's a11y section
+
+Flag any divergence. If a change was confirmed in-session, update the plan and proceed to Check 2.
+
+### Check 2: Intra-plan consistency (cascading updates)
+
+When any part of the plan changes — whether from a session-confirmed decision or a correction — scan the entire plan for other sections affected by that change. Plans are multi-section documents where a single decision can appear in several places.
+
+Common cascading patterns to check:
+
+- **Renamed attribute or property**: search every section of the plan for the old name; update all references, including code examples, breaking change entries, migration guidance, and accessibility notes
+- **Removed dependency or feature**: find every section that assumed that dependency exists — behavior descriptions, constraints, examples — and update or remove them
+- **Changed default value**: find every section that states or relies on the old default, including examples and migration guidance
+- **Added or removed breaking change**: verify the breaking changes section, the migration guide section, and any consumer-facing notes are consistent with each other
+- **Renamed slot or CSS custom property**: check that examples, anatomy descriptions, and migration notes all reflect the new name
+
+This check also applies during plan authoring. If you are writing or editing the plan in Phase 1 and make a change, run the same cascading scan before completing the phase.
+
+## Reporting format
+
+Report both parts together before ending your response:
+
+```
+**Consistency and validity pass — [component], Phase [N]**
+
+Code conformance:
+- ✅ [domain]: passes
+- ⚠️ [file:line] — [issue; what the style guide says; what to change]
+- ❌ [file:line] — [critical issue blocking completion]
+
+Plan validity:
+- ✅ Implementation matches plan for this phase
+- ✅ No cascading inconsistencies found
+- ⚠️ [plan section] — [implementation diverges from plan; flagging for confirmation before updating]
+- ⚠️ [plan section] — [cascading effect of confirmed change X; updated]
+- ❌ [plan section] — [implementation diverges in a way that may require re-alignment]
+```
+
+Fix or flag all ⚠️ and ❌ items before reporting the phase or task complete. Items that cannot be resolved immediately must be noted in the Migration Checkpoint.
+
+## Guideline gaps
+
+If the code is correct and appropriate but no style guide rule covers the pattern, follow the guideline-gap reporting format in `.ai/rules/code-conformance.md` and surface it to the user.

--- a/.ai/rules/migration-phase-awareness.md
+++ b/.ai/rules/migration-phase-awareness.md
@@ -17,11 +17,12 @@ Apply any time:
 
 ## Before declaring a phase complete
 
-Before ending a response that declares a migration phase complete, verify against two sources:
+Before ending a response that declares a migration phase complete, verify against two sources and perform one update:
 
 1. **Phase skill quality gate** — every checklist item in the active skill's quality gate section
 2. **Migration plan** — read `CONTRIBUTOR-DOCS/03_project-planning/03_components/[component]/migration-plan.md` and verify that the work done in this phase matches what the plan specifies for it. If the plan is missing, note that as a risk. If the implementation drifted from the plan, call it out explicitly — do not silently accept drift.
 3. **Consistency pass** — the checks described in `.ai/rules/consistency-pass.md` have been run on files changed in this phase, or are explicitly deferred and noted in the checkpoint
+4. **Status table** — update `CONTRIBUTOR-DOCS/03_project-planning/02_workstreams/02_2nd-gen-component-migration/01_status.md` to reflect the completed phase for this component
 
 Do not silently skip incomplete items. If something cannot be completed, say so and record it in the checkpoint.
 
@@ -29,7 +30,7 @@ Do not silently skip incomplete items. If something cannot be completed, say so 
 
 When you complete a migration phase, end your response with a Migration Checkpoint block using this exact format:
 
-```
+```markdown
 ---
 **Migration Checkpoint: [Component Name]**
 Phase completed: [N] — [Phase Name]

--- a/.ai/rules/migration-phase-awareness.md
+++ b/.ai/rules/migration-phase-awareness.md
@@ -1,0 +1,68 @@
+---
+description: Keeps multi-phase migration obligations in context during a session. Emits Migration Checkpoint blocks at phase completion for cross-session continuity. Apply whenever any migration-* skill is active or migration files are being edited.
+alwaysApply: false
+---
+
+# Migration phase awareness
+
+When working on any part of a 1st-gen to 2nd-gen component migration, maintain explicit awareness of which phase is active, which phases are complete, and what obligations remain — even when the conversation drifts to other topics.
+
+## When this rule applies
+
+Apply any time:
+
+- A migration-\* skill has been invoked in the current session
+- You are editing files that are part of a 2nd-gen component migration
+- The user references a migration phase or a component being migrated
+
+## Before declaring a phase complete
+
+Before ending a response that declares a migration phase complete, verify against two sources:
+
+1. **Phase skill quality gate** — every checklist item in the active skill's quality gate section
+2. **Migration plan** — read `CONTRIBUTOR-DOCS/03_project-planning/03_components/[component]/migration-plan.md` and verify that the work done in this phase matches what the plan specifies for it. If the plan is missing, note that as a risk. If the implementation drifted from the plan, call it out explicitly — do not silently accept drift.
+3. **Consistency pass** — the checks described in `.ai/rules/consistency-pass.md` have been run on files changed in this phase, or are explicitly deferred and noted in the checkpoint
+
+Do not silently skip incomplete items. If something cannot be completed, say so and record it in the checkpoint.
+
+## Emit a Migration Checkpoint at phase completion
+
+When you complete a migration phase, end your response with a Migration Checkpoint block using this exact format:
+
+```
+---
+**Migration Checkpoint: [Component Name]**
+Phase completed: [N] — [Phase Name]
+Next phase: [N+1] — [Phase Name] (invoke `migration-[skill]`)
+Consistency pass: [done | not yet run | deferred — reason]
+Phase blockers: [items from this phase that are incomplete or at risk; "none" if clean — do not include future-phase concerns]
+---
+```
+
+**On phase blockers:** Only include items that are genuinely unresolved within the scope of the phase just completed — known failures, skipped checklist items, plan divergence. Do not populate this field with work that belongs to future phases; those will surface when those phases run.
+
+This block is the cross-session handoff artifact. Because this is an open-source project with multiple engineers and concurrent migrations, no shared tracking file is used. Any engineer resuming this migration in a new session should paste the most recent checkpoint as context.
+
+## When work drifts from the migration
+
+If you are asked to make changes or complete tasks outside the immediate migration phase — for example, fixing a bug, adjusting a story, or updating configuration — complete the requested work, then end your response with a single-line resume prompt:
+
+> Migration paused: to continue [Component Name], invoke `migration-[active-phase-skill]`.
+
+Use the name of the skill that was active when the drift occurred. This gives the engineer an exact phrase to resume without needing to reconstruct context.
+
+## The phase sequence for reference
+
+| Phase | Skill                   |
+| ----- | ----------------------- |
+| 1     | migration-prep          |
+| 2     | migration-setup         |
+| 3     | migration-api           |
+| 4     | migration-a11y          |
+| 5     | migration-styling       |
+| 6     | migration-testing       |
+| —     | migration-conformance   |
+| 7     | migration-documentation |
+| 8     | migration-review        |
+
+The conformance sub-task runs after Phase 6 and before Phase 7. It is not optional — if it was skipped, note it in the checkpoint.

--- a/.cursor/rules/consistency-pass.mdc
+++ b/.cursor/rules/consistency-pass.mdc
@@ -1,0 +1,1 @@
+../../.ai/rules/consistency-pass.md

--- a/.cursor/rules/migration-phase-awareness.mdc
+++ b/.cursor/rules/migration-phase-awareness.mdc
@@ -1,0 +1,1 @@
+../../.ai/rules/migration-phase-awareness.md


### PR DESCRIPTION
## Description

Adds two new AI agent rules that address drift and quality gaps during multi-phase 2nd-gen component migrations:

- **`migration-phase-awareness.md`**: Keeps migration phase obligations in context throughout a session, even when work drifts to unrelated tasks. Validates completion against both the phase skill's quality gate and the migration plan before declaring a phase done. Emits a structured Migration Checkpoint block at phase completion to serve as a cross-session handoff artifact (no shared file needed, avoids git conflicts across concurrent migrations). Appends an actionable resume prompt when the session drifts.

- **`consistency-pass.md`**: Defines a two-part self-audit — code conformance (delegating to the existing `code-conformance` rule) and migration plan validity. The plan validity check treats the plan as authoritative, flags implementation divergence rather than silently updating the plan, and performs an intra-plan cascading consistency scan when any confirmed change is made (e.g., renamed attribute → update all plan sections that reference the old name).

## Motivation and context

During multi-phase migrations, agents completing one phase and moving on to other work frequently lost track of outstanding obligations like the conformance sub-task and the review phase. Engineers were also seeing plan inconsistencies accumulate as implementation decisions were made — a renamed attribute updated in one section but not others, a removed dependency still referenced in behavior notes.

These rules make those checks automatic and keep them visible throughout the session, reducing reliance on engineer memory to ask for them.

## Manual review test cases

> **NOTE**: You probably don't actually want to run a migration phase ad-hoc since they require a large context window, and shouldn't be run out of order even for testing since they are co-dependent. These will be things to keep an eye on for the next few valid phase skill runs.

- [ ] _Migration checkpoint is emitted at phase completion_
  1. Start a migration session using any `migration-*` skill
  2. Complete the phase workflow
  3. Expect a Migration Checkpoint block at the end of the response with `Phase completed`, `Next phase`, `Consistency pass`, and `Phase blockers` fields

- [ ] _Drift reminder fires when work leaves the migration context_
  1. Start a migration session using any `migration-*` skill
  2. Ask the agent to fix an unrelated bug or make an unrelated change
  3. Expect the agent to complete the request and append a "Migration paused: to continue [Component], invoke `migration-[skill]`" line

- [ ] _Consistency pass covers both code conformance and plan validity_
  1. Ask the agent to run a "consistency pass" on a component mid-migration
  2. Expect output with two labeled sections: Code conformance and Plan validity
  3. Plan validity section should flag any implementation divergence from the plan, and note any cascading effects of confirmed in-session changes
