### PR TITLE
chore(tabs): add @internal JSDoc tags to private and implementation-only properties

### DIFF
--- a/2nd-gen/packages/core/components/tabs/Tabs.base.ts
+++ b/2nd-gen/packages/core/components/tabs/Tabs.base.ts
@@ -529,6 +529,8 @@ export abstract class TabsBase extends SpectrumElement {
   // ───────────────────────────────────
 
   /**
+   * @internal
+   *
    * Recalculates the selection indicator's position and size based
    * on the currently selected tab element. Uses CSS transforms for
    * smooth animation between tab positions.

--- a/2nd-gen/packages/core/components/tabs/Tabs.base.ts
+++ b/2nd-gen/packages/core/components/tabs/Tabs.base.ts
@@ -106,6 +106,7 @@ export abstract class TabsBase extends SpectrumElement {
     this.requestUpdate('keyboardActivation', old);
   }
 
+  /** @internal */
   private _keyboardActivation: KeyboardActivation = KEYBOARD_ACTIVATION_DEFAULT;
 
   /**
@@ -139,6 +140,7 @@ export abstract class TabsBase extends SpectrumElement {
     this.requestUpdate('density', old);
   }
 
+  /** @internal */
   private _density: TabDensity = TAB_DENSITY_DEFAULT;
 
   /**
@@ -181,6 +183,7 @@ export abstract class TabsBase extends SpectrumElement {
     this.requestUpdate('direction', oldDirection);
   }
 
+  /** @internal */
   private _direction: TabsDirection = TABS_DEFAULT_DIRECTION;
 
   /**
@@ -209,9 +212,12 @@ export abstract class TabsBase extends SpectrumElement {
   //     IMPLEMENTATION
   // ──────────────────────
 
+  /** @internal */
   private static readonly INDICATOR_BASE_SIZE = 100;
 
   /**
+   * @internal
+   *
    * Inline style applied to the selection indicator element.
    * Computed from the selected tab's position and dimensions.
    */
@@ -219,6 +225,8 @@ export abstract class TabsBase extends SpectrumElement {
   protected selectionIndicatorStyle = '';
 
   /**
+   * @internal
+   *
    * Suppresses the transition on the very first indicator placement
    * so it doesn't animate from the origin.
    */
@@ -226,6 +234,8 @@ export abstract class TabsBase extends SpectrumElement {
   protected shouldAnimate = false;
 
   /**
+   * @internal
+   *
    * Cached list of tab elements managed by this container. Updated
    * via `handleTabSlotChange`.
    */
@@ -565,6 +575,7 @@ export abstract class TabsBase extends SpectrumElement {
     }
   };
 
+  /** @internal */
   private _resizeObserver?: ResizeObserver;
 
   // ───────────────────────────────────

--- a/2nd-gen/packages/swc/components/tabs/Tabs.ts
+++ b/2nd-gen/packages/swc/components/tabs/Tabs.ts
@@ -42,6 +42,8 @@ import styles from './tabs.css';
  */
 export class Tabs extends TabsBase {
   /**
+   * @internal
+   *
    * Shadow `delegatesFocus: true` keeps native focus-delegation where supported;
    * `TabsBase.focus()` focuses the selected slotted tab explicitly so
    * programmatic `focus()` matches 1st-gen expectations regardless of engine.


### PR DESCRIPTION
## Description

Adds `@internal` JSDoc tags to 8 properties in `TabsBase` that were missing them. Without `@internal`, the CEM (Custom Elements Manifest) analyzer treats these as public API and Storybook surfaces them in the Controls panel alongside the real public properties.

**Properties tagged:**

| Property | Kind | Why it leaked |
|---|---|---|
| `_keyboardActivation` | Private backing field | Duplicate of public `keyboardActivation` getter |
| `_density` | Private backing field | Duplicate of public `density` getter |
| `_direction` | Private backing field | Duplicate of public `direction` getter |
| `INDICATOR_BASE_SIZE` | Private static constant | No JSDoc at all |
| `selectionIndicatorStyle` | `@state()` protected | Render-only; not consumer API |
| `shouldAnimate` | `@state()` protected | Render-only; not consumer API |
| `_tabs` | Private collection | Internal cache |
| `_resizeObserver` | Private instance | Internal observer |

## Motivation and context

The Storybook playground for `swc-tabs` displayed 20 controls, including internal implementation details prefixed with `_`. TypeScript's `private` keyword is compile-time only and does not prevent the CEM analyzer from emitting these fields. The `@internal` JSDoc tag is the standard mechanism to exclude them.

After this change, only the 6 intended public properties remain in Controls: `keyboardActivation`, `density`, `direction`, `disabled`, `accessibleLabel`, and `selected`.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Verify internal properties no longer appear in Storybook Controls
  1. Go to the [Tabs Playground story](http://localhost:8001/?path=/story/components-tabs--playground)
  2. Open the **Controls** panel
  3. Confirm that `_density`, `_direction`, `_keyboardActivation`, `_tabs`, `_resizeObserver`, `INDICATOR_BASE_SIZE`, `selectionIndicatorStyle`, and `shouldAnimate` are **not** listed
  4. Confirm that `keyboardActivation`, `density`, `direction`, `disabled`, `accessibleLabel`, and `selected` **are** listed

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [x] **Keyboard** — No interactive changes; this is a JSDoc-only change. No keyboard behavior is affected.
- [x] **Screen reader** — No ARIA or DOM changes; screen reader behavior is unchanged.

Made with [Cursor](https://cursor.com)