### PR TITLE
fix(button): no clickable events in disabled state

### DIFF
--- a/2nd-gen/packages/core/components/button/Button.base.ts
+++ b/2nd-gen/packages/core/components/button/Button.base.ts
@@ -149,11 +149,13 @@ export abstract class ButtonBase extends SizedMixin(
 
   public override connectedCallback(): void {
     super.connectedCallback();
-    this.addEventListener('click', this.handleClick);
+    // Capture phase so slotted light-DOM clicks are suppressed before host
+    // listeners (e.g. Storybook actions) run.
+    this.addEventListener('click', this.handleClick, true);
   }
 
   public override disconnectedCallback(): void {
-    this.removeEventListener('click', this.handleClick);
+    this.removeEventListener('click', this.handleClick, true);
     if (this._pendingTimer !== null) {
       clearTimeout(this._pendingTimer);
       this._pendingTimer = null;
@@ -163,11 +165,15 @@ export abstract class ButtonBase extends SizedMixin(
   }
 
   /**
-   * Suppresses click activation while the button is in a `pending` state.
-   * Subclasses' templates wire this onto the rendered `<button>` via `@click`.
+   * Suppresses click activation while the button is `disabled` or `pending`.
+   *
+   * Slotted icon content lives in the light DOM, so pointer clicks on icons
+   * bypass the disabled inner `<button>` and bubble on the host. The host
+   * listener (capture) and inner `@click` binding both call this handler.
    */
   protected readonly handleClick = (event: Event): void => {
-    if (this.pending) {
+    if (this.disabled || this.pending) {
+      event.preventDefault();
       event.stopImmediatePropagation();
     }
   };

--- a/2nd-gen/packages/swc/components/button/button-base.css
+++ b/2nd-gen/packages/swc/components/button/button-base.css
@@ -53,3 +53,9 @@
   border-color: var(--swc-button-border-color-disabled, transparent);
   transform: none;
 }
+
+/* Slotted icons stay in the light DOM; without this, clicks hit the slotted
+   node and bubble on the host instead of the disabled inner <button>. */
+:host([disabled]) slot[name="icon"]::slotted(*) {
+  pointer-events: none;
+}

--- a/2nd-gen/packages/swc/components/button/test/button.test.ts
+++ b/2nd-gen/packages/swc/components/button/test/button.test.ts
@@ -511,7 +511,20 @@ export const StatesTest: Story = {
 
 export const DisabledBehaviorTest: Story = {
   render: () => html`
-    <swc-button disabled>Save</swc-button>
+    <swc-button disabled>
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 36 36"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
+        />
+      </svg>
+      Save
+    </swc-button>
   `,
   play: async ({ canvasElement, step }) => {
     const button = await getComponent<Button>(canvasElement, 'swc-button');
@@ -525,6 +538,28 @@ export const DisabledBehaviorTest: Story = {
           activeElement,
           'focus not delegated to internal <button disabled>'
         ).toBeNull();
+      }
+    );
+
+    await step(
+      'suppresses host click when slotted icon is clicked while disabled',
+      async () => {
+        const icon = button.querySelector('[slot="icon"]');
+        expect(icon, 'slotted icon is present').toBeTruthy();
+
+        let clickCount = 0;
+        const listener = () => {
+          clickCount++;
+        };
+        button.addEventListener('click', listener);
+        icon?.dispatchEvent(
+          new MouseEvent('click', { bubbles: true, composed: true })
+        );
+        button.removeEventListener('click', listener);
+        expect(
+          clickCount,
+          'click is suppressed when slotted icon is clicked while disabled'
+        ).toBe(0);
       }
     );
   },

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -60,13 +60,6 @@
   outline-offset: token("focus-indicator-gap");
 }
 
-.swc-Button:disabled:is(*, :hover) {
-  color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
-  background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
-  border-color: var(--swc-button-border-color-disabled, transparent);
-  transform: none;
-}
-
 .swc-Button:hover {
   color: var(--swc-button-content-color-hover, token("gray-25"));
   background-color: var(--swc-button-background-color-hover, token("neutral-background-color-hover"));
@@ -79,6 +72,13 @@
   border-color: var(--swc-button-border-color-down, transparent);
   transform: var(--swc-button-down-state-transform, perspective(var(--_swc-button-min-block-size)) translate3d(0, 0, token("component-size-difference-down")));
   will-change: transform;
+}
+
+.swc-Button:disabled:is(*, :hover) {
+  color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
+  background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
+  border-color: var(--swc-button-border-color-disabled, transparent);
+  transform: none;
 }
 
 .swc-Button-label {

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -16,66 +16,80 @@
 
 @layer swc-global-elements {.swc-Button, .swc-Button * {
   box-sizing: border-box;
-}.swc-Button {
+}
+
+.swc-Button {
   -webkit-tap-highlight-color: transparent;
   display: inline-flex;
   position: relative;
+  gap: var(--swc-button-gap, token("text-to-visual-100"));
   align-items: center;
   justify-content: center;
-  margin: 0;
-  text-transform: none;
-  text-decoration: none;
-  border-style: solid;
-  overflow: visible;
-  user-select: none;
-  --_swc-button-border-width: token("border-width-200");
-  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
-
-  gap: var(--swc-button-gap, token("text-to-visual-100"));
   max-inline-size: var(--swc-button-max-inline-size, inherit);
   min-block-size: var(--_swc-button-min-block-size);
   padding-block: calc(var(--swc-button-padding-vertical, token("component-padding-vertical-100")) - var(--_swc-button-border-width));
   padding-inline: calc(var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")) - var(--_swc-button-border-width));
+  margin: 0;
   font-family: token("sans-serif-font");
   font-size: var(--swc-button-font-size, token("font-size-100"));
   font-weight: token("bold-font-weight");
   line-height: round(down, calc(token("line-height-100") * 1em), 1px);
   color: var(--swc-button-content-color-default, token("gray-25"));
+  text-transform: none;
+  text-decoration: none;
   background-color: var(--swc-button-background-color-default, token("neutral-background-color-default"));
   border-color: var(--swc-button-border-color-default, transparent);
+  border-style: solid;
   border-width: var(--_swc-button-border-width);
   border-radius: var(--swc-button-border-radius, calc(var(--_swc-button-min-block-size) / 2));
+  overflow: visible;
+  user-select: none;
   transition-timing-function: token("animation-ease-in-out");
   transition-duration: token("animation-duration-100");
   transition-property: outline, border-color, color, background-color, transform;
-}.swc-Button:focus-visible {
-  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
-  outline-offset: token("focus-indicator-gap");
+
+  --_swc-button-border-width: token("border-width-200");
+  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
+}
+
+.swc-Button:focus-visible {
   color: var(--swc-button-content-color-focus, token("gray-25"));
   background-color: var(--swc-button-background-color-focus, token("neutral-background-color-key-focus"));
   border-color: var(--swc-button-border-color-focus, transparent);
-}.swc-Button:disabled:is(*, :hover) {
+  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
+  outline-offset: token("focus-indicator-gap");
+}
+
+.swc-Button:disabled:is(*, :hover) {
   color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
   background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
   border-color: var(--swc-button-border-color-disabled, transparent);
   transform: none;
-}.swc-Button--disabled .swc-Button-icon {
-  pointer-events: none;
-}.swc-Button:hover {
+}
+
+.swc-Button:hover {
   color: var(--swc-button-content-color-hover, token("gray-25"));
   background-color: var(--swc-button-background-color-hover, token("neutral-background-color-hover"));
   border-color: var(--swc-button-border-color-hover, transparent);
-}.swc-Button:active {
+}
+
+.swc-Button:active {
   color: var(--swc-button-content-color-down, token("gray-25"));
   background-color: var(--swc-button-background-color-down, token("neutral-background-color-down"));
   border-color: var(--swc-button-border-color-down, transparent);
   transform: var(--swc-button-down-state-transform, perspective(var(--_swc-button-min-block-size)) translate3d(0, 0, token("component-size-difference-down")));
   will-change: transform;
-}.swc-Button-label {
+}
+
+.swc-Button-label {
   text-align: center;
-}.swc-Button--hasIcon .swc-Button-label {
+}
+
+.swc-Button--hasIcon .swc-Button-label {
   text-align: start;
-}.swc-Button-icon,
+}
+
+.swc-Button-icon,
 .swc-Button-pendingSpinner {
   --_swc-button-icon-size: var(--swc-button-icon-size, token("workflow-icon-size-100"));
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
@@ -86,10 +100,14 @@
   block-size: var(--_swc-button-icon-block-size);
   margin-block: calc((var(--_swc-button-icon-block-size) - 1lh) / 2 * -1);
   margin-inline-start: calc(var(--swc-button-edge-to-visual, token("component-pill-edge-to-visual-100")) - var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")));
-}.swc-Button-icon {
+}
+
+.swc-Button-icon {
   color: inherit;
   fill: currentcolor;
-}.swc-Button--sizeS {
+}
+
+.swc-Button--sizeS {
   --swc-button-min-block-size: token("component-height-75");
   --swc-button-font-size: token("font-size-75");
   --swc-button-gap: token("text-to-visual-75");
@@ -98,7 +116,9 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-75");
   --swc-button-padding-vertical: token("component-padding-vertical-75");
   --swc-button-icon-size: token("workflow-icon-size-75");
-}.swc-Button--sizeL {
+}
+
+.swc-Button--sizeL {
   --swc-button-min-block-size: token("component-height-200");
   --swc-button-font-size: token("font-size-200");
   --swc-button-gap: token("text-to-visual-200");
@@ -107,7 +127,9 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-200");
   --swc-button-padding-vertical: token("component-padding-vertical-200");
   --swc-button-icon-size: token("workflow-icon-size-200");
-}.swc-Button--sizeXl {
+}
+
+.swc-Button--sizeXl {
   --swc-button-min-block-size: token("component-height-300");
   --swc-button-font-size: token("font-size-300");
   --swc-button-gap: token("text-to-visual-300");
@@ -116,7 +138,9 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-300");
   --swc-button-padding-vertical: token("component-padding-vertical-300");
   --swc-button-icon-size: token("workflow-icon-size-300");
-}.swc-Button--accent {
+}
+
+.swc-Button--accent {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -125,7 +149,9 @@
   --swc-button-background-color-hover: token("accent-background-color-hover");
   --swc-button-background-color-down: token("accent-background-color-down");
   --swc-button-background-color-focus: token("accent-background-color-key-focus");
-}.swc-Button--negative {
+}
+
+.swc-Button--negative {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -134,7 +160,9 @@
   --swc-button-background-color-hover: token("negative-background-color-hover");
   --swc-button-background-color-down: token("negative-background-color-down");
   --swc-button-background-color-focus: token("negative-background-color-key-focus");
-}.swc-Button--secondary {
+}
+
+.swc-Button--secondary {
   --swc-button-content-color-default: token("neutral-content-color-default");
   --swc-button-content-color-hover: token("neutral-content-color-hover");
   --swc-button-content-color-down: token("neutral-content-color-down");
@@ -143,7 +171,9 @@
   --swc-button-background-color-hover: token("gray-200");
   --swc-button-background-color-down: token("gray-200");
   --swc-button-background-color-focus: token("gray-200");
-}.swc-Button--primary.swc-Button--outline {
+}
+
+.swc-Button--primary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -158,7 +188,9 @@
   --swc-button-content-color-focus: token("neutral-content-color-key-focus");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}.swc-Button--secondary.swc-Button--outline {
+}
+
+.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -169,7 +201,9 @@
   --swc-button-border-color-focus: token("gray-400");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}.swc-Button--staticWhite {
+}
+
+.swc-Button--staticWhite {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-white-800");
   --swc-button-background-color-hover: token("transparent-white-900");
@@ -182,7 +216,9 @@
   --swc-button-background-color-disabled: token("disabled-static-white-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}.swc-Button--staticWhite.swc-Button--secondary {
+}
+
+.swc-Button--staticWhite.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-white-100");
   --swc-button-background-color-hover: token("transparent-white-200");
   --swc-button-background-color-down: token("transparent-white-200");
@@ -191,7 +227,9 @@
   --swc-button-content-color-hover: token("transparent-white-900");
   --swc-button-content-color-down: token("transparent-white-900");
   --swc-button-content-color-focus: token("transparent-white-900");
-}.swc-Button--staticWhite.swc-Button--outline {
+}
+
+.swc-Button--staticWhite.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -207,7 +245,9 @@
   --swc-button-background-color-disabled: token("transparent-white-25");
   --swc-button-border-color-disabled: token("disabled-static-white-border-color");
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
+}
+
+.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -216,7 +256,9 @@
   --swc-button-border-color-hover: token("transparent-white-400");
   --swc-button-border-color-down: token("transparent-white-400");
   --swc-button-border-color-focus: token("transparent-white-400");
-}.swc-Button--staticBlack {
+}
+
+.swc-Button--staticBlack {
   --swc-button-focus-indicator-color: token("static-black-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-black-800");
   --swc-button-background-color-hover: token("transparent-black-900");
@@ -229,7 +271,9 @@
   --swc-button-background-color-disabled: token("disabled-static-black-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}.swc-Button--staticBlack.swc-Button--secondary {
+}
+
+.swc-Button--staticBlack.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-black-100");
   --swc-button-background-color-hover: token("transparent-black-200");
   --swc-button-background-color-down: token("transparent-black-200");
@@ -238,7 +282,9 @@
   --swc-button-content-color-hover: token("transparent-black-900");
   --swc-button-content-color-down: token("transparent-black-900");
   --swc-button-content-color-focus: token("transparent-black-900");
-}.swc-Button--staticBlack.swc-Button--outline {
+}
+
+.swc-Button--staticBlack.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -254,7 +300,9 @@
   --swc-button-background-color-disabled: token("transparent-black-25");
   --swc-button-border-color-disabled: token("disabled-static-black-border-color");
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
+}
+
+.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -263,28 +311,40 @@
   --swc-button-border-color-hover: token("transparent-black-400");
   --swc-button-border-color-down: token("transparent-black-400");
   --swc-button-border-color-focus: token("transparent-black-400");
-}.swc-Button--iconOnly {
+}
+
+.swc-Button--iconOnly {
   --swc-button-border-radius: token("corner-radius-full");
   --swc-button-gap: 0;
 
   padding-inline: calc(var(--swc-button-edge-to-visual-only, token("component-pill-edge-to-visual-only-100")) - var(--_swc-button-border-width));
-}.swc-Button--iconOnly .swc-Button-icon {
+}
+
+.swc-Button--iconOnly .swc-Button-icon {
   --swc-button-edge-to-visual: 0;
 
   align-self: center;
-}.swc-Button--truncate .swc-Button-label {
+}
+
+.swc-Button--truncate .swc-Button-label {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}.swc-Button--justified {
+}
+
+.swc-Button--justified {
   flex-grow: 1;
   justify-self: stretch;
   inline-size: 100%;
-}@media (prefers-reduced-motion: reduce) {
+}
+
+@media (prefers-reduced-motion: reduce) {
   .swc-Button {
     transition-duration: 0ms;
   }
 }
-}.swc-Button {
+}
+
+.swc-Button {
 all: revert-layer !important;
 }

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -16,80 +16,66 @@
 
 @layer swc-global-elements {.swc-Button, .swc-Button * {
   box-sizing: border-box;
-}
-
-.swc-Button {
+}.swc-Button {
   -webkit-tap-highlight-color: transparent;
   display: inline-flex;
   position: relative;
-  gap: var(--swc-button-gap, token("text-to-visual-100"));
   align-items: center;
   justify-content: center;
+  margin: 0;
+  text-transform: none;
+  text-decoration: none;
+  border-style: solid;
+  overflow: visible;
+  user-select: none;
+  --_swc-button-border-width: token("border-width-200");
+  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
+
+  gap: var(--swc-button-gap, token("text-to-visual-100"));
   max-inline-size: var(--swc-button-max-inline-size, inherit);
   min-block-size: var(--_swc-button-min-block-size);
   padding-block: calc(var(--swc-button-padding-vertical, token("component-padding-vertical-100")) - var(--_swc-button-border-width));
   padding-inline: calc(var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")) - var(--_swc-button-border-width));
-  margin: 0;
   font-family: token("sans-serif-font");
   font-size: var(--swc-button-font-size, token("font-size-100"));
   font-weight: token("bold-font-weight");
   line-height: round(down, calc(token("line-height-100") * 1em), 1px);
   color: var(--swc-button-content-color-default, token("gray-25"));
-  text-transform: none;
-  text-decoration: none;
   background-color: var(--swc-button-background-color-default, token("neutral-background-color-default"));
   border-color: var(--swc-button-border-color-default, transparent);
-  border-style: solid;
   border-width: var(--_swc-button-border-width);
   border-radius: var(--swc-button-border-radius, calc(var(--_swc-button-min-block-size) / 2));
-  overflow: visible;
-  user-select: none;
   transition-timing-function: token("animation-ease-in-out");
   transition-duration: token("animation-duration-100");
   transition-property: outline, border-color, color, background-color, transform;
-
-  --_swc-button-border-width: token("border-width-200");
-  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
-}
-
-.swc-Button:focus-visible {
+}.swc-Button:focus-visible {
+  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
+  outline-offset: token("focus-indicator-gap");
   color: var(--swc-button-content-color-focus, token("gray-25"));
   background-color: var(--swc-button-background-color-focus, token("neutral-background-color-key-focus"));
   border-color: var(--swc-button-border-color-focus, transparent);
-  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
-  outline-offset: token("focus-indicator-gap");
-}
-
-.swc-Button:disabled:is(*, :hover) {
+}.swc-Button:disabled:is(*, :hover) {
   color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
   background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
   border-color: var(--swc-button-border-color-disabled, transparent);
   transform: none;
-}
-
-.swc-Button:hover {
+}.swc-Button--disabled .swc-Button-icon {
+  pointer-events: none;
+}.swc-Button:hover {
   color: var(--swc-button-content-color-hover, token("gray-25"));
   background-color: var(--swc-button-background-color-hover, token("neutral-background-color-hover"));
   border-color: var(--swc-button-border-color-hover, transparent);
-}
-
-.swc-Button:active {
+}.swc-Button:active {
   color: var(--swc-button-content-color-down, token("gray-25"));
   background-color: var(--swc-button-background-color-down, token("neutral-background-color-down"));
   border-color: var(--swc-button-border-color-down, transparent);
   transform: var(--swc-button-down-state-transform, perspective(var(--_swc-button-min-block-size)) translate3d(0, 0, token("component-size-difference-down")));
   will-change: transform;
-}
-
-.swc-Button-label {
+}.swc-Button-label {
   text-align: center;
-}
-
-.swc-Button--hasIcon .swc-Button-label {
+}.swc-Button--hasIcon .swc-Button-label {
   text-align: start;
-}
-
-.swc-Button-icon,
+}.swc-Button-icon,
 .swc-Button-pendingSpinner {
   --_swc-button-icon-size: var(--swc-button-icon-size, token("workflow-icon-size-100"));
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
@@ -100,14 +86,10 @@
   block-size: var(--_swc-button-icon-block-size);
   margin-block: calc((var(--_swc-button-icon-block-size) - 1lh) / 2 * -1);
   margin-inline-start: calc(var(--swc-button-edge-to-visual, token("component-pill-edge-to-visual-100")) - var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")));
-}
-
-.swc-Button-icon {
+}.swc-Button-icon {
   color: inherit;
   fill: currentcolor;
-}
-
-.swc-Button--sizeS {
+}.swc-Button--sizeS {
   --swc-button-min-block-size: token("component-height-75");
   --swc-button-font-size: token("font-size-75");
   --swc-button-gap: token("text-to-visual-75");
@@ -116,9 +98,7 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-75");
   --swc-button-padding-vertical: token("component-padding-vertical-75");
   --swc-button-icon-size: token("workflow-icon-size-75");
-}
-
-.swc-Button--sizeL {
+}.swc-Button--sizeL {
   --swc-button-min-block-size: token("component-height-200");
   --swc-button-font-size: token("font-size-200");
   --swc-button-gap: token("text-to-visual-200");
@@ -127,9 +107,7 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-200");
   --swc-button-padding-vertical: token("component-padding-vertical-200");
   --swc-button-icon-size: token("workflow-icon-size-200");
-}
-
-.swc-Button--sizeXl {
+}.swc-Button--sizeXl {
   --swc-button-min-block-size: token("component-height-300");
   --swc-button-font-size: token("font-size-300");
   --swc-button-gap: token("text-to-visual-300");
@@ -138,9 +116,7 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-300");
   --swc-button-padding-vertical: token("component-padding-vertical-300");
   --swc-button-icon-size: token("workflow-icon-size-300");
-}
-
-.swc-Button--accent {
+}.swc-Button--accent {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -149,9 +125,7 @@
   --swc-button-background-color-hover: token("accent-background-color-hover");
   --swc-button-background-color-down: token("accent-background-color-down");
   --swc-button-background-color-focus: token("accent-background-color-key-focus");
-}
-
-.swc-Button--negative {
+}.swc-Button--negative {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -160,9 +134,7 @@
   --swc-button-background-color-hover: token("negative-background-color-hover");
   --swc-button-background-color-down: token("negative-background-color-down");
   --swc-button-background-color-focus: token("negative-background-color-key-focus");
-}
-
-.swc-Button--secondary {
+}.swc-Button--secondary {
   --swc-button-content-color-default: token("neutral-content-color-default");
   --swc-button-content-color-hover: token("neutral-content-color-hover");
   --swc-button-content-color-down: token("neutral-content-color-down");
@@ -171,9 +143,7 @@
   --swc-button-background-color-hover: token("gray-200");
   --swc-button-background-color-down: token("gray-200");
   --swc-button-background-color-focus: token("gray-200");
-}
-
-.swc-Button--primary.swc-Button--outline {
+}.swc-Button--primary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -188,9 +158,7 @@
   --swc-button-content-color-focus: token("neutral-content-color-key-focus");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}
-
-.swc-Button--secondary.swc-Button--outline {
+}.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -201,9 +169,7 @@
   --swc-button-border-color-focus: token("gray-400");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}
-
-.swc-Button--staticWhite {
+}.swc-Button--staticWhite {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-white-800");
   --swc-button-background-color-hover: token("transparent-white-900");
@@ -216,9 +182,7 @@
   --swc-button-background-color-disabled: token("disabled-static-white-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}
-
-.swc-Button--staticWhite.swc-Button--secondary {
+}.swc-Button--staticWhite.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-white-100");
   --swc-button-background-color-hover: token("transparent-white-200");
   --swc-button-background-color-down: token("transparent-white-200");
@@ -227,9 +191,7 @@
   --swc-button-content-color-hover: token("transparent-white-900");
   --swc-button-content-color-down: token("transparent-white-900");
   --swc-button-content-color-focus: token("transparent-white-900");
-}
-
-.swc-Button--staticWhite.swc-Button--outline {
+}.swc-Button--staticWhite.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -245,9 +207,7 @@
   --swc-button-background-color-disabled: token("transparent-white-25");
   --swc-button-border-color-disabled: token("disabled-static-white-border-color");
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}
-
-.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
+}.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -256,9 +216,7 @@
   --swc-button-border-color-hover: token("transparent-white-400");
   --swc-button-border-color-down: token("transparent-white-400");
   --swc-button-border-color-focus: token("transparent-white-400");
-}
-
-.swc-Button--staticBlack {
+}.swc-Button--staticBlack {
   --swc-button-focus-indicator-color: token("static-black-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-black-800");
   --swc-button-background-color-hover: token("transparent-black-900");
@@ -271,9 +229,7 @@
   --swc-button-background-color-disabled: token("disabled-static-black-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}
-
-.swc-Button--staticBlack.swc-Button--secondary {
+}.swc-Button--staticBlack.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-black-100");
   --swc-button-background-color-hover: token("transparent-black-200");
   --swc-button-background-color-down: token("transparent-black-200");
@@ -282,9 +238,7 @@
   --swc-button-content-color-hover: token("transparent-black-900");
   --swc-button-content-color-down: token("transparent-black-900");
   --swc-button-content-color-focus: token("transparent-black-900");
-}
-
-.swc-Button--staticBlack.swc-Button--outline {
+}.swc-Button--staticBlack.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -300,9 +254,7 @@
   --swc-button-background-color-disabled: token("transparent-black-25");
   --swc-button-border-color-disabled: token("disabled-static-black-border-color");
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}
-
-.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
+}.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -311,40 +263,28 @@
   --swc-button-border-color-hover: token("transparent-black-400");
   --swc-button-border-color-down: token("transparent-black-400");
   --swc-button-border-color-focus: token("transparent-black-400");
-}
-
-.swc-Button--iconOnly {
+}.swc-Button--iconOnly {
   --swc-button-border-radius: token("corner-radius-full");
   --swc-button-gap: 0;
 
   padding-inline: calc(var(--swc-button-edge-to-visual-only, token("component-pill-edge-to-visual-only-100")) - var(--_swc-button-border-width));
-}
-
-.swc-Button--iconOnly .swc-Button-icon {
+}.swc-Button--iconOnly .swc-Button-icon {
   --swc-button-edge-to-visual: 0;
 
   align-self: center;
-}
-
-.swc-Button--truncate .swc-Button-label {
+}.swc-Button--truncate .swc-Button-label {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.swc-Button--justified {
+}.swc-Button--justified {
   flex-grow: 1;
   justify-self: stretch;
   inline-size: 100%;
-}
-
-@media (prefers-reduced-motion: reduce) {
+}@media (prefers-reduced-motion: reduce) {
   .swc-Button {
     transition-duration: 0ms;
   }
 }
-}
-
-.swc-Button {
+}.swc-Button {
 all: revert-layer !important;
 }


### PR DESCRIPTION
## Description

Fixes disabled 2nd-gen button-like components firing `click` events on the host when users click a **slotted icon**.

2nd-gen buttons render an internal native `<button disabled>`, but slotted icon content remains in the **light DOM** as a child of the host. Clicks on the icon bypass the disabled inner button and bubble to the host, so listeners (Storybook Actions, app `@click` handlers) still ran.

**Changes:**

- **`Button.base.ts`** — Extend `handleClick` to suppress clicks when `disabled` or `pending`. Register the host listener in the **capture** phase so it runs before consumer bubble listeners. Call `preventDefault()` and `stopImmediatePropagation()`.
- **`button-base.css`** — Add `:host([disabled]) slot[name="icon"]::slotted(*) { pointer-events: none; }` so hit testing routes through the disabled inner button (defense in depth for non-`click` pointer events).
- **`global/global-button.css`** — Add `pointer-events: none` for disabled global button icons (`.swc-Button--disabled .swc-Button-icon`).
- **`button.test.ts`** — Extend `DisabledBehaviorTest` to assert host `click` is suppressed when a slotted icon is clicked while disabled.

## Motivation and context

Discovered while implementing `swc-action-button`: the **Action Button → States** story renders a disabled button with a slotted icon that still logged Storybook Actions clicks.

This is a **`ButtonBase`** fix, so all button-like components that extend it inherit the JS behavior automatically — including **`swc-button`** and **`swc-action-button`**.

**Note for action-button:** `swc-action-button` gets the JS guard immediately via `ButtonBase`. To also pick up the shared CSS rule in `button-base.css`, the action-button implementation should import `button-base.css` alongside `action-button.css` (same pattern as `swc-button`).

## Related issue(s)

- Discovered during `swc-action-button` migration work (SWC-2039)

## Screenshots (if appropriate)


https://github.com/user-attachments/assets/c84592f3-388f-4ca6-911f-0da9764cd05a



---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] **Disabled button — slotted icon does not fire host click (`swc-button`)**
  1. Open 2nd-gen Storybook → **Button → States**
  2. Click the **icon** on the disabled button
  3. Expect: no Storybook Actions `click` logged; button does not activate

- [ ] **Disabled button — label area still non-interactive (`swc-button`)**
  1. Open 2nd-gen Storybook → **Button → States**
  2. Click the **label** on the disabled button
  3. Expect: no activation; button remains disabled

- [ ] **Enabled button regression — icon click still works**
  1. Open 2nd-gen Storybook → **Button → States** (or default story with icon)
  2. Click the icon on a **non-disabled** button
  3. Expect: `click` fires normally

- [ ] **Pending behavior unchanged**
  1. Open 2nd-gen Storybook → **Button → Tests → PendingBehaviorTest** (or pending story)
  2. Click while `pending`
  3. Expect: click suppressed (existing behavior)

- [ ] **Action button impact (`swc-action-button`)**
  1. Rebase action-button branch on this fix
  2. Open **Action Button → States**
  3. Click the icon on the disabled variant
  4. Expect: no host `click` / Storybook Actions log (JS fix via `ButtonBase`)

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

**Required:** Complete each applicable item and document your testing steps (replace the placeholders with your component-specific instructions).

- [ ] **Keyboard** (required — document steps below) — _What to test for:_ Focus order is logical; <kbd>Tab</kbd> reaches the component and all interactive descendants; <kbd>Enter</kbd>/<kbd>Space</kbd> activate where appropriate; no focus traps; focus indicator is visible.
  1. Open Storybook → **Button → Tests → DisabledBehaviorTest** (or States story)
  2. <kbd>Tab</kbd> to the disabled button
  3. Expect: disabled button is **skipped** (not in tab order); <kbd>Enter</kbd>/<kbd>Space</kbd> do not activate it

- [ ] **Screen reader** (required — document steps below) — _What to test for:_ Role and name are announced correctly; disabled state is communicated.
  1. Open Storybook → **Button → States**
  2. Navigate to the disabled button with a screen reader
  3. Expect: announced as disabled/unavailable (e.g. "Disabled, dimmed button" or platform equivalent); no duplicate host + inner button announcement