### PR TITLE
WIP exploration: add constrainedSlot decorator and CEM plugin

### DIFF
--- a/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
+++ b/2nd-gen/packages/core/components/illustrated-message/IllustratedMessage.base.ts
@@ -13,6 +13,7 @@
 import { PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
 
+import { constrainedSlot } from '@spectrum-web-components/core/decorators/index.js';
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
 
 import {
@@ -28,8 +29,6 @@ import {
  *
  * @slot - Decorative or informative SVG illustration
  * @slot heading - The heading element, h2–h6
- *   @todo SWC-1943 Add slot constraints once the CEM slot constraints work is complete:
- *   `{required} {allowedChildren: h2, h3, h4, h5, h6} {maxChildren: 1}`
  * @slot description - Supporting description text
  */
 export abstract class IllustratedMessageBase extends SpectrumElement {
@@ -100,27 +99,22 @@ export abstract class IllustratedMessageBase extends SpectrumElement {
     }
   }
 
+  @constrainedSlot({
+    allowed: ['h2', 'h3', 'h4', 'h5', 'h6'],
+    slot: 'heading',
+    docsUrl:
+      'https://spectrum-web-components.adobe.com/?path=/docs/components-illustrated-message--docs',
+  })
+  private _headings!: Element[];
+
   /**
    * @internal
    *
-   * Validates that the heading slot only contains `<h2>`–`<h6>` elements.
+   * Triggers slot constraint validation for the heading slot in DEBUG mode.
    * Rendering subclasses must wire this to the heading slot's `slotchange`
-   * event (e.g. `<slot name="heading" @slotchange=${this.handleHeadingSlotChange}>`)
-   * for the validation warning to fire.
+   * event (e.g. `<slot name="heading" @slotchange=${this.handleHeadingSlotChange}>`).
    */
-  protected handleHeadingSlotChange(event: Event): void {
-    if (window.__swc?.DEBUG) {
-      const headingSlot = event.target as HTMLSlotElement;
-      for (const el of headingSlot.assignedElements()) {
-        if (!['H2', 'H3', 'H4', 'H5', 'H6'].includes(el.tagName)) {
-          window.__swc.warn(
-            this,
-            `<${this.localName}> heading slot received a <${el.tagName.toLowerCase()}> element. Only <h2>–<h6> elements are allowed in the heading slot.`,
-            'https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/',
-            { issues: [`heading slot: <${el.tagName.toLowerCase()}>`] }
-          );
-        }
-      }
-    }
+  protected handleHeadingSlotChange(): void {
+    void this._headings;
   }
 }

--- a/2nd-gen/packages/core/decorators/constrained-slot.ts
+++ b/2nd-gen/packages/core/decorators/constrained-slot.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { LitElement } from 'lit';
+
+export interface ConstrainedSlotOptions {
+  /**
+   * Lowercase tag names that are valid in this slot.
+   *
+   * @example ['swc-button'] or ['h2', 'h3', 'h4', 'h5', 'h6']
+   */
+  allowed: readonly string[];
+
+  /**
+   * The slot name to query. Omit for the default (unnamed) slot.
+   */
+  slot?: string;
+
+  /**
+   * Documentation URL included in dev-mode warning messages so consumers
+   * can find usage guidance quickly.
+   *
+   * @example 'https://spectrum-web-components.adobe.com/?path=/docs/components-button-group--docs'
+   */
+  docsUrl?: string;
+}
+
+/**
+ * Declares a property that returns all elements assigned to a slot,
+ * filtered to the tag names listed in `allowed`. In DEBUG mode, emits a
+ * `window.__swc.warn` for every element outside the allowed list.
+ *
+ * The returned array is always safe to iterate — invalid elements are
+ * excluded rather than passed through.
+ *
+ * Mirrors the Lit `@queryAssignedElements` pattern but adds runtime slot
+ * constraint validation. The companion CEM plugin (`cem-plugin-constrained-slot`
+ * in `cem.config.js`) reads the decorator at build time and annotates the
+ * corresponding slot entry with `allowedElements` in the manifest.
+ */
+export function constrainedSlot(options: ConstrainedSlotOptions) {
+  return (proto: object, name: string | symbol): void => {
+    Object.defineProperty(proto, name, {
+      get(this: LitElement): Element[] {
+        const slotSelector = options.slot
+          ? `slot[name="${options.slot}"]`
+          : 'slot:not([name])';
+
+        const slot =
+          this.renderRoot?.querySelector<HTMLSlotElement>(slotSelector);
+        if (!slot) {
+          return [];
+        }
+
+        const assigned = slot.assignedElements();
+
+        if (window.__swc?.DEBUG) {
+          const slotLabel = options.slot ? `"${options.slot}"` : 'default';
+          const allowedList = options.allowed.join(', ');
+          const verb = options.allowed.length === 1 ? 'is' : 'are';
+
+          for (const el of assigned) {
+            if (!options.allowed.includes(el.localName)) {
+              window.__swc.warn(
+                this,
+                `<${this.localName}> received an invalid <${el.localName}> element in the ${slotLabel} slot. Only ${allowedList} ${verb} allowed.`,
+                options.docsUrl ?? '',
+                { issues: [`${slotLabel} slot: <${el.localName}>`] }
+              );
+            }
+          }
+        }
+
+        return assigned.filter((el) => options.allowed.includes(el.localName));
+      },
+      enumerable: false,
+      configurable: true,
+    });
+  };
+}

--- a/2nd-gen/packages/core/decorators/index.ts
+++ b/2nd-gen/packages/core/decorators/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export {
+  constrainedSlot,
+  type ConstrainedSlotOptions,
+} from './constrained-slot.js';

--- a/2nd-gen/packages/core/package.json
+++ b/2nd-gen/packages/core/package.json
@@ -79,6 +79,18 @@
       "types": "./dist/components/tabs/index.d.ts",
       "import": "./dist/components/tabs/index.js"
     },
+    "./decorators": {
+      "types": "./dist/decorators/index.d.ts",
+      "import": "./dist/decorators/index.js"
+    },
+    "./decorators/constrained-slot.js": {
+      "types": "./dist/decorators/constrained-slot.d.ts",
+      "import": "./dist/decorators/constrained-slot.js"
+    },
+    "./decorators/index.js": {
+      "types": "./dist/decorators/index.d.ts",
+      "import": "./dist/decorators/index.js"
+    },
     "./controllers": {
       "types": "./dist/controllers/index.d.ts",
       "import": "./dist/controllers/index.js"
@@ -212,6 +224,15 @@
       ],
       "components/tabs/index.js": [
         "dist/components/tabs/index.d.ts"
+      ],
+      "decorators": [
+        "dist/decorators/index.d.ts"
+      ],
+      "decorators/constrained-slot.js": [
+        "dist/decorators/constrained-slot.d.ts"
+      ],
+      "decorators/index.js": [
+        "dist/decorators/index.d.ts"
       ],
       "controllers": [
         "dist/controllers/index.d.ts"

--- a/2nd-gen/packages/core/vite.config.js
+++ b/2nd-gen/packages/core/vite.config.js
@@ -83,6 +83,12 @@ function getEntries() {
   // Find all utils/*.ts files
   Object.assign(entries, scanTsFiles(resolve(__dirname, 'utils'), 'utils'));
 
+  // Find all decorators/*.ts files
+  Object.assign(
+    entries,
+    scanTsFiles(resolve(__dirname, 'decorators'), 'decorators')
+  );
+
   return entries;
 }
 

--- a/2nd-gen/packages/swc/.storybook/blocks/ApiTable.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/ApiTable.tsx
@@ -169,8 +169,13 @@ function PropertiesTable({
   );
 }
 
-function SlotsTable({ slots }: { slots: Slot[] }) {
+type SlotWithConstraints = Slot & { allowedElements?: string[] };
+
+function SlotsTable({ slots }: { slots: SlotWithConstraints[] }) {
   if (slots.length === 0) return null;
+
+  const hasConstraints = slots.some((s) => s.allowedElements?.length);
+
   return (
     <>
       <HeaderMdx as="h3" id="slots">
@@ -182,6 +187,7 @@ function SlotsTable({ slots }: { slots: Slot[] }) {
             <tr>
               <th>Name</th>
               <th>Description</th>
+              {hasConstraints && <th>Allowed elements</th>}
             </tr>
           </thead>
           <tbody>
@@ -191,6 +197,18 @@ function SlotsTable({ slots }: { slots: Slot[] }) {
                   <code>{slot.name || '(default)'}</code>
                 </td>
                 <td>{slot.description ?? ''}</td>
+                {hasConstraints && (
+                  <td>
+                    {slot.allowedElements?.length
+                      ? slot.allowedElements.map((el, i) => (
+                          <React.Fragment key={el}>
+                            {i > 0 && ', '}
+                            <code>{el}</code>
+                          </React.Fragment>
+                        ))
+                      : '-'}
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>
@@ -340,7 +358,7 @@ export function ApiTable() {
         attributes={attributes}
         argTypes={argTypes as Record<string, ArgType>}
       />
-      <SlotsTable slots={slots} />
+      <SlotsTable slots={slots as SlotWithConstraints[]} />
       <EventsTable events={events} />
       <CssPropsTable cssProps={cssProps} />
       <CssPartsTable cssParts={cssParts} />

--- a/2nd-gen/packages/swc/cem.config.js
+++ b/2nd-gen/packages/swc/cem.config.js
@@ -11,6 +11,96 @@
  */
 
 /**
+ * CEM plugin that reads `@constrainedSlot` decorator usage on class properties
+ * and annotates the corresponding slot entry in the manifest with an
+ * `allowedElements` array.
+ *
+ * Given a component class with:
+ * ```ts
+ * @constrainedSlot({ allowed: ['swc-button'], slot: '' })
+ * private _buttons!: Element[];
+ * ```
+ *
+ * The plugin finds the `@slot` CEM entry for that slot and adds:
+ * ```json
+ * { "name": "", "allowedElements": ["swc-button"] }
+ * ```
+ *
+ * If no `@slot` entry exists for the given slot name it creates one, so the
+ * constraint is still captured even when the `@slot` JSDoc tag is on a base
+ * class that was analyzed separately.
+ */
+function constrainedSlotPlugin() {
+  return {
+    name: 'cem-plugin-constrained-slot',
+    analyzePhase({ ts, node, moduleDoc }) {
+      if (!ts.isPropertyDeclaration(node)) return;
+
+      const decorators = ts.getDecorators?.(node) ?? node.decorators;
+      if (!decorators?.length) return;
+
+      const csDecorator = [...decorators].find((dec) => {
+        if (!ts.isCallExpression(dec.expression)) return false;
+        return (
+          ts.isIdentifier(dec.expression.expression) &&
+          dec.expression.expression.text === 'constrainedSlot'
+        );
+      });
+      if (!csDecorator || !ts.isCallExpression(csDecorator.expression)) return;
+
+      const optionsArg = csDecorator.expression.arguments[0];
+      if (!optionsArg || !ts.isObjectLiteralExpression(optionsArg)) return;
+
+      let allowed = [];
+      let slotName = '';
+
+      for (const prop of optionsArg.properties) {
+        if (!ts.isPropertyAssignment(prop)) continue;
+        const key = ts.isIdentifier(prop.name) ? prop.name.text : null;
+
+        if (
+          key === 'allowed' &&
+          ts.isArrayLiteralExpression(prop.initializer)
+        ) {
+          allowed = [...prop.initializer.elements]
+            .filter((el) => ts.isStringLiteral(el))
+            .map((el) => el.text);
+        }
+
+        if (key === 'slot' && ts.isStringLiteral(prop.initializer)) {
+          slotName = prop.initializer.text;
+        }
+      }
+
+      if (!allowed.length) return;
+
+      const classNode = node.parent;
+      if (!ts.isClassDeclaration(classNode)) return;
+
+      const className = classNode.name?.getText();
+      if (!className) return;
+
+      const declaration = moduleDoc.declarations?.find(
+        (d) => d.name === className
+      );
+      if (!declaration) return;
+
+      if (!declaration.slots) declaration.slots = [];
+
+      const existingSlot = declaration.slots.find(
+        (s) => (s.name ?? '') === slotName
+      );
+
+      if (existingSlot) {
+        existingSlot.allowedElements = allowed;
+      } else {
+        declaration.slots.push({ name: slotName, allowedElements: allowed });
+      }
+    },
+  };
+}
+
+/**
  * CEM plugin that extracts `@status` and `@since` JSDoc tags from class
  * declarations and attaches them to the corresponding CEM declaration.
  *
@@ -76,6 +166,7 @@ export default {
     '../core/element/**/*.ts',
     '../core/mixins/**/*.ts',
     '../core/utils/**/*.ts',
+    '../core/decorators/**/*.ts',
   ],
   exclude: [
     '**/*.stories.ts',
@@ -89,5 +180,5 @@ export default {
   outdir: '.storybook',
   litelement: true,
   dev: false,
-  plugins: [statusPlugin()],
+  plugins: [constrainedSlotPlugin(), statusPlugin()],
 };


### PR DESCRIPTION
## Description

Introduces `@constrainedSlot` — a Lit-style property decorator for the `@spectrum-web-components/core` package that combines `@queryAssignedElements` with runtime slot content validation and build-time CEM manifest annotation.

### What's included

- **`@constrainedSlot` decorator** (`core/decorators/constrained-slot.ts`): Filters slot-assigned elements to an allowed tag-name list. In DEBUG mode, emits `window.__swc.warn` for any element outside that list. The returned array is always safe to iterate — invalid elements are excluded rather than passed through.

- **`cem-plugin-constrained-slot`** (`packages/swc/cem.config.js`): Reads `@constrainedSlot` decorator arguments at CEM analyze time and annotates the matching slot entry with `allowedElements` in the manifest, making slot constraints visible in the Storybook API table.

- **Applied to `IllustratedMessageBase`** as the first usage, replacing the hand-rolled `handleHeadingSlotChange` validation loop (resolves SWC-1943 `@todo`).

### Before / after — IllustratedMessage heading slot

**Before:**
```ts
protected handleHeadingSlotChange(event: Event): void {
  if (window.__swc?.DEBUG) {
    const headingSlot = event.target as HTMLSlotElement;
    for (const el of headingSlot.assignedElements()) {
      if (!['H2', 'H3', 'H4', 'H5', 'H6'].includes(el.tagName)) {
        window.__swc.warn(
          this,
          `<${this.localName}> heading slot received a <${el.tagName.toLowerCase()}> element. Only <h2>–<h6> elements are allowed in the heading slot.`,
          'https://opensource.adobe.com/spectrum-web-components/components/illustrated-message/',
          { issues: [`heading slot: <${el.tagName.toLowerCase()}>`] }
        );
      }
    }
  }
}
```

**After:**
```ts
@constrainedSlot({
  allowed: ['h2', 'h3', 'h4', 'h5', 'h6'],
  slot: 'heading',
  docsUrl: 'https://spectrum-web-components.adobe.com/?path=/docs/components-illustrated-message--docs',
})
private _headings!: Element[];

protected handleHeadingSlotChange(): void {
  void this._headings;
}
```

### CEM output

The CEM plugin adds `allowedElements` to the slot entry in `custom-elements.json`:

```json
{
  "name": "heading",
  "description": "The heading element, h2–h6",
  "allowedElements": ["h2", "h3", "h4", "h5", "h6"]
}
```

## Motivation and context

Components that accept slotted content often restrict what elements are valid. Previously, each component implemented its own `DEBUG`-mode validation loop. This PR extracts that pattern into a reusable decorator so future components (e.g. `button-group` accepting only `swc-button`) can declare their slot constraints in one line.

The CEM plugin closes the gap noted in the illustrated-message `@todo` (SWC-1943) by propagating those constraints into the manifest automatically.

## Related issue(s)

- Fixes SWC-1943

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Verify warning fires for invalid slot content
  1. Open any Storybook story for `<swc-illustrated-message>` in dev mode
  2. Slot in a `<div>` to the `heading` slot instead of an `<h2>`–`<h6>`
  3. Open the browser console — expect a `window.__swc.warn` message naming the invalid element

- [ ] Verify valid content produces no warning
  1. Slot an `<h2>` into the `heading` slot
  2. Open the browser console — expect no warning

- [ ] Verify CEM output
  1. Run `yarn cem` in `2nd-gen/packages/swc`
  2. Open `.storybook/custom-elements.json`
  3. Find the `swc-illustrated-message` declaration — expect the `heading` slot entry to include `"allowedElements": ["h2", "h3", "h4", "h5", "h6"]`

## Accessibility testing checklist

- [x] **Keyboard**: No interactive behaviour changed; no keyboard regression expected.
- [x] **Screen reader**: No ARIA or role changes; no screen reader regression expected.