### PR TITLE
fix(color-loupe): additional test debugging

### DIFF
--- a/2nd-gen/packages/swc/components/color-loupe/stories/color-loupe.stories.ts
+++ b/2nd-gen/packages/swc/components/color-loupe/stories/color-loupe.stories.ts
@@ -15,7 +15,6 @@ import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
 import '@adobe/spectrum-wc/components/color-loupe/swc-color-loupe.js';
-import '@adobe/spectrum-wc/components/button/swc-button.js';
 
 // ────────────────
 //    METADATA
@@ -217,6 +216,7 @@ OpenAndClosedStates.storyName = 'Open and closed states';
  * simulates that trigger relationship.
  */
 export const ParentDrivenVisibility: Story = {
+  loaders: [() => import('@adobe/spectrum-wc/components/button/swc-button.js')],
   render: (args) => {
     const toggle = (event: MouseEvent) => {
       const btn = event.currentTarget as HTMLElement;

--- a/2nd-gen/packages/swc/utils/a11y-helpers.ts
+++ b/2nd-gen/packages/swc/utils/a11y-helpers.ts
@@ -56,9 +56,10 @@ export async function waitForCustomElement(
   page: Page,
   tagName: string
 ): Promise<void> {
-  await page.evaluate((tag) => {
-    return customElements.whenDefined(tag);
-  }, tagName);
+  await page.waitForFunction(
+    (tag) => customElements.get(tag) !== undefined,
+    tagName
+  );
 }
 
 /**


### PR DESCRIPTION
## Description

- Replaced `page.evaluate + customElements.whenDefined` in `a11y-helpers.ts` with `page.waitForFunction +
customElements.get()` — if element registration never completes, the old approach hung for the full test budget
with no clean failure; the new approach times out with a proper `TimeoutError`
- Moved `swc-button` import in `color-loupe.stories.ts` from module-level to a story `loaders` array so it only
loads for the one story that needs it, removing a potential chunk-ordering issue in the static Storybook build

## Motivation and context

Even after correcting the stale story IDs in the previous commit, `customElements.whenDefined` was still hanging
in CI. The root cause was that `page.evaluate` with a Promise-returning function gives Playwright no timeout
escape hatch — if the browser Promise never resolves, Playwright waits indefinitely.

## Related issue(s)

- fixes SWC-2153

## Author's checklist

- [x] I have read the
**[[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria
Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] a11y snapshot tests complete without hanging
1. Run `yarn test:a11y:2nd` targeting color-loupe
2. Both ARIA snapshot tests should complete without a `customElements.whenDefined` timeout
3. Spot-check one other component's a11y tests to confirm no regressions from the shared helper change

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard**: `<swc-color-loupe>` has no focusable parts; confirm no regressions in surrounding examples
- [ ] **Screen reader**: Confirm SVG remains `aria-hidden="true"` and no extraneous announcements are emitted