### PR TITLE
ci: only run 2nd-gen chromium coverage on PRs targeting main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,42 @@ commands:
               echo "Only docs/other-gen changes; halting because << parameters.gen >> is not affected."
               circleci-agent step halt
             fi
+  resolve-pr-base:
+    description: >
+      Resolve the PR's base branch and export `PR_BASE_BRANCH` to
+      `$BASH_ENV` for later steps to read. On `main`, sets the value to
+      `main`. When the base can't be determined (missing token, fork
+      without PR metadata, parse failure), leaves the value empty so
+      consumers can decide their own default.
+    steps:
+      - run:
+          name: Resolve PR base branch
+          command: |
+            set -e
+
+            BASE=""
+            if [ "$CIRCLE_BRANCH" = "main" ]; then
+              BASE="main"
+            else
+              PR_NUMBER=""
+              if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+                PR_NUMBER=$(echo "$CIRCLE_PULL_REQUEST" | sed 's/.*\/pull\///')
+              elif [ -n "$CIRCLE_PR_NUMBER" ]; then
+                PR_NUMBER="$CIRCLE_PR_NUMBER"
+              elif [[ "$CIRCLE_BRANCH" =~ ^pull/[0-9]+$ ]]; then
+                PR_NUMBER=$(echo "$CIRCLE_BRANCH" | sed 's/pull\///')
+              fi
+
+              if [ -n "$PR_NUMBER" ] && [ -n "$GITHUB_TOKEN" ]; then
+                BASE=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$PR_NUMBER" \
+                  | python3 -c "import json,sys; print(json.load(sys.stdin).get('base',{}).get('ref',''))" 2>/dev/null || echo "")
+              fi
+            fi
+
+            echo "Resolved PR base branch: '${BASE:-<unknown>}'"
+            echo "export PR_BASE_BRANCH=\"${BASE}\"" >> $BASH_ENV
   install-azcopy:
     description: 'Install AzCopy and set up authentication'
     steps:
@@ -381,12 +417,15 @@ jobs:
       - halt-if-not-affected:
           gen: 2nd-gen
       - downstream-2ndgen
+      - resolve-pr-base
       - run:
-          name: Run 2nd-gen browser tests (coverage on Chromium)
+          name: Run 2nd-gen browser tests (coverage on Chromium, base=main only)
           command: |
-            if [ "<< parameters.browser >>" = "chromium" ]; then
+            if [ "<< parameters.browser >>" = "chromium" ] && [ "$PR_BASE_BRANCH" = "main" ]; then
+              echo "Running chromium tests with coverage (PR base is main)."
               VITEST_BROWSER_INSTANCES=chromium yarn workspace @spectrum-web-components/2nd-gen test:coverage
             else
+              echo "Running << parameters.browser >> tests without coverage (browser=<< parameters.browser >>, base='${PR_BASE_BRANCH:-<unknown>}')."
               VITEST_BROWSER_INSTANCES=<< parameters.browser >> yarn test:2nd-gen
             fi
       - store_test_results:


### PR DESCRIPTION
## Description

Gates the coverage variant of the 2nd-gen chromium test run in `test-2ndgen-browser` so it only executes when the PR's base branch is `main`. Other runs (non-chromium browsers, or chromium PRs targeting a feature branch) fall through to the non-coverage `test:2nd-gen` command.

Adds a reusable `resolve-pr-base` CircleCI command that resolves the PR's base via the GitHub API and exports `PR_BASE_BRANCH` to `$BASH_ENV` for later steps to read.

## Motivation and context

Feature-branch PRs (stacked work, epic branches) may not meet coverage thresholds until the work is consolidated and rebased onto its target. Running coverage on every chromium PR causes red signals on intentionally-partial branches. Coverage still runs on every PR that will land on `main` and on the `main` branch itself.

## Related issue(s)

- N/A

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Coverage runs on a PR targeting `main`_
  1. Open a PR with the target branch set to `main` (any chromium-affecting change works)
  2. Watch the CircleCI run for `test-2ndgen-browser-chromium`
  3. Expect the "Resolve PR base branch" step to log `main`, and the test step to log `Running chromium tests with coverage (PR base is main).` and invoke `test:coverage`

- [ ] _Coverage is skipped on a PR targeting a feature branch_
  1. Open a PR whose target branch is not `main` (e.g. a long-lived feature branch)
  2. Watch the CircleCI run for `test-2ndgen-browser-chromium`
  3. Expect the "Resolve PR base branch" step to log the feature branch name, and the test step to log `Running chromium tests without coverage` and invoke `test:2nd-gen`

- [ ] _Non-chromium browsers are unaffected_
  1. On any PR, watch `test-2ndgen-browser-firefox` and `test-2ndgen-browser-webkit`
  2. Expect both to run `test:2nd-gen` (no coverage), regardless of base

- [ ] _`main` branch runs still execute coverage_
  1. Watch a CI run triggered by a push to `main`
  2. Expect `test-2ndgen-browser-chromium` to run `test:coverage`

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

No UI or component changes; CI-only change.

- [ ] **Keyboard** (required — document steps below)
  1. No focusable parts; this change only affects CI workflow execution. Confirm no regressions in component behavior by reviewing the chromium test run on this PR.

- [ ] **Screen reader** (required — document steps below)
  1. No DOM, role, or label changes; this change only affects CI workflow execution. Confirm no regressions in component behavior by reviewing the chromium test run on this PR.