### PR TITLE
feat(tooltip): tests and code conformance

### DIFF
--- a/1st-gen/packages/tooltip/test/tooltip.test.ts
+++ b/1st-gen/packages/tooltip/test/tooltip.test.ts
@@ -271,7 +271,7 @@ describe('Tooltip', () => {
       consoleWarnStub.restore();
     });
 
-    it('warns when incorrectly using `self-managed`', async () => {
+    it('warns when using the deprecated `self-managed` attribute', async () => {
       const el = await fixture<Tooltip>(html`
         <sp-tooltip variant="negative" self-managed>Help text.</sp-tooltip>
       `);
@@ -281,8 +281,8 @@ describe('Tooltip', () => {
       expect(consoleWarnStub.called).to.be.true;
       const spyCall = consoleWarnStub.getCall(0);
       expect(
-        (spyCall.args[0] as string).includes('Self-managed'),
-        'confirm dev warning message includes `Self-managed`'
+        (spyCall.args[0] as string).includes('self-managed'),
+        'confirm dev warning message includes `self-managed`'
       ).to.be.true;
       expect(
         spyCall.args[spyCall.args.length - 1],
@@ -291,7 +291,7 @@ describe('Tooltip', () => {
         data: {
           localName: 'sp-tooltip',
           type: 'api',
-          level: 'high',
+          level: 'deprecation',
         },
       });
     });

--- a/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
+++ b/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
@@ -251,7 +251,10 @@ export abstract class TooltipBase extends SpectrumElement {
       this.open = isOpen;
     }
     // When no CSS transition is active, dispatch after-* immediately since transitionend will not fire.
-    if (getComputedStyle(this).transitionDuration === '0s') {
+    // transitionDuration is comma-separated when multiple properties transition ("0s, 0s, …"),
+    // so check that every value in the list is zero rather than comparing the full string.
+    const durations = getComputedStyle(this).transitionDuration.split(',');
+    if (durations.every((d) => d.trim() === '0s')) {
       this.afterEventPending = false;
       this.dispatchAfterEvent(isOpen);
     }

--- a/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
+++ b/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
@@ -147,9 +147,9 @@ export abstract class TooltipBase extends SpectrumElement {
 
   /**
    * When set, wires `ariaLabelledByElements` instead of `ariaDescribedByElements` on the trigger's
-   * inner interactive element. For icon-only triggers where the tooltip text is the sole accessible name.
-   *
-   * Additive/deferred: active in the additive phase.
+   * inner interactive element. Use for icon-only triggers where the tooltip text is the sole accessible
+   * name and adding an accessible label directly to the trigger host is not possible.
+   * Prefer `accessible-label` on the trigger when feasible — it works without this attribute.
    *
    * @default false
    */
@@ -195,11 +195,28 @@ export abstract class TooltipBase extends SpectrumElement {
     const target = (trigger.shadowRoot?.querySelector('button') ??
       trigger) as Element & {
       ariaDescribedByElements: Element[] | null;
+      ariaLabelledByElements: Element[] | null;
     };
-    const current = target.ariaDescribedByElements ?? [];
-    target.ariaDescribedByElements = this.open
-      ? [...current.filter((el) => el !== this), this]
-      : current.filter((el) => el !== this);
+
+    if (this.labeling) {
+      // Remove any stale describedby reference (e.g. if labeling changed while open).
+      const described = target.ariaDescribedByElements ?? [];
+      target.ariaDescribedByElements = described.filter((el) => el !== this);
+
+      const labelled = target.ariaLabelledByElements ?? [];
+      target.ariaLabelledByElements = this.open
+        ? [...labelled.filter((el) => el !== this), this]
+        : labelled.filter((el) => el !== this);
+    } else {
+      // Remove any stale labelledby reference (e.g. if labeling changed while open).
+      const labelled = target.ariaLabelledByElements ?? [];
+      target.ariaLabelledByElements = labelled.filter((el) => el !== this);
+
+      const described = target.ariaDescribedByElements ?? [];
+      target.ariaDescribedByElements = this.open
+        ? [...described.filter((el) => el !== this), this]
+        : described.filter((el) => el !== this);
+    }
   }
 
   private dispatchAfterEvent(isOpen: boolean): void {
@@ -265,6 +282,8 @@ export abstract class TooltipBase extends SpectrumElement {
           this.hidePopover();
         }
       }
+    }
+    if (changedProperties.has('open') || changedProperties.has('labeling')) {
       this.syncAriaRelationship();
     }
   }

--- a/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
+++ b/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
@@ -248,6 +248,13 @@ export abstract class TooltipBase extends SpectrumElement {
     this.dispatchAfterEvent(this.open);
   };
 
+  // Allows Escape behavior to be testable, does not interfere with native popover dismissal
+  private readonly handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape' && this.open) {
+      this.open = false;
+    }
+  };
+
   protected override updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
     if (changedProperties.has('open')) {
@@ -269,6 +276,7 @@ export abstract class TooltipBase extends SpectrumElement {
     this.addEventListener('beforetoggle', this.handleBeforeToggle);
     this.addEventListener('toggle', this.handleToggle);
     this.addEventListener('transitionend', this.handleTransitionEnd);
+    document.addEventListener('keydown', this.handleKeyDown);
   }
 
   public override disconnectedCallback(): void {
@@ -276,5 +284,6 @@ export abstract class TooltipBase extends SpectrumElement {
     this.removeEventListener('beforetoggle', this.handleBeforeToggle);
     this.removeEventListener('toggle', this.handleToggle);
     this.removeEventListener('transitionend', this.handleTransitionEnd);
+    document.removeEventListener('keydown', this.handleKeyDown);
   }
 }

--- a/2nd-gen/packages/core/global.d.ts
+++ b/2nd-gen/packages/core/global.d.ts
@@ -20,6 +20,15 @@ type SWCWarningOptions = {
 };
 type BrandedSWCWarningID = `${ElementLocalName}:${WarningType}:${WarningLevel}`;
 
+/**
+ * ARIA element-reflection properties (IDRef-free associations). Not yet in the
+ * TypeScript DOM lib.
+ */
+interface ARIAMixin {
+  ariaDescribedByElements: readonly Element[] | null;
+  ariaLabelledByElements: readonly Element[] | null;
+}
+
 interface Window {
   __swc: {
     DEBUG: boolean;

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -248,6 +248,7 @@ const preview = {
               'Tools vs packages',
               'Writing migration guides',
               'Focus management',
+              'Changelog strategy',
             ],
             'Style guide',
             [
@@ -390,6 +391,11 @@ const preview = {
                 ['Rendering and styling migration analysis'],
                 'Field label',
                 ['Rendering and styling migration analysis'],
+                'Grid',
+                [
+                  'Accessibility migration analysis',
+                  'Rendering and styling migration analysis',
+                ],
                 'Help text',
                 ['Rendering and styling migration analysis'],
                 'Illustrated message',
@@ -436,6 +442,7 @@ const preview = {
                 'Popover',
                 [
                   'Accessibility migration analysis',
+                  'Migration plan',
                   'Rendering and styling migration analysis',
                 ],
                 'Progress bar',

--- a/2nd-gen/packages/swc/components/tooltip/Tooltip.ts
+++ b/2nd-gen/packages/swc/components/tooltip/Tooltip.ts
@@ -28,6 +28,11 @@ import styles from './tooltip.css';
  * @slot - Text label displayed in the tooltip.
  *
  * @cssprop --swc-tooltip-background-color - Background color of the tooltip bubble. Defaults to the neutral background color token.
+ *
+ * @fires swc-open - Dispatched when the tooltip begins to open, before the transition plays.
+ * @fires swc-close - Dispatched when the tooltip begins to close, before the transition plays.
+ * @fires swc-after-open - Dispatched after the tooltip finishes opening, once the transition completes.
+ * @fires swc-after-close - Dispatched after the tooltip finishes closing, once the transition completes.
  */
 export class Tooltip extends TooltipBase {
   // ──────────────────────────────

--- a/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
+++ b/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
@@ -147,11 +147,33 @@ const makeToggle = (id: string) => (event: MouseEvent) => {
 const triggered = (
   tooltipArgs: Record<string, unknown>,
   id: string,
-  buttonLabel: string
-) => html`
-  <swc-button id=${id} @click=${makeToggle(id)}>${buttonLabel}</swc-button>
-  ${template({ ...tooltipArgs, for: id })}
-`;
+  buttonLabel?: string,
+  iconOnly: boolean = false
+) => {
+  if (!iconOnly) {
+    return html`
+      <swc-button id=${id} @click=${makeToggle(id)}>${buttonLabel}</swc-button>
+      ${template({ ...tooltipArgs, for: id })}
+    `;
+  } else {
+    return html`
+      <swc-button id=${id} @click=${makeToggle(id)}>
+        <svg
+          slot="icon"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 36 36"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
+          />
+        </svg>
+      </swc-button>
+      ${template({ ...tooltipArgs, for: id })}
+    `;
+  }
+};
 
 /**
  * Each story renders one or more buttons that trigger associated tooltips when clicked.
@@ -323,6 +345,37 @@ export const Placements: Story = {
 // ──────────────────────────
 
 // TODO: will complete in separate documentation pass of phase 7
+
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+/**
+ * When a trigger has no visible text label and the tooltip text is its sole accessible name,
+ * set the `labeling` attribute on the tooltip. This switches the ARIA wiring from
+ * `ariaDescribedByElements` (supplementary description) to `ariaLabelledByElements` (accessible name)
+ * on the trigger's inner interactive element.
+ */
+export const Labeling: Story = {
+  render: (args) => html`
+    ${triggered(
+      {
+        ...args,
+        labeling: true,
+        'default-slot': 'Save changes',
+      },
+      'tooltip-labeling-trigger',
+      undefined,
+      true
+    )}
+  `,
+  args: {
+    placement: 'top',
+    variant: 'neutral',
+  },
+  tags: ['behaviors'],
+  parameters: { 'section-order': 1 },
+};
 
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES

--- a/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
+++ b/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
@@ -126,7 +126,6 @@ const makeToggle = (id: string) => (event: MouseEvent) => {
     return;
   }
 
-  setupEventLogger(tooltip);
   tooltip.open = !tooltip.open;
 
   if (tooltip.open) {
@@ -140,28 +139,6 @@ const makeToggle = (id: string) => (event: MouseEvent) => {
       },
       { once: true }
     );
-  }
-};
-
-// Temporary: logs tooltip lifecycle events to the console to verify event wiring.
-// Replace with proper assertions in migration-testing (Phase 6).
-// Storybook's Actions addon doesn't work well for this since the events are re-dispatched
-// from the popover in the top layer, so we log directly from the component instance instead.
-const loggedTooltips = new WeakSet<Element>();
-const setupEventLogger = (tooltip: Element): void => {
-  if (loggedTooltips.has(tooltip)) {
-    return;
-  }
-  loggedTooltips.add(tooltip);
-  for (const name of [
-    'swc-open',
-    'swc-close',
-    'swc-after-open',
-    'swc-after-close',
-  ]) {
-    tooltip.addEventListener(name, () => {
-      console.log(`[swc-tooltip] ${name}`);
-    });
   }
 };
 
@@ -184,6 +161,9 @@ const meta: Meta = {
   title: 'Tooltip',
   component: 'swc-tooltip',
   parameters: {
+    actions: {
+      handles: ['swc-open', 'swc-close', 'swc-after-open', 'swc-after-close'],
+    },
     docs: {
       subtitle: `Brief contextual message that appears near a trigger element.`,
     },

--- a/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
+++ b/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
@@ -157,7 +157,11 @@ const triggered = (
     `;
   } else {
     return html`
-      <swc-button id=${id} @click=${makeToggle(id)}>
+      <swc-button
+        id=${id}
+        @click=${makeToggle(id)}
+        accessible-label=${String(tooltipArgs['default-slot'] ?? '')}
+      >
         <svg
           slot="icon"
           xmlns="http://www.w3.org/2000/svg"

--- a/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
+++ b/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
@@ -27,9 +27,9 @@ import {
 import '@adobe/spectrum-wc/components/button/swc-button.js';
 import '@adobe/spectrum-wc/components/tooltip/swc-tooltip.js';
 
-// ────────────────────
-//    METADATA SETUP
-// ────────────────────
+// ────────────────
+//    METADATA
+// ────────────────
 
 const { args, argTypes, template } = getStorybookHelpers('swc-tooltip');
 

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.a11y.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { gotoStory } from '../../../utils/a11y-helpers.js';
+
+/**
+ * Accessibility tests for Tooltip component (2nd Generation)
+ *
+ * ARIA snapshot tests validate the accessibility tree structure.
+ * aXe WCAG compliance and color contrast validation are run via
+ * test-storybook (see .storybook/test-runner.ts). Both are included
+ * in the `test:a11y` command.
+ */
+
+test.describe('Tooltip - ARIA Snapshots', () => {
+  test('closed tooltip is hidden from accessibility tree', async ({ page }) => {
+    const root = await gotoStory(
+      page,
+      'components-tooltip--overview',
+      'swc-button'
+    );
+    // The trigger button is accessible; the closed popover is hidden from the tree.
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Open"
+    `);
+  });
+
+  test('open tooltip exposes role="tooltip" in accessibility tree', async ({
+    page,
+  }) => {
+    await gotoStory(page, 'components-tooltip--overview', 'swc-button');
+
+    // Open the tooltip programmatically (HoverController not yet wired).
+    await page.evaluate(() => {
+      const tooltip = document.querySelector('swc-tooltip') as HTMLElement & {
+        open: boolean;
+      };
+      if (tooltip) {
+        tooltip.open = true;
+      }
+    });
+
+    // Wait for the popover to appear in the top layer.
+    await page.waitForFunction(() =>
+      document.querySelector('swc-tooltip')?.matches(':popover-open')
+    );
+
+    const root = page.locator('#storybook-root');
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Open"
+      - tooltip "Save your changes"
+    `);
+  });
+
+  test('tooltip is removed from accessibility tree when closed', async ({
+    page,
+  }) => {
+    await gotoStory(page, 'components-tooltip--overview', 'swc-button');
+
+    // Open then close via the property.
+    await page.evaluate(() => {
+      const tooltip = document.querySelector('swc-tooltip') as HTMLElement & {
+        open: boolean;
+      };
+      if (tooltip) {
+        tooltip.open = true;
+      }
+    });
+    await page.waitForFunction(() =>
+      document.querySelector('swc-tooltip')?.matches(':popover-open')
+    );
+
+    await page.evaluate(() => {
+      const tooltip = document.querySelector('swc-tooltip') as HTMLElement & {
+        open: boolean;
+      };
+      if (tooltip) {
+        tooltip.open = false;
+      }
+    });
+    await page.waitForFunction(
+      () => !document.querySelector('swc-tooltip')?.matches(':popover-open')
+    );
+
+    const root = page.locator('#storybook-root');
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Open"
+    `);
+  });
+
+  test('Escape closes an open tooltip', async ({ page }) => {
+    await gotoStory(page, 'components-tooltip--overview', 'swc-button');
+
+    await page.evaluate(() => {
+      const tooltip = document.querySelector('swc-tooltip') as HTMLElement & {
+        open: boolean;
+      };
+      if (tooltip) {
+        tooltip.open = true;
+      }
+    });
+    await page.waitForFunction(() =>
+      document.querySelector('swc-tooltip')?.matches(':popover-open')
+    );
+
+    await page.keyboard.press('Escape');
+
+    await page.waitForFunction(
+      () => !document.querySelector('swc-tooltip')?.matches(':popover-open')
+    );
+
+    const open = await page.evaluate(
+      () => (document.querySelector('swc-tooltip') as { open?: boolean })?.open
+    );
+    expect(open, 'tooltip.open is false after Escape').toBe(false);
+  });
+
+  test('all variant triggers are accessible', async ({ page }) => {
+    const root = await gotoStory(
+      page,
+      'components-tooltip--variants',
+      'swc-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Save"
+      - button "Upload"
+      - button "Delete"
+    `);
+  });
+
+  test('all placement triggers are accessible', async ({ page }) => {
+    const root = await gotoStory(
+      page,
+      'components-tooltip--placements',
+      'swc-button'
+    );
+    // Each placement renders a separate trigger button.
+    await expect(root).toMatchAriaSnapshot(`
+      - button "top"
+      - button "right"
+      - button "end"
+      - button "bottom"
+      - button "left"
+      - button "start"
+    `);
+  });
+});

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -14,6 +14,7 @@ import { html } from 'lit';
 import { expect, userEvent } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
+import type { Button } from '@adobe/spectrum-wc/button';
 import { Tooltip } from '@adobe/spectrum-wc/tooltip';
 
 import '@adobe/spectrum-wc/components/button/swc-button.js';
@@ -309,11 +310,8 @@ export const AriaWiringSwcTriggerTest: Story = {
     </swc-tooltip>
   `,
   play: async ({ canvasElement, step }) => {
-    const swcButton = canvasElement.querySelector(
-      '#tt-swc-trigger'
-    ) as HTMLElement;
-    await (swcButton as HTMLElement & { updateComplete: Promise<boolean> })
-      .updateComplete;
+    const swcButton = canvasElement.querySelector('#tt-swc-trigger') as Button;
+    await swcButton.updateComplete;
 
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
     const innerButton = swcButton.shadowRoot?.querySelector('button') ?? null;
@@ -365,10 +363,10 @@ export const AriaWiringTriggerElementOverrideTest: Story = {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
     const wrongTarget = canvasElement.querySelector(
       '#tt-wrong-target'
-    ) as HTMLElement & { updateComplete: Promise<boolean> };
+    ) as Button;
     const correctTarget = canvasElement.querySelector(
       '#tt-correct-target'
-    ) as HTMLElement & { updateComplete: Promise<boolean> };
+    ) as Button;
     await wrongTarget.updateComplete;
     await correctTarget.updateComplete;
     const wrongInner = wrongTarget.shadowRoot?.querySelector('button') ?? null;
@@ -432,11 +430,7 @@ export const AriaWiringManualModeTest: Story = {
   `,
   play: async ({ canvasElement, step }) => {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
-    const trigger = canvasElement.querySelector(
-      '#tt-manual-trigger'
-    ) as HTMLElement & {
-      updateComplete: Promise<boolean>;
-    };
+    const trigger = canvasElement.querySelector('#tt-manual-trigger') as Button;
     await trigger.updateComplete;
     const innerButton = trigger.shadowRoot?.querySelector('button') ?? null;
 

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -106,7 +106,7 @@ export const PropertyMutationTest: Story = {
   play: async ({ canvasElement, step }) => {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
-    await step('variant reflects to attribute after mutation', async () => {
+    await step('reflects variant attribute after mutation', async () => {
       tooltip.variant = 'informative';
       await tooltip.updateComplete;
       expect(
@@ -129,7 +129,7 @@ export const PropertyMutationTest: Story = {
       ).toBe('neutral');
     });
 
-    await step('placement reflects to attribute after mutation', async () => {
+    await step('reflects placement attribute after mutation', async () => {
       tooltip.placement = 'bottom';
       await tooltip.updateComplete;
       expect(
@@ -147,10 +147,6 @@ export const PropertyMutationTest: Story = {
   },
 };
 
-// ──────────────────────────────────────────────────────────────
-// TEST: Open / close state
-// ──────────────────────────────────────────────────────────────
-
 export const OpenCloseTest: Story = {
   render: () => html`
     <swc-button id="tt-open-close-trigger">Toggle</swc-button>
@@ -161,29 +157,31 @@ export const OpenCloseTest: Story = {
   play: async ({ canvasElement, step }) => {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
-    await step('open=true reflects [open] attribute on host', async () => {
-      tooltip.open = true;
-      await tooltip.updateComplete;
-      expect(
-        tooltip.hasAttribute('open'),
-        'open attribute is present when open=true'
-      ).toBe(true);
-    });
+    await step(
+      'reflects [open] attribute when open is set to true',
+      async () => {
+        tooltip.open = true;
+        await tooltip.updateComplete;
+        expect(
+          tooltip.hasAttribute('open'),
+          'open attribute is present when open=true'
+        ).toBe(true);
+      }
+    );
 
-    await step('open=false removes [open] attribute from host', async () => {
-      tooltip.open = false;
-      await tooltip.updateComplete;
-      expect(
-        tooltip.hasAttribute('open'),
-        'open attribute is absent when open=false'
-      ).toBe(false);
-    });
+    await step(
+      'removes [open] attribute when open is set to false',
+      async () => {
+        tooltip.open = false;
+        await tooltip.updateComplete;
+        expect(
+          tooltip.hasAttribute('open'),
+          'open attribute is absent when open=false'
+        ).toBe(false);
+      }
+    );
   },
 };
-
-// ──────────────────────────────────────────────────────────────
-// TEST: Lifecycle events
-// ──────────────────────────────────────────────────────────────
 
 export const LifecycleEventsTest: Story = {
   render: () => html`
@@ -195,7 +193,7 @@ export const LifecycleEventsTest: Story = {
   play: async ({ canvasElement, step }) => {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
-    await step('swc-open fires when tooltip is opened', async () => {
+    await step('fires swc-open when tooltip is opened', async () => {
       const openPromise = waitForEvent(tooltip, 'swc-open');
       tooltip.open = true;
       await openPromise;
@@ -203,7 +201,7 @@ export const LifecycleEventsTest: Story = {
       await tooltip.updateComplete;
     });
 
-    await step('swc-close fires when tooltip is closed', async () => {
+    await step('fires swc-close when tooltip is closed', async () => {
       tooltip.open = true;
       await tooltip.updateComplete;
 
@@ -212,24 +210,30 @@ export const LifecycleEventsTest: Story = {
       await closePromise;
     });
 
-    await step('swc-after-open fires after tooltip fully opens', async () => {
-      const afterOpenPromise = waitForEvent(tooltip, 'swc-after-open');
-      tooltip.open = true;
-      await afterOpenPromise;
-      tooltip.open = false;
-      await tooltip.updateComplete;
-    });
+    await step(
+      'fires swc-after-open after the tooltip transition ends',
+      async () => {
+        const afterOpenPromise = waitForEvent(tooltip, 'swc-after-open');
+        tooltip.open = true;
+        await afterOpenPromise;
+        tooltip.open = false;
+        await tooltip.updateComplete;
+      }
+    );
 
-    await step('swc-after-close fires after tooltip fully closes', async () => {
-      tooltip.open = true;
-      await tooltip.updateComplete;
+    await step(
+      'fires swc-after-close after the tooltip transition ends',
+      async () => {
+        tooltip.open = true;
+        await tooltip.updateComplete;
 
-      const afterClosePromise = waitForEvent(tooltip, 'swc-after-close');
-      tooltip.open = false;
-      await afterClosePromise;
-    });
+        const afterClosePromise = waitForEvent(tooltip, 'swc-after-close');
+        tooltip.open = false;
+        await afterClosePromise;
+      }
+    );
 
-    await step('events bubble and are composed', async () => {
+    await step('dispatches events that bubble and are composed', async () => {
       let bubbled = false;
       const handler = () => {
         bubbled = true;
@@ -245,38 +249,6 @@ export const LifecycleEventsTest: Story = {
   },
 };
 
-// ──────────────────────────────────────────────────────────────
-// TEST: Escape closes tooltip
-// ──────────────────────────────────────────────────────────────
-
-export const EscapeClosesTest: Story = {
-  render: () => html`
-    <swc-button id="tt-escape-trigger">Open</swc-button>
-    <swc-tooltip for="tt-escape-trigger" placement="top">
-      Press Escape to close
-    </swc-tooltip>
-  `,
-  play: async ({ canvasElement, step }) => {
-    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
-
-    await step('Escape closes the open tooltip', async () => {
-      tooltip.open = true;
-      await waitForEvent(tooltip, 'swc-open');
-      expect(tooltip.open, 'tooltip is open before Escape').toBe(true);
-
-      const closePromise = waitForEvent(tooltip, 'swc-close');
-      await userEvent.keyboard('{Escape}');
-      await closePromise;
-
-      expect(tooltip.open, 'tooltip is closed after Escape').toBe(false);
-    });
-  },
-};
-
-// ──────────────────────────────────────────────────────────────
-// TEST: ARIA wiring — native trigger
-// ──────────────────────────────────────────────────────────────
-
 export const AriaWiringNativeTest: Story = {
   render: () => html`
     <button id="tt-native-trigger">Save</button>
@@ -291,7 +263,7 @@ export const AriaWiringNativeTest: Story = {
     ) as AriaRelatable;
 
     await step(
-      'sets ariaDescribedByElements on native trigger when open=true',
+      'sets ariaDescribedByElements on a native trigger when open is true',
       async () => {
         tooltip.open = true;
         await tooltip.updateComplete;
@@ -304,7 +276,7 @@ export const AriaWiringNativeTest: Story = {
     );
 
     await step(
-      'removes ariaDescribedByElements from native trigger when open=false',
+      'removes ariaDescribedByElements from a native trigger when open is false',
       async () => {
         tooltip.open = false;
         await tooltip.updateComplete;
@@ -318,10 +290,6 @@ export const AriaWiringNativeTest: Story = {
     );
   },
 };
-
-// ──────────────────────────────────────────────────────────────
-// TEST: ARIA wiring — SWC component trigger (shadow root with <button>)
-// ──────────────────────────────────────────────────────────────
 
 export const AriaWiringSwcTriggerTest: Story = {
   render: () => html`
@@ -343,7 +311,7 @@ export const AriaWiringSwcTriggerTest: Story = {
     ) as AriaRelatable | null;
 
     await step(
-      'inner shadow <button> has correct ARIA relationship when tooltip opens',
+      'wires ariaDescribedByElements on the shadow <button> when the tooltip opens',
       async () => {
         expect(
           innerButton,
@@ -362,7 +330,7 @@ export const AriaWiringSwcTriggerTest: Story = {
     );
 
     await step(
-      'inner shadow <button> ARIA relationship is removed when tooltip closes',
+      'removes ariaDescribedByElements from the shadow <button> when the tooltip closes',
       async () => {
         tooltip.open = false;
         await tooltip.updateComplete;
@@ -376,10 +344,6 @@ export const AriaWiringSwcTriggerTest: Story = {
     );
   },
 };
-
-// ──────────────────────────────────────────────────────────────
-// TEST: ARIA wiring — triggerElement setter overrides `for`
-// ──────────────────────────────────────────────────────────────
 
 export const AriaWiringTriggerElementOverrideTest: Story = {
   render: () => html`
@@ -407,7 +371,7 @@ export const AriaWiringTriggerElementOverrideTest: Story = {
     ) as AriaRelatable | null;
 
     await step(
-      'triggerElement setter routes ARIA wiring away from `for` target',
+      'routes ARIA wiring to the triggerElement target instead of the for target',
       async () => {
         tooltip.triggerElement = correctTarget as HTMLElement;
         tooltip.open = true;
@@ -427,10 +391,6 @@ export const AriaWiringTriggerElementOverrideTest: Story = {
   },
 };
 
-// ──────────────────────────────────────────────────────────────
-// TEST: ARIA wiring — no trigger set
-// ──────────────────────────────────────────────────────────────
-
 export const AriaWiringNoTriggerTest: Story = {
   render: () => html`
     <swc-tooltip placement="top">Standalone tooltip</swc-tooltip>
@@ -439,7 +399,7 @@ export const AriaWiringNoTriggerTest: Story = {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step(
-      'opening tooltip with no for or triggerElement does not throw',
+      'opens without throwing when no for attribute or triggerElement is set',
       async () => {
         let threw = false;
         try {
@@ -457,10 +417,6 @@ export const AriaWiringNoTriggerTest: Story = {
     );
   },
 };
-
-// ──────────────────────────────────────────────────────────────
-// TEST: ARIA wiring — manual mode still wires ARIA
-// ──────────────────────────────────────────────────────────────
 
 export const AriaWiringManualModeTest: Story = {
   render: () => html`
@@ -482,7 +438,7 @@ export const AriaWiringManualModeTest: Story = {
     ) as AriaRelatable | null;
 
     await step(
-      'manual mode does not prevent ARIA wiring when for is set',
+      'wires ariaDescribedByElements even when manual mode is active',
       async () => {
         tooltip.open = true;
         await tooltip.updateComplete;
@@ -498,8 +454,32 @@ export const AriaWiringManualModeTest: Story = {
 };
 
 // ──────────────────────────────────────────────────────────────
-// TEST: Variants
+// TEST: Variants / States
 // ──────────────────────────────────────────────────────────────
+
+export const EscapeClosesTest: Story = {
+  render: () => html`
+    <swc-button id="tt-escape-trigger">Open</swc-button>
+    <swc-tooltip for="tt-escape-trigger" placement="top">
+      Press Escape to close
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step('closes the open tooltip when Escape is pressed', async () => {
+      tooltip.open = true;
+      await waitForEvent(tooltip, 'swc-open');
+      expect(tooltip.open, 'tooltip is open before Escape').toBe(true);
+
+      const closePromise = waitForEvent(tooltip, 'swc-close');
+      await userEvent.keyboard('{Escape}');
+      await closePromise;
+
+      expect(tooltip.open, 'tooltip is closed after Escape').toBe(false);
+    });
+  },
+};
 
 export const VariantsTest: Story = {
   ...Variants,
@@ -523,10 +503,6 @@ export const VariantsTest: Story = {
   },
 };
 
-// ──────────────────────────────────────────────────────────────
-// TEST: Placements
-// ──────────────────────────────────────────────────────────────
-
 export const PlacementsTest: Story = {
   ...Placements,
   play: async ({ canvasElement, step }) => {
@@ -547,7 +523,7 @@ export const PlacementsTest: Story = {
 };
 
 // ──────────────────────────────────────────────────────────────
-// TEST: Debug warnings
+// TEST: Dev mode warnings
 // ──────────────────────────────────────────────────────────────
 
 export const ForIdNotFoundWarningTest: Story = {
@@ -558,7 +534,7 @@ export const ForIdNotFoundWarningTest: Story = {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step(
-      'warns in DEBUG mode when for attribute does not resolve to an element',
+      'warns in DEBUG mode when the for attribute does not resolve to an element',
       () =>
         withWarningSpy(async (warnCalls) => {
           tooltip.open = true;

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -234,17 +234,33 @@ export const LifecycleEventsTest: Story = {
     );
 
     await step('dispatches events that bubble and are composed', async () => {
-      let bubbled = false;
-      const handler = () => {
-        bubbled = true;
+      const received: string[] = [];
+      const handler = (event: Event) => {
+        received.push(event.type);
       };
-      canvasElement.addEventListener('swc-open', handler, { once: true });
+      for (const name of [
+        'swc-open',
+        'swc-close',
+        'swc-after-open',
+        'swc-after-close',
+      ]) {
+        canvasElement.addEventListener(name, handler);
+      }
+
       tooltip.open = true;
-      await waitForEvent(tooltip, 'swc-open');
-      expect(bubbled, 'swc-open bubbled to canvas').toBe(true);
-      canvasElement.removeEventListener('swc-open', handler);
+      await waitForEvent(tooltip, 'swc-after-open');
       tooltip.open = false;
-      await tooltip.updateComplete;
+      await waitForEvent(tooltip, 'swc-after-close');
+
+      for (const name of [
+        'swc-open',
+        'swc-close',
+        'swc-after-open',
+        'swc-after-close',
+      ]) {
+        canvasElement.removeEventListener(name, handler);
+        expect(received, `${name} bubbled to canvas`).toContain(name);
+      }
     });
   },
 };

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -1,0 +1,580 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import { expect, userEvent } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import { Tooltip } from '@adobe/spectrum-wc/tooltip';
+
+import '@adobe/spectrum-wc/components/button/swc-button.js';
+import '@adobe/spectrum-wc/components/tooltip/swc-tooltip.js';
+
+import {
+  TOOLTIP_PLACEMENTS,
+  TOOLTIP_VARIANTS,
+} from '../../../../core/components/tooltip/Tooltip.types.js';
+import {
+  getComponent,
+  getComponents,
+  withWarningSpy,
+} from '../../../utils/test-utils.js';
+import meta, {
+  Overview,
+  Placements,
+  Variants,
+} from '../stories/tooltip.stories.js';
+
+// This file defines dev-only test stories that reuse the main story metadata.
+export default {
+  ...meta,
+  title: 'Tooltip/Tests',
+  parameters: {
+    ...meta.parameters,
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+// Type alias for elements with ariaDescribedByElements (available in Chrome 135+, Firefox 136+, Safari 16.4+).
+type AriaRelatable = Element & { ariaDescribedByElements: Element[] | null };
+
+// Awaits a DOM event dispatched on the given element, resolving with the event object.
+const waitForEvent = <T extends Event>(
+  el: EventTarget,
+  eventName: string
+): Promise<T> =>
+  new Promise<T>((resolve) => {
+    el.addEventListener(eventName, (event) => resolve(event as T), {
+      once: true,
+    });
+  });
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Defaults
+// ──────────────────────────────────────────────────────────────
+
+export const OverviewTest: Story = {
+  ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step('renders expected default property values', async () => {
+      expect(tooltip.variant, 'default variant is neutral').toBe('neutral');
+      expect(tooltip.placement, 'default placement is top').toBe('top');
+      expect(tooltip.open, 'default open is false').toBe(false);
+      expect(tooltip.manual, 'default manual is false').toBe(false);
+      expect(tooltip.delay, 'default delay is 1500').toBe(1500);
+    });
+
+    await step('sets role="tooltip" on the host element', async () => {
+      expect(tooltip.getAttribute('role'), 'host has role="tooltip"').toBe(
+        'tooltip'
+      );
+    });
+
+    await step('sets popover="auto" on the host element', async () => {
+      expect(tooltip.getAttribute('popover'), 'host has popover="auto"').toBe(
+        'auto'
+      );
+    });
+
+    await step('renders text content in default slot', async () => {
+      expect(
+        tooltip.textContent?.trim(),
+        'default slot has text content'
+      ).toBeTruthy();
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Properties / Attributes
+// ──────────────────────────────────────────────────────────────
+
+export const PropertyMutationTest: Story = {
+  ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step('variant reflects to attribute after mutation', async () => {
+      tooltip.variant = 'informative';
+      await tooltip.updateComplete;
+      expect(
+        tooltip.getAttribute('variant'),
+        'variant attribute is informative after mutation'
+      ).toBe('informative');
+
+      tooltip.variant = 'negative';
+      await tooltip.updateComplete;
+      expect(
+        tooltip.getAttribute('variant'),
+        'variant attribute is negative after second mutation'
+      ).toBe('negative');
+
+      tooltip.variant = 'neutral';
+      await tooltip.updateComplete;
+      expect(
+        tooltip.getAttribute('variant'),
+        'variant attribute is neutral after third mutation'
+      ).toBe('neutral');
+    });
+
+    await step('placement reflects to attribute after mutation', async () => {
+      tooltip.placement = 'bottom';
+      await tooltip.updateComplete;
+      expect(
+        tooltip.getAttribute('placement'),
+        'placement attribute is bottom after mutation'
+      ).toBe('bottom');
+
+      tooltip.placement = 'start';
+      await tooltip.updateComplete;
+      expect(
+        tooltip.getAttribute('placement'),
+        'placement attribute is start after mutation'
+      ).toBe('start');
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Open / close state
+// ──────────────────────────────────────────────────────────────
+
+export const OpenCloseTest: Story = {
+  render: () => html`
+    <swc-button id="tt-open-close-trigger">Toggle</swc-button>
+    <swc-tooltip for="tt-open-close-trigger" placement="top">
+      Tooltip text
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step('open=true reflects [open] attribute on host', async () => {
+      tooltip.open = true;
+      await tooltip.updateComplete;
+      expect(
+        tooltip.hasAttribute('open'),
+        'open attribute is present when open=true'
+      ).toBe(true);
+    });
+
+    await step('open=false removes [open] attribute from host', async () => {
+      tooltip.open = false;
+      await tooltip.updateComplete;
+      expect(
+        tooltip.hasAttribute('open'),
+        'open attribute is absent when open=false'
+      ).toBe(false);
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Lifecycle events
+// ──────────────────────────────────────────────────────────────
+
+export const LifecycleEventsTest: Story = {
+  render: () => html`
+    <swc-button id="tt-events-trigger">Open</swc-button>
+    <swc-tooltip for="tt-events-trigger" placement="top">
+      Tooltip content
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step('swc-open fires when tooltip is opened', async () => {
+      const openPromise = waitForEvent(tooltip, 'swc-open');
+      tooltip.open = true;
+      await openPromise;
+      tooltip.open = false;
+      await tooltip.updateComplete;
+    });
+
+    await step('swc-close fires when tooltip is closed', async () => {
+      tooltip.open = true;
+      await tooltip.updateComplete;
+
+      const closePromise = waitForEvent(tooltip, 'swc-close');
+      tooltip.open = false;
+      await closePromise;
+    });
+
+    await step('swc-after-open fires after tooltip fully opens', async () => {
+      const afterOpenPromise = waitForEvent(tooltip, 'swc-after-open');
+      tooltip.open = true;
+      await afterOpenPromise;
+      tooltip.open = false;
+      await tooltip.updateComplete;
+    });
+
+    await step('swc-after-close fires after tooltip fully closes', async () => {
+      tooltip.open = true;
+      await tooltip.updateComplete;
+
+      const afterClosePromise = waitForEvent(tooltip, 'swc-after-close');
+      tooltip.open = false;
+      await afterClosePromise;
+    });
+
+    await step('events bubble and are composed', async () => {
+      let bubbled = false;
+      const handler = () => {
+        bubbled = true;
+      };
+      canvasElement.addEventListener('swc-open', handler, { once: true });
+      tooltip.open = true;
+      await waitForEvent(tooltip, 'swc-open');
+      expect(bubbled, 'swc-open bubbled to canvas').toBe(true);
+      canvasElement.removeEventListener('swc-open', handler);
+      tooltip.open = false;
+      await tooltip.updateComplete;
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Escape closes tooltip
+// ──────────────────────────────────────────────────────────────
+
+export const EscapeClosesTest: Story = {
+  render: () => html`
+    <swc-button id="tt-escape-trigger">Open</swc-button>
+    <swc-tooltip for="tt-escape-trigger" placement="top">
+      Press Escape to close
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step('Escape closes the open tooltip', async () => {
+      tooltip.open = true;
+      await waitForEvent(tooltip, 'swc-open');
+      expect(tooltip.open, 'tooltip is open before Escape').toBe(true);
+
+      const closePromise = waitForEvent(tooltip, 'swc-close');
+      await userEvent.keyboard('{Escape}');
+      await closePromise;
+
+      expect(tooltip.open, 'tooltip is closed after Escape').toBe(false);
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: ARIA wiring — native trigger
+// ──────────────────────────────────────────────────────────────
+
+export const AriaWiringNativeTest: Story = {
+  render: () => html`
+    <button id="tt-native-trigger">Save</button>
+    <swc-tooltip for="tt-native-trigger" placement="top">
+      Changes will be saved
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+    const trigger = canvasElement.querySelector(
+      '#tt-native-trigger'
+    ) as AriaRelatable;
+
+    await step(
+      'sets ariaDescribedByElements on native trigger when open=true',
+      async () => {
+        tooltip.open = true;
+        await tooltip.updateComplete;
+
+        const elements = trigger.ariaDescribedByElements ?? [];
+        expect(elements, 'ariaDescribedByElements contains tooltip').toContain(
+          tooltip
+        );
+      }
+    );
+
+    await step(
+      'removes ariaDescribedByElements from native trigger when open=false',
+      async () => {
+        tooltip.open = false;
+        await tooltip.updateComplete;
+
+        const elements = trigger.ariaDescribedByElements ?? [];
+        expect(
+          elements,
+          'ariaDescribedByElements no longer contains tooltip'
+        ).not.toContain(tooltip);
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: ARIA wiring — SWC component trigger (shadow root with <button>)
+// ──────────────────────────────────────────────────────────────
+
+export const AriaWiringSwcTriggerTest: Story = {
+  render: () => html`
+    <swc-button id="tt-swc-trigger">Save</swc-button>
+    <swc-tooltip for="tt-swc-trigger" placement="top">
+      Changes will be saved
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const swcButton = canvasElement.querySelector(
+      '#tt-swc-trigger'
+    ) as HTMLElement;
+    await (swcButton as HTMLElement & { updateComplete: Promise<boolean> })
+      .updateComplete;
+
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+    const innerButton = swcButton.shadowRoot?.querySelector(
+      'button'
+    ) as AriaRelatable | null;
+
+    await step(
+      'inner shadow <button> has correct ARIA relationship when tooltip opens',
+      async () => {
+        expect(
+          innerButton,
+          'swc-button has an inner <button> in its shadow root'
+        ).toBeTruthy();
+
+        tooltip.open = true;
+        await tooltip.updateComplete;
+
+        const elements = innerButton?.ariaDescribedByElements ?? [];
+        expect(
+          elements,
+          'inner shadow button ariaDescribedByElements contains tooltip host'
+        ).toContain(tooltip);
+      }
+    );
+
+    await step(
+      'inner shadow <button> ARIA relationship is removed when tooltip closes',
+      async () => {
+        tooltip.open = false;
+        await tooltip.updateComplete;
+
+        const elements = innerButton?.ariaDescribedByElements ?? [];
+        expect(
+          elements,
+          'inner shadow button ariaDescribedByElements no longer contains tooltip'
+        ).not.toContain(tooltip);
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: ARIA wiring — triggerElement setter overrides `for`
+// ──────────────────────────────────────────────────────────────
+
+export const AriaWiringTriggerElementOverrideTest: Story = {
+  render: () => html`
+    <swc-button id="tt-wrong-target">Wrong target</swc-button>
+    <swc-button id="tt-correct-target">Correct target</swc-button>
+    <swc-tooltip for="tt-wrong-target" placement="top">
+      Tooltip text
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+    const wrongTarget = canvasElement.querySelector(
+      '#tt-wrong-target'
+    ) as HTMLElement & { updateComplete: Promise<boolean> };
+    const correctTarget = canvasElement.querySelector(
+      '#tt-correct-target'
+    ) as HTMLElement & { updateComplete: Promise<boolean> };
+    await wrongTarget.updateComplete;
+    await correctTarget.updateComplete;
+    const wrongInner = wrongTarget.shadowRoot?.querySelector(
+      'button'
+    ) as AriaRelatable | null;
+    const correctInner = correctTarget.shadowRoot?.querySelector(
+      'button'
+    ) as AriaRelatable | null;
+
+    await step(
+      'triggerElement setter routes ARIA wiring away from `for` target',
+      async () => {
+        tooltip.triggerElement = correctTarget as HTMLElement;
+        tooltip.open = true;
+        await tooltip.updateComplete;
+
+        expect(
+          correctInner?.ariaDescribedByElements ?? [],
+          'correct target inner button receives ariaDescribedByElements'
+        ).toContain(tooltip);
+
+        expect(
+          wrongInner?.ariaDescribedByElements ?? [],
+          'for target inner button does not receive ariaDescribedByElements when triggerElement is set'
+        ).not.toContain(tooltip);
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: ARIA wiring — no trigger set
+// ──────────────────────────────────────────────────────────────
+
+export const AriaWiringNoTriggerTest: Story = {
+  render: () => html`
+    <swc-tooltip placement="top">Standalone tooltip</swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step(
+      'opening tooltip with no for or triggerElement does not throw',
+      async () => {
+        let threw = false;
+        try {
+          tooltip.open = true;
+          await tooltip.updateComplete;
+        } catch {
+          threw = true;
+        }
+        expect(threw, 'no error thrown when opening without trigger').toBe(
+          false
+        );
+        tooltip.open = false;
+        await tooltip.updateComplete;
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: ARIA wiring — manual mode still wires ARIA
+// ──────────────────────────────────────────────────────────────
+
+export const AriaWiringManualModeTest: Story = {
+  render: () => html`
+    <swc-button id="tt-manual-trigger">Save</swc-button>
+    <swc-tooltip for="tt-manual-trigger" manual placement="top">
+      Consumer-controlled tooltip
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+    const trigger = canvasElement.querySelector(
+      '#tt-manual-trigger'
+    ) as HTMLElement & {
+      updateComplete: Promise<boolean>;
+    };
+    await trigger.updateComplete;
+    const innerButton = trigger.shadowRoot?.querySelector(
+      'button'
+    ) as AriaRelatable | null;
+
+    await step(
+      'manual mode does not prevent ARIA wiring when for is set',
+      async () => {
+        tooltip.open = true;
+        await tooltip.updateComplete;
+
+        const elements = innerButton?.ariaDescribedByElements ?? [];
+        expect(
+          elements,
+          'ariaDescribedByElements is set on inner button even in manual mode'
+        ).toContain(tooltip);
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Variants
+// ──────────────────────────────────────────────────────────────
+
+export const VariantsTest: Story = {
+  ...Variants,
+  play: async ({ canvasElement, step }) => {
+    await step('renders all valid tooltip variants', async () => {
+      for (const variant of TOOLTIP_VARIANTS) {
+        const tooltip = canvasElement.querySelector(
+          `swc-tooltip[variant="${variant}"]`
+        ) as Tooltip | null;
+        expect(
+          tooltip,
+          `tooltip with variant="${variant}" is rendered`
+        ).toBeTruthy();
+        await tooltip?.updateComplete;
+        expect(
+          tooltip?.variant,
+          `tooltip variant property is "${variant}"`
+        ).toBe(variant);
+      }
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Placements
+// ──────────────────────────────────────────────────────────────
+
+export const PlacementsTest: Story = {
+  ...Placements,
+  play: async ({ canvasElement, step }) => {
+    await step('renders all valid placement values', async () => {
+      const tooltips = await getComponents<Tooltip>(
+        canvasElement,
+        'swc-tooltip'
+      );
+      for (const placement of TOOLTIP_PLACEMENTS) {
+        const tooltip = tooltips.find((t) => t.placement === placement);
+        expect(
+          tooltip,
+          `tooltip with placement="${placement}" is rendered`
+        ).toBeTruthy();
+      }
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Debug warnings
+// ──────────────────────────────────────────────────────────────
+
+export const ForIdNotFoundWarningTest: Story = {
+  render: () => html`
+    <swc-tooltip for="does-not-exist" placement="top">Tooltip</swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step(
+      'warns in DEBUG mode when for attribute does not resolve to an element',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          tooltip.open = true;
+          await tooltip.updateComplete;
+          tooltip.open = false;
+          await tooltip.updateComplete;
+
+          expect(
+            warnCalls.length,
+            'at least one warning is emitted for unresolved for attribute'
+          ).toBeGreaterThan(0);
+          expect(
+            String(warnCalls[0]?.[1] ?? ''),
+            'warning message references the for attribute value'
+          ).toContain('does-not-exist');
+        })
+    );
+  },
+};

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -234,33 +234,20 @@ export const LifecycleEventsTest: Story = {
     );
 
     await step('dispatches events that bubble and are composed', async () => {
-      const received: string[] = [];
-      const handler = (event: Event) => {
-        received.push(event.type);
-      };
-      for (const name of [
-        'swc-open',
-        'swc-close',
-        'swc-after-open',
-        'swc-after-close',
-      ]) {
-        canvasElement.addEventListener(name, handler);
-      }
+      let openBubbled = false;
+      let closeBubbled = false;
+      canvasElement.addEventListener('swc-open', () => { openBubbled = true; }, { once: true });
+      canvasElement.addEventListener('swc-close', () => { closeBubbled = true; }, { once: true });
 
       tooltip.open = true;
-      await waitForEvent(tooltip, 'swc-after-open');
-      tooltip.open = false;
-      await waitForEvent(tooltip, 'swc-after-close');
+      await waitForEvent(tooltip, 'swc-open');
+      expect(openBubbled, 'swc-open bubbled to canvas').toBe(true);
 
-      for (const name of [
-        'swc-open',
-        'swc-close',
-        'swc-after-open',
-        'swc-after-close',
-      ]) {
-        canvasElement.removeEventListener(name, handler);
-        expect(received, `${name} bubbled to canvas`).toContain(name);
-      }
+      tooltip.open = false;
+      await waitForEvent(tooltip, 'swc-close');
+      expect(closeBubbled, 'swc-close bubbled to canvas').toBe(true);
+
+      await tooltip.updateComplete;
     });
   },
 };

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -456,48 +456,54 @@ export const AriaWiringManualModeTest: Story = {
 
 export const AriaWiringLabelingTest: Story = {
   render: () => html`
-    <button id="tt-labeling-trigger">★</button>
+    <swc-button id="tt-labeling-trigger" accessible-label="Favorite">
+      ★
+    </swc-button>
     <swc-tooltip for="tt-labeling-trigger" labeling placement="top">
       Favorite
     </swc-tooltip>
   `,
   play: async ({ canvasElement, step }) => {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
-    const trigger = canvasElement.querySelector('#tt-labeling-trigger')!;
+    const trigger = canvasElement.querySelector(
+      '#tt-labeling-trigger'
+    ) as Button;
+    await trigger.updateComplete;
+    const innerButton = trigger.shadowRoot?.querySelector('button') ?? null;
 
     await step(
-      'sets ariaLabelledByElements (not ariaDescribedByElements) when labeling is set',
+      'sets ariaLabelledByElements (not ariaDescribedByElements) on inner button when labeling is set',
       async () => {
         tooltip.open = true;
         await tooltip.updateComplete;
 
         expect(
-          trigger.ariaLabelledByElements ?? [],
-          'ariaLabelledByElements contains tooltip when labeling is set'
+          innerButton?.ariaLabelledByElements ?? [],
+          'inner button ariaLabelledByElements contains tooltip when labeling is set'
         ).toContain(tooltip);
 
         expect(
-          trigger.ariaDescribedByElements ?? [],
-          'ariaDescribedByElements does not contain tooltip when labeling is set'
+          innerButton?.ariaDescribedByElements ?? [],
+          'inner button ariaDescribedByElements does not contain tooltip when labeling is set'
         ).not.toContain(tooltip);
       }
     );
 
     await step(
-      'clears ariaLabelledByElements from trigger when closed',
+      'clears ariaLabelledByElements from inner button when closed',
       async () => {
         tooltip.open = false;
         await tooltip.updateComplete;
 
         expect(
-          trigger.ariaLabelledByElements ?? [],
-          'ariaLabelledByElements no longer contains tooltip after close'
+          innerButton?.ariaLabelledByElements ?? [],
+          'inner button ariaLabelledByElements no longer contains tooltip after close'
         ).not.toContain(tooltip);
       }
     );
 
     await step(
-      'switches to ariaDescribedByElements when labeling is removed while open',
+      'switches to ariaDescribedByElements on inner button when labeling is removed while open',
       async () => {
         tooltip.open = true;
         await tooltip.updateComplete;
@@ -506,13 +512,13 @@ export const AriaWiringLabelingTest: Story = {
         await tooltip.updateComplete;
 
         expect(
-          trigger.ariaDescribedByElements ?? [],
-          'ariaDescribedByElements contains tooltip after labeling removed'
+          innerButton?.ariaDescribedByElements ?? [],
+          'inner button ariaDescribedByElements contains tooltip after labeling removed'
         ).toContain(tooltip);
 
         expect(
-          trigger.ariaLabelledByElements ?? [],
-          'ariaLabelledByElements does not contain tooltip after labeling removed'
+          innerButton?.ariaLabelledByElements ?? [],
+          'inner button ariaLabelledByElements does not contain tooltip after labeling removed'
         ).not.toContain(tooltip);
 
         tooltip.open = false;

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -45,9 +45,6 @@ export default {
   tags: ['!autodocs', 'dev'],
 } as Meta;
 
-// Type alias for elements with ariaDescribedByElements (available in Chrome 135+, Firefox 136+, Safari 16.4+).
-type AriaRelatable = Element & { ariaDescribedByElements: Element[] | null };
-
 // Awaits a DOM event dispatched on the given element, resolving with the event object.
 const waitForEvent = <T extends Event>(
   el: EventTarget,
@@ -236,8 +233,20 @@ export const LifecycleEventsTest: Story = {
     await step('dispatches events that bubble and are composed', async () => {
       let openBubbled = false;
       let closeBubbled = false;
-      canvasElement.addEventListener('swc-open', () => { openBubbled = true; }, { once: true });
-      canvasElement.addEventListener('swc-close', () => { closeBubbled = true; }, { once: true });
+      canvasElement.addEventListener(
+        'swc-open',
+        () => {
+          openBubbled = true;
+        },
+        { once: true }
+      );
+      canvasElement.addEventListener(
+        'swc-close',
+        () => {
+          closeBubbled = true;
+        },
+        { once: true }
+      );
 
       tooltip.open = true;
       await waitForEvent(tooltip, 'swc-open');
@@ -261,9 +270,7 @@ export const AriaWiringNativeTest: Story = {
   `,
   play: async ({ canvasElement, step }) => {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
-    const trigger = canvasElement.querySelector(
-      '#tt-native-trigger'
-    ) as AriaRelatable;
+    const trigger = canvasElement.querySelector('#tt-native-trigger')!;
 
     await step(
       'sets ariaDescribedByElements on a native trigger when open is true',
@@ -309,9 +316,7 @@ export const AriaWiringSwcTriggerTest: Story = {
       .updateComplete;
 
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
-    const innerButton = swcButton.shadowRoot?.querySelector(
-      'button'
-    ) as AriaRelatable | null;
+    const innerButton = swcButton.shadowRoot?.querySelector('button') ?? null;
 
     await step(
       'wires ariaDescribedByElements on the shadow <button> when the tooltip opens',
@@ -366,12 +371,9 @@ export const AriaWiringTriggerElementOverrideTest: Story = {
     ) as HTMLElement & { updateComplete: Promise<boolean> };
     await wrongTarget.updateComplete;
     await correctTarget.updateComplete;
-    const wrongInner = wrongTarget.shadowRoot?.querySelector(
-      'button'
-    ) as AriaRelatable | null;
-    const correctInner = correctTarget.shadowRoot?.querySelector(
-      'button'
-    ) as AriaRelatable | null;
+    const wrongInner = wrongTarget.shadowRoot?.querySelector('button') ?? null;
+    const correctInner =
+      correctTarget.shadowRoot?.querySelector('button') ?? null;
 
     await step(
       'routes ARIA wiring to the triggerElement target instead of the for target',
@@ -436,9 +438,7 @@ export const AriaWiringManualModeTest: Story = {
       updateComplete: Promise<boolean>;
     };
     await trigger.updateComplete;
-    const innerButton = trigger.shadowRoot?.querySelector(
-      'button'
-    ) as AriaRelatable | null;
+    const innerButton = trigger.shadowRoot?.querySelector('button') ?? null;
 
     await step(
       'wires ariaDescribedByElements even when manual mode is active',
@@ -451,6 +451,78 @@ export const AriaWiringManualModeTest: Story = {
           elements,
           'ariaDescribedByElements is set on inner button even in manual mode'
         ).toContain(tooltip);
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: ARIA wiring — labeling attribute
+// ──────────────────────────────────────────────────────────────
+
+export const AriaWiringLabelingTest: Story = {
+  render: () => html`
+    <button id="tt-labeling-trigger">★</button>
+    <swc-tooltip for="tt-labeling-trigger" labeling placement="top">
+      Favorite
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+    const trigger = canvasElement.querySelector('#tt-labeling-trigger')!;
+
+    await step(
+      'sets ariaLabelledByElements (not ariaDescribedByElements) when labeling is set',
+      async () => {
+        tooltip.open = true;
+        await tooltip.updateComplete;
+
+        expect(
+          trigger.ariaLabelledByElements ?? [],
+          'ariaLabelledByElements contains tooltip when labeling is set'
+        ).toContain(tooltip);
+
+        expect(
+          trigger.ariaDescribedByElements ?? [],
+          'ariaDescribedByElements does not contain tooltip when labeling is set'
+        ).not.toContain(tooltip);
+      }
+    );
+
+    await step(
+      'clears ariaLabelledByElements from trigger when closed',
+      async () => {
+        tooltip.open = false;
+        await tooltip.updateComplete;
+
+        expect(
+          trigger.ariaLabelledByElements ?? [],
+          'ariaLabelledByElements no longer contains tooltip after close'
+        ).not.toContain(tooltip);
+      }
+    );
+
+    await step(
+      'switches to ariaDescribedByElements when labeling is removed while open',
+      async () => {
+        tooltip.open = true;
+        await tooltip.updateComplete;
+
+        tooltip.labeling = false;
+        await tooltip.updateComplete;
+
+        expect(
+          trigger.ariaDescribedByElements ?? [],
+          'ariaDescribedByElements contains tooltip after labeling removed'
+        ).toContain(tooltip);
+
+        expect(
+          trigger.ariaLabelledByElements ?? [],
+          'ariaLabelledByElements does not contain tooltip after labeling removed'
+        ).not.toContain(tooltip);
+
+        tooltip.open = false;
+        await tooltip.updateComplete;
       }
     );
   },

--- a/2nd-gen/packages/swc/components/tooltip/tooltip.css
+++ b/2nd-gen/packages/swc/components/tooltip/tooltip.css
@@ -267,6 +267,7 @@
    LABEL
    ───────────────────────────────────────────────────────────────────────────── */
 
+/* NOTE: !important ensures these resets override consumer element styles on slotted content. */
 ::slotted(*:not([class])) {
   margin: 0 !important;
   font: inherit !important;

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -16,64 +16,80 @@
 
 @layer swc-global-elements {.swc-Button, .swc-Button * {
   box-sizing: border-box;
-}.swc-Button {
+}
+
+.swc-Button {
   -webkit-tap-highlight-color: transparent;
   display: inline-flex;
   position: relative;
+  gap: var(--swc-button-gap, token("text-to-visual-100"));
   align-items: center;
   justify-content: center;
-  margin: 0;
-  text-transform: none;
-  text-decoration: none;
-  border-style: solid;
-  overflow: visible;
-  user-select: none;
-  --_swc-button-border-width: token("border-width-200");
-  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
-
-  gap: var(--swc-button-gap, token("text-to-visual-100"));
   max-inline-size: var(--swc-button-max-inline-size, inherit);
   min-block-size: var(--_swc-button-min-block-size);
   padding-block: calc(var(--swc-button-padding-vertical, token("component-padding-vertical-100")) - var(--_swc-button-border-width));
   padding-inline: calc(var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")) - var(--_swc-button-border-width));
+  margin: 0;
   font-family: token("sans-serif-font");
   font-size: var(--swc-button-font-size, token("font-size-100"));
   font-weight: token("bold-font-weight");
   line-height: round(down, calc(token("line-height-100") * 1em), 1px);
   color: var(--swc-button-content-color-default, token("gray-25"));
+  text-transform: none;
+  text-decoration: none;
   background-color: var(--swc-button-background-color-default, token("neutral-background-color-default"));
   border-color: var(--swc-button-border-color-default, transparent);
+  border-style: solid;
   border-width: var(--_swc-button-border-width);
   border-radius: var(--swc-button-border-radius, calc(var(--_swc-button-min-block-size) / 2));
+  overflow: visible;
+  user-select: none;
   transition-timing-function: token("animation-ease-in-out");
   transition-duration: token("animation-duration-100");
   transition-property: outline, border-color, color, background-color, transform;
-}.swc-Button:focus-visible {
-  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
-  outline-offset: token("focus-indicator-gap");
+
+  --_swc-button-border-width: token("border-width-200");
+  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
+}
+
+.swc-Button:focus-visible {
   color: var(--swc-button-content-color-focus, token("gray-25"));
   background-color: var(--swc-button-background-color-focus, token("neutral-background-color-key-focus"));
   border-color: var(--swc-button-border-color-focus, transparent);
-}.swc-Button:disabled:is(*, :hover) {
+  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
+  outline-offset: token("focus-indicator-gap");
+}
+
+.swc-Button:disabled:is(*, :hover) {
   color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
   background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
   border-color: var(--swc-button-border-color-disabled, transparent);
   transform: none;
-}.swc-Button:hover {
+}
+
+.swc-Button:hover {
   color: var(--swc-button-content-color-hover, token("gray-25"));
   background-color: var(--swc-button-background-color-hover, token("neutral-background-color-hover"));
   border-color: var(--swc-button-border-color-hover, transparent);
-}.swc-Button:active {
+}
+
+.swc-Button:active {
   color: var(--swc-button-content-color-down, token("gray-25"));
   background-color: var(--swc-button-background-color-down, token("neutral-background-color-down"));
   border-color: var(--swc-button-border-color-down, transparent);
   transform: var(--swc-button-down-state-transform, perspective(var(--_swc-button-min-block-size)) translate3d(0, 0, token("component-size-difference-down")));
   will-change: transform;
-}.swc-Button-label {
+}
+
+.swc-Button-label {
   text-align: center;
-}.swc-Button--hasIcon .swc-Button-label {
+}
+
+.swc-Button--hasIcon .swc-Button-label {
   text-align: start;
-}.swc-Button-icon,
+}
+
+.swc-Button-icon,
 .swc-Button-pendingSpinner {
   --_swc-button-icon-size: var(--swc-button-icon-size, token("workflow-icon-size-100"));
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
@@ -84,10 +100,14 @@
   block-size: var(--_swc-button-icon-block-size);
   margin-block: calc((var(--_swc-button-icon-block-size) - 1lh) / 2 * -1);
   margin-inline-start: calc(var(--swc-button-edge-to-visual, token("component-pill-edge-to-visual-100")) - var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")));
-}.swc-Button-icon {
+}
+
+.swc-Button-icon {
   color: inherit;
   fill: currentcolor;
-}.swc-Button--sizeS {
+}
+
+.swc-Button--sizeS {
   --swc-button-min-block-size: token("component-height-75");
   --swc-button-font-size: token("font-size-75");
   --swc-button-gap: token("text-to-visual-75");
@@ -96,7 +116,9 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-75");
   --swc-button-padding-vertical: token("component-padding-vertical-75");
   --swc-button-icon-size: token("workflow-icon-size-75");
-}.swc-Button--sizeL {
+}
+
+.swc-Button--sizeL {
   --swc-button-min-block-size: token("component-height-200");
   --swc-button-font-size: token("font-size-200");
   --swc-button-gap: token("text-to-visual-200");
@@ -105,7 +127,9 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-200");
   --swc-button-padding-vertical: token("component-padding-vertical-200");
   --swc-button-icon-size: token("workflow-icon-size-200");
-}.swc-Button--sizeXl {
+}
+
+.swc-Button--sizeXl {
   --swc-button-min-block-size: token("component-height-300");
   --swc-button-font-size: token("font-size-300");
   --swc-button-gap: token("text-to-visual-300");
@@ -114,7 +138,9 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-300");
   --swc-button-padding-vertical: token("component-padding-vertical-300");
   --swc-button-icon-size: token("workflow-icon-size-300");
-}.swc-Button--accent {
+}
+
+.swc-Button--accent {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -123,7 +149,9 @@
   --swc-button-background-color-hover: token("accent-background-color-hover");
   --swc-button-background-color-down: token("accent-background-color-down");
   --swc-button-background-color-focus: token("accent-background-color-key-focus");
-}.swc-Button--negative {
+}
+
+.swc-Button--negative {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -132,7 +160,9 @@
   --swc-button-background-color-hover: token("negative-background-color-hover");
   --swc-button-background-color-down: token("negative-background-color-down");
   --swc-button-background-color-focus: token("negative-background-color-key-focus");
-}.swc-Button--secondary {
+}
+
+.swc-Button--secondary {
   --swc-button-content-color-default: token("neutral-content-color-default");
   --swc-button-content-color-hover: token("neutral-content-color-hover");
   --swc-button-content-color-down: token("neutral-content-color-down");
@@ -141,7 +171,9 @@
   --swc-button-background-color-hover: token("gray-200");
   --swc-button-background-color-down: token("gray-200");
   --swc-button-background-color-focus: token("gray-200");
-}.swc-Button--primary.swc-Button--outline {
+}
+
+.swc-Button--primary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -156,7 +188,9 @@
   --swc-button-content-color-focus: token("neutral-content-color-key-focus");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}.swc-Button--secondary.swc-Button--outline {
+}
+
+.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -167,7 +201,9 @@
   --swc-button-border-color-focus: token("gray-400");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}.swc-Button--staticWhite {
+}
+
+.swc-Button--staticWhite {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-white-800");
   --swc-button-background-color-hover: token("transparent-white-900");
@@ -180,7 +216,9 @@
   --swc-button-background-color-disabled: token("disabled-static-white-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}.swc-Button--staticWhite.swc-Button--secondary {
+}
+
+.swc-Button--staticWhite.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-white-100");
   --swc-button-background-color-hover: token("transparent-white-200");
   --swc-button-background-color-down: token("transparent-white-200");
@@ -189,7 +227,9 @@
   --swc-button-content-color-hover: token("transparent-white-900");
   --swc-button-content-color-down: token("transparent-white-900");
   --swc-button-content-color-focus: token("transparent-white-900");
-}.swc-Button--staticWhite.swc-Button--outline {
+}
+
+.swc-Button--staticWhite.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -205,7 +245,9 @@
   --swc-button-background-color-disabled: token("transparent-white-25");
   --swc-button-border-color-disabled: token("disabled-static-white-border-color");
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
+}
+
+.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -214,7 +256,9 @@
   --swc-button-border-color-hover: token("transparent-white-400");
   --swc-button-border-color-down: token("transparent-white-400");
   --swc-button-border-color-focus: token("transparent-white-400");
-}.swc-Button--staticBlack {
+}
+
+.swc-Button--staticBlack {
   --swc-button-focus-indicator-color: token("static-black-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-black-800");
   --swc-button-background-color-hover: token("transparent-black-900");
@@ -227,7 +271,9 @@
   --swc-button-background-color-disabled: token("disabled-static-black-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}.swc-Button--staticBlack.swc-Button--secondary {
+}
+
+.swc-Button--staticBlack.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-black-100");
   --swc-button-background-color-hover: token("transparent-black-200");
   --swc-button-background-color-down: token("transparent-black-200");
@@ -236,7 +282,9 @@
   --swc-button-content-color-hover: token("transparent-black-900");
   --swc-button-content-color-down: token("transparent-black-900");
   --swc-button-content-color-focus: token("transparent-black-900");
-}.swc-Button--staticBlack.swc-Button--outline {
+}
+
+.swc-Button--staticBlack.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -252,7 +300,9 @@
   --swc-button-background-color-disabled: token("transparent-black-25");
   --swc-button-border-color-disabled: token("disabled-static-black-border-color");
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
+}
+
+.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -261,28 +311,40 @@
   --swc-button-border-color-hover: token("transparent-black-400");
   --swc-button-border-color-down: token("transparent-black-400");
   --swc-button-border-color-focus: token("transparent-black-400");
-}.swc-Button--iconOnly {
+}
+
+.swc-Button--iconOnly {
   --swc-button-border-radius: token("corner-radius-full");
   --swc-button-gap: 0;
 
   padding-inline: calc(var(--swc-button-edge-to-visual-only, token("component-pill-edge-to-visual-only-100")) - var(--_swc-button-border-width));
-}.swc-Button--iconOnly .swc-Button-icon {
+}
+
+.swc-Button--iconOnly .swc-Button-icon {
   --swc-button-edge-to-visual: 0;
 
   align-self: center;
-}.swc-Button--truncate .swc-Button-label {
+}
+
+.swc-Button--truncate .swc-Button-label {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}.swc-Button--justified {
+}
+
+.swc-Button--justified {
   flex-grow: 1;
   justify-self: stretch;
   inline-size: 100%;
-}@media (prefers-reduced-motion: reduce) {
+}
+
+@media (prefers-reduced-motion: reduce) {
   .swc-Button {
     transition-duration: 0ms;
   }
 }
-}.swc-Button {
+}
+
+.swc-Button {
 all: revert-layer !important;
 }

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -16,80 +16,64 @@
 
 @layer swc-global-elements {.swc-Button, .swc-Button * {
   box-sizing: border-box;
-}
-
-.swc-Button {
+}.swc-Button {
   -webkit-tap-highlight-color: transparent;
   display: inline-flex;
   position: relative;
-  gap: var(--swc-button-gap, token("text-to-visual-100"));
   align-items: center;
   justify-content: center;
+  margin: 0;
+  text-transform: none;
+  text-decoration: none;
+  border-style: solid;
+  overflow: visible;
+  user-select: none;
+  --_swc-button-border-width: token("border-width-200");
+  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
+
+  gap: var(--swc-button-gap, token("text-to-visual-100"));
   max-inline-size: var(--swc-button-max-inline-size, inherit);
   min-block-size: var(--_swc-button-min-block-size);
   padding-block: calc(var(--swc-button-padding-vertical, token("component-padding-vertical-100")) - var(--_swc-button-border-width));
   padding-inline: calc(var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")) - var(--_swc-button-border-width));
-  margin: 0;
   font-family: token("sans-serif-font");
   font-size: var(--swc-button-font-size, token("font-size-100"));
   font-weight: token("bold-font-weight");
   line-height: round(down, calc(token("line-height-100") * 1em), 1px);
   color: var(--swc-button-content-color-default, token("gray-25"));
-  text-transform: none;
-  text-decoration: none;
   background-color: var(--swc-button-background-color-default, token("neutral-background-color-default"));
   border-color: var(--swc-button-border-color-default, transparent);
-  border-style: solid;
   border-width: var(--_swc-button-border-width);
   border-radius: var(--swc-button-border-radius, calc(var(--_swc-button-min-block-size) / 2));
-  overflow: visible;
-  user-select: none;
   transition-timing-function: token("animation-ease-in-out");
   transition-duration: token("animation-duration-100");
   transition-property: outline, border-color, color, background-color, transform;
-
-  --_swc-button-border-width: token("border-width-200");
-  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
-}
-
-.swc-Button:focus-visible {
+}.swc-Button:focus-visible {
+  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
+  outline-offset: token("focus-indicator-gap");
   color: var(--swc-button-content-color-focus, token("gray-25"));
   background-color: var(--swc-button-background-color-focus, token("neutral-background-color-key-focus"));
   border-color: var(--swc-button-border-color-focus, transparent);
-  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
-  outline-offset: token("focus-indicator-gap");
-}
-
-.swc-Button:disabled:is(*, :hover) {
+}.swc-Button:disabled:is(*, :hover) {
   color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
   background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
   border-color: var(--swc-button-border-color-disabled, transparent);
   transform: none;
-}
-
-.swc-Button:hover {
+}.swc-Button:hover {
   color: var(--swc-button-content-color-hover, token("gray-25"));
   background-color: var(--swc-button-background-color-hover, token("neutral-background-color-hover"));
   border-color: var(--swc-button-border-color-hover, transparent);
-}
-
-.swc-Button:active {
+}.swc-Button:active {
   color: var(--swc-button-content-color-down, token("gray-25"));
   background-color: var(--swc-button-background-color-down, token("neutral-background-color-down"));
   border-color: var(--swc-button-border-color-down, transparent);
   transform: var(--swc-button-down-state-transform, perspective(var(--_swc-button-min-block-size)) translate3d(0, 0, token("component-size-difference-down")));
   will-change: transform;
-}
-
-.swc-Button-label {
+}.swc-Button-label {
   text-align: center;
-}
-
-.swc-Button--hasIcon .swc-Button-label {
+}.swc-Button--hasIcon .swc-Button-label {
   text-align: start;
-}
-
-.swc-Button-icon,
+}.swc-Button-icon,
 .swc-Button-pendingSpinner {
   --_swc-button-icon-size: var(--swc-button-icon-size, token("workflow-icon-size-100"));
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
@@ -100,14 +84,10 @@
   block-size: var(--_swc-button-icon-block-size);
   margin-block: calc((var(--_swc-button-icon-block-size) - 1lh) / 2 * -1);
   margin-inline-start: calc(var(--swc-button-edge-to-visual, token("component-pill-edge-to-visual-100")) - var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")));
-}
-
-.swc-Button-icon {
+}.swc-Button-icon {
   color: inherit;
   fill: currentcolor;
-}
-
-.swc-Button--sizeS {
+}.swc-Button--sizeS {
   --swc-button-min-block-size: token("component-height-75");
   --swc-button-font-size: token("font-size-75");
   --swc-button-gap: token("text-to-visual-75");
@@ -116,9 +96,7 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-75");
   --swc-button-padding-vertical: token("component-padding-vertical-75");
   --swc-button-icon-size: token("workflow-icon-size-75");
-}
-
-.swc-Button--sizeL {
+}.swc-Button--sizeL {
   --swc-button-min-block-size: token("component-height-200");
   --swc-button-font-size: token("font-size-200");
   --swc-button-gap: token("text-to-visual-200");
@@ -127,9 +105,7 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-200");
   --swc-button-padding-vertical: token("component-padding-vertical-200");
   --swc-button-icon-size: token("workflow-icon-size-200");
-}
-
-.swc-Button--sizeXl {
+}.swc-Button--sizeXl {
   --swc-button-min-block-size: token("component-height-300");
   --swc-button-font-size: token("font-size-300");
   --swc-button-gap: token("text-to-visual-300");
@@ -138,9 +114,7 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-300");
   --swc-button-padding-vertical: token("component-padding-vertical-300");
   --swc-button-icon-size: token("workflow-icon-size-300");
-}
-
-.swc-Button--accent {
+}.swc-Button--accent {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -149,9 +123,7 @@
   --swc-button-background-color-hover: token("accent-background-color-hover");
   --swc-button-background-color-down: token("accent-background-color-down");
   --swc-button-background-color-focus: token("accent-background-color-key-focus");
-}
-
-.swc-Button--negative {
+}.swc-Button--negative {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -160,9 +132,7 @@
   --swc-button-background-color-hover: token("negative-background-color-hover");
   --swc-button-background-color-down: token("negative-background-color-down");
   --swc-button-background-color-focus: token("negative-background-color-key-focus");
-}
-
-.swc-Button--secondary {
+}.swc-Button--secondary {
   --swc-button-content-color-default: token("neutral-content-color-default");
   --swc-button-content-color-hover: token("neutral-content-color-hover");
   --swc-button-content-color-down: token("neutral-content-color-down");
@@ -171,9 +141,7 @@
   --swc-button-background-color-hover: token("gray-200");
   --swc-button-background-color-down: token("gray-200");
   --swc-button-background-color-focus: token("gray-200");
-}
-
-.swc-Button--primary.swc-Button--outline {
+}.swc-Button--primary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -188,9 +156,7 @@
   --swc-button-content-color-focus: token("neutral-content-color-key-focus");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}
-
-.swc-Button--secondary.swc-Button--outline {
+}.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -201,9 +167,7 @@
   --swc-button-border-color-focus: token("gray-400");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}
-
-.swc-Button--staticWhite {
+}.swc-Button--staticWhite {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-white-800");
   --swc-button-background-color-hover: token("transparent-white-900");
@@ -216,9 +180,7 @@
   --swc-button-background-color-disabled: token("disabled-static-white-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}
-
-.swc-Button--staticWhite.swc-Button--secondary {
+}.swc-Button--staticWhite.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-white-100");
   --swc-button-background-color-hover: token("transparent-white-200");
   --swc-button-background-color-down: token("transparent-white-200");
@@ -227,9 +189,7 @@
   --swc-button-content-color-hover: token("transparent-white-900");
   --swc-button-content-color-down: token("transparent-white-900");
   --swc-button-content-color-focus: token("transparent-white-900");
-}
-
-.swc-Button--staticWhite.swc-Button--outline {
+}.swc-Button--staticWhite.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -245,9 +205,7 @@
   --swc-button-background-color-disabled: token("transparent-white-25");
   --swc-button-border-color-disabled: token("disabled-static-white-border-color");
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}
-
-.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
+}.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -256,9 +214,7 @@
   --swc-button-border-color-hover: token("transparent-white-400");
   --swc-button-border-color-down: token("transparent-white-400");
   --swc-button-border-color-focus: token("transparent-white-400");
-}
-
-.swc-Button--staticBlack {
+}.swc-Button--staticBlack {
   --swc-button-focus-indicator-color: token("static-black-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-black-800");
   --swc-button-background-color-hover: token("transparent-black-900");
@@ -271,9 +227,7 @@
   --swc-button-background-color-disabled: token("disabled-static-black-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}
-
-.swc-Button--staticBlack.swc-Button--secondary {
+}.swc-Button--staticBlack.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-black-100");
   --swc-button-background-color-hover: token("transparent-black-200");
   --swc-button-background-color-down: token("transparent-black-200");
@@ -282,9 +236,7 @@
   --swc-button-content-color-hover: token("transparent-black-900");
   --swc-button-content-color-down: token("transparent-black-900");
   --swc-button-content-color-focus: token("transparent-black-900");
-}
-
-.swc-Button--staticBlack.swc-Button--outline {
+}.swc-Button--staticBlack.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -300,9 +252,7 @@
   --swc-button-background-color-disabled: token("transparent-black-25");
   --swc-button-border-color-disabled: token("disabled-static-black-border-color");
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}
-
-.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
+}.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -311,40 +261,28 @@
   --swc-button-border-color-hover: token("transparent-black-400");
   --swc-button-border-color-down: token("transparent-black-400");
   --swc-button-border-color-focus: token("transparent-black-400");
-}
-
-.swc-Button--iconOnly {
+}.swc-Button--iconOnly {
   --swc-button-border-radius: token("corner-radius-full");
   --swc-button-gap: 0;
 
   padding-inline: calc(var(--swc-button-edge-to-visual-only, token("component-pill-edge-to-visual-only-100")) - var(--_swc-button-border-width));
-}
-
-.swc-Button--iconOnly .swc-Button-icon {
+}.swc-Button--iconOnly .swc-Button-icon {
   --swc-button-edge-to-visual: 0;
 
   align-self: center;
-}
-
-.swc-Button--truncate .swc-Button-label {
+}.swc-Button--truncate .swc-Button-label {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.swc-Button--justified {
+}.swc-Button--justified {
   flex-grow: 1;
   justify-self: stretch;
   inline-size: 100%;
-}
-
-@media (prefers-reduced-motion: reduce) {
+}@media (prefers-reduced-motion: reduce) {
   .swc-Button {
     transition-duration: 0ms;
   }
 }
-}
-
-.swc-Button {
+}.swc-Button {
 all: revert-layer !important;
 }

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
@@ -244,7 +244,7 @@ Neither controller is available yet. The automatic trigger integration additive 
 | A8 | `cross-offset` | Offset along the cross axis (perpendicular to `offset`). React default: 0. Blocked on `PlacementController` API. |
 | A9 | `should-flip` | Whether to reposition to the opposite side when space runs out. Floating UI `flip` middleware. React default: `true`. Default should also be `true` in `PlacementController`; expose as a consumer attribute if override need is confirmed. |
 | A10 | `--swc-*` CSS custom properties | No `--swc-*` custom properties initially. A small reviewed set may be added if consumer override needs emerge. |
-| A11 | `labeling` attribute — `aria-labelledby` wiring | The base ARIA wiring (A4 in must-ship) always uses `ariaDescribedByElements`. When `labeling` is set, the SWC layer uses `ariaLabelledByElements` instead — for icon-only triggers where the tooltip text is the sole accessible name and adding `accessible-label` directly to the trigger is not possible. `role="tooltip"` is retained. Works in automatic and manual modes. |
+| ~~A11~~ | ~~`labeling` attribute — `aria-labelledby` wiring~~ | **Shipped.** Implemented in the initial release alongside the base ARIA wiring. `syncAriaRelationship()` branches on `this.labeling`: when set, uses `ariaLabelledByElements` instead of `ariaDescribedByElements` on the trigger's inner interactive element. Stale references in the opposite property are cleaned up on each sync. Re-syncs when `labeling` changes while the tooltip is open. |
 | A12 | Inner interactive element selector expansion | Initial implementation uses `querySelector('button')` as the convention for resolving the inner interactive element within a trigger's shadow root. Expand to support additional interactive elements (`<a>`, `<input>`, `<select>`, components using a different inner element) when confirmed by consumer needs. `button` covers the large majority of 2nd-gen button-like component cases; any expansion should be gated on confirmed need. |
 
 Full behavioral requirements for this feature are in the [HoverController interface requirements](#addendum-hovercontroller-interface-requirements) addendum.
@@ -274,7 +274,7 @@ Derived from the 1st-gen implementation, the rendering analysis, the accessibili
 | `disabled` | `boolean` | `false` | `disabled` | **Additive/deferred.** Automatic mode only; no-op when `manual` is set. Ships inactive until the additive phase. |
 | `manual` | `boolean` | `false` | `manual` | **Additive/deferred.** Suppresses `HoverController` and `PlacementController` wiring only. `for` and `trigger-element` are still resolved; ARIA wiring still fires on `open` change. Consumer manages open/close via the `open` property or the popover API directly. Ships in the API shape; effective in the additive phase. |
 | `offset` | `number` | `0` | `offset` | **Additive/deferred.** Passed to `PlacementController` offset middleware. Ships in API shape; effective in the additive phase. Note: React Spectrum defaults to `7`; the `PlacementController` default should align with React — confirm in the controller design before shipping. |
-| `labeling` | `boolean` | `false` | `labeling` | **Additive/deferred.** Changes ARIA wiring from `ariaDescribedByElements` to `ariaLabelledByElements` (see additive A11). For icon-only triggers where the tooltip text is the sole accessible name. Works in automatic and manual modes. Ships inactive until the additive phase. |
+| `labeling` | `boolean` | `false` | `labeling` | **Confirmed.** When set, `syncAriaRelationship()` wires `ariaLabelledByElements` on the trigger's inner interactive element instead of `ariaDescribedByElements`. For icon-only triggers where the tooltip text is the sole accessible name and adding an accessible label to the trigger host is not possible. Re-syncs when changed while the tooltip is open. |
 
 #### Visual matrix (2nd-gen)
 
@@ -379,7 +379,7 @@ Modes 1 and 2 use automatic hover/focus trigger wiring and require `HoverControl
 <swc-tooltip for="save-btn" placement="top">Save changes</swc-tooltip>
 
 
-<!-- ── Mode 1: Automatic — icon-only trigger, labeling attribute (additive)
+<!-- ── Mode 1: Automatic — icon-only trigger, labeling attribute
      When the trigger host cannot have an accessible name added: the labeling
      attribute switches the SWC layer to set ariaLabelledByElements on the
      inner button instead of ariaDescribedByElements.                         -->
@@ -459,7 +459,7 @@ Both paths apply whether the trigger was resolved via `for` or an explicit `trig
 Two resolution paths, in order of preference:
 
 1. **Add an accessible name to the trigger host.** On native elements, use `aria-label`. On 2nd-gen SWC components, use the `accessible-label` attribute — it propagates to the inner button's accessible name computation. This works before controllers land and does not require the `labeling` attribute on the tooltip.
-2. **Set `labeling` on the tooltip** when the trigger host cannot be modified. The SWC layer then sets `ariaLabelledByElements = [tooltipHost]` on the inner button instead of `ariaDescribedByElements` (additive phase, A11).
+2. **Set `labeling` on the tooltip** when the trigger host cannot be modified. The SWC layer sets `ariaLabelledByElements = [tooltipHost]` on the inner button instead of `ariaDescribedByElements`. Active from the initial release.
 
 `role="tooltip"` is retained when `labeling` is set. Suppressing it conditionally adds complexity for marginal semantic gain. Document both paths in the Accessibility story.
 
@@ -663,7 +663,7 @@ The impact is most acute in the additive phase, when `HoverController` will call
 - [ ] Automatic mode: default warm-up/cooldown (1500ms, matching `delay` default); `delay="0"` shows immediately; custom value uses that duration **(additive phase)**
 - [ ] Automatic mode: `for` resolves correctly when trigger and tooltip share a shadow root (ID lookup scoped to that root) — rewrite fresh; do not port the 1st-gen `self manages through a shadow boundary` test, which validates ancestor-walking and does not apply **(additive phase)**
 - [ ] `manual` attribute: controller wiring is skipped when added; consumer-driven `open` changes dispatch all `swc-*` events and ARIA wiring still fires when `for` is set **(additive phase — verify controller suppression)**
-- [ ] `labeling` attribute: `ariaLabelledByElements` is set on the inner interactive element instead of `ariaDescribedByElements`; verify correct AT announcement for icon-only button pattern **(additive phase)**
+- [x] `labeling` attribute: `ariaLabelledByElements` is set on the inner interactive element instead of `ariaDescribedByElements`; stale references in the opposite property are cleaned up; re-syncs when `labeling` changes while open
 - [ ] `ariaDescribedByElements` wiring: verify AT can traverse the association in DevTools Accessibility panel and with NVDA/VoiceOver
 - [ ] `ariaDescribedByElements` wiring fallback: when trigger has no shadow root (native `<button>`, `<a>`, `<input>`), association is established on the host element directly
 - [ ] `disabled` attribute prevents automatic mode response to user input **(additive phase)**
@@ -705,7 +705,7 @@ The impact is most acute in the additive phase, when `HoverController` will call
 - [ ] Variant colors are supplementary: pair each variant with readable text; meaning must not rely on color alone (WCAG 1.4.1)
 - [ ] Touch guidance: tooltip is hover/focus only; direct consumers to `swc-popover` or contextual help for explicit disclosure on touch devices
 - [ ] No auto-dismiss timer: tooltip must remain visible until the user dismisses it or the triggering state becomes invalid (WCAG 1.4.13)
-- [ ] Icon-only trigger pattern: document in Accessibility story that (1) adding an accessible name directly to the trigger host (`aria-label` on native elements; `accessible-label` attribute on 2nd-gen SWC components) is preferred and works from the initial release; (2) the `labeling` attribute switches the SWC layer to wire `aria-labelledby` for cases where the trigger host cannot be modified (additive phase); (3) explain the semantic difference between labeling (accessible name) and describing (supplementary hint)
+- [ ] Icon-only trigger pattern: document in Accessibility story that (1) adding an accessible name directly to the trigger host (`aria-label` on native elements; `accessible-label` attribute on 2nd-gen SWC components) is preferred and works from the initial release; (2) the `labeling` attribute switches the SWC layer to wire `aria-labelledby` for cases where the trigger host cannot be modified — active from the initial release; (3) explain the semantic difference between labeling (accessible name) and describing (supplementary hint)
 - [ ] Verify 200% zoom: tooltip does not obscure critical UI
 
 ### Review

--- a/CONTRIBUTOR-DOCS/03_project-planning/README.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/README.md
@@ -77,8 +77,6 @@
 - [Milestones](04_milestones/README.md)
 - Strategies
     - [Focus Management Strategy: 2nd-Gen Proposal](05_strategies/focus-management-strategy-rfc.md)
-- Initiatives
-    - Decisions
 
 </details>
 

--- a/CONTRIBUTOR-DOCS/README.md
+++ b/CONTRIBUTOR-DOCS/README.md
@@ -43,7 +43,6 @@
     - [Components](03_project-planning/03_components/README.md)
     - [Milestones](03_project-planning/04_milestones/README.md)
     - Strategies
-    - Initiatives
 
 </details>
 


### PR DESCRIPTION
## Description

Adds Phase 6 (migration testing) and the post-Phase-6 code conformance pass for `swc-tooltip`.

**Testing (SWC-2024)**

Adds two test files:

- `tooltip.test.ts` — Storybook play-function tests using Vitest and `@storybook/test`. Covers defaults, property/attribute mutation, open/close state, lifecycle events (`swc-open`, `swc-close`, `swc-after-open`, `swc-after-close`), ARIA `ariaDescribedByElements` wiring for native triggers, `swc-button` shadow triggers, `triggerElement` overrides, standalone (no trigger), and manual mode. Also covers Escape key dismissal, all variants, all placements, and the dev-mode warning for an unresolved `for` attribute.
- `tooltip.a11y.spec.ts` — Playwright ARIA snapshot tests. Validates that a closed tooltip is hidden from the accessibility tree, that an open tooltip exposes `role="tooltip"`, that it is removed from the tree when closed, that Escape closes it, and that variant and placement trigger buttons are reachable.

**Conformance pass (SWC-2025)**

- `Tooltip.ts` — Added `@fires` JSDoc tags for all four lifecycle events.
- `tooltip.css` — Added explanatory comment for `!important` on `::slotted()` resets.
- `tooltip.stories.ts` — Section separator renamed from "METADATA SETUP" to "METADATA"
- `tooltip.test.ts` — Restructured from ad-hoc section headers to the 5 prescribed standard sections; step labels updated to start with verbs; `EscapeClosesTest` moved to the Variants / States section; section renamed from "Debug warnings" to "Dev mode warnings".

## Motivation and context

Phase 6 of the 2nd-gen tooltip migration. Tests validate the full public API surface defined in Phase 3 and the accessibility wiring implemented in Phase 4. The conformance pass ensures all files align with project style guides before Phase 7 (documentation) begins.

## Related issue(s)

- SWC-2024
- SWC-2025

## Manual review test cases

- [ ] Play-function tests pass in the Storybook test runner
  1. Run `yarn test:storybook` (or equivalent) scoped to the tooltip component
  2. Confirm all stories under `Tooltip/Tests` show green in the test results panel
  3. Confirm no regressions in any other component's test stories

- [ ] Playwright a11y tests pass
  1. Run `yarn test:a11y` scoped to tooltip
  2. Confirm all six tests in `tooltip.a11y.spec.ts` pass
  3. Confirm ARIA snapshots match expected output

- [ ] Conformance-only changes produce no behavioral regressions
  1. Open `Tooltip` → `Overview` in Storybook
  2. Click the trigger button; confirm the tooltip opens and closes as expected
  3. Open `Tooltip` → `Variants` and `Tooltip` → `Placements`; confirm all variants and placements render correctly
