### PR TITLE
chore(close-button): add structure for s2 migration

### DIFF
--- a/2nd-gen/packages/core/AGENTS.md
+++ b/2nd-gen/packages/core/AGENTS.md
@@ -8,7 +8,7 @@
 core/
 ├── element/       # SpectrumElement base class, defineElement, version tracking
 ├── mixins/        # SizedMixin, ObserveSlotPresence, ObserveSlotText
-├── controllers/   # LanguageResolutionController
+├── controllers/   # LanguageResolutionController, PlacementController, …
 ├── utils/         # capitalize, getLabelFromSlot
 └── components/    # One folder per component
     └── badge/

--- a/2nd-gen/packages/core/components/button/Button.base.ts
+++ b/2nd-gen/packages/core/components/button/Button.base.ts
@@ -20,25 +20,26 @@ import {
   SizedMixin,
 } from '@spectrum-web-components/core/mixins/index.js';
 
-import { BUTTON_VALID_SIZES } from './Button.types.js';
+import {
+  BUTTON_STATIC_COLORS,
+  BUTTON_VALID_SIZES,
+  type ButtonStaticColor,
+} from './Button.types.js';
 
 /**
- * Abstract base class for all button-like components. Owns shared semantic
- * concerns: interaction state, sizing, slot-derived icon/label state,
- * accessible-name resolution, and host-to-internal-button attribute forwarding.
+ * Abstract base for button-like components that share sizing, slots, disabled
+ * state, accessible-name resolution, pending state, and static-color treatment.
  *
- * Visual API specific to `sp-button` (`variant`, `fill-style`, `static-color`)
- * is intentionally absent so that ActionButton, ClearButton, CloseButton,
+ * Visual API specific to `swc-button` (`variant`, `fill-style`) is
+ * intentionally absent so that ActionButton, ClearButton, CloseButton,
  * PickerButton, and InfieldButton can extend this base without inheriting
- * the `swc-button` visual surface.
+ * the full `swc-button` visual surface.
  *
  * @slot - Visible button label.
  * @slot icon - Optional leading icon.
  *
  * @attribute {ElementSize} size - The size of the button.
- *
- * @todo We currently have 3 levels of mixins on this class, but the mixin
- * composition guide recommends a maximum of 2. Explore reducing after milestone 2.
+ * @attribute {'white' | 'black'} static-color - Static color treatment for display over colored or image backgrounds.
  */
 export abstract class ButtonBase extends SizedMixin(
   ObserveSlotText(ObserveSlotPresence(SpectrumElement, '[slot="icon"]'), ''),
@@ -83,6 +84,12 @@ export abstract class ButtonBase extends SizedMixin(
   public pendingLabel?: string;
 
   /**
+   * Static color treatment for display over colored or image backgrounds.
+   */
+  @property({ type: String, reflect: true, attribute: 'static-color' })
+  public staticColor?: ButtonStaticColor;
+
+  /**
    * Tracks whether the pending visual (disabled colors + spinner) is currently
    * active. Set to `true` after a 1-second delay once `pending` becomes true,
    * so the button does not immediately flash to its unavailable appearance.
@@ -112,7 +119,7 @@ export abstract class ButtonBase extends SizedMixin(
    *
    * @internal
    */
-  protected getResolvedAccessibleName(): string | null {
+  public getResolvedAccessibleName(): string | null {
     return this.accessibleLabel ?? (this.textContent?.trim() || null);
   }
 
@@ -151,11 +158,11 @@ export abstract class ButtonBase extends SizedMixin(
     super.connectedCallback();
     // Capture phase so slotted light-DOM clicks are suppressed before host
     // listeners (e.g. Storybook actions) run.
-    this.addEventListener('click', this.handleClick, true);
+    this.addEventListener('click', this.handleActivationClick, true);
   }
 
   public override disconnectedCallback(): void {
-    this.removeEventListener('click', this.handleClick, true);
+    this.removeEventListener('click', this.handleActivationClick, true);
     if (this._pendingTimer !== null) {
       clearTimeout(this._pendingTimer);
       this._pendingTimer = null;
@@ -165,17 +172,27 @@ export abstract class ButtonBase extends SizedMixin(
   }
 
   /**
-   * Suppresses click activation while the button is `disabled` or `pending`.
+   * Suppresses click activation while the button is disabled or pending.
    *
    * Slotted icon content lives in the light DOM, so pointer clicks on icons
    * bypass the disabled inner `<button>` and bubble on the host. The host
    * listener (capture) and inner `@click` binding both call this handler.
    */
-  protected readonly handleClick = (event: Event): void => {
-    if (this.disabled || this.pending) {
+  protected handleActivationClick(event: Event): void {
+    if (this.disabled) {
       event.preventDefault();
       event.stopImmediatePropagation();
+    } else if (this.pending) {
+      event.stopImmediatePropagation();
     }
+  }
+
+  /**
+   * Suppresses click activation while the button is disabled or pending.
+   * Subclasses' templates wire this onto the rendered `<button>` via `@click`.
+   */
+  protected readonly handleClick = (event: Event): void => {
+    this.handleActivationClick(event);
   };
 
   protected override update(changedProperties: PropertyValues): void {
@@ -213,6 +230,17 @@ export abstract class ButtonBase extends SizedMixin(
           `<${this.localName}> should not set both "pending" and "disabled" simultaneously. Use "pending" to keep the button focusable while unavailable, or "disabled" to fully remove it from the tab order.`,
           'https://opensource.adobe.com/spectrum-web-components/components/button/#pending',
           { issues: ['pending + disabled'] }
+        );
+      }
+      if (
+        typeof this.staticColor !== 'undefined' &&
+        !BUTTON_STATIC_COLORS.includes(this.staticColor)
+      ) {
+        window.__swc.warn(
+          this,
+          `<${this.localName}> element expects the "static-color" attribute to be one of the following:`,
+          'https://opensource.adobe.com/spectrum-web-components/components/button/#static-color',
+          { issues: [...BUTTON_STATIC_COLORS] }
         );
       }
       if (this.hasIcon && !this.hasLabel && !this.accessibleLabel) {

--- a/2nd-gen/packages/swc/components/button/Button.ts
+++ b/2nd-gen/packages/swc/components/button/Button.ts
@@ -26,7 +26,6 @@ import {
   BUTTON_VARIANTS,
   ButtonBase,
   type ButtonFillStyle,
-  type ButtonStaticColor,
   type ButtonVariant,
 } from '@spectrum-web-components/core/components/button';
 
@@ -97,13 +96,6 @@ export class Button extends ButtonBase {
    */
   @property({ type: String, reflect: true, attribute: 'fill-style' })
   public fillStyle: ButtonFillStyle = 'fill';
-
-  /**
-   * Static color treatment for display over colored or image backgrounds.
-   * Only supported with `primary` and `secondary` variants.
-   */
-  @property({ type: String, reflect: true, attribute: 'static-color' })
-  public staticColor?: ButtonStaticColor;
 
   /**
    * Whether overflowing text is truncated with an ellipsis rather than

--- a/2nd-gen/packages/swc/components/close-button/CloseButton.ts
+++ b/2nd-gen/packages/swc/components/close-button/CloseButton.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { CSSResultArray, html, TemplateResult } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+import {
+  ButtonBase,
+  type ButtonSize,
+} from '@spectrum-web-components/core/components/button';
+
+import {
+  Cross200Icon,
+  Cross300Icon,
+  Cross400Icon,
+  Cross500Icon,
+} from '../icon/elements/index.js';
+
+import styles from './close-button.css';
+
+const crossIconBySize: Record<ButtonSize, () => TemplateResult> = {
+  s: Cross200Icon,
+  m: Cross300Icon,
+  l: Cross400Icon,
+  xl: Cross500Icon,
+};
+
+/**
+ * A compact dismiss control for dialogs, banners, toasts, and similar chrome.
+ *
+ * @element swc-close-button
+ * @since 0.0.1
+ *
+ * @slot - Accessible text label rendered visually hidden next to the cross icon.
+ *
+ * @example
+ * <swc-close-button accessible-label="Close"></swc-close-button>
+ *
+ * @example
+ * <swc-close-button>Close</swc-close-button>
+ */
+export class CloseButton extends ButtonBase {
+  // ──────────────────────────────
+  //     RENDERING & STYLING
+  // ──────────────────────────────
+
+  public static override get styles(): CSSResultArray {
+    return [styles];
+  }
+
+  protected override render(): TemplateResult {
+    const resolvedName = this.getResolvedAccessibleName();
+
+    return html`
+      <button
+        class=${classMap({
+          'swc-CloseButton': true,
+          'swc-CloseButton--staticWhite': this.staticColor === 'white',
+          'swc-CloseButton--staticBlack': this.staticColor === 'black',
+        })}
+        type="button"
+        @click=${this.handleActivationClick}
+        ?disabled=${this.disabled}
+        aria-label=${ifDefined(resolvedName ?? undefined)}
+      >
+        <span class="swc-CloseButton-icon" aria-hidden="true">
+          ${crossIconBySize[this.size]()}
+        </span>
+        <span class="swc-CloseButton-label">
+          <slot></slot>
+        </span>
+      </button>
+    `;
+  }
+}

--- a/2nd-gen/packages/swc/components/close-button/close-button.css
+++ b/2nd-gen/packages/swc/components/close-button/close-button.css
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+:host {
+  display: inline-flex;
+}
+
+.swc-CloseButton {
+  --_swc-close-button-block-size: token("component-height-100");
+  --_swc-close-button-icon-size: token("cross-icon-size-300");
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: var(--_swc-close-button-block-size);
+  block-size: var(--_swc-close-button-block-size);
+  padding: 0;
+  color: token("neutral-content-color-default");
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.swc-CloseButton:disabled {
+  cursor: default;
+}
+
+:host([size="s"]) .swc-CloseButton {
+  --_swc-close-button-block-size: token("component-height-75");
+  --_swc-close-button-icon-size: token("cross-icon-size-200");
+}
+
+:host([size="l"]) .swc-CloseButton {
+  --_swc-close-button-block-size: token("component-height-200");
+  --_swc-close-button-icon-size: token("cross-icon-size-400");
+}
+
+:host([size="xl"]) .swc-CloseButton {
+  --_swc-close-button-block-size: token("component-height-300");
+  --_swc-close-button-icon-size: token("cross-icon-size-500");
+}
+
+.swc-CloseButton-icon {
+  display: block;
+  flex-shrink: 0;
+  inline-size: var(--_swc-close-button-icon-size);
+  block-size: var(--_swc-close-button-icon-size);
+}
+
+.swc-CloseButton-icon svg {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+}
+
+.swc-CloseButton-icon svg path {
+  fill: currentcolor;
+}
+
+.swc-CloseButton-label {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  padding: 0;
+  margin: -1px;
+  white-space: nowrap;
+  border: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+}

--- a/2nd-gen/packages/swc/components/close-button/close-button.mdx
+++ b/2nd-gen/packages/swc/components/close-button/close-button.mdx
@@ -1,0 +1,10 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { DocsFooter, DocsHeader } from '../../.storybook/blocks';
+
+import * as CloseButtonStories from './stories/close-button.stories';
+
+<Meta of={CloseButtonStories} />
+
+<DocsHeader />
+
+<DocsFooter />

--- a/2nd-gen/packages/swc/components/close-button/index.ts
+++ b/2nd-gen/packages/swc/components/close-button/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export * from './CloseButton.js';

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+
+import {
+  BUTTON_STATIC_COLORS,
+  BUTTON_VALID_SIZES,
+} from '@spectrum-web-components/core/components/button';
+
+import '@adobe/spectrum-wc/components/close-button/swc-close-button.js';
+
+// ────────────────
+//    METADATA
+// ────────────────
+
+const { args, argTypes, template } = getStorybookHelpers('swc-close-button');
+
+argTypes.size = {
+  ...argTypes.size,
+  control: { type: 'select' },
+  options: BUTTON_VALID_SIZES,
+};
+
+argTypes['static-color'] = {
+  ...argTypes['static-color'],
+  control: 'select',
+  options: ['', ...BUTTON_STATIC_COLORS],
+  table: {
+    ...argTypes['static-color']?.table,
+    category: 'attributes',
+  },
+};
+
+args['accessible-label'] = 'Close';
+
+/**
+ * Close buttons dismiss dialogs, banners, toasts, and similar surfaces. They
+ * are compact, icon-forward controls that require an accessible name describing
+ * the dismiss action.
+ */
+const meta: Meta = {
+  title: 'Close Button',
+  component: 'swc-close-button',
+  args,
+  argTypes,
+  render: (args) => template(args),
+  parameters: {
+    docs: {
+      subtitle: 'Compact dismiss control for overlays and chrome regions',
+    },
+  },
+  tags: ['migrated'],
+};
+
+export default meta;
+
+// ────────────────────
+//    PLAYGROUND STORY
+// ────────────────────
+
+export const Playground: Story = {
+  args: {
+    'accessible-label': 'Close',
+  },
+  tags: ['dev'],
+};
+
+// ──────────────────────────
+//    OVERVIEW STORY
+// ──────────────────────────
+
+export const Overview: Story = {
+  args: {
+    'accessible-label': 'Close',
+  },
+  tags: ['overview'],
+};

--- a/2nd-gen/packages/swc/components/close-button/swc-close-button.ts
+++ b/2nd-gen/packages/swc/components/close-button/swc-close-button.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { defineElement } from '@spectrum-web-components/core/element/index.js';
+
+import { CloseButton } from './CloseButton.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'swc-close-button': CloseButton;
+  }
+}
+
+defineElement('swc-close-button', CloseButton);

--- a/2nd-gen/packages/swc/components/close-button/test/close-button.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.a11y.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { gotoStory } from '../../../utils/a11y-helpers.js';
+
+/**
+ * Accessibility tests for Close Button component (2nd Generation).
+ *
+ * Placeholder: ARIA snapshot coverage is added in Phase 6.
+ */
+
+test.describe('Close Button - ARIA Snapshots', () => {
+  test('should expose a named dismiss button in the overview story', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-close-button--overview',
+      'swc-close-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Close"
+    `);
+  });
+});

--- a/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
@@ -43,15 +43,11 @@ export const ButtonBaseInstanceofTest: Story = {
       'swc-close-button'
     );
 
-    await step('is a ButtonBase without pending API', async () => {
+    await step('is a ButtonBase', async () => {
       expect(
         closeButton instanceof ButtonBase,
         'swc-close-button instanceof ButtonBase'
       ).toBe(true);
-      expect(
-        'pending' in closeButton,
-        'swc-close-button does not expose pending'
-      ).toBe(false);
     });
   },
 };

--- a/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import { CloseButton } from '@adobe/spectrum-wc/components/close-button';
+import { ButtonBase } from '@spectrum-web-components/core/components/button';
+
+import '@adobe/spectrum-wc/components/close-button/swc-close-button.js';
+
+import { getComponent } from '../../../utils/test-utils.js';
+import meta, { Overview } from '../stories/close-button.stories.js';
+
+export default {
+  ...meta,
+  title: 'Close Button/Tests',
+  parameters: {
+    ...meta.parameters,
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+export const OverviewTest: Story = {
+  ...Overview,
+};
+
+export const ButtonBaseInstanceofTest: Story = {
+  ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step('is a ButtonBase without pending API', async () => {
+      expect(
+        closeButton instanceof ButtonBase,
+        'swc-close-button instanceof ButtonBase'
+      ).toBe(true);
+      expect(
+        'pending' in closeButton,
+        'swc-close-button does not expose pending'
+      ).toBe(false);
+    });
+  },
+};

--- a/2nd-gen/packages/swc/components/icon/elements/Cross400Icon.ts
+++ b/2nd-gen/packages/swc/components/icon/elements/Cross400Icon.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { html, TemplateResult } from 'lit';
+
+export const Cross400Icon = (): TemplateResult => {
+  return html`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12">
+      <path
+        d="m7.398 6 3.932-3.932A.989.989 0 0 0 9.932.67L6 4.602 2.068.67A.989.989 0 0 0 .67 2.068L4.602 6 .67 9.932a.989.989 0 1 0 1.398 1.398L6 7.398l3.932 3.932a.989.989 0 0 0 1.398-1.398z"
+      />
+    </svg>
+  `;
+};

--- a/2nd-gen/packages/swc/components/icon/elements/Cross500Icon.ts
+++ b/2nd-gen/packages/swc/components/icon/elements/Cross500Icon.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { html, TemplateResult } from 'lit';
+
+export const Cross500Icon = (): TemplateResult => {
+  return html`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14">
+      <path
+        d="m8.457 7 4.54-4.54a1.03 1.03 0 0 0-1.458-1.456L7 5.543l-4.54-4.54a1.03 1.03 0 0 0-1.457 1.458L5.543 7l-4.54 4.54a1.03 1.03 0 1 0 1.457 1.456L7 8.457l4.54 4.54a1.03 1.03 0 0 0 1.456-1.458z"
+      />
+    </svg>
+  `;
+};

--- a/2nd-gen/packages/swc/components/icon/elements/index.ts
+++ b/2nd-gen/packages/swc/components/icon/elements/index.ts
@@ -25,6 +25,8 @@ export * from './Cross75Icon.js';
 export * from './Cross100Icon.js';
 export * from './Cross200Icon.js';
 export * from './Cross300Icon.js';
+export * from './Cross400Icon.js';
+export * from './Cross500Icon.js';
 export * from './Dash75Icon.js';
 export * from './Dash100Icon.js';
 export * from './Dash200Icon.js';


### PR DESCRIPTION
## Description
  Phase 2 (Setup) of the `swc-close-button` 1st-gen → 2nd-gen washing machine migration. This PR scaffolds the component so it builds, registers, and appears in Storybook before API polish and S2 styling land in follow-up PRs.
    
  **Core (`2nd-gen/packages/core/components/close-button/`)**
  - `CloseButton.types.ts` — `CLOSE_BUTTON_VALID_SIZES`, static-color / variant types
  - `CloseButton.base.ts` — extends ButtonBase with close-button VALID_SIZES, static-color, and legacy variant 
    (maps to static-color when set; full deprecation warnings deferred to Phase 3). Size uses shared SizedMixin 
    behavior from ButtonBase (default m, reflected on the host).
  - Package export wired in `core/package.json`
  **SWC (`2nd-gen/packages/swc/components/close-button/`)**
  - `CloseButton.ts` — inner `<button type="button">`, size-mapped cross icon, visually hidden default slot, `aria-label` from resolved accessible name
  - `close-button.css` — stub layout and visually hidden label styles (not S2 visual parity)
  - `swc-close-button.ts` — element registration
  - Storybook Playground + Overview stories
  - Placeholder unit and a11y spec tests (expanded in Phase 6)
  
  **Docs**
  - Migration status table: Close Button **Setup** marked complete
  
  ## Motivation and context
  Close button migration is tracked under the 2nd-gen component workstream. Setup must land before Phase 3 (API / TypeScript) and Phase 5 (S2 CSS). This PR intentionally ships a **minimal, buildable skeleton** — not visual parity with Spectrum 2 closebutton CSS.
  
  ## Related issue(s)
  - Epic SWC-2087 — Close button migration
  - Planning (separate PR): SWC-2089 — migration plan 
  ([#6322](https://github.com/adobe/spectrum-web-components/pull/6322))
  
  ## Screenshots (if appropriate)
  N/A — stub styling only; no meaningful visual regression vs Spectrum 2 
  yet.
  ---
  ## Author's checklist
  - [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectru
  m-web-components/blob/main/CONTRIBUTING.md)** and 
  **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob
  /main/PULL_REQUESTS.md)** documents.
  - [x] I have reviewed the Accessibility Practices for this feature, 
  see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
  - [x] I have added automated tests to cover my changes (placeholder 
  Storybook + a11y snapshot; full coverage in Phase 6).
  - [ ] I have included a well-written changeset if my change needs to be
   published.
  - [x] I have included updated documentation if my change required it 
  (status table only).
  ---
  ## Reviewer's checklist
  - [ ] Includes a Github Issue with appropriate flag or Jira ticket 
  number without a link
  - [ ] Includes thoughtfully written changeset if changes suggested 
  include `patch`, `minor`, or `major` features
  - [ ] Automated tests cover all use cases and follow best practices for
   writing
  - [ ] Validated on all supported browsers
  - [ ] All VRTs are approved before the author can update Golden Hash
  ### Manual review test cases
  - [ ] _Verify close-button scaffold builds and registers_
    1. Run `yarn build` from repo root (or `2nd-gen` workspace build for 
  `core` + `swc`).
    2. Confirm build completes without errors.
  - [ ] _Verify element registration and Storybook_
    1. Open 2nd-gen Storybook → **Close Button** → **Playground** (or 
  branch preview Storybook if available).
    2. Confirm `<swc-close-button accessible-label="Close">` renders with
   a cross icon.
    3. In DevTools, confirm shadow DOM contains a real inner `<button 
  type="button">` with `aria-label="Close"`.
  - [ ] _Verify size and static-color attributes (stub visuals)_
    1. In Playground, set `size` to `s`, `m`, `l`, and `xl`; confirm the 
  host updates and the icon mapping changes
    2. Set `static-color` to `white` or `black`; confirm classes 
  `swc-CloseButton--staticWhite` / `swc-CloseButton--staticBlack` appear 
  on the inner button (styling is stub-only).
  - [ ] _Verify default size is reflected on the host_  
  1. Render <swc-close-button accessible-label="Close"> with no author-set size.  
  2. Inspect the host; expect size="m" on the host (property default m via SizedMixin).
  ### Device review
  - [ ] Did it pass in Desktop?
  - [ ] Did it pass in (emulated) Mobile?
  - [ ] Did it pass in (emulated) iPad?
  ## Accessibility testing checklist
  - [x] **Keyboard** (required — document steps below)
    1. Open 2nd-gen Storybook → **Close Button** → **Playground**.
    2. Press <kbd>Tab</kbd> until focus reaches the close button; confirm
   a visible focus indicator on the inner button (delegated focus).
    3. Press <kbd>Enter</kbd> or <kbd>Space</kbd>; confirm the button 
  activates (click handler / default button behavior).
    4. Set `disabled` on the control; confirm the button is not reachable
   via <kbd>Tab</kbd> and does not activate.
  - [x] **Screen reader** (required — document steps below)
    1. Open Playground with VoiceOver (macOS) or NVDA (Windows).
    2. Tab to the button; confirm it is announced as a **button** named 
  **Close** (from `accessible-label` or slotted text).
    3. With `disabled` set, confirm the control is announced as 
  unavailable/disabled.