### PR TITLE
ci(publish): lock main branch during release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,6 +135,36 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           echo "✓ NPM authentication configured for 2nd-gen (Adobe namespace)"
 
+      - name: Lock main branch
+        id: lock-main
+        if: steps.extract-tag.outputs.tag == 'latest' && env.HAS_LOCK_TOKEN == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_LOCK_PAT }}
+          HAS_LOCK_TOKEN: ${{ secrets.BRANCH_LOCK_PAT != '' }}
+        run: |
+          # Blocks all pushes to main except those from this workflow's GitHub Actions
+          # identity (integration ID 15368), so the `Commit and push changes` step at the
+          # end of this job can still push the release commit while everyone else waits.
+          RESPONSE=$(gh api -X POST /repos/${{ github.repository }}/rulesets \
+            -f name="Publish in progress (run ${{ github.run_id }})" \
+            -f target=branch \
+            -f enforcement=active \
+            -F 'conditions[ref_name][include][]=refs/heads/main' \
+            -F 'rules[][type]=update' \
+            -F 'bypass_actors[][actor_id]=15368' \
+            -F 'bypass_actors[][actor_type]=Integration' \
+            -F 'bypass_actors[][bypass_mode]=always')
+
+          RULESET_ID=$(echo "$RESPONSE" | jq -r '.id')
+          if [ -z "$RULESET_ID" ] || [ "$RULESET_ID" = "null" ]; then
+            echo "::error::Failed to create lock ruleset"
+            echo "$RESPONSE"
+            exit 1
+          fi
+
+          echo "ruleset_id=$RULESET_ID" >> $GITHUB_OUTPUT
+          echo "✓ Locked main; only this workflow can push (ruleset $RULESET_ID)"
+
       - name: Build all packages
         run: yarn build
 
@@ -304,3 +334,26 @@ jobs:
       - name: Create git tag
         if: steps.extract-tag.outputs.tag == 'latest'
         run: node ./1st-gen/scripts/create-git-tag.js
+
+      - name: Unlock main branch
+        if: always() && steps.lock-main.outputs.ruleset_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_LOCK_PAT }}
+          RULESET_ID: ${{ steps.lock-main.outputs.ruleset_id }}
+        run: |
+          # Always runs (success or failure) so a failed publish doesn't leave main locked.
+          # Retries because a stuck lock blocks every contributor until manually removed.
+          for attempt in 1 2 3 4 5; do
+            if gh api -X DELETE \
+              /repos/${{ github.repository }}/rulesets/${RULESET_ID}; then
+              echo "✓ Unlocked main on attempt $attempt"
+              exit 0
+            fi
+            echo "✗ Unlock attempt $attempt failed; retrying in 5s"
+            sleep 5
+          done
+
+          echo "::error::Failed to unlock main after 5 attempts."
+          echo "::error::Manually delete ruleset ${RULESET_ID} at:"
+          echo "::error::https://github.com/${{ github.repository }}/settings/rules"
+          exit 1


### PR DESCRIPTION
## Description

Prevent the race condition that caused the most recent `Publish Packages` workflow to fail at its final `git push`: another commit landed on `main` between checkout and push, so the release commit could not be fast-forwarded.

This PR adds two steps to `.github/workflows/publish.yml`:

1. **`Lock main branch`** — runs right after NPM authentication, only when publishing the `latest` tag. Creates a temporary GitHub repository ruleset with an `update` rule targeting `refs/heads/main`. Only the GitHub Actions integration (ID `15368`) is added as a bypass actor, so the workflow's own push at the end of the job still succeeds while every other contributor's push to `main` is blocked.
2. **`Unlock main branch`** — runs at the very end with `if: always()`. Deletes the temporary ruleset with a 5-attempt retry, since a stuck lock would block all contributors until manually removed. On final failure it prints the ruleset URL so a human can clear it.

The lock only applies when `tag == 'latest'`. Snapshot publishes from PRs do not touch `main` and do not need the lock.

## Prerequisites for this to take effect

This PR is safe to merge as-is. The lock steps gate themselves on whether `secrets.BRANCH_LOCK_PAT` is configured; if it isn't, they no-op and the workflow behaves as it does today.

To enable the lock, a maintainer needs to:

1. **Create a fine-grained Personal Access Token** with **`Administration: Read and write`** scope on `adobe/spectrum-web-components`. A classic PAT with `repo` + `admin:org` works too. The owning user must have admin on the repo so the ruleset API accepts the call.
2. **Add it as a repository secret** named `BRANCH_LOCK_PAT` under Settings → Secrets and variables → Actions.

No ruleset needs to be pre-created. The workflow creates a fresh, uniquely-named ruleset per run (`Publish in progress (run <RUN_ID>)`) and tears it down at the end. The ruleset is targeted, scoped, and disposable.

## Motivation and context

The previous failure mode (recovered in #6324):

```
[main 0ad419c07e] chore: release packages #publish
...
! [rejected]              main -> main (fetch first)
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
```

The publish workflow runs for ~10 minutes; any PR merged during that window leaves the runner's `HEAD` behind `origin/main`. The other reasonable fix is to rebase-and-retry the push, which is the industry-standard approach (used by `changesets/action` and `semantic-release`). We are taking the heavier "block main during publish" approach instead because:

- Publishes are infrequent (a few per week at most).
- A ~10-minute lock is acceptable given the low frequency.
- Locking prevents the race entirely rather than tolerating it, so we never end up with partial state where npm has published but `main` has not been updated.

## Trade-offs

- **Pro:** No more race-condition push failures. `main` and npm stay in lock-step.
- **Pro:** Self-contained — no permanent ruleset to manage; the lock is created and destroyed per run.
- **Pro:** Graceful degradation — if `BRANCH_LOCK_PAT` is unset, the workflow runs exactly as today.
- **Con:** Contributors who try to merge to `main` during a publish window will be blocked for ~10 minutes. The block manifests as a normal protected-branch error.
- **Con:** Requires an admin-scoped PAT, which has a higher blast radius than `GITHUB_TOKEN`. The token is only used for ruleset CRUD on this single repo.

## Related issue(s)

- Recovers the workflow design from the failure recovered in #6324.

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

> _N/A — CI workflow change only; no shipped code or component behavior is affected._

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Lock step gates on secret presence_
  1. Inspect `.github/workflows/publish.yml`
  2. Confirm `Lock main branch` step has `if: ... && env.HAS_LOCK_TOKEN == 'true'`
  3. Confirm `HAS_LOCK_TOKEN` is set from `secrets.BRANCH_LOCK_PAT != ''`
  4. Expect: if the secret is missing, the lock step is skipped and the workflow behaves as today.

- [ ] _Unlock runs on failure_
  1. Confirm `Unlock main branch` has `if: always() && steps.lock-main.outputs.ruleset_id != ''`
  2. Expect: even if any earlier step fails, the ruleset is torn down.

- [ ] _Bypass actor is GitHub Actions_
  1. Confirm `bypass_actors[][actor_id]=15368` and `actor_type=Integration`
  2. Expect: the workflow's own `git push` at the end of the job succeeds against the lock.

- [ ] _Live publish smoke test (after secret is added)_
  1. Set up `BRANCH_LOCK_PAT` per the Prerequisites section.
  2. Run the next `latest` release.
  3. While the workflow is running, confirm Settings → Rules shows an active `Publish in progress (run …)` ruleset.
  4. Attempt to merge an unrelated PR to `main` during the window; expect it to be blocked.
  5. Confirm the workflow's release commit lands on `main` successfully.
  6. After the workflow finishes, confirm the ruleset is gone and merges work again.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

> _N/A — CI workflow change; no UI, focus, or assistive-tech surface is affected._

- [ ] **Keyboard** (required — document steps below)
  1. N/A — workflow file change only.

- [ ] **Screen reader** (required — document steps below)
  1. N/A — workflow file change only.