### PR TITLE
feat(close-button): phase 3–4 API and accessibility

### DIFF
--- a/2nd-gen/packages/swc/components/close-button/CloseButton.ts
+++ b/2nd-gen/packages/swc/components/close-button/CloseButton.ts
@@ -15,11 +15,8 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import {
-  BUTTON_STATIC_COLORS,
-  BUTTON_VALID_SIZES,
   ButtonBase,
   type ButtonSize,
-  type ButtonStaticColor,
 } from '@spectrum-web-components/core/components/button';
 
 import {
@@ -66,21 +63,6 @@ const crossIconBySize: Record<ButtonSize, () => TemplateResult> = {
  * ```
  */
 export class CloseButton extends ButtonBase {
-  /**
-   * @internal
-   *
-   * A readonly array of the valid size values for the close button.
-   */
-  static readonly VALID_SIZES: readonly ButtonSize[] = BUTTON_VALID_SIZES;
-
-  /**
-   * @internal
-   *
-   * A readonly array of the valid static color values for the close button.
-   */
-  static readonly STATIC_COLORS: readonly ButtonStaticColor[] =
-    BUTTON_STATIC_COLORS;
-
   /**
    * Close buttons always render a cross icon; treat as icon-present for
    * shared {@link ButtonBase} accessibility checks.

--- a/2nd-gen/packages/swc/components/close-button/CloseButton.ts
+++ b/2nd-gen/packages/swc/components/close-button/CloseButton.ts
@@ -15,8 +15,11 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import {
+  BUTTON_STATIC_COLORS,
+  BUTTON_VALID_SIZES,
   ButtonBase,
   type ButtonSize,
+  type ButtonStaticColor,
 } from '@spectrum-web-components/core/components/button';
 
 import {
@@ -38,18 +41,56 @@ const crossIconBySize: Record<ButtonSize, () => TemplateResult> = {
 /**
  * A compact dismiss control for dialogs, banners, toasts, and similar chrome.
  *
+ * Renders a native `<button type="button">` with delegated focus. Every
+ * instance needs a discernible name via `accessible-label` or default slot text.
+ * The cross icon is decorative (`aria-hidden="true"`).
+ *
  * @element swc-close-button
  * @since 0.0.1
  *
  * @slot - Accessible text label rendered visually hidden next to the cross icon.
  *
  * @example
+ * ```html
  * <swc-close-button accessible-label="Close"></swc-close-button>
+ * ```
  *
  * @example
+ * ```html
  * <swc-close-button>Close</swc-close-button>
+ * ```
+ *
+ * @example
+ * ```html
+ * <swc-close-button static-color="white" accessible-label="Close"></swc-close-button>
+ * ```
  */
 export class CloseButton extends ButtonBase {
+  /**
+   * @internal
+   *
+   * A readonly array of the valid size values for the close button.
+   */
+  static readonly VALID_SIZES: readonly ButtonSize[] = BUTTON_VALID_SIZES;
+
+  /**
+   * @internal
+   *
+   * A readonly array of the valid static color values for the close button.
+   */
+  static readonly STATIC_COLORS: readonly ButtonStaticColor[] =
+    BUTTON_STATIC_COLORS;
+
+  /**
+   * Close buttons always render a cross icon; treat as icon-present for
+   * shared {@link ButtonBase} accessibility checks.
+   *
+   * @internal
+   */
+  protected override get hasIcon(): boolean {
+    return true;
+  }
+
   // ──────────────────────────────
   //     RENDERING & STYLING
   // ──────────────────────────────

--- a/2nd-gen/packages/swc/components/close-button/close-button.mdx
+++ b/2nd-gen/packages/swc/components/close-button/close-button.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
 import { DocsFooter, DocsHeader } from '../../.storybook/blocks';
 
 import * as CloseButtonStories from './stories/close-button.stories';
@@ -6,5 +6,29 @@ import * as CloseButtonStories from './stories/close-button.stories';
 <Meta of={CloseButtonStories} />
 
 <DocsHeader />
+
+## Options
+
+### Sizes
+
+Close buttons use the same size scale as `swc-button`: `s`, `m`, `l`, and `xl`. Medium is the default.
+
+<Canvas of={CloseButtonStories.Sizes} />
+
+### Static colors
+
+Use `static-color="white"` or `static-color="black"` when the dismiss control sits on a colored or image background.
+
+<Canvas of={CloseButtonStories.StaticColors} />
+
+## States
+
+<Canvas of={CloseButtonStories.States} />
+
+## Accessibility
+
+Every close button needs a discernible name via `accessible-label` or default slot text. The cross icon is decorative.
+
+<Canvas of={CloseButtonStories.Accessibility} />
 
 <DocsFooter />

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -49,14 +49,6 @@ argTypes['static-color'] = {
   },
 };
 
-// Inherited from ButtonBase; not part of the close-button public API.
-for (const attribute of ['pending', 'pending-label'] as const) {
-  argTypes[attribute] = {
-    ...argTypes[attribute],
-    table: { disable: true },
-  };
-}
-
 args['accessible-label'] = 'Close';
 
 /**

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -14,7 +14,10 @@ import { html } from 'lit';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
-import { CloseButton } from '@adobe/spectrum-wc/components/close-button';
+import {
+  BUTTON_STATIC_COLORS,
+  BUTTON_VALID_SIZES,
+} from '@spectrum-web-components/core/components/button';
 
 import '@adobe/spectrum-wc/components/close-button/swc-close-button.js';
 
@@ -27,7 +30,7 @@ const { args, argTypes, template } = getStorybookHelpers('swc-close-button');
 argTypes.size = {
   ...argTypes.size,
   control: { type: 'select' },
-  options: CloseButton.VALID_SIZES,
+  options: BUTTON_VALID_SIZES,
   table: {
     category: 'attributes',
     defaultValue: {
@@ -39,7 +42,7 @@ argTypes.size = {
 argTypes['static-color'] = {
   ...argTypes['static-color'],
   control: 'select',
-  options: ['', ...CloseButton.STATIC_COLORS],
+  options: ['', ...BUTTON_STATIC_COLORS],
   table: {
     ...argTypes['static-color']?.table,
     category: 'attributes',
@@ -106,7 +109,7 @@ export const Overview: Story = {
 export const Sizes: Story = {
   render: (args) => html`
     <div style="display: flex; align-items: center; gap: 16px;">
-      ${CloseButton.VALID_SIZES.map(
+      ${BUTTON_VALID_SIZES.map(
         (size) => html`
           ${template({
             ...args,

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -178,7 +178,7 @@ export const Accessibility: Story = {
           <code>accessible-label</code>
           is omitted.
         </p>
-        <swc-close-button size=${args.size}>Dismiss</swc-close-button>
+        ${template({ ...args, 'accessible-label': undefined }, 'Dismiss')}
       </section>
 
       <section

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -10,13 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
+import { html } from 'lit';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
-import {
-  BUTTON_STATIC_COLORS,
-  BUTTON_VALID_SIZES,
-} from '@spectrum-web-components/core/components/button';
+import { CloseButton } from '@adobe/spectrum-wc/components/close-button';
 
 import '@adobe/spectrum-wc/components/close-button/swc-close-button.js';
 
@@ -29,18 +27,32 @@ const { args, argTypes, template } = getStorybookHelpers('swc-close-button');
 argTypes.size = {
   ...argTypes.size,
   control: { type: 'select' },
-  options: BUTTON_VALID_SIZES,
+  options: CloseButton.VALID_SIZES,
+  table: {
+    category: 'attributes',
+    defaultValue: {
+      summary: 'm',
+    },
+  },
 };
 
 argTypes['static-color'] = {
   ...argTypes['static-color'],
   control: 'select',
-  options: ['', ...BUTTON_STATIC_COLORS],
+  options: ['', ...CloseButton.STATIC_COLORS],
   table: {
     ...argTypes['static-color']?.table,
     category: 'attributes',
   },
 };
+
+// Inherited from ButtonBase; not part of the close-button public API.
+for (const attribute of ['pending', 'pending-label'] as const) {
+  argTypes[attribute] = {
+    ...argTypes[attribute],
+    table: { disable: true },
+  };
+}
 
 args['accessible-label'] = 'Close';
 
@@ -85,4 +97,127 @@ export const Overview: Story = {
     'accessible-label': 'Close',
   },
   tags: ['overview'],
+};
+
+// ──────────────────────────
+//    OPTIONS STORIES
+// ──────────────────────────
+
+export const Sizes: Story = {
+  render: (args) => html`
+    <div style="display: flex; align-items: center; gap: 16px;">
+      ${CloseButton.VALID_SIZES.map(
+        (size) => html`
+          ${template({
+            ...args,
+            size,
+            'accessible-label': `Close (${size})`,
+          })}
+        `
+      )}
+    </div>
+  `,
+  tags: ['options'],
+};
+
+export const StaticColors: Story = {
+  render: (args) => html`
+    <div
+      style="display: flex; align-items: center; gap: 16px; padding: 16px; background: var(--spectrum-gray-800, #222);"
+    >
+      ${template({ ...args, 'accessible-label': 'Close (default)' })}
+      ${template({
+        ...args,
+        'static-color': 'white',
+        'accessible-label': 'Close (white)',
+      })}
+      ${template({
+        ...args,
+        'static-color': 'black',
+        'accessible-label': 'Close (black)',
+      })}
+    </div>
+  `,
+  tags: ['options'],
+};
+
+// ──────────────────────────
+//    STATES STORIES
+// ──────────────────────────
+
+export const States: Story = {
+  render: (args) => html`
+    <div style="display: flex; align-items: center; gap: 16px;">
+      ${template({ ...args, 'accessible-label': 'Close' })}
+      ${template({ ...args, disabled: true, 'accessible-label': 'Close' })}
+    </div>
+  `,
+  tags: ['states'],
+};
+
+// ────────────────────────────────
+//    ACCESSIBILITY STORIES
+// ────────────────────────────────
+
+export const Accessibility: Story = {
+  render: (args) => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 24px; max-inline-size: 28rem;"
+    >
+      <section>
+        <h4 style="margin: 0 0 8px;">Icon-only with accessible-label</h4>
+        <p style="margin: 0 0 12px;">
+          The cross icon is decorative (
+          <code>aria-hidden</code>
+          ). The name comes from
+          <code>accessible-label</code>
+          on the host.
+        </p>
+        ${template({ ...args, 'accessible-label': 'Close' })}
+      </section>
+
+      <section>
+        <h4 style="margin: 0 0 8px;">Visible slot label</h4>
+        <p style="margin: 0 0 12px;">
+          Slotted text is visually hidden but exposed as the button name when
+          <code>accessible-label</code>
+          is omitted.
+        </p>
+        <swc-close-button size=${args.size}>Dismiss</swc-close-button>
+      </section>
+
+      <section
+        style="padding: 16px; border: 1px solid var(--spectrum-gray-300, #ccc); border-radius: 4px;"
+      >
+        <div
+          style="display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;"
+        >
+          <div>
+            <h4 style="margin: 0 0 4px;">Dialog title</h4>
+            <p style="margin: 0;">
+              Use a dismiss name that matches the action (for example
+              &quot;Close&quot;), not a clear/reset verb.
+            </p>
+          </div>
+          ${template({
+            ...args,
+            'accessible-label': 'Close dialog',
+          })}
+        </div>
+      </section>
+
+      <section>
+        <h4 style="margin: 0 0 8px;">Disabled</h4>
+        ${template({
+          ...args,
+          disabled: true,
+          'accessible-label': 'Close',
+        })}
+      </section>
+    </div>
+  `,
+  parameters: {
+    flexLayout: 'column-stretch',
+  },
+  tags: ['a11y'],
 };

--- a/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
@@ -17,6 +17,7 @@ import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { CloseButton } from '@adobe/spectrum-wc/components/close-button';
 import {
   BUTTON_STATIC_COLORS,
+  BUTTON_VALID_SIZES,
   ButtonBase,
 } from '@spectrum-web-components/core/components/button';
 
@@ -333,7 +334,7 @@ export const SizesStoryTest: Story = {
     await step('renders all size variants', async () => {
       const closeButtons = canvasElement.querySelectorAll('swc-close-button');
       expect(closeButtons.length, 'one close button per size variant').toBe(
-        CloseButton.VALID_SIZES.length
+        BUTTON_VALID_SIZES.length
       );
     });
   },

--- a/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
@@ -10,16 +10,26 @@
  * governing permissions and limitations under the License.
  */
 
-import { expect } from '@storybook/test';
+import { html } from 'lit';
+import { expect, userEvent } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
 import { CloseButton } from '@adobe/spectrum-wc/components/close-button';
-import { ButtonBase } from '@spectrum-web-components/core/components/button';
+import {
+  BUTTON_STATIC_COLORS,
+  ButtonBase,
+} from '@spectrum-web-components/core/components/button';
 
 import '@adobe/spectrum-wc/components/close-button/swc-close-button.js';
 
-import { getComponent } from '../../../utils/test-utils.js';
-import meta, { Overview } from '../stories/close-button.stories.js';
+import { getComponent, withWarningSpy } from '../../../utils/test-utils.js';
+import meta, {
+  Accessibility,
+  Overview,
+  Sizes,
+  States,
+  StaticColors,
+} from '../stories/close-button.stories.js';
 
 export default {
   ...meta,
@@ -31,8 +41,437 @@ export default {
   tags: ['!autodocs', 'dev'],
 } as Meta;
 
+// ──────────────────────────────────────────────────────────────
+// TEST: Defaults
+// ──────────────────────────────────────────────────────────────
+
 export const OverviewTest: Story = {
   ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step('renders with default size and accessible name', async () => {
+      expect(closeButton.size, 'default size is m').toBe('m');
+      expect(
+        closeButton.getAttribute('size'),
+        'default size is reflected on the host'
+      ).toBe('m');
+      expect(
+        closeButton.getAttribute('accessible-label'),
+        'accessible-label is set from story args'
+      ).toBe('Close');
+      const button = closeButton.shadowRoot?.querySelector('button');
+      expect(
+        button?.getAttribute('aria-label'),
+        'inner button exposes the accessible name'
+      ).toBe('Close');
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Properties / attributes
+// ──────────────────────────────────────────────────────────────
+
+export const PropertyMutationTest: Story = {
+  ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step('reflects size on the host', async () => {
+      expect(
+        closeButton.getAttribute('size'),
+        'default size is reflected on the host'
+      ).toBe('m');
+
+      closeButton.size = 'l';
+      await closeButton.updateComplete;
+      expect(
+        closeButton.getAttribute('size'),
+        'size attribute is reflected'
+      ).toBe('l');
+    });
+
+    await step('reflects static-color when set', async () => {
+      closeButton.staticColor = 'white';
+      await closeButton.updateComplete;
+      expect(
+        closeButton.getAttribute('static-color'),
+        'static-color attribute is reflected'
+      ).toBe('white');
+    });
+
+    await step('reflects disabled when set', async () => {
+      closeButton.disabled = true;
+      await closeButton.updateComplete;
+      expect(
+        closeButton.shadowRoot?.querySelector('button')?.disabled,
+        'inner button is disabled'
+      ).toBe(true);
+    });
+  },
+};
+
+export const AccessibleLabelMutationTest: Story = {
+  render: () => html`
+    <swc-close-button>Close</swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+    const internalButton = closeButton.shadowRoot?.querySelector('button');
+
+    await step(
+      'uses slot text as aria-label when accessible-label is not set',
+      async () => {
+        expect(
+          internalButton?.getAttribute('aria-label'),
+          'aria-label comes from slot text when accessible-label is unset'
+        ).toBe('Close');
+      }
+    );
+
+    await step(
+      'forwards accessible-label as aria-label on internal button after mutation',
+      async () => {
+        closeButton.accessibleLabel = 'Close dialog';
+        await closeButton.updateComplete;
+        expect(
+          internalButton?.getAttribute('aria-label'),
+          'aria-label matches new accessibleLabel'
+        ).toBe('Close dialog');
+      }
+    );
+
+    await step(
+      'prefers accessible-label over slot text when both are present',
+      async () => {
+        closeButton.accessibleLabel = 'Dismiss overlay';
+        await closeButton.updateComplete;
+        expect(
+          internalButton?.getAttribute('aria-label'),
+          'accessible-label takes precedence over slot text'
+        ).toBe('Dismiss overlay');
+      }
+    );
+
+    await step(
+      'falls back to slot text when accessible-label is cleared',
+      async () => {
+        closeButton.accessibleLabel = undefined;
+        await closeButton.updateComplete;
+        expect(
+          internalButton?.getAttribute('aria-label'),
+          'aria-label matches slot text after clearing accessible-label'
+        ).toBe('Close');
+      }
+    );
+  },
+};
+
+export const SlotLabelAccessibleNameTest: Story = {
+  render: () => html`
+    <swc-close-button>Dismiss</swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step('uses slot text for the accessible name', async () => {
+      await closeButton.updateComplete;
+      const button = closeButton.shadowRoot?.querySelector('button');
+      expect(
+        button?.getAttribute('aria-label'),
+        'inner button aria-label matches slot text'
+      ).toBe('Dismiss');
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Accessibility
+// ──────────────────────────────────────────────────────────────
+
+export const DelegatesFocusTest: Story = {
+  render: () => html`
+    <swc-close-button accessible-label="Close"></swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step(
+      'routes programmatic focus to internal button via delegatesFocus',
+      async () => {
+        closeButton.focus();
+        const activeElement = (closeButton.renderRoot as ShadowRoot)
+          .activeElement;
+        expect(
+          activeElement?.tagName.toLowerCase(),
+          'delegatesFocus routes focus to internal <button>'
+        ).toBe('button');
+      }
+    );
+  },
+};
+
+export const HostSemanticsTest: Story = {
+  render: () => html`
+    <swc-close-button accessible-label="Close"></swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step('host does not duplicate button role', async () => {
+      expect(
+        closeButton.getAttribute('role'),
+        'host has no explicit role attribute'
+      ).toBeNull();
+      expect(
+        closeButton.shadowRoot?.querySelector('button')?.tagName.toLowerCase(),
+        'inner native button is the semantic control'
+      ).toBe('button');
+    });
+
+    await step('cross icon is hidden from assistive technology', async () => {
+      expect(
+        closeButton.shadowRoot
+          ?.querySelector('.swc-CloseButton-icon')
+          ?.getAttribute('aria-hidden'),
+        'icon wrapper is aria-hidden'
+      ).toBe('true');
+    });
+  },
+};
+
+export const KeyboardActivationTest: Story = {
+  render: () => html`
+    <swc-close-button accessible-label="Close"></swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+    const internalButton = closeButton.shadowRoot?.querySelector('button');
+
+    await step('Enter activates the close button', async () => {
+      let activated = false;
+      closeButton.addEventListener('click', () => {
+        activated = true;
+      });
+
+      internalButton?.focus();
+      await userEvent.keyboard('{Enter}');
+
+      expect(activated, 'Enter key activates the control').toBe(true);
+    });
+
+    await step('Space activates the close button', async () => {
+      let activated = false;
+      closeButton.addEventListener('click', () => {
+        activated = true;
+      });
+
+      internalButton?.focus();
+      await userEvent.keyboard(' ');
+
+      expect(activated, 'Space key activates the control').toBe(true);
+    });
+  },
+};
+
+export const DisabledKeyboardTest: Story = {
+  render: () => html`
+    <swc-close-button disabled accessible-label="Close"></swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+    const internalButton = closeButton.shadowRoot?.querySelector('button');
+
+    await step('disabled close button does not activate on click', async () => {
+      let activated = false;
+      closeButton.addEventListener('click', () => {
+        activated = true;
+      });
+
+      internalButton?.click();
+      expect(activated, 'click is suppressed when disabled').toBe(false);
+      expect(
+        internalButton?.disabled,
+        'inner button is natively disabled'
+      ).toBe(true);
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Story coverage
+// ──────────────────────────────────────────────────────────────
+
+export const SizesStoryTest: Story = {
+  ...Sizes,
+  play: async ({ canvasElement, step }) => {
+    await step('renders all size variants', async () => {
+      const closeButtons = canvasElement.querySelectorAll('swc-close-button');
+      expect(closeButtons.length, 'one close button per size variant').toBe(
+        CloseButton.VALID_SIZES.length
+      );
+    });
+  },
+};
+
+export const StaticColorsStoryTest: Story = {
+  ...StaticColors,
+  play: async ({ canvasElement, step }) => {
+    await step('renders static color variants', async () => {
+      const closeButtons = canvasElement.querySelectorAll('swc-close-button');
+      expect(
+        closeButtons.length,
+        'default and static color examples render'
+      ).toBe(3);
+    });
+  },
+};
+
+export const AccessibilityStoryTest: Story = {
+  ...Accessibility,
+  play: async ({ canvasElement, step }) => {
+    await step('renders accessibility examples', async () => {
+      const closeButtons = canvasElement.querySelectorAll('swc-close-button');
+      expect(
+        closeButtons.length,
+        'icon-only, slot label, dialog chrome, and disabled examples render'
+      ).toBe(4);
+    });
+  },
+};
+
+export const StatesStoryTest: Story = {
+  ...States,
+  play: async ({ canvasElement, step }) => {
+    await step('renders default and disabled states', async () => {
+      const closeButtons = canvasElement.querySelectorAll('swc-close-button');
+      expect(closeButtons.length, 'default and disabled examples render').toBe(
+        2
+      );
+      const disabledButton =
+        closeButtons[1]?.shadowRoot?.querySelector('button');
+      expect(
+        disabledButton?.disabled,
+        'disabled example is not interactive'
+      ).toBe(true);
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Dev mode warnings
+// ──────────────────────────────────────────────────────────────
+
+export const InvalidStaticColorWarningTest: Story = {
+  render: () => html`
+    <swc-close-button accessible-label="Close"></swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step('warns when an invalid static-color is set in DEBUG mode', () =>
+      withWarningSpy(async (warnCalls) => {
+        closeButton.staticColor =
+          'not-a-color' as unknown as CloseButton['staticColor'];
+        await closeButton.updateComplete;
+
+        expect(
+          warnCalls.length,
+          'at least one warning is emitted for invalid static-color'
+        ).toBeGreaterThan(0);
+        expect(
+          String(warnCalls[0]?.[1] || ''),
+          'warning message references static-color attribute'
+        ).toContain('static-color');
+      })
+    );
+  },
+};
+
+export const MissingAccessibleLabelWarningTest: Story = {
+  render: () => html`
+    <swc-close-button></swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step(
+      'warns when icon-only close button has no accessible name in DEBUG mode',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          closeButton.requestUpdate();
+          await closeButton.updateComplete;
+
+          expect(
+            warnCalls.length,
+            'at least one warning is emitted for missing accessible-label'
+          ).toBeGreaterThan(0);
+          expect(
+            String(warnCalls[0]?.[1] || ''),
+            'warning message references accessible-label'
+          ).toContain('accessible-label');
+        })
+    );
+  },
+};
+
+export const ValidStaticColorNoWarningTest: Story = {
+  render: () => html`
+    <swc-close-button accessible-label="Close"></swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step(
+      'does not warn for any valid static-color value in DEBUG mode',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          for (const color of BUTTON_STATIC_COLORS) {
+            closeButton.staticColor = color;
+            await closeButton.updateComplete;
+          }
+
+          expect(
+            warnCalls.length,
+            'no warnings are emitted for valid static-color values'
+          ).toBe(0);
+        })
+    );
+  },
 };
 
 export const ButtonBaseInstanceofTest: Story = {

--- a/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
@@ -199,6 +199,30 @@ export const SlotLabelAccessibleNameTest: Story = {
   },
 };
 
+export const AccessibleLabelPrecedenceTest: Story = {
+  render: () => html`
+    <swc-close-button accessible-label="Close dialog">Dismiss</swc-close-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const closeButton = await getComponent<CloseButton>(
+      canvasElement,
+      'swc-close-button'
+    );
+
+    await step(
+      'prefers accessible-label over slot text when both are set at render',
+      async () => {
+        await closeButton.updateComplete;
+        const button = closeButton.shadowRoot?.querySelector('button');
+        expect(
+          button?.getAttribute('aria-label'),
+          'accessible-label takes precedence over slot text at render'
+        ).toBe('Close dialog');
+      }
+    );
+  },
+};
+
 // ──────────────────────────────────────────────────────────────
 // TEST: Accessibility
 // ──────────────────────────────────────────────────────────────

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/close-button/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/close-button/migration-plan.md
@@ -57,7 +57,7 @@
 
 - `swc-close-button` should ship as a dedicated 2nd-gen component in both `core` and `swc` layers, not as an extension point buried inside `swc-button`.
 - API should align with modern button conventions: `accessible-label` (consumer-facing), `static-color`, and `size` (`s|m|l|xl`).
-- Variant aliases from 1st-gen (`variant="white|black"`) should be deprecated in favor of `static-color`.
+- 2nd-gen does not ship the 1st-gen `variant="white|black"` alias; use `static-color` only. Deprecation of `variant` is a 1st-gen (`sp-close-button`) concern.
 - Styling source of truth is Spectrum CSS `spectrum-two` `components/closebutton`; 2nd-gen should not re-expose the 1st-gen `--mod-closebutton-*` surface.
 - Accessibility is must-ship: real inner `<button type="button">`, delegated focus, mandatory discernible name, and keyboard parity for Enter/Space.
 
@@ -149,7 +149,7 @@ Prerequisite dependency:
 | --- | --- | --- | --- | --- |
 | B1 | Tag rename | `<sp-close-button>` | `<swc-close-button>` | Rename markup and import path. |
 | B2 | Accessible name channel rename | `label` | `accessible-label` | Rename attribute/property and keep semantics identical. |
-| B3 | Static color API cleanup and deprecation | `variant="white|black"` and `static-color` both allowed | `static-color` is canonical; `variant` is deprecated in this migration and scheduled for removal after deprecation window | Replace `variant` with `static-color`; treat `variant` usage as migration debt. |
+| B3 | Static color API cleanup | `variant="white|black"` and `static-color` both allowed on `sp-close-button` | `static-color` only on `swc-close-button`; `variant` attribute is not supported | Replace `variant` with `static-color` when migrating to 2nd-gen. |
 
 #### Styling and visuals
 
@@ -184,13 +184,14 @@ Prerequisite dependency:
 | `staticColor` | `'white' \| 'black' \| undefined` | `undefined` | `static-color` | Confirmed |
 | `accessibleLabel` | `string \| undefined` | `undefined` | `accessible-label` | Confirmed |
 | `disabled` | `boolean` | `false` | `disabled` | Confirmed |
-| `variant` (deprecated alias) | `'white' \| 'black' \| ''` | `''` | `variant` | Deprecated in 2nd-gen close-button migration; map to `static-color` with deprecation warning during transition, then remove. |
+| — | — | — | `variant` | **Removed in 2nd-gen.** Use `static-color` only. Deprecation and alias mapping belong on 1st-gen (`sp-close-button`) until that generation is retired. |
 
 ### Behavioral semantics
 
 - Component must be a dismiss control, not a clear/reset control.
 - Enter and Space activate like native button behavior.
 - Focus-visible ring behavior must match S2 closebutton semantics including forced-colors compatibility.
+- `pending` and `pending-label` are not part of the close-button public API (unlike `swc-button`). `swc-close-button` extends `ButtonBase` for shared accessible naming, disabled state, and sizing only; the SWC template does not implement pending visuals, and Storybook docs omit those attributes.
 
 ### Accessibility semantics notes (2nd-gen)
 
@@ -201,9 +202,9 @@ Prerequisite dependency:
 
 ## Architecture: core vs SWC split
 
-- `core`: `CloseButton.base.ts`, types, validations, semantic contracts.
+- `core`: reuse `ButtonBase` for shared button semantics; close-button-specific API lives on the SWC class.
 - `swc`: render template, CSS, element registration, stories, tests.
-- Reuse button-base patterns where possible, but keep close-button semantics distinct from clear-button.
+- Reuse `ButtonBase` for shared button semantics (accessible naming, disabled, sizing), but keep close-button semantics distinct from `swc-button` and clear-button. Do not surface or implement `ButtonBase` pending APIs on close-button.
 
 ---
 
@@ -215,27 +216,27 @@ Prerequisite dependency:
 - [x] Migration plan exists and is reviewable.
 
 ### Setup
-- [ ] Create `2nd-gen/packages/core/components/close-button/`.
-- [ ] Create `2nd-gen/packages/swc/components/close-button/`.
-- [ ] Wire exports and package entrypoints.
+- [x] Reuse `ButtonBase` from core (no separate close-button core package).
+- [x] Create `2nd-gen/packages/swc/components/close-button/`.
+- [x] Wire exports and package entrypoints.
 
 ### API
-- [ ] Define `size`, `static-color`, `accessible-label`, `disabled`.
-- [ ] Add deprecation strategy for `variant="white|black"`.
+- [x] Define `size`, `static-color`, `accessible-label`, `disabled`.
+- [x] Omit `variant` from 2nd-gen public API (breaking change; use `static-color` only).
 
 ### Styling
 - [ ] Implement S2 closebutton selectors/tokens in SWC CSS.
 - [ ] Define minimal public `--swc-close-button-*` properties.
 
 ### Accessibility
-- [ ] Real inner button with delegated focus.
-- [ ] Discernible name enforcement/warnings.
-- [ ] Keyboard and focus-visible parity.
+- [x] Real inner button with delegated focus.
+- [x] Discernible name enforcement/warnings.
+- [x] Keyboard activation covered in Storybook tests (focus-visible polish deferred to styling phase).
 
 ### Testing
-- [ ] Unit tests for API and DOM contract.
+- [x] Unit tests for API and DOM contract (Storybook interaction tests on integration branch).
 - [ ] Playwright a11y snapshots and keyboard tests.
-- [ ] Storybook interaction coverage.
+- [x] Storybook interaction coverage for API and accessibility contract.
 
 ### Documentation
 - [ ] Storybook docs complete.

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/close-button/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/close-button/migration-plan.md
@@ -191,7 +191,7 @@ Prerequisite dependency:
 - Component must be a dismiss control, not a clear/reset control.
 - Enter and Space activate like native button behavior.
 - Focus-visible ring behavior must match S2 closebutton semantics including forced-colors compatibility.
-- `pending` and `pending-label` are not part of the close-button public API (unlike `swc-button`). `swc-close-button` extends `ButtonBase` for shared accessible naming, disabled state, and sizing only; the SWC template does not implement pending visuals, and Storybook docs omit those attributes.
+- `pending` and `pending-label` are inherited from `ButtonBase` for now; the close-button SWC template does not implement pending visuals. When pending moves off `ButtonBase` (button pending-controller work), close-button should not need follow-up changes.
 
 ### Accessibility semantics notes (2nd-gen)
 
@@ -204,7 +204,7 @@ Prerequisite dependency:
 
 - `core`: reuse `ButtonBase` for shared button semantics; close-button-specific API lives on the SWC class.
 - `swc`: render template, CSS, element registration, stories, tests.
-- Reuse `ButtonBase` for shared button semantics (accessible naming, disabled, sizing), but keep close-button semantics distinct from `swc-button` and clear-button. Do not surface or implement `ButtonBase` pending APIs on close-button.
+- Reuse `ButtonBase` for shared button semantics (accessible naming, disabled, sizing). Do not implement pending visuals on close-button; inherited pending host attributes are acceptable until pending moves off `ButtonBase`.
 
 ---
 


### PR DESCRIPTION
Phase 3 API migration for swc-close-button. Builds on the Phase 2 scaffold PR into ttomar/migrate-close-button (SharedButtonBase, minimal render/CSS, no pending on close-button).

  • Finalize public API on CloseButtonBase extending SharedButtonBase: size, static-color, accessible-label, disabled
  • Breaking change: no variant on swc-close-button — use static-color only (1st-gen sp-close-button unchanged in this PR)
  • Add STATIC_COLORS on base and invalid static-color DEBUG validation (Divider pattern)
  • Expand JSDoc on base class and fenced @example blocks on CloseButton.ts
  • Add API-focused Storybook stories: Sizes, StaticColors, States
  • Add Storybook contract tests: defaults/reflection, slot accessible name, invalid static-color / missing accessible-label warnings, options-story smoke tests

  **Docs**

  • Tick API items in close-button migration plan (CONTRIBUTOR-DOCS/03_project-planning/03_components/close-button/migration-plan.md)

  **Out of scope (follow-up PRs on integration branch)**

  • S2 closebutton CSS / token fidelity
  • Playwright a11y snapshots, keyboard suite, VRT
  • Consumer migration-guide.mdx, changeset, final merge to main

  **Motivation and context**

  Close-button migration follows the washing-machine Phase 3 — API step: lock the 2nd-gen public surface, add DEBUG validation, and prove the contract with tests
  before styling and full a11y work land.

  This PR targets the integration branch (ttomar/migrate-close-button), not main. Migration phases merge there first; one final merge to main when the component is complete.

  **Related issue(s)**

  • SWC-2087 (epic — close-button 2nd-gen migration)
  • SWC-2089 (planning)

  Depends on the scaffold PR in ttomar/migrate-close-button (stacked review is fine).

  **Screenshots (if appropriate)**

  N/A — no visual fidelity changes beyond existing scaffold stub CSS.

  ────────────────────────────────────────

  **Author's checklist**

  ◼ I have read the CONTRIBUTING (https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md) and PULL_REQUESTS 
    (https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md) documents.
  ◼ I have reviewed the Accessibility Practices for this feature, see: Aria Practices (https://www.w3.org/TR/wai-aria-practices/)
  ◼ I have added automated tests to cover my changes.
  ◻ I have included a well-written changeset if my change needs to be published. (Deferred — integration branch; changeset with final merge to main)
  ◻ I have included updated documentation if my change required it. (Migration plan API checklist only; consumer guide in a later phase)

  ────────────────────────────────────────

  **Reviewer's checklist**

  ◻ Includes a Github Issue with appropriate flag or Jira ticket number without a link
  ◻ Includes thoughtfully written changeset if changes suggested include patch, minor, or major features (N/A for integration-branch PR)
  ◻ Automated tests cover all use cases and follow best practices for writing
  ◻ Validated on all supported browsers
  ◻ All VRTs are approved before the author can update Golden Hash

  **Manual review test cases**

  ◻ Public API (CEM / Storybook controls)
    1. Open 2nd-gen Storybook → Close Button → Playground.
    2. Confirm controls: size, static-color, accessible-label, disabled.
    3. Confirm no variant, pending, or pending-label on swc-close-button.

  ◻ Invalid static-color (DEBUG)
    1. Run with window.__swc.DEBUG = true.
    2. Open Close Button → Tests → Invalid Static Color Warning Test.
    3. Expect console warning listing allowed static-color values.

  ◻ API stories
    1. Sizes — four sizes render with distinct cross icons.
    2. StaticColors — default, white, and black on dark background.
    3. States — default and disabled; disabled control not activatable.

  ◻ Accessible name
    1. Tests → Overview Test — accessible-label → inner <button> aria-label.
    2. Slot Label Accessible Name Test — slot text Dismiss → aria-label="Dismiss".

  ◻ Build
    1. yarn workspace @spectrum-web-components/core build
    2. yarn workspace @adobe/spectrum-wc build
    3. yarn workspace @adobe/spectrum-wc test -- --run --project storybook components/close-button

  Device review

  ◻ Did it pass in Desktop?
  ◻ Did it pass in (emulated) Mobile?
  ◻ Did it pass in (emulated) iPad?

  **Accessibility testing checklist**

  Note: Full a11y phase is a follow-up PR. This PR adds API-level accessible-name tests; keyboard/focus uses the inner <button> from the scaffold.

  ◻ Keyboard (required — document steps below)
    1. Open 2nd-gen Storybook → Close Button → Overview.
    2. Tab to swc-close-button; focus should land on the inner button (delegated focus).
    3. Press Enter and Space — button activates (dismiss handler is author-owned).
    4. Open States; tab to disabled instance — skipped / not activatable via native disabled.
    5. Expect a visible focus indicator (stub CSS from scaffold).

  ◻ Screen reader (required — document steps below)
    1. Overview with accessible-label="Close" — announced as button, name "Close".
    2. Slot Label Accessible Name Test — name "Dismiss" from slot text.
    3. Icon must not duplicate the name (aria-hidden="true" on icon span).