### PR TITLE
fix(storybook): expand kebab-case argTypes in ApiTable

### DIFF
--- a/2nd-gen/packages/swc/.storybook/blocks/ApiTable.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/ApiTable.tsx
@@ -78,9 +78,28 @@ const tableStyle: React.CSSProperties = {
 /** Storybook argType shape (subset we care about). */
 interface ArgType {
   options?: string[];
+  control?: unknown;
   table?: {
     type?: { summary?: string };
+    disable?: boolean;
   };
+}
+
+function getArgTypeForMember(
+  argTypes: Record<string, ArgType>,
+  propName: string,
+  attrName?: string
+): ArgType | undefined {
+  const candidates = [
+    attrName ? argTypes[attrName] : undefined,
+    argTypes[propName],
+  ].filter((candidate): candidate is ArgType => candidate != null);
+
+  return (
+    candidates.find((candidate) => candidate.options?.length) ??
+    candidates.find((candidate) => candidate.control) ??
+    candidates[0]
+  );
 }
 
 function PropertiesTable({
@@ -128,7 +147,11 @@ function PropertiesTable({
           <tbody>
             {props.map((prop) => {
               const attr = attrByField.get(prop.name);
-              const argType = argTypes[prop.name] ?? argTypes[attr?.name ?? ''];
+              const argType = getArgTypeForMember(
+                argTypes,
+                prop.name,
+                attr?.name
+              );
 
               // Prefer expanded options from argTypes, fall back to CEM type text.
               const typeName = argType?.options


### PR DESCRIPTION
## Summary

- Fix `ApiTable` argType lookup so properties whose HTML attribute name differs from the field name (e.g. `fillStyle` / `fill-style`) resolve to the storybook control entry instead of the disable stub.
- Expand enum types from story `options` for those properties, so docs show values like `'fill' | 'outline'` instead of collapsed CEM aliases such as `ButtonFillStyle`.

## Motivation and context

`@wc-toolkit/storybook-helpers` registers two argType keys for reflected kebab-case attributes: a camelCase disable stub and a kebab-case control entry with `options`. `ApiTable` previously checked the property name first, so it always hit the stub and never expanded types configured in stories.

## Related issue(s)

- N/A

## Test plan

- [ ] Open Button docs in Storybook (`/docs/button--docs`).
- [ ] In the API table, confirm `fillStyle` type shows `'fill' | 'outline'` instead of `ButtonFillStyle`.
- [ ] Confirm `staticColor` type shows `'white' | 'black'` instead of `ButtonStaticColor | undefined`.
- [ ] Confirm existing expanded types (`variant`, `size`) are unchanged.

## Accessibility testing checklist

### Keyboard

- No interactive changes. Confirm the docs page still renders and the API table is readable; no focusable behavior changed.

### Screen reader

- No semantic or ARIA changes. Confirm the API table content is still announced as static documentation text.


Made with [Cursor](https://cursor.com)