### PR TITLE
fix(2nd-gen): replace cross-package relative imports with package paths

### DIFF
--- a/2nd-gen/packages/core/package.json
+++ b/2nd-gen/packages/core/package.json
@@ -27,7 +27,15 @@
       "types": "./dist/components/avatar/index.d.ts",
       "import": "./dist/components/avatar/index.js"
     },
+    "./components/avatar/index.js": {
+      "types": "./dist/components/avatar/index.d.ts",
+      "import": "./dist/components/avatar/index.js"
+    },
     "./components/badge": {
+      "types": "./dist/components/badge/index.d.ts",
+      "import": "./dist/components/badge/index.js"
+    },
+    "./components/badge/index.js": {
       "types": "./dist/components/badge/index.d.ts",
       "import": "./dist/components/badge/index.js"
     },
@@ -36,6 +44,10 @@
       "import": "./dist/components/button/index.js"
     },
     "./components/divider": {
+      "types": "./dist/components/divider/index.d.ts",
+      "import": "./dist/components/divider/index.js"
+    },
+    "./components/divider/index.js": {
       "types": "./dist/components/divider/index.d.ts",
       "import": "./dist/components/divider/index.js"
     },
@@ -55,7 +67,15 @@
       "types": "./dist/components/status-light/index.d.ts",
       "import": "./dist/components/status-light/index.js"
     },
+    "./components/status-light/index.js": {
+      "types": "./dist/components/status-light/index.d.ts",
+      "import": "./dist/components/status-light/index.js"
+    },
     "./components/tabs": {
+      "types": "./dist/components/tabs/index.d.ts",
+      "import": "./dist/components/tabs/index.js"
+    },
+    "./components/tabs/index.js": {
       "types": "./dist/components/tabs/index.d.ts",
       "import": "./dist/components/tabs/index.js"
     },
@@ -154,13 +174,22 @@
       "components/avatar": [
         "dist/components/avatar/index.d.ts"
       ],
+      "components/avatar/index.js": [
+        "dist/components/avatar/index.d.ts"
+      ],
       "components/badge": [
+        "dist/components/badge/index.d.ts"
+      ],
+      "components/badge/index.js": [
         "dist/components/badge/index.d.ts"
       ],
       "components/button": [
         "dist/components/button/index.d.ts"
       ],
       "components/divider": [
+        "dist/components/divider/index.d.ts"
+      ],
+      "components/divider/index.js": [
         "dist/components/divider/index.d.ts"
       ],
       "components/icon": [
@@ -175,7 +204,13 @@
       "components/status-light": [
         "dist/components/status-light/index.d.ts"
       ],
+      "components/status-light/index.js": [
+        "dist/components/status-light/index.d.ts"
+      ],
       "components/tabs": [
+        "dist/components/tabs/index.d.ts"
+      ],
+      "components/tabs/index.js": [
         "dist/components/tabs/index.d.ts"
       ],
       "controllers": [

--- a/2nd-gen/packages/swc/components/avatar/stories/avatar.stories.ts
+++ b/2nd-gen/packages/swc/components/avatar/stories/avatar.stories.ts
@@ -15,10 +15,9 @@ import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
 import { Avatar } from '@adobe/spectrum-wc/avatar';
+import { AVATAR_VALID_SIZES } from '@spectrum-web-components/core/components/avatar/index.js';
 
 import '@adobe/spectrum-wc/components/avatar/swc-avatar.js';
-
-import { AVATAR_VALID_SIZES } from '../../../../core/components/avatar/Avatar.types.js';
 
 // ────────────────
 //    METADATA

--- a/2nd-gen/packages/swc/components/avatar/test/avatar.test.ts
+++ b/2nd-gen/packages/swc/components/avatar/test/avatar.test.ts
@@ -14,10 +14,10 @@ import { expect } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
 import { Avatar } from '@adobe/spectrum-wc/avatar';
+import { AVATAR_VALID_SIZES } from '@spectrum-web-components/core/components/avatar/index.js';
 
 import '@adobe/spectrum-wc/components/avatar/swc-avatar.js';
 
-import { AVATAR_VALID_SIZES } from '../../../../core/components/avatar/Avatar.types.js';
 import {
   getComponent,
   getComponents,

--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -15,10 +15,6 @@ import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
 import { Badge } from '@adobe/spectrum-wc/badge';
-
-import '@adobe/spectrum-wc/components/badge/swc-badge.js';
-import '@adobe/spectrum-wc/components/icon/swc-icon.js';
-
 import {
   BADGE_VALID_SIZES,
   BADGE_VARIANTS,
@@ -29,7 +25,11 @@ import {
   type BadgeSize,
   FIXED_VALUES,
   type FixedValues,
-} from '../../../../core/components/badge/Badge.types.js';
+} from '@spectrum-web-components/core/components/badge/index.js';
+
+import '@adobe/spectrum-wc/components/badge/swc-badge.js';
+import '@adobe/spectrum-wc/components/icon/swc-icon.js';
+
 import { iconForSize } from '../../../.storybook/helpers/index.js';
 import * as Icons from '../../icon/elements/index.js';
 

--- a/2nd-gen/packages/swc/components/badge/test/badge.test.ts
+++ b/2nd-gen/packages/swc/components/badge/test/badge.test.ts
@@ -14,16 +14,16 @@ import { expect } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
 import { Badge } from '@adobe/spectrum-wc/badge';
-
-import '@adobe/spectrum-wc/components/badge/swc-badge.js';
-
 import {
   BADGE_VALID_SIZES,
   BADGE_VARIANTS,
   BADGE_VARIANTS_COLOR,
   BADGE_VARIANTS_SEMANTIC,
   FIXED_VALUES,
-} from '../../../../core/components/badge/Badge.types.js';
+} from '@spectrum-web-components/core/components/badge/index.js';
+
+import '@adobe/spectrum-wc/components/badge/swc-badge.js';
+
 import {
   getComponent,
   getComponents,

--- a/2nd-gen/packages/swc/components/divider/test/divider.test.ts
+++ b/2nd-gen/packages/swc/components/divider/test/divider.test.ts
@@ -14,13 +14,13 @@ import { expect } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
 import { Divider } from '@adobe/spectrum-wc/divider';
-
-import '@adobe/spectrum-wc/components/divider/swc-divider.js';
-
 import {
   DIVIDER_STATIC_COLORS,
   DIVIDER_VALID_SIZES,
-} from '../../../../core/components/divider/Divider.types.js';
+} from '@spectrum-web-components/core/components/divider/index.js';
+
+import '@adobe/spectrum-wc/components/divider/swc-divider.js';
+
 import {
   getComponent,
   getComponents,

--- a/2nd-gen/packages/swc/components/status-light/test/status-light.test.ts
+++ b/2nd-gen/packages/swc/components/status-light/test/status-light.test.ts
@@ -18,14 +18,14 @@ import type {
 } from '@storybook/web-components';
 
 import { StatusLight } from '@adobe/spectrum-wc/status-light';
-
-import '@adobe/spectrum-wc/components/status-light/swc-status-light.js';
-
 import {
   STATUS_LIGHT_VALID_SIZES,
   STATUS_LIGHT_VARIANTS_COLOR,
   STATUS_LIGHT_VARIANTS_SEMANTIC,
-} from '../../../../core/components/status-light/StatusLight.types.js';
+} from '@spectrum-web-components/core/components/status-light/index.js';
+
+import '@adobe/spectrum-wc/components/status-light/swc-status-light.js';
+
 import { getComponent, withWarningSpy } from '../../../utils/test-utils.js';
 import meta, {
   Anatomy,

--- a/2nd-gen/packages/swc/components/tabs/stories/tabs.stories.ts
+++ b/2nd-gen/packages/swc/components/tabs/stories/tabs.stories.ts
@@ -13,10 +13,6 @@
 import { html, type TemplateResult } from 'lit';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
-import '@adobe/spectrum-wc/components/tabs/swc-tabs.js';
-import '@adobe/spectrum-wc/components/tabs/swc-tab.js';
-import '@adobe/spectrum-wc/components/tabs/swc-tab-panel.js';
-
 import {
   KEYBOARD_ACTIVATIONS,
   type KeyboardActivation,
@@ -24,7 +20,11 @@ import {
   type TabDensity,
   TABS_DIRECTIONS,
   type TabsDirection,
-} from '../../../../core/components/tabs/Tabs.types.js';
+} from '@spectrum-web-components/core/components/tabs/index.js';
+
+import '@adobe/spectrum-wc/components/tabs/swc-tabs.js';
+import '@adobe/spectrum-wc/components/tabs/swc-tab.js';
+import '@adobe/spectrum-wc/components/tabs/swc-tab-panel.js';
 
 const events = ['change'];
 

--- a/2nd-gen/packages/swc/components/tabs/test/tabs.test.ts
+++ b/2nd-gen/packages/swc/components/tabs/test/tabs.test.ts
@@ -14,12 +14,12 @@ import { expect } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
 import { Tab, TabPanel, Tabs } from '@adobe/spectrum-wc/tabs';
+import { TABS_DIRECTIONS } from '@spectrum-web-components/core/components/tabs/index.js';
 
 import '@adobe/spectrum-wc/components/tabs/swc-tabs.js';
 import '@adobe/spectrum-wc/components/tabs/swc-tab.js';
 import '@adobe/spectrum-wc/components/tabs/swc-tab-panel.js';
 
-import { TABS_DIRECTIONS } from '../../../../core/components/tabs/Tabs.types.js';
 import {
   fixture,
   getComponent,


### PR DESCRIPTION
## Description

Replaces deep relative imports across package boundaries with explicit public package entry points, and adds the missing `index.js` export variants to the core package to support them.

**Before:**
```ts
import { AVATAR_VALID_SIZES } from '../../../../core/components/avatar/Avatar.types.js';
```

**After:**
```ts
import { AVATAR_VALID_SIZES } from '@spectrum-web-components/core/components/avatar/index.js';
```

### Changes

**`packages/core/package.json`** — adds `./components/*/index.js` export entries (alongside the existing directory-style exports) for the 5 components that need them, mirroring the `./controllers/index.js` pattern already in place. `typesVersions` updated to match.

**8 files in `packages/swc`** — relative `../../../../core/components/*/types.js` imports replaced with package paths:

| File | New import |
|---|---|
| `avatar/stories`, `avatar/test` | `@spectrum-web-components/core/components/avatar/index.js` |
| `badge/stories`, `badge/test` | `@spectrum-web-components/core/components/badge/index.js` |
| `divider/test` | `@spectrum-web-components/core/components/divider/index.js` |
| `status-light/test` | `@spectrum-web-components/core/components/status-light/index.js` |
| `tabs/stories`, `tabs/test` | `@spectrum-web-components/core/components/tabs/index.js` |

## Motivation and context

Cross-package relative paths bypass the `exports` map entirely, making internal file moves invisible to consumers and harder to catch in review. Package paths go through the public API contract and break loudly if an export is ever removed or moved.

## Related issue(s)

N/A

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Accessibility testing checklist

Not applicable — this is a refactor of import paths with no user-facing or component behavior changes.

- [x] **Keyboard**: no interactive components changed
- [x] **Screen reader**: no interactive components changed