### PR TITLE
feat(link): gen2 migration plan

### DIFF
--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
@@ -75,6 +75,7 @@
     - [In-field progress circle migration roadmap](infield-progress-circle/rendering-and-styling-migration-analysis.md)
 - Link
     - [Link accessibility migration analysis](link/accessibility-migration-analysis.md)
+    - [Link migration plan](link/migration-plan.md)
     - [Link migration roadmap](link/rendering-and-styling-migration-analysis.md)
 - Menu
     - [Menu accessibility migration analysis](menu/accessibility-migration-analysis.md)

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/link/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/link/migration-plan.md
@@ -1,0 +1,426 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../../../README.md) / [Project planning](../../README.md) / [Components](../README.md) / Link / Link migration plan
+
+<!-- Document title (editable) -->
+
+# Link migration plan
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [TL;DR](#tldr)
+    - [Most blocking open questions](#most-blocking-open-questions)
+- [1st-gen API surface](#1st-gen-api-surface)
+    - [Properties / attributes](#properties--attributes)
+    - [Methods](#methods)
+    - [Events](#events)
+    - [Slots](#slots)
+    - [CSS custom properties](#css-custom-properties)
+    - [Shadow DOM output (rendered HTML)](#shadow-dom-output-rendered-html)
+- [Dependencies](#dependencies)
+- [Migration sequencing and prerequisites](#migration-sequencing-and-prerequisites)
+    - [Dependency-aware recommendation](#dependency-aware-recommendation)
+    - [Related components and ordering notes](#related-components-and-ordering-notes)
+    - [User confirmation needed](#user-confirmation-needed)
+    - [Recommended packaging (default)](#recommended-packaging-default)
+- [Changes overview](#changes-overview)
+    - [Must ship — breaking or a11y-required](#must-ship--breaking-or-a11y-required)
+    - [Additive — ships when ready, zero breakage for consumers already on 2nd-gen](#additive--ships-when-ready-zero-breakage-for-consumers-already-on-2nd-gen)
+- [2nd-gen API decisions](#2nd-gen-api-decisions)
+    - [Public API](#public-api)
+    - [Behavioral semantics](#behavioral-semantics)
+    - [Accessibility semantics notes (2nd-gen)](#accessibility-semantics-notes-2nd-gen)
+- [Architecture: core vs SWC split](#architecture-core-vs-swc-split)
+- [Migration checklist](#migration-checklist)
+    - [Preparation (this ticket)](#preparation-this-ticket)
+    - [Setup](#setup)
+    - [API](#api)
+    - [Styling](#styling)
+    - [Accessibility](#accessibility)
+    - [Testing](#testing)
+    - [Documentation](#documentation)
+    - [Review](#review)
+- [Blockers and open questions](#blockers-and-open-questions)
+    - [Design](#design)
+    - [Architecture and behavior](#architecture-and-behavior)
+    - [Scope and prerequisites](#scope-and-prerequisites)
+- [References](#references)
+- [Breaking changes to verify](#breaking-changes-to-verify)
+- [What is still provisional](#what-is-still-provisional)
+- [What to provide next](#what-to-provide-next)
+
+</details>
+
+<!-- Document content (editable) -->
+
+> **Epic [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956)** · Planning output. Must be reviewed before implementation begins.
+>
+> **Design sign-off (Q1):** Confirmed — linked [Figma — S2 / Web, Link](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=18850-110) covers **overview, properties, and variants**. Optional **Copy as PNG** remains available if a review packet needs an offline artifact.
+
+---
+
+## TL;DR
+
+- **Atypical migration.** The approved [accessibility migration analysis](./accessibility-migration-analysis.md) positions 2nd-gen **default** link delivery as **Spectrum link styles on native `<a href>`** in the light DOM (especially inside prose / typography), **not** a per-sentence `<sp-link>` custom element. **Q2 (resolved):** **CSS + native `<a>` only** — no transitional `sp-link` compatibility CE in scope for this migration.
+- **Styling gap (confirmed from roadmap).** Spectrum 2 adds `.spectrum-Link--inline` for inline copy; 1st-gen `sp-link` does not map that modifier yet ([rendering analysis](./rendering-and-styling-migration-analysis.md)). Closing this gap belongs in **must ship** work for S2 parity, regardless of CE vs CSS-only packaging.
+- **A11y-required corrections.** Remove or deprecate **`disabled` on navigational links** ([SWC-966](https://jira.corp.adobe.com/browse/SWC-966)); align contrast and “link vs body text” presentation with WCAG expectations ([SWC-1160](https://jira.corp.adobe.com/browse/SWC-1160)); document **quiet** links for **section-scoped** patterns (e.g. footers), not undifferentiated body prose (per accessibility analysis).
+- **Consumer migration.** Track global native-anchor styling and API deprecation direction ([SWC-926](https://jira.corp.adobe.com/browse/SWC-926), [SWC-1428](https://jira.corp.adobe.com/browse/SWC-1428)) in the written migration path for teams still on `sp-link`.
+- **Open decisions:** **Q4** only — confirm or override the canonical **repo location and import story** for link CSS (see [Recommended packaging (default)](#recommended-packaging-default)). **Epic:** [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956) (resolved). **Q1** (Figma scope) and **Q2** (architecture) are **resolved** — see [Blockers and open questions](#blockers-and-open-questions).
+
+### Most blocking open questions
+
+- **Q4** ([Architecture and behavior](#architecture-and-behavior)): Confirm canonical **2nd-gen repo location** for link rules — default is **[`stylesheets/link.css` + compose into `typography.css`](#recommended-packaging-default)** unless you explicitly override (e.g. different filename, no `@import` into typography, or `global-elements.css` with design sign-off).
+- **Q1** ([Design](#design)): **Resolved** — [Figma — S2 / Web, Link (`18850-110`)](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=18850-110); confirmed to cover **overview, properties, and variants**.
+- **Q2** ([Architecture and behavior](#architecture-and-behavior)): **Resolved** — **CSS + native `<a>` only** (no transitional `sp-link` / CE in this migration).
+- **Q3** ([Scope and prerequisites](#scope-and-prerequisites)): **Resolved** — migration Epic is [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956).
+
+---
+
+## 1st-gen API surface
+
+**Source:** [`1st-gen/packages/link/src/Link.ts`](../../../../1st-gen/packages/link/src/Link.ts)
+**Version:** `@spectrum-web-components/link@1.12.0`
+**Custom element tag:** `sp-link`
+
+### Properties / attributes
+
+| Property | Type | Default | Attribute | Notes |
+| -------- | ---- | ------- | --------- | ----- |
+| `variant` | `'secondary' \| undefined` | `undefined` | `variant` | When set, only supported value is `secondary` |
+| `staticColor` | `'black' \| 'white' \| undefined` | `undefined` | `static-color` | Reflected |
+| `quiet` | `boolean` | `false` | `quiet` | Reflected boolean |
+| `download` | `string \| undefined` | `undefined` | `download` | From `LikeAnchor` |
+| `label` | `string \| undefined` | `undefined` | `label` | Applied as `aria-label` on inner `<a>` |
+| `href` | `string \| undefined` | `undefined` | `href` | From `LikeAnchor` |
+| `target` | `'_blank' \| '_parent' \| '_self' \| '_top' \| undefined` | `undefined` | `target` | From `LikeAnchor` |
+| `referrerpolicy` | *see LikeAnchor* | `undefined` | `referrerpolicy` | From `LikeAnchor` |
+| `rel` | `string \| undefined` | `undefined` | `rel` | From `LikeAnchor` |
+| `disabled` | `boolean` | `false` | `disabled` | From `Focusable`; **invalid for real navigational links** — [SWC-966](https://jira.corp.adobe.com/browse/SWC-966) |
+| `autofocus` | `boolean` | `false` | (none) | From `Focusable`; not reflected in declaration file as attribute name |
+| `tabIndex` | `number` | delegated | `tabindex` | Getter/setter on host; inner anchor receives delegated focus |
+
+### Methods
+
+None declared on `Link` beyond inherited `ReactiveElement` / mixin behavior.
+
+### Events
+
+No component-specific custom events documented on `Link`. Activation follows the inner native `<a>`.
+
+### Slots
+
+| Slot | Content | Notes |
+| ---- | ------- | ----- |
+| *(default)* | Link text / phrasing content | Rendered inside shadow `<a>` |
+
+### CSS custom properties
+
+1st-gen bundles Spectrum-derived rules plus overrides; public `--mod-*` surface is **not** a supported consumer contract for 2nd-gen (see [Rendering analysis — Modifiers](./rendering-and-styling-migration-analysis.md)). 2nd-gen will not re-expose `--mod-*`; any new surface follows [`--swc-*` guidelines](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md#component-custom-property-exposure).
+
+### Shadow DOM output (rendered HTML)
+
+```html
+<a
+    id="anchor"
+    href="[href]"
+    download="[download]"
+    target="[target]"
+    aria-label="[label]"
+    tabindex="[tabindex from Focusable delegation]"
+    referrerpolicy="[referrerpolicy]"
+    rel="[rel]"
+>
+    <slot></slot>
+</a>
+```
+
+---
+
+## Dependencies
+
+| Package | Version | Role |
+| ------- | ------- | ---- |
+| `@spectrum-web-components/base` | `1.12.0` | `SpectrumElement`, Lit `html`, `@property` |
+| `@spectrum-web-components/shared` | `1.12.0` | `LikeAnchor` ([`like-anchor.ts`](../../../../1st-gen/tools/shared/src/like-anchor.ts)), `Focusable` ([`focusable.ts`](../../../../1st-gen/tools/shared/src/focusable.ts)) |
+
+---
+
+## Migration sequencing and prerequisites
+
+### Dependency-aware recommendation
+
+- **Ship link styling with typography / prose consumption paths** in 2nd-gen so conversational and document UIs that already use `swc-Typography--prose` ([examples](../../../../2nd-gen/packages/swc/patterns/conversational-ai/system-message/stories/system-message.stories.ts)) get correct `<a href>` appearance without requiring `sp-link` per link.
+- **Do not** hard-block on unrelated component migrations unless a shared token pipeline change is required; coordinate with **Typography** owners for where link selectors live and how Storybook documents native anchors inside prose.
+
+### Related components and ordering notes
+
+- **Typography (2nd-gen):** Primary integration point for prose link appearance and documentation ([`typography` component](../../../../2nd-gen/packages/swc/components/typography/), [migration guide](../../../../2nd-gen/packages/swc/components/typography/migration-guide.mdx)).
+- **Button / app navigation:** Accessibility analysis distinguishes **button-shaped route changes** (prefer real `<button>` + routing) from text links — aligns with existing 1st-gen direction away from “link that looks like a button” misuse.
+
+### User confirmation needed
+
+- Confirm **Q4**: canonical link CSS home — [default recommendation](#recommended-packaging-default) is **`stylesheets/link.css`** composed into **`typography.css`**; override only if Typography / CSS owners agree on a different split.
+
+### Recommended packaging (default)
+
+**Q2 is resolved** (CSS + native `<a>` only — no compatibility CE). Unless **Q4** chooses a different layout, treat Link like **Typography** for repo shape: **no `2nd-gen/packages/core/components/link/`** (Typography today has **no** core `.ts` layer — only [`2nd-gen/packages/swc/components/typography/`](../../../../2nd-gen/packages/swc/components/typography/) for stories/tests/docs and [`2nd-gen/packages/swc/stylesheets/typography.css`](../../../../2nd-gen/packages/swc/stylesheets/typography.css) for rules).
+
+- **NPM package:** still **`@adobe/spectrum-wc`** (`2nd-gen/packages/swc`); there is no separate link-only package.
+- **Stylesheet source of truth:** add **`2nd-gen/packages/swc/stylesheets/link.css`** (name TBD) holding Spectrum 2 link rules migrated from Spectrum CSS; keeps ownership and review scope clear.
+- **Compose into prose by default:** **`@import`** (or build-time equivalent) that **`link.css`** from **`typography.css`** so apps loading typography for `.swc-Typography--prose` get correct native `<a href>` styling without a second manual import.
+- **Optional direct import:** document importing **`link.css`** alone for apps that need link appearance **without** full typography — same package, different entry.
+- **`global-elements.css`:** use only if design explicitly wants **unscoped** native-anchor styling; higher blast radius — not the default recommendation.
+- **Core folder:** for this CSS-only path, **no** core TypeScript is required, matching Typography.
+
+---
+
+## Changes overview
+
+### Must ship — breaking or a11y-required
+
+#### API and naming
+
+| # | What changes | 1st-gen behavior | 2nd-gen behavior | Consumer migration path |
+| --- | ------------ | ---------------- | ---------------- | ----------------------- |
+| **B1** | Prefer **native `<a href>`** for in-body / prose links | `<sp-link>` wraps shadow anchor | Classed **`<a>`** with Spectrum S2 link CSS; docs show prose wrapper patterns | Replace `sp-link` in running text with `<a class="…">` + import documented CSS; follow [SWC-1428](https://jira.corp.adobe.com/browse/SWC-1428) / [SWC-926](https://jira.corp.adobe.com/browse/SWC-926) when tickets land |
+| **B2** | Remove **`disabled`** as a supported pattern on navigational links | `disabled` blocks click in tests | Not supported on real anchors; use button + routing or remove control | Remove `disabled` from links; use disabled **button** or different UX ([SWC-966](https://jira.corp.adobe.com/browse/SWC-966)) |
+
+#### Styling and visuals
+
+| # | What changes | 1st-gen behavior | 2nd-gen behavior | Consumer migration path |
+| --- | ------------ | ---------------- | ---------------- | ----------------------- |
+| **B3** | **S2 inline** presentation | No `spectrum-Link--inline` mapping | CSS includes inline / standalone semantics per S2 | Update markup/classes per final Typography + Link docs once **Q4** packaging is settled |
+| **B4** | **Token / contrast** fixes | Known contrast risk vs body ([SWC-1160](https://jira.corp.adobe.com/browse/SWC-1160)) | S2 tokens + tests in prose contexts | Retest adjacent-text contrast in authored examples |
+
+#### Accessibility and behavior
+
+| # | What changes | 1st-gen behavior | 2nd-gen behavior | Consumer migration path |
+| --- | ------------ | ---------------- | ---------------- | ----------------------- |
+| **B5** | **Quiet** usage scope | README warns but attribute is global | Docs + design guidance: quiet styles only where section context makes links obvious | Restrict quiet styling to approved patterns (footer-like regions) per [accessibility analysis](./accessibility-migration-analysis.md) |
+| **B6** | Avoid **double-activation** architectures | Ecosystem issues referenced in analysis | Single real target for `href` + router | Follow [SWC-923](https://jira.corp.adobe.com/browse/SWC-923), [SWC-921](https://jira.corp.adobe.com/browse/SWC-921) patterns in docs |
+
+### Additive — ships when ready, zero breakage for consumers already on 2nd-gen
+
+| # | What is added | Notes |
+| --- | ------------- | ----- |
+| **A1** | Optional **compatibility** `sp-link` | **Out of scope** — **Q2** approved CSS + native `<a>` only (no CE) |
+| **A2** | Extra Storybook coverage for **static color** on imagery / dark backgrounds | Visual regression alongside typography stories |
+
+---
+
+## 2nd-gen API decisions
+
+These are derived from 1st-gen, the [rendering roadmap](./rendering-and-styling-migration-analysis.md), the [accessibility analysis](./accessibility-migration-analysis.md), and [React Spectrum Link](https://react-spectrum.adobe.com/Link). **Q1** (Figma) and **Q2** (native `<a>` only) are **resolved**. **Q4** remains if packaging needs an explicit owner sign-off beyond the default below (**Q3** / Epic: [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956)).
+
+### Public API
+
+#### Properties / attributes (2nd-gen)
+
+**Confirmed (Q2):** no custom element — use native HTML attributes on `<a>` (`href`, `target`, `rel`, `download`, `referrerpolicy`, `aria-label`, `lang`, etc.). No transitional `sp-link` in this migration.
+
+#### Visual matrix (2nd-gen)
+
+N/A as a “fill / outline” matrix. Planned **presentation modes** (from roadmap + 1st-gen README + React):
+
+| Mode | Notes |
+| ---- | ----- |
+| Default / primary inline (S2) | **Confirmed** against Figma handoff (**Q1**) — implement per S2 / CSS once **Q4** packaging is settled |
+| Secondary | `variant="secondary"` today → class or data-attribute pattern on `<a>` (**Inferred**) |
+| Quiet | Boolean-style presentation; **scope** per **B5** |
+| Static white / black | `static-color` analog as classes on `<a>` for on-image / on-tint contexts |
+
+#### Slots (2nd-gen)
+
+N/A for native `<a>` (element content is the link text). **Open question** only if a CE returns: default slot remains phrasing content.
+
+#### CSS custom properties (2nd-gen)
+
+No `--mod-*` properties will be exposed. New `--swc-*` component-level properties may be introduced where needed — additive and not breaking. See [Component Custom Property Exposure](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md#component-custom-property-exposure).
+
+Initial expectation for **Link** is a **small reviewed set** (likely tied to typography / prose), not a large modifier fan-out.
+
+### Behavioral semantics
+
+- **Navigation:** real `href` or framework `Link` that renders a real `<a>`; avoid JS-only “fake” links for standard navigation (**Confirmed** from accessibility analysis).
+- **Quiet + critical flows:** treat as design-governed; engineering ships CSS but docs must encode constraints (**Confirmed** policy direction from accessibility analysis).
+
+### Accessibility semantics notes (2nd-gen)
+
+Follow the [accessibility migration analysis](./accessibility-migration-analysis.md) as the controlling document: implicit **link** role from `<a href>`, no `role="link"` on non-anchors, no `disabled` on anchors, icon-only links need discoverable name, focus-visible must remain perceivable.
+
+---
+
+## Architecture: core vs SWC split
+
+> The 1st-gen component is a **reference only** — 2nd-gen is built independently. Neither generation imports from the other.
+
+**Link-specific deviation:** the [Badge migration reference](../../02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#reference-badge-migration) describes the default **core + `sp-*` SWC** split. For Link, the **primary** 2nd-gen deliverable is **shared CSS + documentation** with **native anchors** (**Q2** resolved). **Q4** only adjusts *where* those rules live in-repo if the default packaging is overridden.
+
+| Layer | Path | Contains |
+| ----- | ---- | -------- |
+| **Core** | `2nd-gen/packages/core/components/link/` | **N/A** — **Q2** resolved: CSS + native `<a>` only (same as Typography; no core) |
+| **SWC** | `2nd-gen/packages/swc/components/link/` | **N/A** — no `sp-link` CE; rules under [`stylesheets/`](../../../../2nd-gen/packages/swc/stylesheets/) per [Recommended packaging (default)](#recommended-packaging-default) unless **Q4** overrides; stories/tests extend **Typography** |
+
+Planned rendering shape (native-`<a>` model — **preferred**):
+
+- **No shadow boundary** around the activation target for default prose links.
+- **CSS** applies Spectrum Link classes / design tokens to the author’s `<a>`.
+- **Docs + Storybook** show correct combinations with `swc-Typography--prose` (or successor) wrappers.
+
+---
+
+## Migration checklist
+
+### Preparation (this ticket)
+
+- [ ] 1st-gen API surface documented
+- [ ] Dependencies identified
+- [ ] Breaking changes documented
+- [ ] 2nd-gen API decisions drafted
+- [ ] Plan reviewed by at least one other engineer
+
+### Setup
+
+- [ ] Confirm **Q4** (or accept default): `stylesheets/link.css` + import from `typography.css` — see [Recommended packaging (default)](#recommended-packaging-default)
+- [ ] If a new package is created: wire exports in the relevant `package.json` files
+- [ ] Check out `spectrum-css` at `spectrum-two` branch as sibling directory
+
+### API
+
+#### Naming and public surface
+
+- [x] Publish author-facing decision: **native `<a>`** only (**Q2** resolved)
+- [ ] ~~If CE path: define `Link.types.ts` / base~~ **N/A** — no CE
+
+#### Alignment checks
+
+- [ ] Align prose examples with [React Spectrum Link](https://react-spectrum.adobe.com/Link) naming where applicable
+- [x] **Q1:** Figma parity — confirmed overview / properties / variants at [S2 / Web — Link (`18850-110`)](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=18850-110)
+
+### Styling
+
+> Follow the [CSS style guide](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/) as the source of truth for all styling work. Key references: [migration steps](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/04_spectrum-swc-migration.md), [custom properties](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md), [anti-patterns](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/05_anti-patterns.md).
+
+- [ ] ~~If a CE exists: add `.swc-Link`~~ **N/A** — no CE (**Q2**)
+- [ ] Copy S2 source from `spectrum-css` `spectrum-two` branch [`components/link/index.css`](https://github.com/adobe/spectrum-css/tree/spectrum-two/components/link) (not `/dist`) into the chosen 2nd-gen stylesheet entry point
+- [ ] Implement **inline** modifier parity called out in [rendering analysis](./rendering-and-styling-migration-analysis.md)
+
+#### Visual model and regressions
+
+- [ ] Verify i18n size modifiers (`:lang(ja)`, `:lang(ko)`, `:lang(zh)`) if present in S2 source
+- [ ] Add `@cssprop` JSDoc on any **new** exposed `--swc-*` tokens (likely on Typography / prose entry if no Link CE)
+- [ ] Pass stylelint (property order, `no-descending-specificity`, token validation)
+
+### Accessibility
+
+#### Naming and semantics
+
+- [ ] Ship docs + examples per [accessibility migration analysis](./accessibility-migration-analysis.md) checklist (native `<a>`, quiet scope, no `disabled` on links)
+- [ ] Cross-link [Semantic HTML and ARIA](../../../../2nd-gen/packages/swc/.storybook/guides/accessibility-guides/semantic_html_aria.mdx) from Typography / Link docs
+
+#### State verification
+
+- [ ] Validate focus-visible in prose on light / dark / static-color backgrounds
+- [ ] Confirm no regression on [SWC-1160](https://jira.corp.adobe.com/browse/SWC-1160) class of issues
+
+### Testing
+
+- [ ] Port applicable assertions from [`1st-gen/packages/link/test/link.test.ts`](../../../../1st-gen/packages/link/test/link.test.ts) **only if** a CE remains; otherwise replace with **native `<a>`** fixture tests in typography / pattern packages
+- [ ] Add Playwright coverage for prose + links (`toMatchAriaSnapshot`) in the package that owns prose styles
+
+#### Behavior
+
+- [ ] Regression guard: single navigation per user gesture (patterns from [SWC-923](https://jira.corp.adobe.com/browse/SWC-923), [SWC-921](https://jira.corp.adobe.com/browse/SWC-921))
+
+#### Visual regression
+
+- [ ] VRT: default / secondary / quiet / static black / static white × hover / focus-visible (scoped to final home per **Q4**)
+- [ ] VRT: inline vs standalone presentation per **Q1** Figma / **Q4** stylesheet home
+
+### Documentation
+
+#### General
+
+- [ ] JSDoc / MDX for public CSS entries (no CE — **Q2**)
+- [ ] Storybook: Typography / prose examples show `<a href>` patterns (per accessibility analysis summary checklist)
+
+#### Breaking changes
+
+- [ ] Migration guide section: `sp-link` → native `<a>` + classes; `disabled` removal; quiet usage guidance
+
+### Review
+
+- [ ] `yarn lint:2nd-gen` passes (ESLint, Stylelint, Prettier)
+- [ ] Status table in workstream doc updated
+- [ ] PR created with description referencing Epic [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956)
+- [ ] Peer engineer sign-off
+
+---
+
+## Blockers and open questions
+
+### Design
+
+| # | Item | Blocking? | Status | Owner |
+| --- | ---- | --------- | ------ | ----- |
+| **Q1** | **Figma:** [S2 / Web (Desktop scale) — Link (`node-id=18850-110`)](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=18850-110) — overview, properties, variants | No | Resolved | Design + implementation |
+
+### Architecture and behavior
+
+| # | Item | Blocking? | Status | Owner |
+| --- | ---- | --------- | ------ | ----- |
+| **Q2** | **Architecture:** **CSS + native `<a>` only** — no transitional `sp-link` / CE in this migration | No | Resolved | Architecture + accessibility reviewers |
+| **Q4** | Canonical **code location** for link CSS — default **[`link.css` + compose into `typography.css`](#recommended-packaging-default)**; confirm with Typography + CSS owners or document an override (e.g. no `@import` into typography, different filename, or `global-elements.css` with explicit design sign-off) | Yes, until confirmed or defaulted | Open | CSS reviewer + Typography owner |
+
+### Scope and prerequisites
+
+| # | Item | Blocking? | Status | Owner |
+| --- | ---- | --------- | ------ | ----- |
+| **Q3** | **Epic** for Link migration work — [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956) | No | Resolved | Ticket owner |
+
+---
+
+## References
+
+- [Washing machine workflow](../../02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md)
+- [2nd-gen migration status table](../../02_workstreams/02_2nd-gen-component-migration/01_status.md)
+- [Accessibility migration analysis](./accessibility-migration-analysis.md)
+- [Rendering and styling migration analysis](./rendering-and-styling-migration-analysis.md)
+- [CSS style guide — Component Custom Property Exposure](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md#component-custom-property-exposure)
+- [CSS style guide — Selector conventions](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/02_custom-properties.md#selector-conventions)
+- [1st-gen `Link.ts`](../../../../1st-gen/packages/link/src/Link.ts)
+- [1st-gen `LikeAnchor` mixin](../../../../1st-gen/tools/shared/src/like-anchor.ts)
+- [1st-gen `Focusable` mixin](../../../../1st-gen/tools/shared/src/focusable.ts)
+- [1st-gen tests — `link.test.ts`](../../../../1st-gen/packages/link/test/link.test.ts)
+- [1st-gen README](../../../../1st-gen/packages/link/README.md)
+- [React Spectrum — Link](https://react-spectrum.adobe.com/Link)
+- [Spectrum CSS — `spectrum-two` / `components/link`](https://github.com/adobe/spectrum-css/tree/spectrum-two/components/link)
+- [Spectrum CSS migration PR (context)](https://github.com/adobe/spectrum-css/pull/3570)
+- [Badge migration reference](../../02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#reference-badge-migration)
+- [2nd-gen Typography migration guide](../../../../2nd-gen/packages/swc/components/typography/migration-guide.mdx)
+- [2nd-gen — Semantic HTML and ARIA](../../../../2nd-gen/packages/swc/.storybook/guides/accessibility-guides/semantic_html_aria.mdx)
+- Epic: [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956) — Link migration (program Epic)
+- [Figma — S2 / Web (Desktop scale), Link (`node-id=18850-110`)](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=18850-110)
+
+**Related Jira (from accessibility analysis):** [SWC-1160](https://jira.corp.adobe.com/browse/SWC-1160), [SWC-926](https://jira.corp.adobe.com/browse/SWC-926), [SWC-1428](https://jira.corp.adobe.com/browse/SWC-1428), [SWC-966](https://jira.corp.adobe.com/browse/SWC-966), [SWC-923](https://jira.corp.adobe.com/browse/SWC-923), [SWC-921](https://jira.corp.adobe.com/browse/SWC-921)
+
+---
+
+## Breaking changes to verify
+
+1. **Dropping default `sp-link` for prose / in-body copy** in favor of native `<a>` + Spectrum classes — **Q2** approves this architecture; confirm major consumers are informed via migration comms / [SWC-1428](https://jira.corp.adobe.com/browse/SWC-1428) / [SWC-926](https://jira.corp.adobe.com/browse/SWC-926) as applicable.
+2. **`disabled` removal on links** — confirm product teams have no blocking reliance on current `sp-link disabled` behavior ([SWC-966](https://jira.corp.adobe.com/browse/SWC-966)).
+3. **Quiet link styling scope** — confirm design agrees quiet is **not** for undifferentiated long-form body without additional visual cues.
+
+## What is still provisional
+
+- **Repo layout / import graph** for link CSS until **Q4** is confirmed or explicitly defaulted to [Recommended packaging (default)](#recommended-packaging-default).
+
+## What to provide next
+
+1. **Q4:** Typography + CSS owners **confirm the default** (`stylesheets/link.css` + pulled into `typography.css`) or **write down an override** (what changes, and why).
+
+When deferred work is ticketed under [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956), replace drafting-time rows in [Blockers and open questions](#blockers-and-open-questions) with the deferred-ticket table format described in the migration-prep skill (`Ticket`, `Deferred item`, `Why deferred`, `Related plan section`).

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/link/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/link/migration-plan.md
@@ -65,17 +65,14 @@
 ## TL;DR
 
 - **Atypical migration.** The approved [accessibility migration analysis](./accessibility-migration-analysis.md) positions 2nd-gen **default** link delivery as **Spectrum link styles on native `<a href>`** in the light DOM (especially inside prose / typography), **not** a per-sentence `<sp-link>` custom element. **Q2 (resolved):** **CSS + native `<a>` only** — no transitional `sp-link` compatibility CE in scope for this migration.
-- **Styling gap (confirmed from roadmap).** Spectrum 2 adds `.spectrum-Link--inline` for inline copy; 1st-gen `sp-link` does not map that modifier yet ([rendering analysis](./rendering-and-styling-migration-analysis.md)). Closing this gap belongs in **must ship** work for S2 parity, regardless of CE vs CSS-only packaging.
+- **Styling / S2 parity.** Spectrum CSS may use internal selectors (e.g. `.spectrum-Link--inline`) while mapping S2; **authors do not get an “inline” variant** in the sense 1st-gen `variant` attributes worked. Default `<a>` styles should **inherit surrounding typography** and “blend in” inside paragraphs; Storybook demonstrates links **in body copy** without treating inline as a separate consumer-facing variant ([rendering analysis](./rendering-and-styling-migration-analysis.md) remains the CSS source reference).
 - **A11y-required corrections.** Remove or deprecate **`disabled` on navigational links** ([SWC-966](https://jira.corp.adobe.com/browse/SWC-966)); align contrast and “link vs body text” presentation with WCAG expectations ([SWC-1160](https://jira.corp.adobe.com/browse/SWC-1160)); document **quiet** links for **section-scoped** patterns (e.g. footers), not undifferentiated body prose (per accessibility analysis).
 - **Consumer migration.** Track global native-anchor styling and API deprecation direction ([SWC-926](https://jira.corp.adobe.com/browse/SWC-926), [SWC-1428](https://jira.corp.adobe.com/browse/SWC-1428)) in the written migration path for teams still on `sp-link`.
-- **Open decisions:** **Q4** only — confirm or override the canonical **repo location and import story** for link CSS (see [Recommended packaging (default)](#recommended-packaging-default)). **Epic:** [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956) (resolved). **Q1** (Figma scope) and **Q2** (architecture) are **resolved** — see [Blockers and open questions](#blockers-and-open-questions).
+- **Packaging defaults (Q4):** **Resolved** for engineering direction — see [Recommended packaging (default)](#recommended-packaging-default) and **PR 6304** peer review (2026-05-15). **Additive:** confirm **trailing icon** with Design / React (Figma update ~Feb 2026); not required for initial release.
 
 ### Most blocking open questions
 
-- **Q4** ([Architecture and behavior](#architecture-and-behavior)): Confirm canonical **2nd-gen repo location** for link rules — default is **[`stylesheets/link.css` + compose into `typography.css`](#recommended-packaging-default)** unless you explicitly override (e.g. different filename, no `@import` into typography, or `global-elements.css` with design sign-off).
-- **Q1** ([Design](#design)): **Resolved** — [Figma — S2 / Web, Link (`18850-110`)](https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=18850-110); confirmed to cover **overview, properties, and variants**.
-- **Q2** ([Architecture and behavior](#architecture-and-behavior)): **Resolved** — **CSS + native `<a>` only** (no transitional `sp-link` / CE in this migration).
-- **Q3** ([Scope and prerequisites](#scope-and-prerequisites)): **Resolved** — migration Epic is [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956).
+- **None currently.** **Q1** (Figma), **Q2** (native `<a>` only), **Q3** (Epic), and **Q4** (packaging defaults) are **resolved** — see [Blockers and open questions](#blockers-and-open-questions). **Additive follow-up:** trailing icon (Figma) — sync with Design / React; see **A3** under [Additive](#additive--ships-when-ready-zero-breakage-for-consumers-already-on-2nd-gen).
 
 ---
 
@@ -162,18 +159,22 @@ No component-specific custom events documented on `Link`. Activation follows the
 
 ### User confirmation needed
 
-- Confirm **Q4**: canonical link CSS home — [default recommendation](#recommended-packaging-default) is **`stylesheets/link.css`** composed into **`typography.css`**; override only if Typography / CSS owners agree on a different split.
+- **Implementation:** Typography + CSS owners execute the [Recommended packaging (default)](#recommended-packaging-default) approach (generator change + `link.css` + optional `global-link.css`) and finalize **BEM** class names during build-out.
 
 ### Recommended packaging (default)
 
-**Q2 is resolved** (CSS + native `<a>` only — no compatibility CE). Unless **Q4** chooses a different layout, treat Link like **Typography** for repo shape: **no `2nd-gen/packages/core/components/link/`** (Typography today has **no** core `.ts` layer — only [`2nd-gen/packages/swc/components/typography/`](../../../../2nd-gen/packages/swc/components/typography/) for stories/tests/docs and [`2nd-gen/packages/swc/stylesheets/typography.css`](../../../../2nd-gen/packages/swc/stylesheets/typography.css) for rules).
+**Q2 is resolved** (CSS + native `<a>` only — no compatibility CE). Treat Link like **Typography** for repo shape: **no `2nd-gen/packages/core/components/link/`** (Typography today has **no** core `.ts` layer — only [`2nd-gen/packages/swc/components/typography/`](../../../../2nd-gen/packages/swc/components/typography/) for stories/tests/docs and [`2nd-gen/packages/swc/stylesheets/typography.css`](../../../../2nd-gen/packages/swc/stylesheets/typography.css) for generated rules).
 
 - **NPM package:** still **`@adobe/spectrum-wc`** (`2nd-gen/packages/swc`); there is no separate link-only package.
-- **Stylesheet source of truth:** add **`2nd-gen/packages/swc/stylesheets/link.css`** (name TBD) holding Spectrum 2 link rules migrated from Spectrum CSS; keeps ownership and review scope clear.
-- **Compose into prose by default:** **`@import`** (or build-time equivalent) that **`link.css`** from **`typography.css`** so apps loading typography for `.swc-Typography--prose` get correct native `<a href>` styling without a second manual import.
-- **Optional direct import:** document importing **`link.css`** alone for apps that need link appearance **without** full typography — same package, different entry.
-- **`global-elements.css`:** use only if design explicitly wants **unscoped** native-anchor styling; higher blast radius — not the default recommendation.
+- **Primary link stylesheet:** **`2nd-gen/packages/swc/stylesheets/link.css`** — all **variant / modifier** rules live here; authors apply **BEM-style classes** on `<a>` for presentation. **Do not** encode presentation as custom attributes (beyond normal HTML anchor attributes such as `href`, `rel`, etc.).
+- **Prose default appearance (no `@import`):** extend the **typography stylesheet generator** so emitted `typography.css` **includes the default link appearance inside `.swc-Typography--prose`** (append generated rules; keep **link.css** and **typography generation** as **separate concerns** — do **not** `@import` `link.css` into `typography.css`). Consumers who need **full modifier control** load **`link.css`** separately and apply modifier classes as documented.
+- **Section wrappers:** add **wrapper utilities** (e.g. **`swc-Links`** plural + modifiers) so footers / sidebars can style **all** anchors in a region **without** per-link classes on every `<a>`.
+- **Opt-in global baseline:** ship **`2nd-gen/packages/swc/stylesheets/global/global-link.css`** for **bare `<a>`** baseline styling app-wide when explicitly imported — **no** extra wrapper selector required; **do not** put this file in the **cascade layer** pattern used elsewhere — it should behave like an easily overridden **link reset**, not a locked layer.
 - **Core folder:** for this CSS-only path, **no** core TypeScript is required, matching Typography.
+
+#### Peer review — PR 6304 (requested changes, incorporated)
+
+Engineering review on [PR 6304](https://github.com/adobe/spectrum-web-components/pull/6304) records the above: confirm **`link.css`** location; **no** custom element; **no `@import`** into typography (generator instead); **BEM classes** for presentation; **quiet** may require a **modifier pair** analogous to React’s `isStandalone` for removing underline; **inline** is **not** an author-facing variant (inherit + stories); **`swc-Links`** section utility; **`global-link.css`** opt-in without cascade layers; **trailing icon** in Figma → **additive** / Design+React check-in, not blocking v1.
 
 ---
 
@@ -192,7 +193,7 @@ No component-specific custom events documented on `Link`. Activation follows the
 
 | # | What changes | 1st-gen behavior | 2nd-gen behavior | Consumer migration path |
 | --- | ------------ | ---------------- | ---------------- | ----------------------- |
-| **B3** | **S2 inline** presentation | No `spectrum-Link--inline` mapping | CSS includes inline / standalone semantics per S2 | Update markup/classes per final Typography + Link docs once **Q4** packaging is settled |
+| **B3** | **S2 typography + link parity** | 1st-gen `sp-link` predates some S2 selector nuances | Default anchors in prose **inherit** surrounding type; internal CSS may mirror Spectrum’s inline/standalone selectors where needed — **not** a new author “variant” vs 1st-gen (no `inline` attribute parity) | Rely on **typography generator** + **`link.css`** docs; add Storybook for **link inside body copy** |
 | **B4** | **Token / contrast** fixes | Known contrast risk vs body ([SWC-1160](https://jira.corp.adobe.com/browse/SWC-1160)) | S2 tokens + tests in prose contexts | Retest adjacent-text contrast in authored examples |
 
 #### Accessibility and behavior
@@ -208,18 +209,21 @@ No component-specific custom events documented on `Link`. Activation follows the
 | --- | ------------- | ----- |
 | **A1** | Optional **compatibility** `sp-link` | **Out of scope** — **Q2** approved CSS + native `<a>` only (no CE) |
 | **A2** | Extra Storybook coverage for **static color** on imagery / dark backgrounds | Visual regression alongside typography stories |
+| **A3** | **Trailing icon** (Figma S2 / Web, ~Feb 2026) | **Additive** — not in React yet; confirm with **Design / React**; not a blocker for initial link CSS / prose work |
 
 ---
 
 ## 2nd-gen API decisions
 
-These are derived from 1st-gen, the [rendering roadmap](./rendering-and-styling-migration-analysis.md), the [accessibility analysis](./accessibility-migration-analysis.md), and [React Spectrum Link](https://react-spectrum.adobe.com/Link). **Q1** (Figma) and **Q2** (native `<a>` only) are **resolved**. **Q4** remains if packaging needs an explicit owner sign-off beyond the default below (**Q3** / Epic: [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956)).
+These are derived from 1st-gen, the [rendering roadmap](./rendering-and-styling-migration-analysis.md), the [accessibility analysis](./accessibility-migration-analysis.md), and [React Spectrum Link](https://react-spectrum.adobe.com/Link). **Q1** (Figma), **Q2** (native `<a>` only), **Q3** (Epic), and **Q4** (packaging — [PR 6304](https://github.com/adobe/spectrum-web-components/pull/6304) review) are **resolved** for planning purposes. Remaining work is **implementation** plus **additive** **A3** coordination.
 
 ### Public API
 
 #### Properties / attributes (2nd-gen)
 
-**Confirmed (Q2):** no custom element — use native HTML attributes on `<a>` (`href`, `target`, `rel`, `download`, `referrerpolicy`, `aria-label`, `lang`, etc.). No transitional `sp-link` in this migration.
+**Confirmed (Q2):** no custom element. Authors use **standard HTML** on `<a>` for behavior and semantics (`href`, `target`, `rel`, `download`, `referrerpolicy`, `aria-label`, `lang`, etc.).
+
+**Presentation:** **BEM-style classes only** (and documented **wrapper** utilities such as **`swc-Links`**) — do **not** introduce shadow-CE-style **presentation attributes** (e.g. no `quiet="` on a hostless pattern); map old `sp-link` attributes to **classes** in migration docs.
 
 #### Visual matrix (2nd-gen)
 
@@ -227,10 +231,10 @@ N/A as a “fill / outline” matrix. Planned **presentation modes** (from roadm
 
 | Mode | Notes |
 | ---- | ----- |
-| Default / primary inline (S2) | **Confirmed** against Figma handoff (**Q1**) — implement per S2 / CSS once **Q4** packaging is settled |
-| Secondary | `variant="secondary"` today → class or data-attribute pattern on `<a>` (**Inferred**) |
-| Quiet | Boolean-style presentation; **scope** per **B5** |
-| Static white / black | `static-color` analog as classes on `<a>` for on-image / on-tint contexts |
+| Default (body / prose) | Anchors **inherit** surrounding typography; default link color / decoration per S2 inside `.swc-Typography--prose` (generator) and/or **`link.css`** — **not** an “inline variant” for authors |
+| Secondary | **BEM modifier class** (replaces `variant="secondary"` on `sp-link`) |
+| Quiet | **BEM modifiers** — likely **two classes** required (analogous to React requiring **`isStandalone`** to remove underline); document exact pairing when CSS lands |
+| Static white / black | **BEM modifier classes** on `<a>` (replaces `static-color` attribute) |
 
 #### Slots (2nd-gen)
 
@@ -245,7 +249,7 @@ Initial expectation for **Link** is a **small reviewed set** (likely tied to typ
 ### Behavioral semantics
 
 - **Navigation:** real `href` or framework `Link` that renders a real `<a>`; avoid JS-only “fake” links for standard navigation (**Confirmed** from accessibility analysis).
-- **Quiet + critical flows:** treat as design-governed; engineering ships CSS but docs must encode constraints (**Confirmed** policy direction from accessibility analysis).
+- **Quiet + critical flows:** treat as design-governed; engineering ships CSS but docs must encode constraints (**Confirmed** policy direction from accessibility analysis). **Implementation note (PR 6304):** quiet underline removal may require **paired modifier classes** (see visual matrix).
 
 ### Accessibility semantics notes (2nd-gen)
 
@@ -257,12 +261,12 @@ Follow the [accessibility migration analysis](./accessibility-migration-analysis
 
 > The 1st-gen component is a **reference only** — 2nd-gen is built independently. Neither generation imports from the other.
 
-**Link-specific deviation:** the [Badge migration reference](../../02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#reference-badge-migration) describes the default **core + `sp-*` SWC** split. For Link, the **primary** 2nd-gen deliverable is **shared CSS + documentation** with **native anchors** (**Q2** resolved). **Q4** only adjusts *where* those rules live in-repo if the default packaging is overridden.
+**Link-specific deviation:** the [Badge migration reference](../../02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#reference-badge-migration) describes the default **core + `sp-*` SWC** split. For Link, the **primary** 2nd-gen deliverable is **shared CSS + documentation** with **native anchors** (**Q2** resolved). Packaging defaults are **set** in [Recommended packaging (default)](#recommended-packaging-default) (including **PR 6304** review).
 
 | Layer | Path | Contains |
 | ----- | ---- | -------- |
 | **Core** | `2nd-gen/packages/core/components/link/` | **N/A** — **Q2** resolved: CSS + native `<a>` only (same as Typography; no core) |
-| **SWC** | `2nd-gen/packages/swc/components/link/` | **N/A** — no `sp-link` CE; rules under [`stylesheets/`](../../../../2nd-gen/packages/swc/stylesheets/) per [Recommended packaging (default)](#recommended-packaging-default) unless **Q4** overrides; stories/tests extend **Typography** |
+| **SWC** | `2nd-gen/packages/swc/components/link/` | **N/A** — no `sp-link` CE; rules under [`stylesheets/`](../../../../2nd-gen/packages/swc/stylesheets/) and [`stylesheets/global/`](../../../../2nd-gen/packages/swc/stylesheets/) per [Recommended packaging (default)](#recommended-packaging-default); stories/tests extend **Typography** |
 
 Planned rendering shape (native-`<a>` model — **preferred**):
 
@@ -284,7 +288,7 @@ Planned rendering shape (native-`<a>` model — **preferred**):
 
 ### Setup
 
-- [ ] Confirm **Q4** (or accept default): `stylesheets/link.css` + import from `typography.css` — see [Recommended packaging (default)](#recommended-packaging-default)
+- [ ] Implement [Recommended packaging (default)](#recommended-packaging-default): `link.css`, typography **generator** updates for prose defaults, optional `global-link.css`, `swc-Links` utilities — no `@import` of `link.css` into `typography.css`
 - [ ] If a new package is created: wire exports in the relevant `package.json` files
 - [ ] Check out `spectrum-css` at `spectrum-two` branch as sibling directory
 
@@ -337,8 +341,8 @@ Planned rendering shape (native-`<a>` model — **preferred**):
 
 #### Visual regression
 
-- [ ] VRT: default / secondary / quiet / static black / static white × hover / focus-visible (scoped to final home per **Q4**)
-- [ ] VRT: inline vs standalone presentation per **Q1** Figma / **Q4** stylesheet home
+- [ ] VRT: default / secondary / quiet / static black / static white × hover / focus-visible (per `link.css` + prose / wrapper stories)
+- [ ] VRT: links **inside running text** vs **section / quiet** stories (paired modifiers per plan)
 
 ### Documentation
 
@@ -373,7 +377,7 @@ Planned rendering shape (native-`<a>` model — **preferred**):
 | # | Item | Blocking? | Status | Owner |
 | --- | ---- | --------- | ------ | ----- |
 | **Q2** | **Architecture:** **CSS + native `<a>` only** — no transitional `sp-link` / CE in this migration | No | Resolved | Architecture + accessibility reviewers |
-| **Q4** | Canonical **code location** for link CSS — default **[`link.css` + compose into `typography.css`](#recommended-packaging-default)**; confirm with Typography + CSS owners or document an override (e.g. no `@import` into typography, different filename, or `global-elements.css` with explicit design sign-off) | Yes, until confirmed or defaulted | Open | CSS reviewer + Typography owner |
+| **Q4** | **Packaging:** `link.css` + typography **generator** (no `@import`), **`swc-Links`** section utilities, **`global/global-link.css`** opt-in per [Recommended packaging (default)](#recommended-packaging-default); **PR 6304** review incorporated | No | Resolved | CSS + Typography (PR 6304 — 5t3ph) |
 
 ### Scope and prerequisites
 
@@ -417,10 +421,12 @@ Planned rendering shape (native-`<a>` model — **preferred**):
 
 ## What is still provisional
 
-- **Repo layout / import graph** for link CSS until **Q4** is confirmed or explicitly defaulted to [Recommended packaging (default)](#recommended-packaging-default).
+- **Exact BEM class names** and the final **quiet** modifier **pairing** — finalize during CSS implementation and Storybook.
+- **Trailing icon** presentation — **additive** (**A3**); align with Design / React when ready.
 
 ## What to provide next
 
-1. **Q4:** Typography + CSS owners **confirm the default** (`stylesheets/link.css` + pulled into `typography.css`) or **write down an override** (what changes, and why).
+1. **Implementation pass:** land `link.css`, typography generator output, `global-link.css`, and `swc-Links` per [Recommended packaging (default)](#recommended-packaging-default).
+2. **Design / React:** short sync on **trailing icon** (Figma) when scheduling **A3**.
 
 When deferred work is ticketed under [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956), replace drafting-time rows in [Blockers and open questions](#blockers-and-open-questions) with the deferred-ticket table format described in the migration-prep skill (`Ticket`, `Deferred item`, `Why deferred`, `Related plan section`).

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/link/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/link/migration-plan.md
@@ -167,14 +167,22 @@ No component-specific custom events documented on `Link`. Activation follows the
 
 - **NPM package:** still **`@adobe/spectrum-wc`** (`2nd-gen/packages/swc`); there is no separate link-only package.
 - **Primary link stylesheet:** **`2nd-gen/packages/swc/stylesheets/link.css`** — all **variant / modifier** rules live here; authors apply **BEM-style classes** on `<a>` for presentation. **Do not** encode presentation as custom attributes (beyond normal HTML anchor attributes such as `href`, `rel`, etc.).
-- **Prose default appearance (no `@import`):** extend the **typography stylesheet generator** so emitted `typography.css` **includes the default link appearance inside `.swc-Typography--prose`** (append generated rules; keep **link.css** and **typography generation** as **separate concerns** — do **not** `@import` `link.css` into `typography.css`). Consumers who need **full modifier control** load **`link.css`** separately and apply modifier classes as documented.
-- **Section wrappers:** add **wrapper utilities** (e.g. **`swc-Links`** plural + modifiers) so footers / sidebars can style **all** anchors in a region **without** per-link classes on every `<a>`.
+- **Typography generator — prose + link groups (no `@import`):** extend the **typography stylesheet generator** so emitted `typography.css` includes **default** anchor appearance for both document prose and link lists in **one** appended rule block — keep **`link.css`** and typography generation as **separate concerns** (do **not** `@import` `link.css` into `typography.css`). Example shape:
+
+  ```css
+  .swc-Typography--links  :where(a),
+  .swc-Typography--prose :where(a) { }
+  ```
+
+  Use **`:where(a)`** so specificity stays at class level and **BEM modifier classes** on `<a>` can override defaults. **`.swc-Typography--links`** is a **Typography modifier** (same pattern as `--prose`, `--emphasized`) for footers, sidebars, and `<ul>` link lists — not a separate `swc-Links` utility. Consumers who need **full modifier control** load **`link.css`** separately and apply modifier classes as documented.
+- **Documentation (Link → Typography, no story duplication):** Link-facing docs (migration guide / contributor notes / any Link MDX) should **call out** that **default** and **wrapper** anchor styles ship with the **Typography** package (`@adobe/spectrum-wc/typography.css`, modifiers **`.swc-Typography--prose`** and **`.swc-Typography--links`**, optional **`link.css`** for BEM modifiers). **Do not** duplicate the full Typography Storybook catalog under Link — cross-link [`typography` docs](../../../../2nd-gen/packages/swc/components/typography/) and the [Typography migration guide](../../../../2nd-gen/packages/swc/components/typography/migration-guide.mdx) instead.
+- **Storybook (Typography owns link-list demo):** add **one** Typography story for the links-specific use case — e.g. a **`<ul class="swc-Typography--links">`** with **~3** list items, each containing an `<a href>`. Keep prose-in-paragraph link examples in existing Typography prose stories; Link docs **reference** that story rather than re-implementing it.
 - **Opt-in global baseline:** ship **`2nd-gen/packages/swc/stylesheets/global/global-link.css`** for **bare `<a>`** baseline styling app-wide when explicitly imported — **no** extra wrapper selector required; **do not** put this file in the **cascade layer** pattern used elsewhere — it should behave like an easily overridden **link reset**, not a locked layer.
 - **Core folder:** for this CSS-only path, **no** core TypeScript is required, matching Typography.
 
 #### Peer review — PR 6304 (requested changes, incorporated)
 
-Engineering review on [PR 6304](https://github.com/adobe/spectrum-web-components/pull/6304) records the above: confirm **`link.css`** location; **no** custom element; **no `@import`** into typography (generator instead); **BEM classes** for presentation; **quiet** may require a **modifier pair** analogous to React’s `isStandalone` for removing underline; **inline** is **not** an author-facing variant (inherit + stories); **`swc-Links`** section utility; **`global-link.css`** opt-in without cascade layers; **trailing icon** in Figma → **additive** / Design+React check-in, not blocking v1.
+Engineering review on [PR 6304](https://github.com/adobe/spectrum-web-components/pull/6304) records the above: confirm **`link.css`** location; **no** custom element; **no `@import`** into typography (generator instead); **BEM classes** for presentation; **quiet** may require a **modifier pair** analogous to React’s `isStandalone` for removing underline; **inline** is **not** an author-facing variant (inherit + stories); **`swc-Typography--links`** + **`--prose`** default anchors via generator with **`:where(a)`** ([discussion](https://github.com/adobe/spectrum-web-components/pull/6304#discussion_r3259963381)); **Link docs → Typography callout** (no duplicate stories); **one Typography story** for `swc-Typography--links` link lists; **`global-link.css`** opt-in without cascade layers; **trailing icon** in Figma → **additive** / Design+React check-in, not blocking v1.
 
 ---
 
@@ -208,7 +216,7 @@ Engineering review on [PR 6304](https://github.com/adobe/spectrum-web-components
 | # | What is added | Notes |
 | --- | ------------- | ----- |
 | **A1** | Optional **compatibility** `sp-link` | **Out of scope** — **Q2** approved CSS + native `<a>` only (no CE) |
-| **A2** | Extra Storybook coverage for **static color** on imagery / dark backgrounds | Visual regression alongside typography stories |
+| **A2** | Extra Storybook coverage for **static color** on imagery / dark backgrounds | Visual regression alongside Typography stories (modifier / `link.css` demos — not a duplicate Typography catalog) |
 | **A3** | **Trailing icon** (Figma S2 / Web, ~Feb 2026) | **Additive** — not in React yet; confirm with **Design / React**; not a blocker for initial link CSS / prose work |
 
 ---
@@ -223,7 +231,7 @@ These are derived from 1st-gen, the [rendering roadmap](./rendering-and-styling-
 
 **Confirmed (Q2):** no custom element. Authors use **standard HTML** on `<a>` for behavior and semantics (`href`, `target`, `rel`, `download`, `referrerpolicy`, `aria-label`, `lang`, etc.).
 
-**Presentation:** **BEM-style classes only** (and documented **wrapper** utilities such as **`swc-Links`**) — do **not** introduce shadow-CE-style **presentation attributes** (e.g. no `quiet="` on a hostless pattern); map old `sp-link` attributes to **classes** in migration docs.
+**Presentation:** **BEM-style classes only** (and Typography modifiers such as **`.swc-Typography--links`** / **`.swc-Typography--prose`** for unclassed anchors inside wrappers) — do **not** introduce shadow-CE-style **presentation attributes** (e.g. no `quiet="` on a hostless pattern); map old `sp-link` attributes to **classes** in migration docs.
 
 #### Visual matrix (2nd-gen)
 
@@ -272,7 +280,7 @@ Planned rendering shape (native-`<a>` model — **preferred**):
 
 - **No shadow boundary** around the activation target for default prose links.
 - **CSS** applies Spectrum Link classes / design tokens to the author’s `<a>`.
-- **Docs + Storybook** show correct combinations with `swc-Typography--prose` (or successor) wrappers.
+- **Docs:** Link migration content **points to Typography** for base/wrapper styles; **Storybook:** Typography owns the **`swc-Typography--links`** list story and existing prose link examples — Link does not mirror the full Typography story set.
 
 ---
 
@@ -288,7 +296,7 @@ Planned rendering shape (native-`<a>` model — **preferred**):
 
 ### Setup
 
-- [ ] Implement [Recommended packaging (default)](#recommended-packaging-default): `link.css`, typography **generator** updates for prose defaults, optional `global-link.css`, `swc-Links` utilities — no `@import` of `link.css` into `typography.css`
+- [ ] Implement [Recommended packaging (default)](#recommended-packaging-default): `link.css`, typography **generator** updates (`.swc-Typography--links` / `--prose` + `:where(a)`), optional `global-link.css` — no `@import` of `link.css` into `typography.css`
 - [ ] If a new package is created: wire exports in the relevant `package.json` files
 - [ ] Check out `spectrum-css` at `spectrum-two` branch as sibling directory
 
@@ -348,12 +356,19 @@ Planned rendering shape (native-`<a>` model — **preferred**):
 
 #### General
 
-- [ ] JSDoc / MDX for public CSS entries (no CE — **Q2**)
-- [ ] Storybook: Typography / prose examples show `<a href>` patterns (per accessibility analysis summary checklist)
+- [ ] JSDoc / MDX for public CSS entries in **`link.css`** (no CE — **Q2**)
+- [ ] **Link docs callout (no story duplication):** document that default anchor appearance comes from **Typography** (`typography.css`, **`.swc-Typography--prose`**, **`.swc-Typography--links`**) and that **`link.css`** is for BEM modifier classes; cross-link [Typography migration guide](../../../../2nd-gen/packages/swc/components/typography/migration-guide.mdx) — **do not** copy the full Typography Storybook surface under Link
+- [ ] Prose / in-body `<a href>` patterns remain documented in **Typography** stories and migration guide (per accessibility analysis)
+
+#### Storybook (Typography)
+
+- [ ] Add **one** Typography story: **link list** use case — `<ul class="swc-Typography--links">` with **~3** `<li>` items, each with an `<a href>` (footers / sidebars pattern)
+- [ ] Confirm existing Typography **prose** story(ies) show `<a href>` inside running text (no separate Link storybook package required)
+- [ ] **A2:** static-color / on-image link demos live under Typography or `link.css` stories as needed — not a second full catalog
 
 #### Breaking changes
 
-- [ ] Migration guide section: `sp-link` → native `<a>` + classes; `disabled` removal; quiet usage guidance
+- [ ] Migration guide section: `sp-link` → native `<a>` + classes; `disabled` removal; quiet usage guidance; import path **`@adobe/spectrum-wc/typography.css`** (+ optional **`link.css`**)
 
 ### Review
 
@@ -377,7 +392,7 @@ Planned rendering shape (native-`<a>` model — **preferred**):
 | # | Item | Blocking? | Status | Owner |
 | --- | ---- | --------- | ------ | ----- |
 | **Q2** | **Architecture:** **CSS + native `<a>` only** — no transitional `sp-link` / CE in this migration | No | Resolved | Architecture + accessibility reviewers |
-| **Q4** | **Packaging:** `link.css` + typography **generator** (no `@import`), **`swc-Links`** section utilities, **`global/global-link.css`** opt-in per [Recommended packaging (default)](#recommended-packaging-default); **PR 6304** review incorporated | No | Resolved | CSS + Typography (PR 6304 — 5t3ph) |
+| **Q4** | **Packaging:** `link.css` + typography **generator** (no `@import`; **`.swc-Typography--links`** / **`--prose`** + `:where(a)`), **`global/global-link.css`** opt-in per [Recommended packaging (default)](#recommended-packaging-default); **PR 6304** review incorporated | No | Resolved | CSS + Typography (PR 6304 — 5t3ph) |
 
 ### Scope and prerequisites
 
@@ -426,7 +441,7 @@ Planned rendering shape (native-`<a>` model — **preferred**):
 
 ## What to provide next
 
-1. **Implementation pass:** land `link.css`, typography generator output, `global-link.css`, and `swc-Links` per [Recommended packaging (default)](#recommended-packaging-default).
+1. **Implementation pass:** land `link.css`, typography generator output (`.swc-Typography--links` / `--prose` + `:where(a)`), `global-link.css`, Link docs callout, and Typography **links list** story per [Recommended packaging (default)](#recommended-packaging-default).
 2. **Design / React:** short sync on **trailing icon** (Figma) when scheduling **A3**.
 
 When deferred work is ticketed under [SWC-1956](https://jira.corp.adobe.com/browse/SWC-1956), replace drafting-time rows in [Blockers and open questions](#blockers-and-open-questions) with the deferred-ticket table format described in the migration-prep skill (`Ticket`, `Deferred item`, `Why deferred`, `Related plan section`).

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/tabs/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/tabs/migration-plan.md
@@ -802,7 +802,7 @@ Any 2nd-gen change to DOM arrangement must preserve ID resolution. Options inclu
 - [CSS style guide — Custom properties](../../../02_style-guide/01_css/02_custom-properties.md)
 - [1st-gen source](../../../../1st-gen/packages/tabs/src/)
 - [1st-gen tests](../../../../1st-gen/packages/tabs/test/)
-- [Consumer migration guide](../../../../2nd-gen/packages/swc/components/tabs/migration.md)
+- [Consumer migration guide](../../../../2nd-gen/packages/swc/components/tabs/migration-guide.mdx)
 - [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/)
 - [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
 - [Using ARIA (read this first)](https://www.w3.org/WAI/ARIA/apg/practices/read-me-first/)

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
@@ -30,6 +30,7 @@
     - [Public API](#public-api)
     - [Behavioral semantics](#behavioral-semantics)
     - [Accessibility semantics notes (2nd-gen)](#accessibility-semantics-notes-2nd-gen)
+    - [ARIA relationship wiring](#aria-relationship-wiring)
 - [Architecture: core vs SWC split](#architecture-core-vs-swc-split)
 - [Controller integration assumptions](#controller-integration-assumptions)
     - [Event dispatch ownership](#event-dispatch-ownership)
@@ -431,7 +432,7 @@ In the initial release, the tooltip uses native popover for open/close but has n
 - Tooltips must respond to both hover and keyboard focus. React Spectrum's `trigger="focus"` (focus-only mode) is not applicable here: WCAG 1.4.13 requires the tooltip to be available via pointer hover, so restricting to focus-only would fail mouse users. Both trigger methods are always active in automatic mode.
 - Toggletip mode (touch/longpress disclosure pattern, SWC-2022) is not applicable for the 2nd-gen Tooltip. Consumers needing toggletip behavior should use `swc-popover` or a popover-derived component instead.
 
-#### ARIA relationship wiring
+### ARIA relationship wiring
 
 The SWC layer uses `Element.ariaDescribedByElements` to wire the ARIA relationship between the trigger and tooltip on `open` change. This API was chosen specifically because 2nd-gen button-like components render a semantic `<button>` inside their shadow DOM — the inner button is the AT-facing interactive element, not the host. A string `aria-describedby` attribute on the trigger host cannot reference an element across a shadow boundary; `ariaDescribedByElements` uses element references that bypass cross-root ID scoping. String-ID `aria-describedby` on the host must not be used as a fallback.
 


### PR DESCRIPTION
## Description

- Delivers the complete **Phase 1** migration plan for Link (`sp-link` / 1st-gen → 2nd-gen CSS + native `<a>` model)
- Documents the full **1st-gen API surface** (including `LikeAnchor` / `Focusable` mixin attributes), **dependencies**, and **Shadow DOM** reference output
- Establishes **must ship** consumer impact (**B1–B6**), **additive** items (**A2**; **A1** compatibility CE marked out of scope), **2nd-gen API decisions**, **architecture** (no `2nd-gen/packages/core/components/link/`, no `swc/components/link` CE), **recommended packaging** (`stylesheets/link.css` + compose into `typography.css`), and a full **migration checklist**
- Records **resolved** design and architecture sign-off (**Q1** Figma scope; **Q2** CSS + native `<a>` only; **Q3** Epic) and **one open packaging item** (**Q4**) for Typography + CSS owners to confirm or override

### Motivation and context

Link is an **atypical** 2nd-gen migration: the accessibility analysis positions default delivery as **Spectrum link styles on real `<a href>`** in the light DOM (especially inside `.swc-Typography--prose`), not a per-sentence `<sp-link>` custom element. This PR is the **Phase 1 preparation artifact** so reviewers can agree on scope, breaking changes, and where implementation lands before any code ships.

Key decisions recorded in the plan:

**Six must-ship changes (B1–B6):**

- **B1:** Prefer **native `<a href>`** with documented Spectrum classes for in-body / prose links (vs defaulting on `<sp-link>`); consumer migration path references SWC-1428 / SWC-926 direction
- **B2:** **`disabled`** is not a supported pattern on navigational links (SWC-966); use `<button disabled>` + routing or remove the control
- **B3:** Ship **S2 inline** presentation (`.spectrum-Link--inline` parity from Spectrum CSS); 1st-gen `sp-link` gap called out in the rendering roadmap
- **B4:** **Contrast / tokens** in prose so link vs body text meets WCAG expectations (SWC-1160 class of issues must not regress)
- **B5:** **Quiet** link styling is **section-scoped** in docs (e.g. footers), not undifferentiated long-form body copy
- **B6:** Document **single activation target** for `href` + router patterns (SWC-923 / SWC-921 ecosystem issues)

**Architecture (Q2 resolved):** **CSS + native `<a>` only** — no transitional `sp-link` custom element in this migration; **no core package** for Link (same pattern as Typography today).

**Packaging default (Q4):** Add `2nd-gen/packages/swc/stylesheets/link.css` (name TBD), migrate from Spectrum CSS `spectrum-two` `components/link`, **`@import`** into `typography.css` for prose-by-default; document optional standalone `link.css` import; `global-elements.css` only with explicit design sign-off.


### Related issue(s)

- Epic SWC-1956 — Link migration
- SWC-1957 (this ticket)

## Manual review test cases

- [ ] *Verify the six must-ship rows (B1–B6) are documented with consumer migration paths*
  1. Open [`CONTRIBUTOR-DOCS/03_project-planning/03_components/link/migration-plan.md`](CONTRIBUTOR-DOCS/03_project-planning/03_components/link/migration-plan.md)
  2. Navigate to **Changes overview → Must ship — breaking or a11y-required**
  3. Confirm B1–B6 each have a clear **Consumer migration path** and that B2 aligns with SWC-966 (no `disabled` on real links)

- [ ] *Verify the 2nd-gen API and architecture match the approved model (no CE, no core)*
  1. Navigate to **2nd-gen API decisions → Public API**
  2. Confirm the plan states **native `<a>`** attributes only and **no** transitional `sp-link`
  3. Navigate to **Architecture: core vs SWC split**
  4. Confirm **Core** and **`swc/components/link`** rows are **N/A** with rationale tied to Q2

- [ ] *Verify recommended packaging and Q4 scope*
  1. Navigate to **Migration sequencing and prerequisites → Recommended packaging (default)**
  2. Confirm default is **`link.css` + compose into `typography.css`**, optional direct `link.css` import, and `global-elements.css` called out as non-default / high blast radius
  3. Navigate to **Blockers and open questions**
  4. Confirm **Q4** is the only open blocker for packaging confirmation (or explicit override) and **Q1–Q3** are resolved as documented

- [ ] *Verify README index*
  1. Open [`CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md`](CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md)
  2. Under **Link**, confirm **Link migration plan** links to `link/migration-plan.md` alongside the existing accessibility and roadmap docs

- [ ] *Verify cross-links and external references resolve in GitHub preview*
  1. From the migration plan, spot-check links to Figma, Epic/Jira references, sibling analyses (`accessibility-migration-analysis.md`, `rendering-and-styling-migration-analysis.md`), and in-repo paths (Typography, style guide, washing machine workflow)
