### PR TITLE
chore(conversational-ai): internalize thread focus state and align stories

### DIFF
--- a/.changeset/short-ends-stay.md
+++ b/.changeset/short-ends-stay.md
@@ -1,0 +1,9 @@
+---
+'@adobe/spectrum-wc': patch
+---
+
+**refactor(conversational-ai):** Tighten `swc-conversation-thread` focus handling and story layout for conversational AI.
+
+- Roving focus for the thread is driven only by `FocusgroupNavigationController`; the reflected `active-index` attribute and related public surface are removed.
+- Conversation thread stories avoid host inline layout styles in favor of neutral wrappers where needed.
+- `swc-user-message` no longer applies host `margin-inline-end` gutter; rely on thread or app shell spacing for edge inset.

--- a/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/ConversationThread.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/ConversationThread.ts
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import { CSSResultArray, html, PropertyValues, TemplateResult } from 'lit';
-import { property, queryAssignedElements } from 'lit/decorators.js';
+import { CSSResultArray, html, TemplateResult } from 'lit';
+import { queryAssignedElements } from 'lit/decorators.js';
 
 import { FocusgroupNavigationController } from '@spectrum-web-components/core/controllers/index.js';
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
@@ -32,12 +32,6 @@ import styles from './conversation-thread.css';
  * @slot - Conversation turns, typically `<swc-conversation-turn>` elements.
  */
 export class ConversationThread extends SpectrumElement {
-  /**
-   * Active turn index used by roving focus.
-   */
-  @property({ type: Number, attribute: 'active-index' })
-  public activeIndex = 0;
-
   @queryAssignedElements({ flatten: true, selector: 'swc-conversation-turn' })
   private _assignedTurns!: HTMLElement[];
 
@@ -46,7 +40,6 @@ export class ConversationThread extends SpectrumElement {
     {
       direction: 'vertical',
       getItems: () => this._getItemsFromSlot(),
-      onActiveItemChange: (active) => this._syncActiveIndex(active),
     }
   );
 
@@ -62,52 +55,30 @@ export class ConversationThread extends SpectrumElement {
    */
   public override focus(options?: FocusOptions): void {
     this._syncRovingFocusTarget();
-    const turns = this._getItemsFromSlot();
     const active = this.focusgroupNavigationController.getActiveItem();
     active?.focus(options);
-    if (!active && turns.length) {
-      turns[this._clampIndex(this.activeIndex, turns)]?.focus(options);
-    }
   }
 
   /**
    * Sets the active roving turn to the last slotted turn.
    * This aligns focus re-entry with the latest message in the thread.
    */
-  public setActiveIndexToLast(): void {
+  private _setActiveToLast(): void {
     const turns = this._getItemsFromSlot();
     if (!turns.length) {
       return;
     }
-    this._setActiveTurn(turns[turns.length - 1]);
-  }
-
-  protected override updated(changedProperties: PropertyValues<this>): void {
-    super.updated(changedProperties);
-    if (changedProperties.has('activeIndex')) {
-      this._syncActiveItemFromProperty();
-    }
+    this.focusgroupNavigationController.setActiveItem(turns[turns.length - 1]);
   }
 
   private _getItemsFromSlot(): HTMLElement[] {
     return Array.from(this._assignedTurns ?? []);
   }
 
-  private _clampIndex(index: number, turns: HTMLElement[]): number {
-    if (!turns.length) {
-      return 0;
-    }
-
-    return Math.min(Math.max(index, 0), turns.length - 1);
-  }
-
   private _syncRovingFocusTarget(setLatestAsTabStop = false): void {
     this.focusgroupNavigationController.refresh();
     const turns = this._getItemsFromSlot();
     if (!turns.length) {
-      if (this.activeIndex !== 0) {
-        this.activeIndex = 0;
-      }
       return;
     }
 
@@ -116,16 +87,6 @@ export class ConversationThread extends SpectrumElement {
         turns[turns.length - 1]
       );
     }
-    this._syncActiveIndex(this.focusgroupNavigationController.getActiveItem());
-  }
-
-  private _syncActiveItemFromProperty(): void {
-    const turns = this._getItemsFromSlot();
-    if (!turns.length) {
-      return;
-    }
-
-    this._setActiveTurn(turns[this._clampIndex(this.activeIndex, turns)]);
   }
 
   private _handleSlotChange(): void {
@@ -141,7 +102,7 @@ export class ConversationThread extends SpectrumElement {
       return;
     }
 
-    this.setActiveIndexToLast();
+    this._setActiveToLast();
   }
 
   private _hasFocusWithin(): boolean {
@@ -150,29 +111,6 @@ export class ConversationThread extends SpectrumElement {
     );
 
     return active instanceof Node && this.contains(active);
-  }
-
-  private _setActiveTurn(turn: HTMLElement | undefined): void {
-    if (!turn) {
-      return;
-    }
-
-    this.focusgroupNavigationController.setActiveItem(turn);
-    this._syncActiveIndex(this.focusgroupNavigationController.getActiveItem());
-  }
-
-  private _syncActiveIndex(active: HTMLElement | null): void {
-    if (!active) {
-      if (this.activeIndex !== 0) {
-        this.activeIndex = 0;
-      }
-      return;
-    }
-
-    const index = this._getItemsFromSlot().indexOf(active);
-    if (index !== -1 && index !== this.activeIndex) {
-      this.activeIndex = index;
-    }
   }
 
   protected override render(): TemplateResult {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
@@ -594,7 +594,6 @@ class ConversationFullPatternDemo extends LitElement {
           flex-shrink: 0;
           padding-block-start: 8px;
         }
-
       </style>
       <div
         class="swc-ConversationFullPatternDemo-shell"

--- a/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
@@ -59,51 +59,19 @@ const meta: Meta = {
 export { meta };
 export default meta;
 
-const threadExampleSource = `<swc-conversation-thread style="max-inline-size: 720px;">
-  <swc-conversation-turn type="user">
-    <swc-user-message>
-      Can you help me create a 45-minute presentation, with animations, for an executive update?
-    </swc-user-message>
-  </swc-conversation-turn>
-  <swc-conversation-turn type="system">
-    <swc-system-message>
-      <swc-response-status slot="status">I interpreted your request as an executive narrative task and prioritized a concise, audience-ready structure.</swc-response-status>
-      <div class="swc-Typography--prose">
-        <h3>Big idea/core narrative: The warmth of welcome</h3>
-        <p>Hospitality begins the moment our customers set foot off their plane.</p>
-      </div>
-      <swc-message-feedback slot="feedback"></swc-message-feedback>
-      <swc-message-sources slot="sources">
-        <a href="#source-1">Brand brief Q1 2026</a>
-      </swc-message-sources>
-    </swc-system-message>
-  </swc-conversation-turn>
-  <swc-conversation-turn type="user">
-    <swc-user-message>Great. Can you shorten that into three slides?</swc-user-message>
-  </swc-conversation-turn>
-</swc-conversation-thread>`;
-
-const renderThread = () => html`
-  <swc-conversation-thread style="max-inline-size: 720px;">
+const threadExampleSource = `<div style="max-inline-size: 720px;">
+  <swc-conversation-thread>
     <swc-conversation-turn type="user">
       <swc-user-message>
-        Can you help me create a 45-minute presentation, with animations, for an
-        executive update?
+        Can you help me create a 45-minute presentation, with animations, for an executive update?
       </swc-user-message>
     </swc-conversation-turn>
-
     <swc-conversation-turn type="system">
       <swc-system-message>
-        <swc-response-status slot="status">
-          I interpreted your request as an executive narrative task and
-          prioritized a concise, audience-ready structure.
-        </swc-response-status>
+        <swc-response-status slot="status">I interpreted your request as an executive narrative task and prioritized a concise, audience-ready structure.</swc-response-status>
         <div class="swc-Typography--prose">
           <h3>Big idea/core narrative: The warmth of welcome</h3>
-          <p>
-            Hospitality begins the moment our customers set foot off their
-            plane.
-          </p>
+          <p>Hospitality begins the moment our customers set foot off their plane.</p>
         </div>
         <swc-message-feedback slot="feedback"></swc-message-feedback>
         <swc-message-sources slot="sources">
@@ -111,13 +79,49 @@ const renderThread = () => html`
         </swc-message-sources>
       </swc-system-message>
     </swc-conversation-turn>
-
     <swc-conversation-turn type="user">
-      <swc-user-message>
-        Great. Can you shorten that into three slides?
-      </swc-user-message>
+      <swc-user-message>Great. Can you shorten that into three slides?</swc-user-message>
     </swc-conversation-turn>
   </swc-conversation-thread>
+</div>`;
+
+const renderThread = () => html`
+  <div style="max-inline-size: 720px;">
+    <swc-conversation-thread>
+      <swc-conversation-turn type="user">
+        <swc-user-message>
+          Can you help me create a 45-minute presentation, with animations, for
+          an executive update?
+        </swc-user-message>
+      </swc-conversation-turn>
+
+      <swc-conversation-turn type="system">
+        <swc-system-message>
+          <swc-response-status slot="status">
+            I interpreted your request as an executive narrative task and
+            prioritized a concise, audience-ready structure.
+          </swc-response-status>
+          <div class="swc-Typography--prose">
+            <h3>Big idea/core narrative: The warmth of welcome</h3>
+            <p>
+              Hospitality begins the moment our customers set foot off their
+              plane.
+            </p>
+          </div>
+          <swc-message-feedback slot="feedback"></swc-message-feedback>
+          <swc-message-sources slot="sources">
+            <a href="#source-1">Brand brief Q1 2026</a>
+          </swc-message-sources>
+        </swc-system-message>
+      </swc-conversation-turn>
+
+      <swc-conversation-turn type="user">
+        <swc-user-message>
+          Great. Can you shorten that into three slides?
+        </swc-user-message>
+      </swc-conversation-turn>
+    </swc-conversation-thread>
+  </div>
 `;
 
 type DemoArtifact = {
@@ -573,9 +577,9 @@ class ConversationFullPatternDemo extends LitElement {
           min-block-size: 0;
           overflow-y: auto;
           overflow-x: hidden;
-          padding-inline: 4px 8px;
           padding-block-end: 24px;
-          scroll-padding-inline-end: 8px;
+          padding-block-start: 4px;
+          padding-inline: 4px;
           scroll-padding-block-end: 24px;
           overscroll-behavior: contain;
           scrollbar-width: none;
@@ -590,6 +594,7 @@ class ConversationFullPatternDemo extends LitElement {
           flex-shrink: 0;
           padding-block-start: 8px;
         }
+
       </style>
       <div
         class="swc-ConversationFullPatternDemo-shell"
@@ -600,7 +605,7 @@ class ConversationFullPatternDemo extends LitElement {
         @swc-message-sources-toggle=${this.handleSourcesToggle}
       >
         <div class="swc-ConversationFullPatternDemo-scroll">
-          <swc-conversation-thread style="padding:4px;">
+          <swc-conversation-thread>
             ${this.renderTurns()}
           </swc-conversation-thread>
         </div>

--- a/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/test/conversation-thread.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/test/conversation-thread.test.ts
@@ -41,7 +41,6 @@ export const OverviewTest: Story = {
     );
 
     await step('first turn is tabbable by default', async () => {
-      expect(el.activeIndex).toBe(0);
       expect(turns[0]?.getAttribute('tabindex')).toBe('0');
       expect(turns[1]?.getAttribute('tabindex')).toBe('-1');
       expect(turns[2]?.getAttribute('tabindex')).toBe('-1');
@@ -51,7 +50,6 @@ export const OverviewTest: Story = {
       turns[1]?.focus();
       await el.updateComplete;
 
-      expect(el.activeIndex).toBe(1);
       expect(turns[0]?.getAttribute('tabindex')).toBe('-1');
       expect(turns[1]?.getAttribute('tabindex')).toBe('0');
       expect(turns[2]?.getAttribute('tabindex')).toBe('-1');
@@ -69,7 +67,6 @@ export const OverviewTest: Story = {
       );
       await el.updateComplete;
 
-      expect(el.activeIndex).toBe(1);
       expect(canvasElement.ownerDocument.activeElement).toBe(turns[1]);
       expect(turns[1]?.getAttribute('tabindex')).toBe('0');
     });
@@ -84,7 +81,6 @@ export const OverviewTest: Story = {
       );
       await el.updateComplete;
 
-      expect(el.activeIndex).toBe(0);
       expect(canvasElement.ownerDocument.activeElement).toBe(turns[0]);
     });
 
@@ -100,7 +96,6 @@ export const OverviewTest: Story = {
         })
       );
       await el.updateComplete;
-      expect(el.activeIndex).toBe(2);
       expect(canvasElement.ownerDocument.activeElement).toBe(turns[2]);
 
       turns[2]?.dispatchEvent(
@@ -111,7 +106,6 @@ export const OverviewTest: Story = {
         })
       );
       await el.updateComplete;
-      expect(el.activeIndex).toBe(0);
       expect(canvasElement.ownerDocument.activeElement).toBe(turns[0]);
     });
 
@@ -128,7 +122,6 @@ export const OverviewTest: Story = {
           canvasElement.querySelectorAll<HTMLElement>('swc-conversation-turn')
         );
         expect(currentTurns.length).toBe(4);
-        expect(el.activeIndex).toBe(0);
         expect(currentTurns[0]?.getAttribute('tabindex')).toBe('0');
         expect(currentTurns[3]?.getAttribute('tabindex')).toBe('-1');
 
@@ -140,7 +133,6 @@ export const OverviewTest: Story = {
           canvasElement.querySelectorAll<HTMLElement>('swc-conversation-turn')
         );
         expect(currentTurns.length).toBe(3);
-        expect(el.activeIndex).toBe(0);
         expect(currentTurns[0]?.getAttribute('tabindex')).toBe('0');
       }
     );
@@ -157,13 +149,12 @@ export const OverviewTest: Story = {
         );
         currentTurns[0]?.focus();
         await el.updateComplete;
-        expect(el.activeIndex).toBe(0);
+        expect(currentTurns[0]?.getAttribute('tabindex')).toBe('0');
 
         promptField.focus();
         await el.updateComplete;
         el.focus();
         await el.updateComplete;
-        expect(el.activeIndex).toBe(currentTurns.length - 1);
         expect(canvasElement.ownerDocument.activeElement).toBe(
           currentTurns[currentTurns.length - 1]
         );
@@ -181,7 +172,6 @@ export const OverviewTest: Story = {
           canvasElement.querySelectorAll<HTMLElement>('swc-conversation-turn')
         );
         expect(canvasElement.ownerDocument.activeElement).toBe(promptField);
-        expect(el.activeIndex).toBe(currentTurns.length - 1);
         expect(
           currentTurns[currentTurns.length - 1]?.getAttribute('tabindex')
         ).toBe('0');
@@ -193,5 +183,6 @@ export const OverviewTest: Story = {
         );
       }
     );
+
   },
 };

--- a/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/test/conversation-thread.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/test/conversation-thread.test.ts
@@ -183,6 +183,5 @@ export const OverviewTest: Story = {
         );
       }
     );
-
   },
 };

--- a/2nd-gen/packages/swc/patterns/conversational-ai/user-message/user-message.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/user-message/user-message.css
@@ -17,9 +17,7 @@
  * media — shrinks to the fixed 180×180px inner card + 2×8px padding ≈ 196px square
  *
  * The host IS the visible bubble so focus rings rendered by the parent
- * `swc-conversation-turn` hug its border box exactly. `margin-inline-end`
- * stays on the host because margins sit outside the border box and therefore
- * outside the focus ring.
+ * `swc-conversation-turn` hug its border box exactly.
  */
 
 :host {
@@ -28,7 +26,6 @@
   max-inline-size: 536px;
   padding-block: var(--swc-user-message-padding-block, token("spacing-100"));
   padding-inline: var(--swc-user-message-padding-inline, token("spacing-300"));
-  margin-inline-end: var(--swc-user-message-margin-inline-end, token("spacing-400"));
   font-family: token("sans-serif-font");
   font-size: token("font-size-200");
   font-weight: token("regular-font-weight");


### PR DESCRIPTION
## Description

- **`swc-conversation-thread`:** Removed public `active-index` / `activeIndex`; roving focus is owned by `FocusgroupNavigationController` only. Dropped the `focus()` fallback that focused a turn from cached index when `getActiveItem()` was null, and removed internal `_activeIndex` / `_syncActiveIndex` plumbing tied to that path.
- **`conversation-thread` stories:** Avoid styling `swc-conversation-thread` directly for layout (e.g. max width moved to a wrapper `div`); removed extra scroll-area inline padding used only for the full-pattern demo.
- **`swc-user-message`:** Removed host `margin-inline-end` gutter; trimmed the comment that described margin vs focus ring.

## Motivation and context

- Public `active-index` was not part of a clear consumer contract and duplicated controller state.
- Story-only padding / host inline styles suggested consumers had to style the thread to get correct layout or spacing.
- User-message end margin was easy to misread as required for correctness; spacing at the thread edge should come from intentional layout (container padding or design tokens), not hidden margin on the bubble host.

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] **Conversation thread — keyboard**
  1. Storybook → **Conversational AI → Conversation thread** (Overview / Playground).
  2. Tab into the thread; use Arrow Up/Down, Home/End between turns.
  3. Expect one turn `tabindex="0"` at a time; focus moves predictably; no reliance on `active-index` in DOM.

- [ ] **Conversation thread — full pattern**
  1. Open **Full pattern** story.
  2. Send messages / scroll; tab between prompt and thread.
  3. Expect re-entry behavior unchanged; layout acceptable without story-only thread host padding.

- [ ] **User message — edge / focus**
  1. Stories with user bubbles flush to scroll edge (e.g. full pattern or narrow viewport).
  2. Focus a user turn / message.
  3. Expect focus ring not clipped; if it is, confirm product shell adds padding or we follow up with tokenized gutter in turn/thread CSS.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  1. Storybook → **Conversation thread** stories above.
  2. Tab from outside into thread; Arrow Up/Down between `swc-conversation-turn`; Tab into inner controls (e.g. feedback, sources) and back.
  3. Expect logical order, visible focus indicator on user/system content, no trap; behavior matches prior stories except no public `active-index`.

- [ ] **Screen reader** (required — document steps below)
  1. Same stories with VoiceOver / NVDA (or team default).
  2. Navigate by landmarks / groups through turns.
  3. Expect turn grouping labels (“User message” / “System message”) unchanged; no new duplicate announcements from thread host.