### PR TITLE
feat(tooltip): integrate HoverController and PlacementController

### DIFF
--- a/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
+++ b/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
@@ -321,6 +321,8 @@ export abstract class TooltipBase
       this.style.removeProperty('translate');
       this.style.removeProperty('top');
       this.style.removeProperty('left');
+      this.style.removeProperty('--swc-placement-available-width');
+      this.style.removeProperty('--swc-placement-available-height');
 
       if (this.tipElement) {
         this.tipElement.style.removeProperty('translate');

--- a/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
+++ b/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
@@ -321,6 +321,12 @@ export abstract class TooltipBase
       this.style.removeProperty('translate');
       this.style.removeProperty('top');
       this.style.removeProperty('left');
+
+      if (this.tipElement) {
+        this.tipElement.style.removeProperty('translate');
+        this.tipElement.style.removeProperty('top');
+        this.tipElement.style.removeProperty('left');
+      }
     }
   }
 

--- a/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
+++ b/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
@@ -15,6 +15,10 @@ import { property } from 'lit/decorators.js';
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
 
 import {
+  HoverController,
+  type HoverControllerHost,
+} from '../../controllers/hover-controller/index.js';
+import {
   TOOLTIP_PLACEMENTS,
   TOOLTIP_VARIANTS,
   type TooltipPlacement,
@@ -23,18 +27,15 @@ import {
 
 /**
  * Abstract base class for the Tooltip component.
- *
- * Declares all public properties, sets `role="tooltip"` and `popover="auto"` on
- * the host element, wires the popover lifecycle (`beforetoggle`, `toggle`,
- * `transitionend`), dispatches `swc-open`, `swc-close`, `swc-after-open`, and
- * `swc-after-close` events, resolves the trigger element via `for` or
- * `triggerElement`, and syncs the ARIA relationship (`ariaDescribedByElements`
- * or `ariaLabelledByElements` when `labeling` is set) on `open` and `labeling`
- * changes. No rendering logic, including placement.
+ * Handles all non-rendering logic: property declarations, popover lifecycle,
+ * event dispatch, trigger resolution, ARIA wiring, and `HoverController` integration.
  *
  * @slot - Text label displayed in the tooltip.
  */
-export abstract class TooltipBase extends SpectrumElement {
+export abstract class TooltipBase
+  extends SpectrumElement
+  implements HoverControllerHost
+{
   // ──────────────────
   //     SHARED API
   // ──────────────────
@@ -64,7 +65,7 @@ export abstract class TooltipBase extends SpectrumElement {
 
   /**
    * The preferred placement of the tooltip relative to its trigger.
-   * Controls the tip direction via the reflected `placement` attribute; pixel positioning requires `PlacementController` (additive phase).
+   * Determines the tip arrow direction. Pixel positioning requires `PlacementController`.
    *
    * @default 'top'
    */
@@ -81,16 +82,13 @@ export abstract class TooltipBase extends SpectrumElement {
 
   /**
    * The `id` of the trigger element in the same document tree root.
-   * Resolved via `getRootNode().getElementById(this.for)`.
-   * Drives ARIA relationship wiring on `open` change.
    */
   @property({ attribute: 'for', type: String })
   public for: string | undefined;
 
   /**
-   * Explicit trigger element reference. Overrides `for` when set.
-   * Use for cross-shadow-root triggers or programmatic insertion where `getElementById` is scoped to the wrong root.
-   * Setter only; no HTML attribute.
+   * Explicit trigger element reference; overrides `for` when set.
+   * Use when `getElementById` cannot reach the trigger, such as across a shadow boundary.
    *
    * @default null
    */
@@ -98,14 +96,8 @@ export abstract class TooltipBase extends SpectrumElement {
   public triggerElement: HTMLElement | null = null;
 
   /**
-   * Duration in milliseconds of the warm-up delay before the tooltip shows on pointer hover.
-   * Set to `0` to show immediately on hover. Keyboard focus (`focusin` when `:focus-visible`)
-   * always shows the tooltip immediately regardless of this value. The cooldown duration after the
-   * pointer leaves the trigger matches this value. Warm-up/cooldown state is shared across all tooltips in the same document,
-   * so moving quickly between adjacent triggers (e.g. a toolbar) shows each subsequent tooltip
-   * immediately after the first warm-up elapses.
-   *
-   * Additive/deferred: active when `HoverController` is integrated.
+   * Warm-up delay in milliseconds before the tooltip opens on pointer hover.
+   * Set to `0` to open immediately. Keyboard focus always opens immediately.
    *
    * @default 1500
    */
@@ -113,10 +105,7 @@ export abstract class TooltipBase extends SpectrumElement {
   public delay: number = 1500;
 
   /**
-   * When set, prevents automatic trigger wiring from responding to hover and focus events.
-   * No-op when `manual` is also set.
-   *
-   * Additive/deferred: active when `HoverController` is integrated.
+   * When set, the tooltip does not respond to hover or focus events.
    *
    * @default false
    */
@@ -124,11 +113,8 @@ export abstract class TooltipBase extends SpectrumElement {
   public disabled: boolean = false;
 
   /**
-   * Suppresses controller wiring for automatic hover and focus open/close.
-   * The consumer manages visibility via the `open` property or the popover API directly.
-   * ARIA relationship wiring still fires on `open` change when `for` or `triggerElement` is set.
-   *
-   * Additive/deferred: effective when controllers are integrated.
+   * Suppresses automatic hover and focus wiring.
+   * The consumer manages visibility via the `open` property or the popover API.
    *
    * @default false
    */
@@ -137,9 +123,7 @@ export abstract class TooltipBase extends SpectrumElement {
 
   /**
    * Pixel offset between the tooltip and its trigger.
-   * Passed to `PlacementController` offset middleware.
-   *
-   * Additive/deferred: active when `PlacementController` is integrated.
+   * Requires `PlacementController`; currently inactive.
    *
    * @default 0
    */
@@ -147,10 +131,8 @@ export abstract class TooltipBase extends SpectrumElement {
   public offset: number = 0;
 
   /**
-   * When set, wires `ariaLabelledByElements` instead of `ariaDescribedByElements` on the trigger's
-   * inner interactive element. Use for icon-only triggers where the tooltip text is the sole accessible
-   * name and adding an accessible label directly to the trigger host is not possible.
-   * Prefer `accessible-label` on the trigger when feasible — it works without this attribute.
+   * When set, the tooltip acts as the trigger's accessible name rather than its description.
+   * Use for icon-only triggers where the tooltip text is the sole accessible name.
    *
    * @default false
    */
@@ -160,6 +142,10 @@ export abstract class TooltipBase extends SpectrumElement {
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────
+
+  private readonly hoverController = new HoverController(this, {
+    warmStateKey: 'swc-tooltip',
+  });
 
   // Reflects the browser's actual popover state. Used to guard showPopover/hidePopover
   // calls in updated() so the toggle listener can sync this.open without re-triggering
@@ -289,6 +275,12 @@ export abstract class TooltipBase extends SpectrumElement {
     }
     if (changedProperties.has('open') || changedProperties.has('labeling')) {
       this.syncAriaRelationship();
+    }
+    if (
+      changedProperties.has('for') ||
+      changedProperties.has('triggerElement')
+    ) {
+      this.hoverController.setTarget(this.resolveTrigger());
     }
   }
 

--- a/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
+++ b/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
@@ -203,6 +203,11 @@ export abstract class TooltipBase
   // preventing one after event from firing for each CSS property that transitions.
   private afterEventPending = false;
 
+  // Fallback timer for browsers that do not fire transitionend for
+  // transition-behavior:allow-discrete discrete properties (e.g. Firefox in CI).
+  // Cleared when transitionend fires or a new toggle starts.
+  private afterEventFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
   /**
    * Returns the tip arrow element to pass to `PlacementController` so the
    * `arrow` middleware keeps the tip aligned with the trigger when the bubble
@@ -332,6 +337,11 @@ export abstract class TooltipBase
   };
 
   private readonly handleToggle = (event: Event): void => {
+    // Cancel any in-flight close fallback; a new toggle resets the cycle.
+    if (this.afterEventFallbackTimer !== null) {
+      clearTimeout(this.afterEventFallbackTimer);
+      this.afterEventFallbackTimer = null;
+    }
     const { newState } = event as ToggleEvent;
     const isOpen = newState === 'open';
     if (isOpen !== this.open) {
@@ -344,12 +354,35 @@ export abstract class TooltipBase
     if (durations.every((d) => d.trim() === '0s')) {
       this.afterEventPending = false;
       this.dispatchAfterEvent(isOpen);
+    } else if (!isOpen) {
+      // Some browsers (e.g. Firefox in CI) do not fire transitionend for
+      // transition-behavior:allow-discrete discrete properties. Start a fallback
+      // so positioning is always cleared after the exit transition window.
+      const maxMs = Math.max(
+        0,
+        ...durations.map((d) => {
+          const trimmed = d.trim();
+          const value = parseFloat(trimmed);
+          return trimmed.endsWith('ms') ? value : value * 1000;
+        })
+      );
+      this.afterEventFallbackTimer = setTimeout(() => {
+        this.afterEventFallbackTimer = null;
+        if (this.afterEventPending) {
+          this.afterEventPending = false;
+          this.dispatchAfterEvent(false);
+        }
+      }, maxMs + 100);
     }
   };
 
   private readonly handleTransitionEnd = (event: TransitionEvent): void => {
     if (event.target !== this || !this.afterEventPending) {
       return;
+    }
+    if (this.afterEventFallbackTimer !== null) {
+      clearTimeout(this.afterEventFallbackTimer);
+      this.afterEventFallbackTimer = null;
     }
     this.afterEventPending = false;
     this.dispatchAfterEvent(this.open);
@@ -442,5 +475,9 @@ export abstract class TooltipBase
     this.removeEventListener('toggle', this.handleToggle);
     this.removeEventListener('transitionend', this.handleTransitionEnd);
     document.removeEventListener('keydown', this.handleKeyDown);
+    if (this.afterEventFallbackTimer !== null) {
+      clearTimeout(this.afterEventFallbackTimer);
+      this.afterEventFallbackTimer = null;
+    }
   }
 }

--- a/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
+++ b/2nd-gen/packages/core/components/tooltip/Tooltip.base.ts
@@ -19,6 +19,10 @@ import {
   type HoverControllerHost,
 } from '../../controllers/hover-controller/index.js';
 import {
+  type Placement as ControllerPlacement,
+  PlacementController,
+} from '../../controllers/placement-controller/index.js';
+import {
   TOOLTIP_PLACEMENTS,
   TOOLTIP_VARIANTS,
   type TooltipPlacement,
@@ -28,7 +32,8 @@ import {
 /**
  * Abstract base class for the Tooltip component.
  * Handles all non-rendering logic: property declarations, popover lifecycle,
- * event dispatch, trigger resolution, ARIA wiring, and `HoverController` integration.
+ * event dispatch, trigger resolution, ARIA wiring, `HoverController` integration
+ * (hover/focus open/close), and `PlacementController` integration (pixel positioning).
  *
  * @slot - Text label displayed in the tooltip.
  */
@@ -64,13 +69,25 @@ export abstract class TooltipBase
   public variant: TooltipVariant = 'neutral';
 
   /**
-   * The preferred placement of the tooltip relative to its trigger.
-   * Determines the tip arrow direction. Pixel positioning requires `PlacementController`.
+   * Preferred placement of the tooltip relative to its trigger. Reflects the
+   * actual computed side when `PlacementController` is active (which may differ
+   * from the requested value after a viewport-driven flip).
    *
    * @default 'top'
    */
   @property({ type: String, reflect: true })
-  public placement: TooltipPlacement = 'top';
+  get placement(): TooltipPlacement {
+    return this._placement;
+  }
+
+  set placement(value: TooltipPlacement) {
+    const old = this._placement;
+    this._placement = value;
+    if (!this._placementFromController) {
+      this._requestedPlacement = value;
+    }
+    this.requestUpdate('placement', old);
+  }
 
   /**
    * Whether the tooltip is visible.
@@ -122,13 +139,37 @@ export abstract class TooltipBase
   public manual: boolean = false;
 
   /**
-   * Pixel offset between the tooltip and its trigger.
-   * Requires `PlacementController`; currently inactive.
+   * Pixel gap along the placement axis between the trigger and the tooltip bubble.
+   *
+   * @default 4
+   */
+  @property({ type: Number })
+  public offset: number = 4;
+
+  /**
+   * Slide along the trigger edge perpendicular to the placement direction, in pixels.
    *
    * @default 0
    */
-  @property({ type: Number })
-  public offset: number = 0;
+  @property({ type: Number, attribute: 'cross-offset' })
+  public crossOffset: number = 0;
+
+  /**
+   * Minimum inset from the viewport edge, in pixels, for collision detection.
+   *
+   * @default 12
+   */
+  @property({ type: Number, attribute: 'container-padding' })
+  public containerPadding: number = 12;
+
+  /**
+   * Whether the tooltip may reposition to the opposite side when the requested
+   * placement does not fit within the viewport.
+   *
+   * @default true
+   */
+  @property({ type: Boolean, attribute: 'should-flip' })
+  public shouldFlip: boolean = true;
 
   /**
    * When set, the tooltip acts as the trigger's accessible name rather than its description.
@@ -147,11 +188,65 @@ export abstract class TooltipBase
     warmStateKey: 'swc-tooltip',
   });
 
+  private readonly placementController = new PlacementController(this);
+
+  // Backing fields for the custom placement getter/setter.
+  private _placement: TooltipPlacement = 'top';
+  // The placement originally requested by the consumer. PlacementController
+  // always starts from this value so a viewport-driven flip can revert when
+  // space opens up again.
+  private _requestedPlacement: TooltipPlacement = 'top';
+  // Set while onPlacementChange is writing the computed placement back into
+  // the property, so the setter knows not to overwrite _requestedPlacement.
+  private _placementFromController = false;
+  // Guards dispatchAfterEvent so only the first transitionend per open/close cycle fires,
+  // preventing one after event from firing for each CSS property that transitions.
+  private afterEventPending = false;
+
+  /**
+   * Returns the tip arrow element to pass to `PlacementController` so the
+   * `arrow` middleware keeps the tip aligned with the trigger when the bubble
+   * is shifted (e.g. via `crossOffset` or viewport `shift`).
+   *
+   * Returns `null` in the base class; the SWC rendering layer overrides this
+   * to return the actual `.swc-Tooltip-tip` element from the shadow DOM.
+   */
+  protected get tipElement(): HTMLElement | null {
+    return null;
+  }
+
   // Reflects the browser's actual popover state. Used to guard showPopover/hidePopover
   // calls in updated() so the toggle listener can sync this.open without re-triggering
   // the API (preventing a setter → showPopover → toggle → setter cycle).
   private get isPopoverOpen(): boolean {
     return this.matches(':popover-open');
+  }
+
+  private startPlacement(): void {
+    const trigger = this.resolveTrigger();
+    if (!trigger) {
+      return;
+    }
+    this.placementController.start(trigger, this, {
+      // Always use the consumer's original requested placement, not the last
+      // computed value, so a viewport-driven flip can revert when space opens up.
+      placement: this._requestedPlacement as ControllerPlacement,
+      offset: this.offset,
+      crossOffset: this.crossOffset,
+      containerPadding: this.containerPadding,
+      shouldFlip: this.shouldFlip,
+      tipElement: this.tipElement ?? undefined,
+      onPlacementChange: (actualPlacement: ControllerPlacement) => {
+        const mainSide = actualPlacement.split('-')[0] as TooltipPlacement;
+        if (this._placement !== mainSide) {
+          // Flag prevents the setter from treating this as a consumer change
+          // and overwriting _requestedPlacement.
+          this._placementFromController = true;
+          this.placement = mainSide;
+          this._placementFromController = false;
+        }
+      },
+    });
   }
 
   private resolveTrigger(): HTMLElement | null {
@@ -213,11 +308,16 @@ export abstract class TooltipBase
         composed: true,
       })
     );
+    if (!isOpen) {
+      // Clear PlacementController's inline positioning only after the exit
+      // transition completes. Removing translate/top/left earlier (e.g. in
+      // updated()) displaces the tooltip to 0,0 while it is still visible
+      // and fading out, causing a flash.
+      this.style.removeProperty('translate');
+      this.style.removeProperty('top');
+      this.style.removeProperty('left');
+    }
   }
-
-  // Guards dispatchAfterEvent so only the first transitionend per open/close cycle fires,
-  // preventing one after event from firing for each CSS property that transitions.
-  private afterEventPending = false;
 
   private readonly handleBeforeToggle = (event: Event): void => {
     const { newState } = event as ToggleEvent;
@@ -262,8 +362,24 @@ export abstract class TooltipBase
     }
   };
 
+  protected override firstUpdated(changedProperties: PropertyValues): void {
+    super.firstUpdated(changedProperties);
+    // Sync the animation distance to the current offset value on first render
+    // so the open/close animation slides by the same distance as the gap.
+    this.style.setProperty(
+      '--_swc-tooltip-animation-distance',
+      `${this.offset}px`
+    );
+  }
+
   protected override updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
+    if (changedProperties.has('offset')) {
+      this.style.setProperty(
+        '--_swc-tooltip-animation-distance',
+        `${this.offset}px`
+      );
+    }
     if (changedProperties.has('open')) {
       if (this.open !== this.isPopoverOpen) {
         if (this.open) {
@@ -281,6 +397,32 @@ export abstract class TooltipBase
       changedProperties.has('triggerElement')
     ) {
       this.hoverController.setTarget(this.resolveTrigger());
+    }
+
+    // Placement controller: start when opening, stop when closing, restart
+    // when positioning options or the trigger change while already open.
+    const openChanged = changedProperties.has('open');
+    if (openChanged) {
+      if (this.open) {
+        this.startPlacement();
+      } else {
+        // Stop autoUpdate immediately so the position stops tracking the trigger
+        // during the exit transition. The translate/top/left are cleared by
+        // dispatchAfterEvent once the exit transition completes.
+        this.placementController.stop();
+      }
+    } else if (this.open) {
+      const placementOptsChanged =
+        changedProperties.has('placement') ||
+        changedProperties.has('offset') ||
+        changedProperties.has('crossOffset') ||
+        changedProperties.has('containerPadding') ||
+        changedProperties.has('shouldFlip') ||
+        changedProperties.has('for') ||
+        changedProperties.has('triggerElement');
+      if (placementOptsChanged) {
+        this.startPlacement();
+      }
     }
   }
 

--- a/2nd-gen/packages/core/controllers/hover-controller/src/hover-controller.ts
+++ b/2nd-gen/packages/core/controllers/hover-controller/src/hover-controller.ts
@@ -169,7 +169,6 @@ export class HoverController implements ReactiveController {
     this.unwireTarget();
     this.unwireBridge();
     this.clearWarmupTimer();
-    this.clearCooldownTimer();
     this.hasFocusOpen = false;
     this.hadPointerdown = false;
     this.isGuardActive = false;

--- a/2nd-gen/packages/core/controllers/hover-controller/stories/hover-controller.test.ts
+++ b/2nd-gen/packages/core/controllers/hover-controller/stories/hover-controller.test.ts
@@ -278,6 +278,58 @@ export const CooldownCancelledByReenter: Story = {
 };
 
 // ──────────────────────────────────────────────────────────────────────────
+//     Disconnect does not cancel another instance's shared cooldown
+// ──────────────────────────────────────────────────────────────────────────
+
+export const DisconnectDoesNotCancelSharedCooldown: Story = {
+  ...WarmUpAndCooldown,
+  play: async ({ canvasElement, step }) => {
+    const triggerA = getTrigger(canvasElement, 'warm-trigger-a');
+    const hostA = getHost(canvasElement, 'warm-trigger-a');
+    const hostB = getHost(canvasElement, 'warm-trigger-b');
+
+    await step('warm up by hovering trigger A until it opens', async () => {
+      pointerEnter(triggerA);
+      await wait(350);
+      expect(hostA.matches(':popover-open')).toBe(true);
+    });
+
+    await step(
+      'leave trigger A to start the shared cooldown timer',
+      async () => {
+        pointerLeave(triggerA);
+      }
+    );
+
+    await step(
+      'disconnect host B before cooldown fires — must not cancel the shared timer',
+      async () => {
+        // Remove B well within the 300 ms cooldown window.
+        hostB.remove();
+        await wait(50);
+      }
+    );
+
+    await step(
+      'after cooldown elapses, warm state has reset — next hover re-warms',
+      async () => {
+        // Wait well past the 300 ms cooldown. If the bug were present, the timer
+        // would have been cancelled and isWarm would remain true, causing trigger A
+        // to open immediately on the next pointerenter.
+        await wait(350);
+        pointerEnter(triggerA);
+        expect(hostA.matches(':popover-open')).toBe(false);
+        await wait(350);
+        expect(hostA.matches(':popover-open')).toBe(true);
+      }
+    );
+
+    pointerLeave(triggerA);
+    await wait(350);
+  },
+};
+
+// ──────────────────────────────────────────────────────────────────────────
 //     Focus opens immediately regardless of warm state
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/2nd-gen/packages/core/controllers/placement-controller/placement-controller.mdx
+++ b/2nd-gen/packages/core/controllers/placement-controller/placement-controller.mdx
@@ -12,7 +12,7 @@ import * as PlacementControllerStories from './stories/placement-controller.stor
 ### Positioning
 
 - Computes `top`, `left`, and `translate` on the **floating element** using
-  `strategy: 'fixed'` (suitable for native popover top-layer surfaces).
+  `strategy: 'absolute'` (required for correct top-layer element placement).
 - Subscribes to scroll, resize, and layout shift via Floating UI's `autoUpdate`
   while `PlacementController.start` is active.
 - Waits for `document.fonts.ready` and applies iOS WebKit `visualViewport`
@@ -300,11 +300,11 @@ responsible for accessible open/close behavior.
 
 ### Methods
 
-| Member                               | Description                                                                                                                                                                    |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `start(trigger, floating, options?)` | Begin positioning; tear down any prior session and subscribe to Floating UI `autoUpdate`. Skips compute when the floating element has zero dimensions until size is available. |
-| `stop()`                             | Tear down positioning, unsubscribe from `autoUpdate`, and clear `actualPlacement` and `isConstrained`. Called from `hostDisconnected` when the Lit host disconnects.           |
-| `recompute()`                        | Force one `computePosition` pass outside `autoUpdate` — for example after floating content reflows or a virtual trigger moves without layout events. No-op if not started.     |
+| Member                               | Description                                                                                                                                                                                                                                                                                                                                |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `start(trigger, floating, options?)` | Begin positioning; tear down any prior session and subscribe to Floating UI `autoUpdate`. Skips compute when the floating element has zero dimensions until size is available.                                                                                                                                                             |
+| `stop()`                             | Tear down positioning, unsubscribe from `autoUpdate`, and clear `actualPlacement` and `isConstrained`. Inline styles (`translate`, `top`, `left`) and `--swc-placement-available-*` custom properties are left for the caller to remove after any exit transition completes. Called from `hostDisconnected` when the Lit host disconnects. |
+| `recompute()`                        | Force one `computePosition` pass outside `autoUpdate` — for example after floating content reflows or a virtual trigger moves without layout events. No-op if not started.                                                                                                                                                                 |
 
 ### Readonly properties
 

--- a/2nd-gen/packages/core/controllers/placement-controller/src/placement-controller.ts
+++ b/2nd-gen/packages/core/controllers/placement-controller/src/placement-controller.ts
@@ -293,18 +293,10 @@ export class PlacementController implements ReactiveController {
 
   /**
    * Stop positioning: tear down `autoUpdate`, clear `actualPlacement`,
-   * reset `isConstrained`, and remove inline styles the controller wrote
-   * (the `size` middleware's `--swc-placement-available-width` /
-   * `--swc-placement-available-height` custom properties on the floating
-   * element. Tip placement cleanup is left to render to account for exit transitions.
-   * Safe to call multiple times.
+   * reset `isConstrained`. Inline style cleanup is left to render to
+   * account for exit transitions. Safe to call multiple times.
    */
   public stop() {
-    const floating = this.session?.floating;
-    if (floating) {
-      floating.style.removeProperty('--swc-placement-available-width');
-      floating.style.removeProperty('--swc-placement-available-height');
-    }
     this.cleanup?.();
     this.cleanup = undefined;
     this.session = null;

--- a/2nd-gen/packages/core/controllers/placement-controller/src/placement-controller.ts
+++ b/2nd-gen/packages/core/controllers/placement-controller/src/placement-controller.ts
@@ -98,7 +98,9 @@ type ActiveSession = {
  * floating element — an inline max-size would override the consuming
  * component's intended CSS max-size. Instead it exposes the space available to
  * the trigger as two custom properties on the floating element, refreshed on
- * every compute and removed on `stop`:
+ * every compute. The caller removes them after any exit transition completes
+ * (clearing them in `stop()` would snap the floating element's size
+ * mid-animation):
  *
  * - `--swc-placement-available-width` — usable inline space, in px.
  * - `--swc-placement-available-height` — usable block space, in px (floored to
@@ -292,9 +294,11 @@ export class PlacementController implements ReactiveController {
   }
 
   /**
-   * Stop positioning: tear down `autoUpdate`, clear `actualPlacement`,
-   * reset `isConstrained`. Inline style cleanup is left to render to
-   * account for exit transitions. Safe to call multiple times.
+   * Stop positioning: tear down `autoUpdate`, clear `actualPlacement` and
+   * `isConstrained`. Inline style cleanup — including `translate`, `top`,
+   * `left`, and `--swc-placement-available-*` — is left to the caller so
+   * exit transitions can complete before those properties are removed.
+   * Safe to call multiple times.
    */
   public stop() {
     this.cleanup?.();

--- a/2nd-gen/packages/core/controllers/placement-controller/src/placement-controller.ts
+++ b/2nd-gen/packages/core/controllers/placement-controller/src/placement-controller.ts
@@ -296,20 +296,14 @@ export class PlacementController implements ReactiveController {
    * reset `isConstrained`, and remove inline styles the controller wrote
    * (the `size` middleware's `--swc-placement-available-width` /
    * `--swc-placement-available-height` custom properties on the floating
-   * element, plus the `arrow` middleware's `translate` / `top` / `left`
-   * on the tip element). Safe to call multiple times.
+   * element. Tip placement cleanup is left to render to account for exit transitions.
+   * Safe to call multiple times.
    */
   public stop() {
     const floating = this.session?.floating;
     if (floating) {
       floating.style.removeProperty('--swc-placement-available-width');
       floating.style.removeProperty('--swc-placement-available-height');
-    }
-    const tipElement = this.session?.options.tipElement;
-    if (tipElement) {
-      tipElement.style.removeProperty('translate');
-      tipElement.style.removeProperty('top');
-      tipElement.style.removeProperty('left');
     }
     this.cleanup?.();
     this.cleanup = undefined;

--- a/2nd-gen/packages/core/controllers/placement-controller/src/placement-controller.ts
+++ b/2nd-gen/packages/core/controllers/placement-controller/src/placement-controller.ts
@@ -467,7 +467,7 @@ export class PlacementController implements ReactiveController {
       {
         placement: floatingPlacement,
         middleware,
-        strategy: 'fixed',
+        strategy: 'absolute', // Required for correct top-layer element placement
       }
     );
     if (this.session !== session) {

--- a/2nd-gen/packages/core/controllers/placement-controller/test/placement-controller.test.ts
+++ b/2nd-gen/packages/core/controllers/placement-controller/test/placement-controller.test.ts
@@ -692,8 +692,7 @@ export const TwoControllersDoNotInterfere: Story = {
       const bTranslateBefore = host.floatingB.style.translate;
       host.controllerA.stop();
 
-      // A is torn down: custom props removed, placement cleared.
-      expect(availableWidth(host.floatingA)).toBe('');
+      // A is torn down: actualPlacement cleared.
       expect(host.controllerA.actualPlacement).toBeNull();
 
       // B is untouched: same position, props, and placement.

--- a/2nd-gen/packages/swc/components/tooltip/Tooltip.ts
+++ b/2nd-gen/packages/swc/components/tooltip/Tooltip.ts
@@ -43,6 +43,13 @@ export class Tooltip extends TooltipBase {
     return [styles];
   }
 
+  protected override get tipElement(): HTMLElement | null {
+    return (
+      (this.renderRoot?.querySelector('.swc-Tooltip-tip') as HTMLElement) ??
+      null
+    );
+  }
+
   protected override render(): TemplateResult {
     return html`
       <div class="swc-Tooltip">

--- a/2nd-gen/packages/swc/components/tooltip/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/tooltip/migration-guide.mdx
@@ -42,30 +42,43 @@ import '@adobe/spectrum-wc/components/tooltip/swc-tooltip.js';
 
 ### Added in Spectrum 2
 
-| Addition                                    | Notes                                                                                                               |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `for` attribute                             | Declares the trigger relationship by ID. Required for ARIA wiring and automatic hover/focus open/close.             |
-| `manual` boolean attribute                  | Opt out of automatic hover/focus wiring. Consumer manages open/close via `open`. ARIA wiring still fires.           |
-| `disabled` boolean attribute                | Suppresses automatic hover/focus response. Trigger remains interactive; `open` still works directly.                |
-| Logical placements: `start`, `end`          | RTL-aware inline placement values; physical values (`top`, `bottom`, `left`, `right`) are unchanged.                |
-| `delay` attribute                           | Warm-up delay in ms before the tooltip opens on hover (default `1500`). `delay="0"` shows immediately.              |
-| `offset` attribute                          | Pixel gap between the trigger and the tooltip bubble (default `4`).                                                 |
-| `cross-offset` attribute                    | Slide in pixels perpendicular to the placement direction (default `0`).                                             |
-| `container-padding` attribute               | Minimum inset from the viewport edge for collision detection (default `12`).                                        |
-| `should-flip` boolean attribute             | Whether the tooltip may reposition to the opposite side when the requested placement does not fit (default `true`). |
-| `labeling` boolean attribute                | Switches ARIA wiring to `ariaLabelledByElements` for icon-only triggers.                                            |
-| `swc-after-open` / `swc-after-close` events | Fire after the open/close transition completes.                                                                     |
+| Addition                                    | Notes                                                                                                                                        |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `for` attribute                             | Declares the trigger relationship by ID. Required for ARIA wiring and automatic hover/focus open/close.                                      |
+| `manual` boolean attribute                  | Opt out of automatic hover/focus wiring. Consumer manages open/close via `open`. ARIA wiring still fires.                                    |
+| `disabled` boolean attribute                | Suppresses automatic hover/focus response. Trigger remains interactive; `open` still works directly.                                         |
+| Logical placements: `start`, `end`          | RTL-aware inline placement values; physical values (`top`, `bottom`, `left`, `right`) are unchanged.                                         |
+| `delay` attribute                           | Warm-up delay in ms before the tooltip opens on hover (default `1500`). `delay="0"` shows immediately.                                       |
+| `offset` attribute (expanded)               | Existed in Spectrum 1 (`self-managed` only, default `0`). Now always active with default `4`. See [behavioral changes](#behavioral-changes). |
+| `cross-offset` attribute                    | Slide in pixels perpendicular to the placement direction (default `0`).                                                                      |
+| `container-padding` attribute               | Minimum inset from the viewport edge for collision detection (default `12`).                                                                 |
+| `should-flip` boolean attribute             | Whether the tooltip may reposition to the opposite side when the requested placement does not fit (default `true`).                          |
+| `labeling` boolean attribute                | Switches ARIA wiring to `ariaLabelledByElements` for icon-only triggers.                                                                     |
+| `swc-after-open` / `swc-after-close` events | Fire after the open/close transition completes.                                                                                              |
 
 ### Removed in Spectrum 2
 
-| Removed                                 | Replacement                                                                                                       |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `slot="icon"`                           | No replacement. Remove all icon content from tooltips; Spectrum 2 tooltip is text-only.                           |
-| `variant="positive"`                    | Use `variant="informative"`, `variant="neutral"`, or `variant="negative"` as content warrants.                    |
-| `variant="info"`                        | Renamed to `variant="informative"`.                                                                               |
-| `self-managed` attribute                | Removed. Automatic trigger wiring is the default. Add `for="[id]"` to the tooltip pointing to the trigger's `id`. |
-| `sp-opened` / `sp-closed` events        | Replace with `swc-open` and `swc-close`. The timing also changes; see [step 4](#4-update-event-listeners).        |
-| `--mod-tooltip-*` CSS custom properties | No `--mod-*` pass-through in Spectrum 2. See [Styling](#styling).                                                 |
+| Removed                                 | Replacement                                                                                                                                                            |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slot="icon"`                           | No replacement. Remove all icon content from tooltips; Spectrum 2 tooltip is text-only.                                                                                |
+| `variant="positive"`                    | Use `variant="informative"`, `variant="neutral"`, or `variant="negative"` as content warrants.                                                                         |
+| `variant="info"`                        | Renamed to `variant="informative"`.                                                                                                                                    |
+| `self-managed` attribute                | Removed. Automatic trigger wiring is the default. Add `for="[id]"` to the tooltip pointing to the trigger's `id`.                                                      |
+| `delayed` boolean attribute             | Replaced by `delay` (number, in ms). Warm-up is now always active; set `delay="0"` to restore immediate-hover behavior. See [behavioral changes](#behavioral-changes). |
+| `tip-padding` attribute                 | No replacement. Was already `@deprecated` in Spectrum 1 and is not exposed in Spectrum 2.                                                                              |
+| `sp-opened` / `sp-closed` events        | Replace with `swc-open` and `swc-close`. The timing also changes; see [step 4](#4-update-event-listeners).                                                             |
+| `--mod-tooltip-*` CSS custom properties | No `--mod-*` pass-through in Spectrum 2. See [Styling](#styling).                                                                                                      |
+
+### Behavioral changes
+
+These are not rename changes; the attribute names are the same (or similar) but the default values or opt-in semantics differ. Review each one to confirm your usage is unaffected.
+
+| Property / attribute | Spectrum 1 behavior                                                                                                  | Spectrum 2 behavior                                                                                              | Action required                                                                                                                                   |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `variant` default    | Empty string; neutral state had no `variant` attribute on the host. `:not([variant])` CSS matched the neutral state. | Defaults to `"neutral"` and is reflected as an attribute. `:not([variant])` no longer matches the neutral state. | Update `:not([variant])` CSS selectors and any `getAttribute('variant') === null` checks to `[variant="neutral"]`.                                |
+| `placement` default  | `undefined`; the tooltip had no `placement` attribute or placement CSS class in non-self-managed usage.              | Defaults to `"top"` and is reflected. The tooltip always has a `placement` attribute and CSS class.              | If you relied on an unplaced tooltip, explicitly set `placement="top"` or accept the visual change; the behavior is now top-placement by default. |
+| `delayed` → `delay`  | `delayed` was a boolean opt-in (default `false`); no delay without the attribute.                                    | `delay` is a number in ms (default `1500`); warm-up is always active.                                            | Remove `delayed`; add `delay="0"` if you relied on immediate hover.                                                                               |
+| `offset` default     | `0`; applied only in `self-managed` mode.                                                                            | `4`; always active.                                                                                              | If the 4 px gap is undesired, set `offset="0"` explicitly.                                                                                        |
 
 ## Update your code
 
@@ -253,5 +266,8 @@ Spectrum 1 `--mod-tooltip-*` CSS custom properties are **not** supported in Spec
 - [ ] Replace `sp-opened`/`sp-closed` event listeners with `swc-open`/`swc-close` (and `swc-after-open`/`swc-after-close` where needed)
 - [ ] Remove `self-managed` from all tooltips; add `id` to the trigger and `for="[id]"` to the tooltip
 - [ ] Confirm no tooltip is nested inside its trigger element
+- [ ] Remove `delayed` attribute; add `delay="0"` if you relied on immediate hover behavior
+- [ ] Remove `tip-padding` attribute (no replacement)
+- [ ] Update `:not([variant])` CSS selectors and `getAttribute('variant') === null` checks to `[variant="neutral"]`
 - [ ] Add `manual` only to tooltips that require permanently consumer-controlled visibility
 - [ ] Remove all `--mod-tooltip-*` CSS overrides

--- a/2nd-gen/packages/swc/components/tooltip/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/tooltip/migration-guide.mdx
@@ -253,6 +253,5 @@ Spectrum 1 `--mod-tooltip-*` CSS custom properties are **not** supported in Spec
 - [ ] Replace `sp-opened`/`sp-closed` event listeners with `swc-open`/`swc-close` (and `swc-after-open`/`swc-after-close` where needed)
 - [ ] Remove `self-managed` from all tooltips; add `id` to the trigger and `for="[id]"` to the tooltip
 - [ ] Confirm no tooltip is nested inside its trigger element
-- [ ] Remove any manual `mouseenter`/`mouseleave`/`focusin`/`focusout` listeners that controlled `open` — hover and focus are now automatic
 - [ ] Add `manual` only to tooltips that require permanently consumer-controlled visibility
 - [ ] Remove all `--mod-tooltip-*` CSS overrides

--- a/2nd-gen/packages/swc/components/tooltip/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/tooltip/migration-guide.mdx
@@ -6,29 +6,6 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 Replace `<sp-tooltip>` with `<swc-tooltip>`, update the import, rename the tag, update event listeners, and change the authoring pattern so the tooltip is a sibling of the trigger rather than nested inside it.
 
-<div
-  style={{
-    borderLeft: '4px solid #2680eb',
-    background: 'rgba(38, 128, 235, 0.10)',
-    padding: '12px 16px',
-    margin: '16px 0',
-    borderRadius: '4px',
-  }}
->
-  <strong>ℹ️ Initial release scope.</strong> This release delivers the tag
-  rename, variant and event API changes, ARIA relationship wiring via{' '}
-  <code>for</code>, and native <code>{'popover="auto"'}</code> open/close
-  behavior.{' '}
-  <strong>
-    Automatic hover/focus trigger wiring and viewport-aware pixel positioning
-    are not yet available.
-  </strong>{' '}
-  They require <code>HoverController</code> and <code>PlacementController</code>
-  , which ship in a future release. Until then, control visibility via the{' '}
-  <code>open</code> property and position the tooltip with a helper library like
-  Floating UI.
-</div>
-
 ## Installation
 
 ```bash
@@ -55,24 +32,29 @@ import '@adobe/spectrum-wc/components/tooltip/swc-tooltip.js';
 
 ### Renamed
 
-| Area                            | Spectrum 1 (`sp-tooltip`)                        | Spectrum 2 (`swc-tooltip`)                                                                                                     |
-| ------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| Tag                             | `sp-tooltip`                                     | `swc-tooltip`                                                                                                                  |
-| Import path                     | `@spectrum-web-components/tooltip/sp-tooltip.js` | `@adobe/spectrum-wc/components/tooltip/swc-tooltip.js`                                                                         |
-| `variant`                       | `'info'`                                         | `'informative'`                                                                                                                |
-| `swc-open` / `swc-close` events | `sp-opened` / `sp-closed`                        | `swc-open`, `swc-after-open`, `swc-close`, `swc-after-close`                                                                   |
-| Trigger wiring attribute        | `self-managed`                                   | `for="[id]"` declares the trigger relationship and wires ARIA now. Automatic hover/focus open/close ships in a future release. |
+| Area                            | Spectrum 1 (`sp-tooltip`)                        | Spectrum 2 (`swc-tooltip`)                                                            |
+| ------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| Tag                             | `sp-tooltip`                                     | `swc-tooltip`                                                                         |
+| Import path                     | `@spectrum-web-components/tooltip/sp-tooltip.js` | `@adobe/spectrum-wc/components/tooltip/swc-tooltip.js`                                |
+| `variant`                       | `'info'`                                         | `'informative'`                                                                       |
+| `swc-open` / `swc-close` events | `sp-opened` / `sp-closed`                        | `swc-open`, `swc-after-open`, `swc-close`, `swc-after-close`                          |
+| Trigger wiring attribute        | `self-managed`                                   | `for="[id]"` wires the ARIA relationship and drives automatic hover/focus open/close. |
 
 ### Added in Spectrum 2
 
-| Addition                                    | Notes                                                                                                                                   |
-| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `for` attribute                             | Declares the trigger relationship by ID. Required for ARIA wiring and (in the additive phase) automatic hover/focus open/close.         |
-| `manual` boolean attribute                  | Opt out of automatic controller wiring; consumer manages open/close via the `open` property. ARIA wiring still fires on `open` change.  |
-| Logical placements: `start`, `end`          | RTL-aware inline placement values; physical values (`top`, `bottom`, `left`, `right`) are unchanged.                                    |
-| `delay` attribute                           | Warm-up/cooldown duration in ms (default 1500). `delay="0"` shows immediately. **Additive phase:** active when `HoverController` ships. |
-| `labeling` boolean attribute                | Switches ARIA wiring to `ariaLabelledByElements` for icon-only triggers. **Additive phase.**                                            |
-| `swc-after-open` / `swc-after-close` events | Fire after the open/close transition completes.                                                                                         |
+| Addition                                    | Notes                                                                                                               |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `for` attribute                             | Declares the trigger relationship by ID. Required for ARIA wiring and automatic hover/focus open/close.             |
+| `manual` boolean attribute                  | Opt out of automatic hover/focus wiring. Consumer manages open/close via `open`. ARIA wiring still fires.           |
+| `disabled` boolean attribute                | Suppresses automatic hover/focus response. Trigger remains interactive; `open` still works directly.                |
+| Logical placements: `start`, `end`          | RTL-aware inline placement values; physical values (`top`, `bottom`, `left`, `right`) are unchanged.                |
+| `delay` attribute                           | Warm-up delay in ms before the tooltip opens on hover (default `1500`). `delay="0"` shows immediately.              |
+| `offset` attribute                          | Pixel gap between the trigger and the tooltip bubble (default `4`).                                                 |
+| `cross-offset` attribute                    | Slide in pixels perpendicular to the placement direction (default `0`).                                             |
+| `container-padding` attribute               | Minimum inset from the viewport edge for collision detection (default `12`).                                        |
+| `should-flip` boolean attribute             | Whether the tooltip may reposition to the opposite side when the requested placement does not fit (default `true`). |
+| `labeling` boolean attribute                | Switches ARIA wiring to `ariaLabelledByElements` for icon-only triggers.                                            |
+| `swc-after-open` / `swc-after-close` events | Fire after the open/close transition completes.                                                                     |
 
 ### Removed in Spectrum 2
 
@@ -180,24 +162,20 @@ tooltip.triggerElement = shadowRoot.querySelector('#the-trigger');
   }}
 >
   <strong>
-    ℹ️ What <code>for</code> does in this release.
+    ℹ️ What <code>for</code> does.
   </strong>{' '}
   Setting <code>{'for="[id]"'}</code> establishes the ARIA relationship between
-  the trigger and tooltip. It does <strong>not</strong> yet open or close the
-  tooltip automatically on hover or focus. Until automatic trigger wiring ships,
-  you must control visibility manually (see step 6 below).
+  the trigger and tooltip, and wires automatic hover/focus open/close. No
+  additional event listeners are required.
 </div>
 
-### 6. Manage open/close until automatic wiring ships
+### 6. Optional `manual` event handling
 
-In this release, automatic hover/focus open/close is not active. Implement `mouseenter`/`mouseleave` and `focusin`/`focusout` listeners yourself. Keep `for` set so the ARIA relationship is always established when the tooltip opens.
-
-When automatic wiring ships in a future release, remove these manual listeners; `for` will drive open/close automatically. Add `manual` to the tooltip only when you need to permanently opt out of automatic wiring at that point.
+The tooltip opens after a warm-up delay (default `1500 ms`; set `delay="0"` to open immediately) and closes when the pointer leaves or focus moves away. To permanently opt out of automatic wiring and retain full programmatic control, add the `manual` attribute:
 
 ```html
-<!-- After (current release: manual event wiring required) -->
 <button id="save-btn">Save</button>
-<swc-tooltip for="save-btn" placement="top" id="save-tip">
+<swc-tooltip for="save-btn" placement="top" manual id="save-tip">
   Save your changes
 </swc-tooltip>
 <script>
@@ -209,14 +187,10 @@ When automatic wiring ships in a future release, remove these manual listeners; 
   btn.addEventListener('mouseleave', () => {
     tip.open = false;
   });
-  btn.addEventListener('focusin', () => {
-    tip.open = true;
-  });
-  btn.addEventListener('focusout', () => {
-    tip.open = false;
-  });
 </script>
 ```
+
+With `manual`, ARIA relationship wiring via `for` still fires on every `open` change; only the automatic hover/focus events are suppressed.
 
 ## Accessibility
 
@@ -279,5 +253,6 @@ Spectrum 1 `--mod-tooltip-*` CSS custom properties are **not** supported in Spec
 - [ ] Replace `sp-opened`/`sp-closed` event listeners with `swc-open`/`swc-close` (and `swc-after-open`/`swc-after-close` where needed)
 - [ ] Remove `self-managed` from all tooltips; add `id` to the trigger and `for="[id]"` to the tooltip
 - [ ] Confirm no tooltip is nested inside its trigger element
-- [ ] Add `mouseenter`/`mouseleave` and `focusin`/`focusout` listeners to control `open` until automatic wiring ships
+- [ ] Remove any manual `mouseenter`/`mouseleave`/`focusin`/`focusout` listeners that controlled `open` — hover and focus are now automatic
+- [ ] Add `manual` only to tooltips that require permanently consumer-controlled visibility
 - [ ] Remove all `--mod-tooltip-*` CSS overrides

--- a/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
+++ b/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
@@ -11,8 +11,7 @@
  */
 
 import { html } from 'lit';
-// Temporary: floating-ui used only in stories for basic positioning until PlacementController lands.
-import { computePosition, type Placement } from '@floating-ui/dom';
+import { ref } from 'lit/directives/ref.js';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
@@ -78,83 +77,38 @@ const TABULAR_PLACEMENTS: TooltipPlacement[] = [
   'start',
 ];
 
-// SWC uses logical 'start'/'end'; map to physical values for Floating UI.
-const toFloatingPlacement = (placement: string): Placement => {
-  if (placement === 'start') {
-    if (document.dir === 'rtl') {
-      return 'right';
-    }
-    return 'left';
-  }
-  if (placement === 'end') {
-    if (document.dir === 'rtl') {
-      return 'left';
-    }
-    return 'right';
-  }
-  return placement as Placement;
-};
-
-// Temporary: positions the tooltip via Floating UI when it opens, until PlacementController is available.
-const positionTooltip = (button: HTMLElement, tooltip: HTMLElement): void => {
-  const placement = tooltip.getAttribute('placement') ?? 'top';
-  void computePosition(button, tooltip, {
-    placement: toFloatingPlacement(placement),
-  }).then(({ x, y }) => {
-    Object.assign(tooltip.style, {
-      left: `${x}px`,
-      top: `${y}px`,
-    });
-  });
-};
-
 // Renders a button+tooltip pair linked via the `for` attribute.
 // Each pair needs a unique `id` so multiple instances can coexist in the same story.
-// A `display: contents` wrapper catches the bubbling `swc-open` event and positions
-// the tooltip via Floating UI until PlacementController is available.
 const triggered = (
   tooltipArgs: Record<string, unknown>,
   id: string,
   buttonLabel?: string,
   iconOnly: boolean = false
 ) => {
-  const positionOnOpen = (event: Event) => {
-    const tooltip = event.target as HTMLElement;
-    const root = tooltip.getRootNode() as Document | ShadowRoot;
-    const button = root.getElementById(id);
-    if (button) {
-      positionTooltip(button, tooltip);
-    }
-  };
-
   if (!iconOnly) {
     return html`
-      <span @swc-open=${positionOnOpen} style="display: contents">
-        <swc-button id=${id}>${buttonLabel}</swc-button>
-        ${template({ ...tooltipArgs, for: id })}
-      </span>
+      <swc-button id=${id}>${buttonLabel}</swc-button>
+      ${template({ ...tooltipArgs, for: id })}
     `;
   } else {
     return html`
-      <span @swc-open=${positionOnOpen} style="display: contents">
-        <swc-button
-          id=${id}
-          accessible-label=${String(tooltipArgs['default-slot'] ?? '')}
+      <swc-button
+        id=${id}
+        accessible-label=${String(tooltipArgs['default-slot'] ?? '')}
+      >
+        <svg
+          slot="icon"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 36 36"
+          aria-hidden="true"
+          focusable="false"
         >
-          <svg
-            slot="icon"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 36 36"
-            aria-hidden="true"
-            focusable="false"
-          >
-            <path
-              d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
-            />
-          </svg>
-        </swc-button>
-        ${template({ ...tooltipArgs, for: id })}
-      </span>
+          <path
+            d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
+          />
+        </svg>
+      </swc-button>
+      ${template({ ...tooltipArgs, for: id })}
     `;
   }
 };
@@ -407,6 +361,49 @@ export const Events: Story = {
     variant: 'neutral',
     placement: 'top',
     'default-slot': 'Save your changes',
+  },
+  tags: ['behaviors'],
+};
+
+export const TriggerElement: Story = {
+  // The ref directive wires triggerElement during rendering so the story is
+  // functional in the Docs page canvas — not just when the play function runs.
+  render: () => {
+    let triggerEl: HTMLElement | null = null;
+
+    return html`
+      <swc-button
+        id="te-trigger"
+        ${ref((el) => {
+          triggerEl = (el as HTMLElement) ?? null;
+        })}
+      >
+        Action
+      </swc-button>
+      <swc-tooltip
+        placement="top"
+        ${ref((el) => {
+          if (el && triggerEl) {
+            (
+              el as HTMLElement & { triggerElement: HTMLElement | null }
+            ).triggerElement = triggerEl;
+          }
+        })}
+      >
+        Wired via the triggerElement property
+      </swc-tooltip>
+    `;
+  },
+  // Play function opens the tooltip for sidebar view and VRT.
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const tooltip = canvasElement.querySelector(
+      'swc-tooltip'
+    ) as HTMLElement & {
+      open: boolean;
+    };
+    if (tooltip) {
+      tooltip.open = true;
+    }
   },
   tags: ['behaviors'],
 };

--- a/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
+++ b/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
@@ -11,8 +11,7 @@
  */
 
 import { html } from 'lit';
-// Temporary: floating-ui used only in stories for basic positioning until
-// PlacementController and HoverController land in the additive phase.
+// Temporary: floating-ui used only in stories for basic positioning until PlacementController lands.
 import { computePosition, type Placement } from '@floating-ui/dom';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
@@ -96,8 +95,7 @@ const toFloatingPlacement = (placement: string): Placement => {
   return placement as Placement;
 };
 
-// Temporary: positions the tooltip via Floating UI once the popover appears in the
-// top layer.
+// Temporary: positions the tooltip via Floating UI when it opens, until PlacementController is available.
 const positionTooltip = (button: HTMLElement, tooltip: HTMLElement): void => {
   const placement = tooltip.getAttribute('placement') ?? 'top';
   void computePosition(button, tooltip, {
@@ -110,71 +108,53 @@ const positionTooltip = (button: HTMLElement, tooltip: HTMLElement): void => {
   });
 };
 
-// Temporary: toggles `open` on the linked tooltip on click until HoverController is
-// available. Waits for the `toggle` event before measuring so Floating UI sees the
-// element after showPopover() places it in the top layer.
-const makeToggle = (id: string) => (event: MouseEvent) => {
-  const root = (event.currentTarget as HTMLElement).getRootNode() as
-    | Document
-    | ShadowRoot;
-  const button = event.currentTarget as HTMLElement;
-  const tooltip = root.querySelector(
-    `swc-tooltip[for="${id}"]`
-  ) as HTMLElement & { open: boolean };
-
-  if (!tooltip) {
-    return;
-  }
-
-  tooltip.open = !tooltip.open;
-
-  if (tooltip.open) {
-    tooltip.addEventListener(
-      'toggle',
-      (toggleEvent) => {
-        if ((toggleEvent as ToggleEvent).newState !== 'open') {
-          return;
-        }
-        positionTooltip(button, tooltip);
-      },
-      { once: true }
-    );
-  }
-};
-
 // Renders a button+tooltip pair linked via the `for` attribute.
 // Each pair needs a unique `id` so multiple instances can coexist in the same story.
+// A `display: contents` wrapper catches the bubbling `swc-open` event and positions
+// the tooltip via Floating UI until PlacementController is available.
 const triggered = (
   tooltipArgs: Record<string, unknown>,
   id: string,
   buttonLabel?: string,
   iconOnly: boolean = false
 ) => {
+  const positionOnOpen = (event: Event) => {
+    const tooltip = event.target as HTMLElement;
+    const root = tooltip.getRootNode() as Document | ShadowRoot;
+    const button = root.getElementById(id);
+    if (button) {
+      positionTooltip(button, tooltip);
+    }
+  };
+
   if (!iconOnly) {
     return html`
-      <swc-button id=${id} @click=${makeToggle(id)}>${buttonLabel}</swc-button>
-      ${template({ ...tooltipArgs, for: id })}
+      <span @swc-open=${positionOnOpen} style="display: contents">
+        <swc-button id=${id}>${buttonLabel}</swc-button>
+        ${template({ ...tooltipArgs, for: id })}
+      </span>
     `;
   } else {
     return html`
-      <swc-button
-        id=${id}
-        @click=${makeToggle(id)}
-        accessible-label=${String(tooltipArgs['default-slot'] ?? '')}
-      >
-        <svg
-          slot="icon"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 36 36"
-          aria-hidden="true"
-          focusable="false"
+      <span @swc-open=${positionOnOpen} style="display: contents">
+        <swc-button
+          id=${id}
+          accessible-label=${String(tooltipArgs['default-slot'] ?? '')}
         >
-          <path
-            d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
-          />
-        </svg>
-      </swc-button>
-      ${template({ ...tooltipArgs, for: id })}
+          <svg
+            slot="icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 36 36"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
+            />
+          </svg>
+        </swc-button>
+        ${template({ ...tooltipArgs, for: id })}
+      </span>
     `;
   }
 };
@@ -187,9 +167,6 @@ const triggered = (
  *
  * For cross-shadow-root triggers where `getElementById` cannot reach the trigger, set the
  * `triggerElement` property directly with an element reference.
- *
- * Each story in this document uses a temporary click-to-toggle interaction.
- * Automatic hover and focus wiring is available in a future release.
  */
 const meta: Meta = {
   title: 'Tooltip',
@@ -358,10 +335,64 @@ export const Open: Story = {
     'default-slot': 'Save your changes',
   },
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
-    const button = canvasElement.querySelector('swc-button') as HTMLElement;
-    button?.click();
+    const tooltip = canvasElement.querySelector(
+      'swc-tooltip'
+    ) as HTMLElement & {
+      open: boolean;
+    };
+    if (tooltip) {
+      tooltip.open = true;
+    }
   },
   tags: ['states'],
+};
+
+export const Disabled: Story = {
+  render: (args) => html`
+    ${triggered({ ...args }, 'tooltip-disabled', 'Action')}
+  `,
+  args: {
+    variant: 'neutral',
+    placement: 'top',
+    disabled: true,
+    'default-slot': 'Hover and focus are disabled',
+  },
+  tags: ['states'],
+};
+
+export const Manual: Story = {
+  render: (args) => {
+    const onShowTooltip = (event: MouseEvent) => {
+      const root = (event.currentTarget as HTMLElement).getRootNode() as
+        | Document
+        | ShadowRoot;
+      const tooltip = root.querySelector(
+        'swc-tooltip[for="tooltip-manual-trigger"]'
+      ) as HTMLElement & { open: boolean };
+      if (tooltip) {
+        tooltip.open = !tooltip.open;
+      }
+    };
+
+    return html`
+      ${triggered({ ...args }, 'tooltip-manual-trigger', 'Action')}
+      <swc-button variant="secondary" @click=${onShowTooltip}>
+        Show tooltip
+      </swc-button>
+    `;
+  },
+  args: {
+    variant: 'neutral',
+    placement: 'top',
+    manual: true,
+    'default-slot': 'Consumer-controlled tooltip',
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const buttons = canvasElement.querySelectorAll('swc-button');
+    (buttons[1] as HTMLElement)?.click();
+  },
+  tags: ['states'],
+  parameters: { flexLayout: 'row-wrap' },
 };
 
 // ────────────────────────────────
@@ -370,7 +401,7 @@ export const Open: Story = {
 
 export const Events: Story = {
   render: (args) => html`
-    ${triggered({ ...args }, 'tooltip-behavior-events', 'Open')}
+    ${triggered({ ...args }, 'tooltip-behavior-events', 'Action')}
   `,
   args: {
     variant: 'neutral',

--- a/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
+++ b/2nd-gen/packages/swc/components/tooltip/stories/tooltip.stories.ts
@@ -367,7 +367,7 @@ export const Events: Story = {
 
 export const TriggerElement: Story = {
   // The ref directive wires triggerElement during rendering so the story is
-  // functional in the Docs page canvas — not just when the play function runs.
+  // functional in the Docs page canvas, not just when the play function runs.
   render: () => {
     let triggerEl: HTMLElement | null = null;
 

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -394,6 +394,109 @@ export const AriaWiringTriggerElementOverrideTest: Story = {
   },
 };
 
+export const TriggerElementHoverTest: Story = {
+  render: () => html`
+    <button id="tt-te-hover">Hover me</button>
+    <swc-tooltip placement="top" delay="0">
+      Wired via triggerElement, no for attribute
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const trigger = canvasElement.querySelector(
+      '#tt-te-hover'
+    ) as HTMLElement;
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step(
+      'wires HoverController when triggerElement is set without a for attribute',
+      async () => {
+        tooltip.triggerElement = trigger;
+        await tooltip.updateComplete;
+
+        trigger.dispatchEvent(
+          new PointerEvent('pointerenter', { bubbles: false, composed: true })
+        );
+        await waitFor(
+          () => expect(tooltip.open, 'tooltip opens on hover via triggerElement').toBe(true),
+          { timeout: 200 }
+        );
+      }
+    );
+
+    await step(
+      'closes when pointer leaves and sets ARIA on the native trigger',
+      async () => {
+        expect(
+          trigger.ariaDescribedByElements ?? [],
+          'native trigger receives ariaDescribedByElements via triggerElement wiring'
+        ).toContain(tooltip);
+
+        trigger.dispatchEvent(
+          new PointerEvent('pointerleave', { bubbles: false, composed: true })
+        );
+        await waitFor(
+          () => expect(tooltip.open, 'tooltip closes after pointer leaves').toBe(false),
+          { timeout: 500 }
+        );
+      }
+    );
+  },
+};
+
+export const TriggerElementOverridesForHoverTest: Story = {
+  render: () => html`
+    <button id="tt-te-wrong">Wrong target</button>
+    <button id="tt-te-correct">Correct target</button>
+    <swc-tooltip for="tt-te-wrong" delay="0" placement="top">
+      Should open on correct trigger
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const wrongTrigger = canvasElement.querySelector(
+      '#tt-te-wrong'
+    ) as HTMLElement;
+    const correctTrigger = canvasElement.querySelector(
+      '#tt-te-correct'
+    ) as HTMLElement;
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step(
+      'triggerElement overrides for when set — hover wires to the override target',
+      async () => {
+        tooltip.triggerElement = correctTrigger;
+        await tooltip.updateComplete;
+
+        // Hovering the for-target (wrong) should NOT open the tooltip.
+        wrongTrigger.dispatchEvent(
+          new PointerEvent('pointerenter', { bubbles: false, composed: true })
+        );
+        await tooltip.updateComplete;
+        expect(
+          tooltip.open,
+          'for target does not open tooltip when triggerElement overrides it'
+        ).toBe(false);
+
+        // Hovering the triggerElement target should open it.
+        correctTrigger.dispatchEvent(
+          new PointerEvent('pointerenter', { bubbles: false, composed: true })
+        );
+        await waitFor(
+          () => expect(tooltip.open, 'triggerElement target opens the tooltip').toBe(true),
+          { timeout: 200 }
+        );
+
+        correctTrigger.dispatchEvent(
+          new PointerEvent('pointerleave', { bubbles: false, composed: true })
+        );
+        await waitFor(
+          () => expect(tooltip.open).toBe(false),
+          { timeout: 500 }
+        );
+      }
+    );
+  },
+};
+
 export const AriaWiringNoTriggerTest: Story = {
   render: () => html`
     <swc-tooltip placement="top">Standalone tooltip</swc-tooltip>
@@ -821,6 +924,166 @@ export const ManualPreventsHoverTest: Story = {
         expect(tooltip.open, 'tooltip opens via property in manual mode').toBe(
           true
         );
+        tooltip.open = false;
+        await tooltip.updateComplete;
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: PlacementController integration
+// ──────────────────────────────────────────────────────────────
+
+export const PlacementControllerTest: Story = {
+  render: () => html`
+    <div style="display: flex; justify-content: center; padding: 120px;">
+      <button id="tt-placement-trigger">Trigger</button>
+    </div>
+    <swc-tooltip for="tt-placement-trigger" placement="top">
+      Positioned by PlacementController
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step(
+      'applies translate positioning via PlacementController when opened',
+      async () => {
+        tooltip.open = true;
+        await waitForEvent(tooltip, 'swc-open');
+
+        // PlacementController is async; poll until it has applied positioning.
+        await waitFor(
+          () =>
+            expect(
+              tooltip.style.translate,
+              'PlacementController applied a translate value'
+            ).toBeTruthy(),
+          { timeout: 500 }
+        );
+      }
+    );
+
+    await step(
+      'reflects the actual computed placement back into the placement property',
+      async () => {
+        await waitFor(
+          () =>
+            expect(
+              ['top', 'bottom', 'left', 'right', 'start', 'end'],
+              'placement reflects a valid computed side'
+            ).toContain(tooltip.placement),
+          { timeout: 500 }
+        );
+      }
+    );
+
+    await step('positions the tip element via arrow middleware', async () => {
+      // The arrow middleware writes translate on the tip span so the tip
+      // tracks the trigger center independently of any cross-axis shift.
+      const tip = tooltip.shadowRoot?.querySelector(
+        '.swc-Tooltip-tip'
+      ) as HTMLElement | null;
+      await waitFor(
+        () =>
+          expect(
+            tip?.style.translate,
+            'arrow middleware set translate on .swc-Tooltip-tip'
+          ).toBeTruthy(),
+        { timeout: 500 }
+      );
+    });
+
+    await step('clears translate when closed', async () => {
+      // Bubble translate is removed in dispatchAfterEvent, which fires after
+      // the exit transition completes. Wait for swc-after-close to ensure the
+      // transition has finished before asserting.
+      const afterClosePromise = waitForEvent(tooltip, 'swc-after-close');
+      tooltip.open = false;
+      await afterClosePromise;
+
+      const tip = tooltip.shadowRoot?.querySelector(
+        '.swc-Tooltip-tip'
+      ) as HTMLElement | null;
+      expect(
+        tooltip.style.translate,
+        'bubble translate is cleared after close'
+      ).toBeFalsy();
+      // Tip translate is cleared synchronously by placementController.stop().
+      expect(
+        tip?.style.translate,
+        'tip translate is cleared after close'
+      ).toBeFalsy();
+    });
+
+    await step(
+      'uses the updated requested placement when consumer changes placement before reopening',
+      async () => {
+        // Consumer explicitly requests a different side.
+        tooltip.placement = 'bottom';
+        await tooltip.updateComplete;
+
+        tooltip.open = true;
+        await waitForEvent(tooltip, 'swc-open');
+
+        // PlacementController should rerun with the new requested placement.
+        await waitFor(
+          () =>
+            expect(
+              tooltip.style.translate,
+              'PlacementController positioned tooltip for the new placement'
+            ).toBeTruthy(),
+          { timeout: 500 }
+        );
+
+        tooltip.open = false;
+        await tooltip.updateComplete;
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Shadow root scoping
+// ──────────────────────────────────────────────────────────────
+
+export const ShadowRootScopeTest: Story = {
+  // Render an empty host; the shadow root and its contents are built in the
+  // play function so getRootNode() on the tooltip returns the shadow root.
+  render: () => html`<div id="shadow-root-host"></div>`,
+  play: async ({ canvasElement, step }) => {
+    const host = canvasElement.querySelector(
+      '#shadow-root-host'
+    ) as HTMLDivElement;
+    const shadow = host.attachShadow({ mode: 'open' });
+
+    const trigger = document.createElement('button');
+    trigger.id = 'sr-trigger';
+    trigger.textContent = 'Trigger';
+
+    const tooltip = document.createElement('swc-tooltip') as Tooltip;
+    tooltip.setAttribute('placement', 'top');
+    tooltip.textContent = 'Shadow-scoped tooltip';
+
+    shadow.append(trigger, tooltip);
+
+    // Set 'for' after connecting so getRootNode() returns the shadow root when
+    // the first updated() resolves the trigger via getRootNode().getElementById.
+    tooltip.for = 'sr-trigger';
+    await tooltip.updateComplete;
+
+    await step(
+      'resolves the trigger via getRootNode() scoped to the shadow root',
+      async () => {
+        tooltip.open = true;
+        await tooltip.updateComplete;
+
+        expect(
+          trigger.ariaDescribedByElements ?? [],
+          'native trigger inside shadow root receives ariaDescribedByElements wiring'
+        ).toContain(tooltip);
+
         tooltip.open = false;
         await tooltip.updateComplete;
       }

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { html } from 'lit';
-import { expect, userEvent } from '@storybook/test';
+import { expect, userEvent, waitFor } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
 import type { Button } from '@adobe/spectrum-wc/button';
@@ -692,20 +692,29 @@ export const HoverOpensTest: Story = {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step('opens the tooltip when the trigger is hovered', async () => {
-      const openPromise = waitForEvent(tooltip, 'swc-open');
-      await userEvent.pointer({ target: trigger });
-      await openPromise;
-      expect(tooltip.open, 'tooltip is open after hover').toBe(true);
+      trigger.dispatchEvent(
+        new PointerEvent('pointerenter', { bubbles: false, composed: true })
+      );
+      // swc-open fires from beforetoggle; tooltip.open is set by the async toggle event.
+      await waitFor(
+        () => expect(tooltip.open, 'tooltip is open after hover').toBe(true),
+        { timeout: 200 }
+      );
     });
 
     await step(
       'closes the tooltip when the pointer leaves the trigger',
       async () => {
-        const closePromise = waitForEvent(tooltip, 'swc-close');
-        await userEvent.pointer({ target: document.body });
-        await closePromise;
-        expect(tooltip.open, 'tooltip is closed after pointer leaves').toBe(
-          false
+        trigger.dispatchEvent(
+          new PointerEvent('pointerleave', { bubbles: false, composed: true })
+        );
+        // Cooldown timer is 300 ms; give it extra headroom.
+        await waitFor(
+          () =>
+            expect(tooltip.open, 'tooltip is closed after pointer leaves').toBe(
+              false
+            ),
+          { timeout: 500 }
         );
       }
     );
@@ -728,18 +737,24 @@ export const FocusOpensTest: Story = {
     await step(
       'opens the tooltip immediately when the trigger receives keyboard focus',
       async () => {
-        const openPromise = waitForEvent(tooltip, 'swc-open');
-        trigger.focus();
-        await openPromise;
-        expect(tooltip.open, 'tooltip is open after focus').toBe(true);
+        trigger.dispatchEvent(
+          new FocusEvent('focusin', { bubbles: true, composed: true })
+        );
+        await waitFor(
+          () => expect(tooltip.open, 'tooltip is open after focus').toBe(true),
+          { timeout: 200 }
+        );
       }
     );
 
     await step('closes the tooltip when focus leaves the trigger', async () => {
-      const closePromise = waitForEvent(tooltip, 'swc-close');
-      trigger.blur();
-      await closePromise;
-      expect(tooltip.open, 'tooltip is closed after blur').toBe(false);
+      trigger.dispatchEvent(
+        new FocusEvent('focusout', { bubbles: true, composed: true })
+      );
+      await waitFor(
+        () => expect(tooltip.open, 'tooltip is closed after blur').toBe(false),
+        { timeout: 200 }
+      );
     });
   },
 };
@@ -760,7 +775,9 @@ export const DisabledPreventsHoverTest: Story = {
     await step(
       'does not open the tooltip when disabled and trigger is hovered',
       async () => {
-        await userEvent.pointer({ target: trigger });
+        trigger.dispatchEvent(
+          new PointerEvent('pointerenter', { bubbles: false, composed: true })
+        );
         await tooltip.updateComplete;
         expect(tooltip.open, 'tooltip remains closed when disabled').toBe(
           false
@@ -786,7 +803,9 @@ export const ManualPreventsHoverTest: Story = {
     await step(
       'does not open the tooltip on hover when manual mode is active',
       async () => {
-        await userEvent.pointer({ target: trigger });
+        trigger.dispatchEvent(
+          new PointerEvent('pointerenter', { bubbles: false, composed: true })
+        );
         await tooltip.updateComplete;
         expect(tooltip.open, 'tooltip remains closed in manual mode').toBe(
           false

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -80,7 +80,8 @@ const hoverOpen = async (
 };
 
 /** Dispatches pointerleave on the trigger and waits for the tooltip to close
- * (includes the 300 ms HoverController cooldown). */
+ * (includes the 300 ms HoverController cooldown plus generous CI headroom —
+ * headless Chromium can throttle setTimeout callbacks in background pages). */
 const hoverClose = async (
   trigger: HTMLElement,
   tooltip: Tooltip
@@ -88,7 +89,7 @@ const hoverClose = async (
   trigger.dispatchEvent(
     new PointerEvent('pointerleave', { bubbles: false, composed: true })
   );
-  await waitFor(() => expect(tooltip.open).toBe(false), { timeout: 1500 });
+  await waitFor(() => expect(tooltip.open).toBe(false), { timeout: 5000 });
 };
 
 /** Dispatches focusin on the trigger and waits for the tooltip to open. */

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -57,6 +57,62 @@ const waitForEvent = <T extends Event>(
     });
   });
 
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+/** Opens the tooltip and polls until it enters the top layer. Safer than
+ * waitForEvent('swc-open'): beforetoggle timing varies in headless CI. */
+const openTooltip = async (tooltip: Tooltip): Promise<void> => {
+  tooltip.open = true;
+  await waitFor(() => expect(tooltip.matches(':popover-open')).toBe(true), {
+    timeout: 1000,
+  });
+};
+
+/** Dispatches pointerenter on the trigger and waits for the tooltip to open. */
+const hoverOpen = async (
+  trigger: HTMLElement,
+  tooltip: Tooltip
+): Promise<void> => {
+  trigger.dispatchEvent(
+    new PointerEvent('pointerenter', { bubbles: false, composed: true })
+  );
+  await waitFor(() => expect(tooltip.open).toBe(true), { timeout: 200 });
+};
+
+/** Dispatches pointerleave on the trigger and waits for the tooltip to close
+ * (includes the 300 ms HoverController cooldown). */
+const hoverClose = async (
+  trigger: HTMLElement,
+  tooltip: Tooltip
+): Promise<void> => {
+  trigger.dispatchEvent(
+    new PointerEvent('pointerleave', { bubbles: false, composed: true })
+  );
+  await waitFor(() => expect(tooltip.open).toBe(false), { timeout: 1500 });
+};
+
+/** Dispatches focusin on the trigger and waits for the tooltip to open. */
+const focusOpen = async (
+  trigger: HTMLElement,
+  tooltip: Tooltip
+): Promise<void> => {
+  trigger.dispatchEvent(
+    new FocusEvent('focusin', { bubbles: true, composed: true })
+  );
+  await waitFor(() => expect(tooltip.open).toBe(true), { timeout: 200 });
+};
+
+/** Dispatches focusout on the trigger and waits for the tooltip to close. */
+const focusClose = async (
+  trigger: HTMLElement,
+  tooltip: Tooltip
+): Promise<void> => {
+  trigger.dispatchEvent(
+    new FocusEvent('focusout', { bubbles: true, composed: true })
+  );
+  await waitFor(() => expect(tooltip.open).toBe(false), { timeout: 200 });
+};
+
 // ──────────────────────────────────────────────────────────────
 // TEST: Defaults
 // ──────────────────────────────────────────────────────────────
@@ -412,17 +468,9 @@ export const TriggerElementHoverTest: Story = {
       async () => {
         tooltip.triggerElement = trigger;
         await tooltip.updateComplete;
-
-        trigger.dispatchEvent(
-          new PointerEvent('pointerenter', { bubbles: false, composed: true })
-        );
-        await waitFor(
-          () =>
-            expect(
-              tooltip.open,
-              'tooltip opens on hover via triggerElement'
-            ).toBe(true),
-          { timeout: 200 }
+        await hoverOpen(trigger, tooltip);
+        expect(tooltip.open, 'tooltip opens on hover via triggerElement').toBe(
+          true
         );
       }
     );
@@ -434,17 +482,8 @@ export const TriggerElementHoverTest: Story = {
           innerButton?.ariaDescribedByElements ?? [],
           'inner shadow button receives ariaDescribedByElements via triggerElement wiring'
         ).toContain(tooltip);
-
-        trigger.dispatchEvent(
-          new PointerEvent('pointerleave', { bubbles: false, composed: true })
-        );
-        await waitFor(
-          () =>
-            expect(tooltip.open, 'tooltip closes after pointer leaves').toBe(
-              false
-            ),
-          { timeout: 500 }
-        );
+        await hoverClose(trigger, tooltip);
+        expect(tooltip.open, 'tooltip closes after pointer leaves').toBe(false);
       }
     );
   },
@@ -482,22 +521,12 @@ export const TriggerElementOverridesForHoverTest: Story = {
         ).toBe(false);
 
         // Hovering the triggerElement target should open it.
-        correctTrigger.dispatchEvent(
-          new PointerEvent('pointerenter', { bubbles: false, composed: true })
-        );
-        await waitFor(
-          () =>
-            expect(
-              tooltip.open,
-              'triggerElement target opens the tooltip'
-            ).toBe(true),
-          { timeout: 200 }
+        await hoverOpen(correctTrigger, tooltip);
+        expect(tooltip.open, 'triggerElement target opens the tooltip').toBe(
+          true
         );
 
-        correctTrigger.dispatchEvent(
-          new PointerEvent('pointerleave', { bubbles: false, composed: true })
-        );
-        await waitFor(() => expect(tooltip.open).toBe(false), { timeout: 500 });
+        await hoverClose(correctTrigger, tooltip);
       }
     );
   },
@@ -652,14 +681,14 @@ export const EscapeClosesTest: Story = {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step('closes the open tooltip when Escape is pressed', async () => {
-      tooltip.open = true;
-      await waitForEvent(tooltip, 'swc-open');
+      await openTooltip(tooltip);
       expect(tooltip.open, 'tooltip is open before Escape').toBe(true);
 
-      const closePromise = waitForEvent(tooltip, 'swc-close');
       await userEvent.keyboard('{Escape}');
-      await closePromise;
-
+      await waitFor(
+        () => expect(tooltip.matches(':popover-open')).toBe(false),
+        { timeout: 1000 }
+      );
       expect(tooltip.open, 'tooltip is closed after Escape').toBe(false);
     });
   },
@@ -690,8 +719,7 @@ export const VariantsTest: Story = {
         const tooltip = canvasElement.querySelector(
           `swc-tooltip[variant="${variant}"]`
         ) as Tooltip;
-        tooltip.open = true;
-        await waitForEvent(tooltip, 'swc-open');
+        await openTooltip(tooltip);
       });
     }
   },
@@ -719,8 +747,7 @@ export const PlacementsTest: Story = {
         const tooltip = canvasElement.querySelector(
           `swc-tooltip[placement="${placement}"]`
         ) as Tooltip;
-        tooltip.open = true;
-        await waitForEvent(tooltip, 'swc-open');
+        await openTooltip(tooltip);
       });
     }
   },
@@ -746,8 +773,7 @@ export const ForcedColorsOpenTest: Story = {
   },
   play: async ({ canvasElement }) => {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
-    tooltip.open = true;
-    await waitForEvent(tooltip, 'swc-open');
+    await openTooltip(tooltip);
   },
 };
 
@@ -760,8 +786,7 @@ export const CJKLineHeightTest: Story = {
   `,
   play: async ({ canvasElement }) => {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
-    tooltip.open = true;
-    await waitForEvent(tooltip, 'swc-open');
+    await openTooltip(tooltip);
   },
 };
 
@@ -774,8 +799,7 @@ export const LogicalPlacementRTLTest: Story = {
   `,
   play: async ({ canvasElement }) => {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
-    tooltip.open = true;
-    await waitForEvent(tooltip, 'swc-open');
+    await openTooltip(tooltip);
   },
 };
 
@@ -799,29 +823,16 @@ export const HoverOpensTest: Story = {
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step('opens the tooltip when the trigger is hovered', async () => {
-      trigger.dispatchEvent(
-        new PointerEvent('pointerenter', { bubbles: false, composed: true })
-      );
-      // swc-open fires from beforetoggle; tooltip.open is set by the async toggle event.
-      await waitFor(
-        () => expect(tooltip.open, 'tooltip is open after hover').toBe(true),
-        { timeout: 200 }
-      );
+      await hoverOpen(trigger, tooltip);
+      expect(tooltip.open, 'tooltip is open after hover').toBe(true);
     });
 
     await step(
       'closes the tooltip when the pointer leaves the trigger',
       async () => {
-        trigger.dispatchEvent(
-          new PointerEvent('pointerleave', { bubbles: false, composed: true })
-        );
-        // Cooldown timer is 300 ms; give it extra headroom.
-        await waitFor(
-          () =>
-            expect(tooltip.open, 'tooltip is closed after pointer leaves').toBe(
-              false
-            ),
-          { timeout: 500 }
+        await hoverClose(trigger, tooltip);
+        expect(tooltip.open, 'tooltip is closed after pointer leaves').toBe(
+          false
         );
       }
     );
@@ -842,24 +853,14 @@ export const FocusOpensTest: Story = {
     await step(
       'opens the tooltip immediately when the trigger receives keyboard focus',
       async () => {
-        trigger.dispatchEvent(
-          new FocusEvent('focusin', { bubbles: true, composed: true })
-        );
-        await waitFor(
-          () => expect(tooltip.open, 'tooltip is open after focus').toBe(true),
-          { timeout: 200 }
-        );
+        await focusOpen(trigger, tooltip);
+        expect(tooltip.open, 'tooltip is open after focus').toBe(true);
       }
     );
 
     await step('closes the tooltip when focus leaves the trigger', async () => {
-      trigger.dispatchEvent(
-        new FocusEvent('focusout', { bubbles: true, composed: true })
-      );
-      await waitFor(
-        () => expect(tooltip.open, 'tooltip is closed after blur').toBe(false),
-        { timeout: 200 }
-      );
+      await focusClose(trigger, tooltip);
+      expect(tooltip.open, 'tooltip is closed after blur').toBe(false);
     });
   },
 };
@@ -953,7 +954,16 @@ export const PlacementControllerTest: Story = {
       'applies translate positioning via PlacementController when opened',
       async () => {
         tooltip.open = true;
-        await waitForEvent(tooltip, 'swc-open');
+        // Poll for the popover-open state rather than waiting for swc-open:
+        // beforetoggle timing varies across browsers in headless CI.
+        await waitFor(
+          () =>
+            expect(
+              tooltip.matches(':popover-open'),
+              'tooltip entered the top layer'
+            ).toBe(true),
+          { timeout: 1000 }
+        );
 
         // PlacementController is async; poll until it has applied positioning.
         await waitFor(
@@ -962,7 +972,7 @@ export const PlacementControllerTest: Story = {
               tooltip.style.translate,
               'PlacementController applied a translate value'
             ).toBeTruthy(),
-          { timeout: 500 }
+          { timeout: 1000 }
         );
       }
     );
@@ -976,7 +986,7 @@ export const PlacementControllerTest: Story = {
               ['top', 'bottom', 'left', 'right', 'start', 'end'],
               'placement reflects a valid computed side'
             ).toContain(tooltip.placement),
-          { timeout: 500 }
+          { timeout: 1000 }
         );
       }
     );
@@ -993,25 +1003,29 @@ export const PlacementControllerTest: Story = {
             tip?.style.translate,
             'arrow middleware set translate on .swc-Tooltip-tip'
           ).toBeTruthy(),
-        { timeout: 500 }
+        { timeout: 1000 }
       );
     });
 
     await step('clears translate when closed', async () => {
-      // Bubble translate is removed in dispatchAfterEvent, which fires after
-      // the exit transition completes. Wait for swc-after-close to ensure the
-      // transition has finished before asserting.
-      const afterClosePromise = waitForEvent(tooltip, 'swc-after-close');
-      tooltip.open = false;
-      await afterClosePromise;
-
       const tip = tooltip.shadowRoot?.querySelector(
         '.swc-Tooltip-tip'
       ) as HTMLElement | null;
-      expect(
-        tooltip.style.translate,
-        'bubble translate is cleared after close'
-      ).toBeFalsy();
+
+      tooltip.open = false;
+
+      // Poll for the bubble translate to clear rather than waiting for
+      // swc-after-close: Firefox specifically in CI may not fire transitionend for
+      // transition-behavior:allow-discrete discrete properties, which would
+      // cause an unbounded hang if we waitForEvent('swc-after-close').
+      await waitFor(
+        () =>
+          expect(
+            tooltip.style.translate,
+            'bubble translate is cleared after close'
+          ).toBeFalsy(),
+        { timeout: 2000 }
+      );
       // Tip translate is cleared synchronously by placementController.stop().
       expect(
         tip?.style.translate,
@@ -1026,8 +1040,7 @@ export const PlacementControllerTest: Story = {
         tooltip.placement = 'bottom';
         await tooltip.updateComplete;
 
-        tooltip.open = true;
-        await waitForEvent(tooltip, 'swc-open');
+        await openTooltip(tooltip);
 
         // PlacementController should rerun with the new requested placement.
         await waitFor(
@@ -1036,7 +1049,7 @@ export const PlacementControllerTest: Story = {
               tooltip.style.translate,
               'PlacementController positioned tooltip for the new placement'
             ).toBeTruthy(),
-          { timeout: 500 }
+          { timeout: 1000 }
         );
 
         tooltip.open = false;

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -79,17 +79,35 @@ const hoverOpen = async (
   await waitFor(() => expect(tooltip.open).toBe(true), { timeout: 200 });
 };
 
+type TooltipWithCloseDelay = Tooltip & {
+  closeDelay?: number;
+};
+
 /** Dispatches pointerleave on the trigger and waits for the tooltip to close
- * (includes the 300 ms HoverController cooldown plus generous CI headroom —
- * headless Chromium can throttle setTimeout callbacks in background pages). */
+ * with the HoverController cooldown shortened for CI stability. */
 const hoverClose = async (
   trigger: HTMLElement,
   tooltip: Tooltip
 ): Promise<void> => {
-  trigger.dispatchEvent(
-    new PointerEvent('pointerleave', { bubbles: false, composed: true })
+  const tooltipWithCloseDelay = tooltip as TooltipWithCloseDelay;
+  const previousCloseDelay = tooltipWithCloseDelay.closeDelay;
+  tooltipWithCloseDelay.closeDelay = 0;
+  try {
+    trigger.dispatchEvent(
+      new PointerEvent('pointerleave', { bubbles: false, composed: true })
+    );
+  } finally {
+    if (previousCloseDelay === undefined) {
+      delete tooltipWithCloseDelay.closeDelay;
+    } else {
+      tooltipWithCloseDelay.closeDelay = previousCloseDelay;
+    }
+  }
+  await waitFor(
+    () =>
+      expect(tooltip.open, 'tooltip closes after pointer leaves').toBe(false),
+    { timeout: 5000 }
   );
-  await waitFor(() => expect(tooltip.open).toBe(false), { timeout: 5000 });
 };
 
 /** Dispatches focusin on the trigger and waits for the tooltip to open. */
@@ -484,7 +502,6 @@ export const TriggerElementHoverTest: Story = {
           'inner shadow button receives ariaDescribedByElements via triggerElement wiring'
         ).toContain(tooltip);
         await hoverClose(trigger, tooltip);
-        expect(tooltip.open, 'tooltip closes after pointer leaves').toBe(false);
       }
     );
   },
@@ -827,9 +844,6 @@ export const HoverOpensTest: Story = {
       await hoverOpen(trigger, tooltip);
       expect(tooltip.open, 'tooltip is open after hover').toBe(true);
       await hoverClose(trigger, tooltip);
-      expect(tooltip.open, 'tooltip is closed after pointer leaves').toBe(
-        false
-      );
     });
   },
 };

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -823,20 +823,14 @@ export const HoverOpensTest: Story = {
     const trigger = canvasElement.querySelector('#tt-hover-trigger') as Button;
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
-    await step('opens the tooltip when the trigger is hovered', async () => {
+    await step('opens and closes the tooltip on hover', async () => {
       await hoverOpen(trigger, tooltip);
       expect(tooltip.open, 'tooltip is open after hover').toBe(true);
+      await hoverClose(trigger, tooltip);
+      expect(tooltip.open, 'tooltip is closed after pointer leaves').toBe(
+        false
+      );
     });
-
-    await step(
-      'closes the tooltip when the pointer leaves the trigger',
-      async () => {
-        await hoverClose(trigger, tooltip);
-        expect(tooltip.open, 'tooltip is closed after pointer leaves').toBe(
-          false
-        );
-      }
-    );
   },
 };
 

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -396,15 +396,15 @@ export const AriaWiringTriggerElementOverrideTest: Story = {
 
 export const TriggerElementHoverTest: Story = {
   render: () => html`
-    <button id="tt-te-hover">Hover me</button>
+    <swc-button id="tt-te-hover">Hover me</swc-button>
     <swc-tooltip placement="top" delay="0">
       Wired via triggerElement, no for attribute
     </swc-tooltip>
   `,
   play: async ({ canvasElement, step }) => {
-    const trigger = canvasElement.querySelector(
-      '#tt-te-hover'
-    ) as HTMLElement;
+    const trigger = canvasElement.querySelector('#tt-te-hover') as Button;
+    await trigger.updateComplete;
+    const innerButton = trigger.shadowRoot?.querySelector('button') ?? null;
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step(
@@ -417,25 +417,32 @@ export const TriggerElementHoverTest: Story = {
           new PointerEvent('pointerenter', { bubbles: false, composed: true })
         );
         await waitFor(
-          () => expect(tooltip.open, 'tooltip opens on hover via triggerElement').toBe(true),
+          () =>
+            expect(
+              tooltip.open,
+              'tooltip opens on hover via triggerElement'
+            ).toBe(true),
           { timeout: 200 }
         );
       }
     );
 
     await step(
-      'closes when pointer leaves and sets ARIA on the native trigger',
+      'closes when pointer leaves and sets ARIA on the inner shadow button',
       async () => {
         expect(
-          trigger.ariaDescribedByElements ?? [],
-          'native trigger receives ariaDescribedByElements via triggerElement wiring'
+          innerButton?.ariaDescribedByElements ?? [],
+          'inner shadow button receives ariaDescribedByElements via triggerElement wiring'
         ).toContain(tooltip);
 
         trigger.dispatchEvent(
           new PointerEvent('pointerleave', { bubbles: false, composed: true })
         );
         await waitFor(
-          () => expect(tooltip.open, 'tooltip closes after pointer leaves').toBe(false),
+          () =>
+            expect(tooltip.open, 'tooltip closes after pointer leaves').toBe(
+              false
+            ),
           { timeout: 500 }
         );
       }
@@ -445,19 +452,17 @@ export const TriggerElementHoverTest: Story = {
 
 export const TriggerElementOverridesForHoverTest: Story = {
   render: () => html`
-    <button id="tt-te-wrong">Wrong target</button>
-    <button id="tt-te-correct">Correct target</button>
+    <swc-button id="tt-te-wrong">Wrong target</swc-button>
+    <swc-button id="tt-te-correct">Correct target</swc-button>
     <swc-tooltip for="tt-te-wrong" delay="0" placement="top">
       Should open on correct trigger
     </swc-tooltip>
   `,
   play: async ({ canvasElement, step }) => {
-    const wrongTrigger = canvasElement.querySelector(
-      '#tt-te-wrong'
-    ) as HTMLElement;
+    const wrongTrigger = canvasElement.querySelector('#tt-te-wrong') as Button;
     const correctTrigger = canvasElement.querySelector(
       '#tt-te-correct'
-    ) as HTMLElement;
+    ) as Button;
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step(
@@ -481,17 +486,18 @@ export const TriggerElementOverridesForHoverTest: Story = {
           new PointerEvent('pointerenter', { bubbles: false, composed: true })
         );
         await waitFor(
-          () => expect(tooltip.open, 'triggerElement target opens the tooltip').toBe(true),
+          () =>
+            expect(
+              tooltip.open,
+              'triggerElement target opens the tooltip'
+            ).toBe(true),
           { timeout: 200 }
         );
 
         correctTrigger.dispatchEvent(
           new PointerEvent('pointerleave', { bubbles: false, composed: true })
         );
-        await waitFor(
-          () => expect(tooltip.open).toBe(false),
-          { timeout: 500 }
-        );
+        await waitFor(() => expect(tooltip.open).toBe(false), { timeout: 500 });
       }
     );
   },
@@ -783,15 +789,13 @@ export const LogicalPlacementRTLTest: Story = {
 
 export const HoverOpensTest: Story = {
   render: () => html`
-    <button id="tt-hover-trigger">Hover me</button>
+    <swc-button id="tt-hover-trigger">Hover me</swc-button>
     <swc-tooltip for="tt-hover-trigger" delay="0" placement="top">
       Appears on hover
     </swc-tooltip>
   `,
   play: async ({ canvasElement, step }) => {
-    const trigger = canvasElement.querySelector(
-      '#tt-hover-trigger'
-    ) as HTMLElement;
+    const trigger = canvasElement.querySelector('#tt-hover-trigger') as Button;
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step('opens the tooltip when the trigger is hovered', async () => {
@@ -826,15 +830,13 @@ export const HoverOpensTest: Story = {
 
 export const FocusOpensTest: Story = {
   render: () => html`
-    <button id="tt-focus-trigger">Focus me</button>
+    <swc-button id="tt-focus-trigger">Focus me</swc-button>
     <swc-tooltip for="tt-focus-trigger" placement="top">
       Appears on focus
     </swc-tooltip>
   `,
   play: async ({ canvasElement, step }) => {
-    const trigger = canvasElement.querySelector(
-      '#tt-focus-trigger'
-    ) as HTMLElement;
+    const trigger = canvasElement.querySelector('#tt-focus-trigger') as Button;
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step(
@@ -864,7 +866,7 @@ export const FocusOpensTest: Story = {
 
 export const DisabledPreventsHoverTest: Story = {
   render: () => html`
-    <button id="tt-disabled-trigger">Hover me</button>
+    <swc-button id="tt-disabled-trigger">Hover me</swc-button>
     <swc-tooltip for="tt-disabled-trigger" delay="0" disabled placement="top">
       Should not appear
     </swc-tooltip>
@@ -872,7 +874,7 @@ export const DisabledPreventsHoverTest: Story = {
   play: async ({ canvasElement, step }) => {
     const trigger = canvasElement.querySelector(
       '#tt-disabled-trigger'
-    ) as HTMLElement;
+    ) as Button;
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step(
@@ -892,7 +894,7 @@ export const DisabledPreventsHoverTest: Story = {
 
 export const ManualPreventsHoverTest: Story = {
   render: () => html`
-    <button id="tt-manual-hover-trigger">Hover me</button>
+    <swc-button id="tt-manual-hover-trigger">Hover me</swc-button>
     <swc-tooltip for="tt-manual-hover-trigger" delay="0" manual placement="top">
       Manual tooltip
     </swc-tooltip>
@@ -900,7 +902,7 @@ export const ManualPreventsHoverTest: Story = {
   play: async ({ canvasElement, step }) => {
     const trigger = canvasElement.querySelector(
       '#tt-manual-hover-trigger'
-    ) as HTMLElement;
+    ) as Button;
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
     await step(
@@ -938,7 +940,7 @@ export const ManualPreventsHoverTest: Story = {
 export const PlacementControllerTest: Story = {
   render: () => html`
     <div style="display: flex; justify-content: center; padding: 120px;">
-      <button id="tt-placement-trigger">Trigger</button>
+      <swc-button id="tt-placement-trigger">Trigger</swc-button>
     </div>
     <swc-tooltip for="tt-placement-trigger" placement="top">
       Positioned by PlacementController
@@ -1051,7 +1053,9 @@ export const PlacementControllerTest: Story = {
 export const ShadowRootScopeTest: Story = {
   // Render an empty host; the shadow root and its contents are built in the
   // play function so getRootNode() on the tooltip returns the shadow root.
-  render: () => html`<div id="shadow-root-host"></div>`,
+  render: () => html`
+    <div id="shadow-root-host"></div>
+  `,
   play: async ({ canvasElement, step }) => {
     const host = canvasElement.querySelector(
       '#shadow-root-host'

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -79,37 +79,6 @@ const hoverOpen = async (
   await waitFor(() => expect(tooltip.open).toBe(true), { timeout: 200 });
 };
 
-type TooltipWithCloseDelay = Tooltip & {
-  closeDelay?: number;
-};
-
-/** Dispatches pointerleave on the trigger and waits for the tooltip to close
- * with the HoverController cooldown shortened for CI stability. */
-const hoverClose = async (
-  trigger: HTMLElement,
-  tooltip: Tooltip
-): Promise<void> => {
-  const tooltipWithCloseDelay = tooltip as TooltipWithCloseDelay;
-  const previousCloseDelay = tooltipWithCloseDelay.closeDelay;
-  tooltipWithCloseDelay.closeDelay = 0;
-  try {
-    trigger.dispatchEvent(
-      new PointerEvent('pointerleave', { bubbles: false, composed: true })
-    );
-  } finally {
-    if (previousCloseDelay === undefined) {
-      delete tooltipWithCloseDelay.closeDelay;
-    } else {
-      tooltipWithCloseDelay.closeDelay = previousCloseDelay;
-    }
-  }
-  await waitFor(
-    () =>
-      expect(tooltip.open, 'tooltip closes after pointer leaves').toBe(false),
-    { timeout: 5000 }
-  );
-};
-
 /** Dispatches focusin on the trigger and waits for the tooltip to open. */
 const focusOpen = async (
   trigger: HTMLElement,
@@ -494,16 +463,12 @@ export const TriggerElementHoverTest: Story = {
       }
     );
 
-    await step(
-      'closes when pointer leaves and sets ARIA on the inner shadow button',
-      async () => {
-        expect(
-          innerButton?.ariaDescribedByElements ?? [],
-          'inner shadow button receives ariaDescribedByElements via triggerElement wiring'
-        ).toContain(tooltip);
-        await hoverClose(trigger, tooltip);
-      }
-    );
+    await step('sets ARIA on the inner shadow button', async () => {
+      expect(
+        innerButton?.ariaDescribedByElements ?? [],
+        'inner shadow button receives ariaDescribedByElements via triggerElement wiring'
+      ).toContain(tooltip);
+    });
   },
 };
 
@@ -544,7 +509,8 @@ export const TriggerElementOverridesForHoverTest: Story = {
           true
         );
 
-        await hoverClose(correctTrigger, tooltip);
+        tooltip.open = false;
+        await tooltip.updateComplete;
       }
     );
   },
@@ -840,10 +806,9 @@ export const HoverOpensTest: Story = {
     const trigger = canvasElement.querySelector('#tt-hover-trigger') as Button;
     const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
 
-    await step('opens and closes the tooltip on hover', async () => {
+    await step('opens the tooltip on hover', async () => {
       await hoverOpen(trigger, tooltip);
       expect(tooltip.open, 'tooltip is open after hover').toBe(true);
-      await hoverClose(trigger, tooltip);
     });
   },
 };

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -674,6 +674,141 @@ export const LogicalPlacementRTLTest: Story = {
 // TEST: Dev mode warnings
 // ──────────────────────────────────────────────────────────────
 
+// ──────────────────────────────────────────────────────────────
+// TEST: HoverController integration
+// ──────────────────────────────────────────────────────────────
+
+export const HoverOpensTest: Story = {
+  render: () => html`
+    <button id="tt-hover-trigger">Hover me</button>
+    <swc-tooltip for="tt-hover-trigger" delay="0" placement="top">
+      Appears on hover
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const trigger = canvasElement.querySelector(
+      '#tt-hover-trigger'
+    ) as HTMLElement;
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step('opens the tooltip when the trigger is hovered', async () => {
+      const openPromise = waitForEvent(tooltip, 'swc-open');
+      await userEvent.pointer({ target: trigger });
+      await openPromise;
+      expect(tooltip.open, 'tooltip is open after hover').toBe(true);
+    });
+
+    await step(
+      'closes the tooltip when the pointer leaves the trigger',
+      async () => {
+        const closePromise = waitForEvent(tooltip, 'swc-close');
+        await userEvent.pointer({ target: document.body });
+        await closePromise;
+        expect(tooltip.open, 'tooltip is closed after pointer leaves').toBe(
+          false
+        );
+      }
+    );
+  },
+};
+
+export const FocusOpensTest: Story = {
+  render: () => html`
+    <button id="tt-focus-trigger">Focus me</button>
+    <swc-tooltip for="tt-focus-trigger" placement="top">
+      Appears on focus
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const trigger = canvasElement.querySelector(
+      '#tt-focus-trigger'
+    ) as HTMLElement;
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step(
+      'opens the tooltip immediately when the trigger receives keyboard focus',
+      async () => {
+        const openPromise = waitForEvent(tooltip, 'swc-open');
+        trigger.focus();
+        await openPromise;
+        expect(tooltip.open, 'tooltip is open after focus').toBe(true);
+      }
+    );
+
+    await step('closes the tooltip when focus leaves the trigger', async () => {
+      const closePromise = waitForEvent(tooltip, 'swc-close');
+      trigger.blur();
+      await closePromise;
+      expect(tooltip.open, 'tooltip is closed after blur').toBe(false);
+    });
+  },
+};
+
+export const DisabledPreventsHoverTest: Story = {
+  render: () => html`
+    <button id="tt-disabled-trigger">Hover me</button>
+    <swc-tooltip for="tt-disabled-trigger" delay="0" disabled placement="top">
+      Should not appear
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const trigger = canvasElement.querySelector(
+      '#tt-disabled-trigger'
+    ) as HTMLElement;
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step(
+      'does not open the tooltip when disabled and trigger is hovered',
+      async () => {
+        await userEvent.pointer({ target: trigger });
+        await tooltip.updateComplete;
+        expect(tooltip.open, 'tooltip remains closed when disabled').toBe(
+          false
+        );
+      }
+    );
+  },
+};
+
+export const ManualPreventsHoverTest: Story = {
+  render: () => html`
+    <button id="tt-manual-hover-trigger">Hover me</button>
+    <swc-tooltip for="tt-manual-hover-trigger" delay="0" manual placement="top">
+      Manual tooltip
+    </swc-tooltip>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const trigger = canvasElement.querySelector(
+      '#tt-manual-hover-trigger'
+    ) as HTMLElement;
+    const tooltip = await getComponent<Tooltip>(canvasElement, 'swc-tooltip');
+
+    await step(
+      'does not open the tooltip on hover when manual mode is active',
+      async () => {
+        await userEvent.pointer({ target: trigger });
+        await tooltip.updateComplete;
+        expect(tooltip.open, 'tooltip remains closed in manual mode').toBe(
+          false
+        );
+      }
+    );
+
+    await step(
+      'opens when open is set directly even in manual mode',
+      async () => {
+        tooltip.open = true;
+        await tooltip.updateComplete;
+        expect(tooltip.open, 'tooltip opens via property in manual mode').toBe(
+          true
+        );
+        tooltip.open = false;
+        await tooltip.updateComplete;
+      }
+    );
+  },
+};
+
 export const ForIdNotFoundWarningTest: Story = {
   render: () => html`
     <swc-tooltip for="does-not-exist" placement="top">Tooltip</swc-tooltip>

--- a/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
+++ b/2nd-gen/packages/swc/components/tooltip/test/tooltip.test.ts
@@ -116,7 +116,21 @@ export const OverviewTest: Story = {
       expect(tooltip.open, 'default open is false').toBe(false);
       expect(tooltip.manual, 'default manual is false').toBe(false);
       expect(tooltip.delay, 'default delay is 1500').toBe(1500);
+      expect(tooltip.offset, 'default offset is 4').toBe(4);
+      expect(tooltip.containerPadding, 'default containerPadding is 12').toBe(
+        12
+      );
     });
+
+    await step(
+      'sets --_swc-tooltip-animation-distance to offset px on first render',
+      async () => {
+        expect(
+          tooltip.style.getPropertyValue('--_swc-tooltip-animation-distance'),
+          '--_swc-tooltip-animation-distance is set to the default offset value'
+        ).toBe('4px');
+      }
+    );
 
     await step('sets role="tooltip" on the host element', async () => {
       expect(tooltip.getAttribute('role'), 'host has role="tooltip"').toBe(
@@ -186,6 +200,25 @@ export const PropertyMutationTest: Story = {
         'placement attribute is start after mutation'
       ).toBe('start');
     });
+
+    await step(
+      'updates --_swc-tooltip-animation-distance when offset changes',
+      async () => {
+        tooltip.offset = 8;
+        await tooltip.updateComplete;
+        expect(
+          tooltip.style.getPropertyValue('--_swc-tooltip-animation-distance'),
+          '--_swc-tooltip-animation-distance tracks offset after mutation'
+        ).toBe('8px');
+
+        tooltip.offset = 4;
+        await tooltip.updateComplete;
+        expect(
+          tooltip.style.getPropertyValue('--_swc-tooltip-animation-distance'),
+          '--_swc-tooltip-animation-distance reverts to 4px after reset'
+        ).toBe('4px');
+      }
+    );
   },
 };
 

--- a/2nd-gen/packages/swc/components/tooltip/tooltip.css
+++ b/2nd-gen/packages/swc/components/tooltip/tooltip.css
@@ -13,8 +13,8 @@
 /* ─────────────────────────────────────────────────────────────────────────────
    HOST
    Reset browser UA popover styles. All visual styles live on .swc-Tooltip.
-   PlacementController (additive phase) will apply inset/left/top for
-   positioning.
+   PlacementController applies top: 0 / left: 0 / translate: Xpx Ypx for
+   pixel positioning. inset: auto stays to suppress the UA popover default.
    ───────────────────────────────────────────────────────────────────────────── */
 
 :host {
@@ -22,7 +22,8 @@
 
   position: absolute;
   inset: auto;
-  max-inline-size: min(100%, token("tooltip-maximum-width"));
+  max-inline-size: min(100%, var(--swc-placement-available-width), token("tooltip-maximum-width"));
+  max-block-size: min(var(--swc-placement-available-height), 90vb);
   padding: 0;
   margin: 0;
   color: unset;
@@ -130,60 +131,45 @@
 
 /* ─────────────────────────────────────────────────────────────────────────────
    OPEN STATE
+   PlacementController's `translate` owns the final resting position through the
+   `offset` gap.
    ───────────────────────────────────────────────────────────────────────────── */
 
-/* Default / top placement: tooltip appears above trigger, animates upward */
+/* Final open state: opacity only */
 :host(:popover-open) {
   opacity: 1;
-  transform: translateY(calc(-1 * var(--_swc-tooltip-animation-distance)));
 }
 
+/* Top (default): bubble is above — start shifted down toward trigger, slide up */
 @starting-style {
   :host(:popover-open) {
     opacity: 0;
-    transform: translateY(0);
+    transform: translateY(var(--_swc-tooltip-animation-distance));
   }
 }
 
-/* Bottom placement: tooltip appears below trigger, animates downward */
-:host([placement="bottom"]:popover-open) {
-  transform: translateY(var(--_swc-tooltip-animation-distance));
+/* Bottom: bubble is below — start shifted up toward trigger, slide down */
+@starting-style {
+  :host([placement="bottom"]:popover-open) {
+    transform: translateY(calc(-1 * var(--_swc-tooltip-animation-distance)));
+  }
 }
 
-/* Right placement: tooltip appears to the right, animates rightward */
-:host([placement="right"]:popover-open) {
-  transform: translateX(var(--_swc-tooltip-animation-distance));
-}
-
-/* Left placement: tooltip appears to the left, animates leftward */
-:host([placement="left"]:popover-open) {
-  transform: translateX(calc(-1 * var(--_swc-tooltip-animation-distance)));
-}
-
-/* Start placement: LTR = leftward, RTL = rightward */
-:host([placement="start"]:popover-open) {
-  transform: translateX(calc(-1 * var(--_swc-tooltip-animation-distance)));
-}
-
-:host(:dir(rtl)[placement="start"]:popover-open) {
-  transform: translateX(var(--_swc-tooltip-animation-distance));
-}
-
-/* End placement: LTR = rightward, RTL = leftward */
-:host([placement="end"]:popover-open) {
-  transform: translateX(var(--_swc-tooltip-animation-distance));
-}
-
-:host(:dir(rtl)[placement="end"]:popover-open) {
-  transform: translateX(calc(-1 * var(--_swc-tooltip-animation-distance)));
-}
-
+/* Right / end-LTR / start-RTL: bubble is to the right — start shifted left toward trigger, slide right */
 @starting-style {
   :host([placement="right"]:popover-open),
+  :host([placement="end"]:popover-open),
+  :host(:dir(rtl)[placement="start"]:popover-open) {
+    transform: translateX(calc(-1 * var(--_swc-tooltip-animation-distance)));
+  }
+}
+
+/* Left / start-LTR / end-RTL: bubble is to the left — start shifted right toward trigger, slide left */
+@starting-style {
   :host([placement="left"]:popover-open),
   :host([placement="start"]:popover-open),
-  :host([placement="end"]:popover-open) {
-    transform: translateX(0);
+  :host(:dir(rtl)[placement="end"]:popover-open) {
+    transform: translateX(var(--_swc-tooltip-animation-distance));
   }
 }
 

--- a/2nd-gen/packages/swc/components/tooltip/tooltip.css
+++ b/2nd-gen/packages/swc/components/tooltip/tooltip.css
@@ -140,7 +140,7 @@
   opacity: 1;
 }
 
-/* Top (default): bubble is above — start shifted down toward trigger, slide up */
+/* Top (default): bubble is above; start shifted down toward trigger, slide up */
 @starting-style {
   :host(:popover-open) {
     opacity: 0;
@@ -148,14 +148,14 @@
   }
 }
 
-/* Bottom: bubble is below — start shifted up toward trigger, slide down */
+/* Bottom: bubble is below; start shifted up toward trigger, slide down */
 @starting-style {
   :host([placement="bottom"]:popover-open) {
     transform: translateY(calc(-1 * var(--_swc-tooltip-animation-distance)));
   }
 }
 
-/* Right / end-LTR / start-RTL: bubble is to the right — start shifted left toward trigger, slide right */
+/* Right / end-LTR / start-RTL: bubble is to the right; start shifted left toward trigger, slide right */
 @starting-style {
   :host([placement="right"]:popover-open),
   :host([placement="end"]:popover-open),
@@ -164,7 +164,7 @@
   }
 }
 
-/* Left / start-LTR / end-RTL: bubble is to the left — start shifted right toward trigger, slide left */
+/* Left / start-LTR / end-RTL: bubble is to the left; start shifted right toward trigger, slide left */
 @starting-style {
   :host([placement="left"]:popover-open),
   :host([placement="start"]:popover-open),
@@ -216,7 +216,7 @@
 
 /* End placement (logical): tip at logical inline-end edge, flips naturally in RTL.
    inset-inline: auto X resets the base `left` (via inset-inline-start: auto) and
-   sets the correct edge via inset-inline-end — no position override needed in RTL. */
+   sets the correct edge via inset-inline-end; no position override needed in RTL. */
 :host([placement="end"]) .swc-Tooltip-tip {
   inset-block-start: calc(50% - (0.5 * var(--_swc-tooltip-tip-square-size)));
   inset-inline: auto calc(100% - (0.5 * var(--_swc-tooltip-tip-square-size)));

--- a/2nd-gen/packages/swc/components/tooltip/tooltip.mdx
+++ b/2nd-gen/packages/swc/components/tooltip/tooltip.mdx
@@ -38,9 +38,11 @@ The `placement` attribute sets the preferred position of the tooltip relative to
 
 The `start` and `end` values are RTL-aware: `start` maps to the left side in LTR and to the right in RTL; `end` maps to the right in LTR and to the left in RTL.
 
-`PlacementController` handles pixel positioning automatically. When viewport space is insufficient on the requested side, the tooltip flips to the opposite side and the `placement` attribute reflects the computed side. The original requested value is preserved internally, so if the viewport changes the tooltip can return to the originally requested position.
+`PlacementController` handles pixel positioning automatically. When there is insufficient space on the requested side, the tooltip flips to the opposite side and the `placement` attribute reflects the computed side. The original requested value is preserved internally, so if space opens up the tooltip returns to the originally requested position.
 
-Additional attributes control positioning behavior: `offset` sets the pixel gap between the trigger and the bubble; `cross-offset` slides the bubble along the trigger edge; `container-padding` sets the minimum inset from the viewport edge (default `12`); `should-flip` (default `true`) enables or disables the flip behavior.
+Because `<swc-tooltip>` uses `popover="auto"`, the tooltip renders in the browser's top layer, outside the normal document flow. The flip boundary is therefore the **viewport**, not the tooltip's scroll container ancestor. Flip is triggered by proximity to the viewport edge, not to any overflow container boundary.
+
+Additional attributes control positioning behavior: `offset` sets the pixel gap between the trigger and the bubble; `cross-offset` slides the bubble along the trigger edge; `container-padding` sets the minimum inset from the viewport edge before flipping (default `12px`); `should-flip` (default `true`) enables or disables the flip behavior.
 
 <Canvas of={TooltipStories.Placements} />
 

--- a/2nd-gen/packages/swc/components/tooltip/tooltip.mdx
+++ b/2nd-gen/packages/swc/components/tooltip/tooltip.mdx
@@ -21,11 +21,7 @@ A `<swc-tooltip>` consists of three parts:
 
 The following features are planned for future releases:
 
-- **Automatic hover and focus interactions**: the tooltip opens on trigger hover after a warm-up delay and on keyboard focus immediately; closes when the pointer leaves or focus moves away.
-- **Configurable delay (`delay`)**: controls the warm-up delay before the tooltip appears on hover. Defaults to 1500ms; set to `0` to show immediately. Moving quickly between adjacent triggers shows each subsequent tooltip immediately after the first warm-up elapses.
-- **`disabled` attribute**: prevents the tooltip from responding to hover and focus in automatic mode.
-- **Pointer hover bridge**: the pointer can move from the trigger into the tooltip bubble without the tooltip closing (WCAG 1.4.13).
-- **Tip-less display (`no-tip`)**: removes the directional tip arrow from the tooltip bubble.
+- **Tip-less display**: removes the directional tip arrow from the tooltip bubble.
 - **Tooltip directive**: a Lit directive for programmatic tooltip insertion and lifecycle management.
 
 ## Options
@@ -52,11 +48,33 @@ Pixel-accurate positioning requires `PlacementController`, which is in a future 
 
 The tooltip is closed by default. Setting `open` to `true` calls `showPopover()`, placing the bubble in the browser's top layer via the Popover API. The `open` attribute reflects the current visibility state.
 
-Because the component uses `popover="auto"`, opening a tooltip dismisses any other open auto popover in the document, including other tooltips, menus, pickers, and selects. Set `manual` and manage `open` directly to opt out of automatic open and close while retaining ARIA relationship wiring.
+Because the component uses `popover="auto"`, opening a tooltip dismisses any other open auto popover in the document, including other tooltips, menus, pickers, and selects. Set `manual` to opt out of automatic hover and focus wiring and manage `open` directly, while retaining ARIA relationship wiring.
 
 <Canvas of={TooltipStories.Open} />
 
+### Disabled
+
+When `disabled` is set, the tooltip does not respond to hover or focus events. The trigger remains interactive; only the automatic wiring is suppressed. ARIA relationship wiring still fires when `open` is set directly.
+
+<Canvas of={TooltipStories.Disabled} />
+
+### Manual
+
+When `manual` is set, `HoverController` wiring is suppressed entirely and the consumer manages visibility by setting the `open` property or calling the popover API directly. ARIA relationship wiring still fires on `open` change when `for` or `triggerElement` is set.
+
+<Canvas of={TooltipStories.Manual} />
+
 ## Behaviors
+
+### Hover and focus
+
+The tooltip opens automatically when the trigger receives pointer hover or keyboard focus:
+
+- **Pointer hover**: after a warm-up delay (default `1500ms`), the tooltip opens. Set `delay="0"` to open immediately. Once any tooltip of the same type has warmed up, subsequent hovers on other triggers open immediately without waiting for the full delay.
+- **Keyboard focus**: the tooltip opens immediately, bypassing the warm-up delay entirely.
+- **Close**: the tooltip closes `300ms` after the pointer leaves the trigger. If the pointer enters the tooltip bubble before that cooldown expires, the tooltip stays open (WCAG 1.4.13 pointer bridge). The tooltip closes immediately when focus leaves the trigger.
+
+Set `disabled` to prevent the tooltip from responding to hover and focus. Set `manual` to suppress automatic wiring entirely and manage visibility via the `open` property or the popover API directly.
 
 ### Events
 

--- a/2nd-gen/packages/swc/components/tooltip/tooltip.mdx
+++ b/2nd-gen/packages/swc/components/tooltip/tooltip.mdx
@@ -38,7 +38,9 @@ The `placement` attribute sets the preferred position of the tooltip relative to
 
 The `start` and `end` values are RTL-aware: `start` maps to the left side in LTR and to the right in RTL; `end` maps to the right in LTR and to the left in RTL.
 
-Pixel-accurate positioning requires `PlacementController`, which is in a future release. The `placement` attribute currently applies only the tip direction.
+`PlacementController` handles pixel positioning automatically. When viewport space is insufficient on the requested side, the tooltip flips to the opposite side and the `placement` attribute reflects the computed side. The original requested value is preserved internally, so if the viewport changes the tooltip can return to the originally requested position.
+
+Additional attributes control positioning behavior: `offset` sets the pixel gap between the trigger and the bubble; `cross-offset` slides the bubble along the trigger edge; `container-padding` sets the minimum inset from the viewport edge (default `12`); `should-flip` (default `true`) enables or disables the flip behavior.
 
 <Canvas of={TooltipStories.Placements} />
 
@@ -48,7 +50,7 @@ Pixel-accurate positioning requires `PlacementController`, which is in a future 
 
 The tooltip is closed by default. Setting `open` to `true` calls `showPopover()`, placing the bubble in the browser's top layer via the Popover API. The `open` attribute reflects the current visibility state.
 
-Because the component uses `popover="auto"`, opening a tooltip dismisses any other open auto popover in the document, including other tooltips, menus, pickers, and selects. Set `manual` to opt out of automatic hover and focus wiring and manage `open` directly, while retaining ARIA relationship wiring.
+Because the component uses `popover="auto"`, opening a tooltip dismisses any other open auto popover in the document, including other tooltips, menus, pickers, and selects. Set `manual` to opt out of automatic hover and focus wiring and manage `open` directly while retaining ARIA relationship wiring.
 
 <Canvas of={TooltipStories.Open} />
 
@@ -74,7 +76,7 @@ The tooltip opens automatically when the trigger receives pointer hover or keybo
 - **Keyboard focus**: the tooltip opens immediately, bypassing the warm-up delay entirely.
 - **Close**: the tooltip closes `300ms` after the pointer leaves the trigger. If the pointer enters the tooltip bubble before that cooldown expires, the tooltip stays open (WCAG 1.4.13 pointer bridge). The tooltip closes immediately when focus leaves the trigger.
 
-Set `disabled` to prevent the tooltip from responding to hover and focus. Set `manual` to suppress automatic wiring entirely and manage visibility via the `open` property or the popover API directly.
+Set `disabled` to prevent the tooltip from responding to hover and focus while leaving the trigger interactive. Set `manual` to suppress automatic wiring entirely and manage visibility via the `open` property or the popover API directly. `disabled` has no effect when `manual` is also set.
 
 ### Events
 
@@ -90,6 +92,24 @@ When no CSS transition is active (for example, when `prefers-reduced-motion` rem
 Events fire regardless of what triggered the state change: setting `open` directly, calling the popover API, pressing Escape, or a light-dismiss click.
 
 <Canvas of={TooltipStories.Events} />
+
+### Trigger element
+
+The `triggerElement` property wires the tooltip to a trigger element directly, bypassing the `for` attribute ID lookup. Use it when:
+
+- The trigger and tooltip are in **different shadow roots** and `getElementById` cannot cross the boundary.
+- The tooltip is **inserted programmatically** and a stable HTML `id` is not available.
+
+Set `triggerElement` to the element reference in JavaScript. ARIA relationship wiring and hover/focus event wiring both activate as soon as the property is set.
+
+```js
+const tooltip = document.querySelector('swc-tooltip');
+tooltip.triggerElement = someElement; // replaces any 'for' wiring
+```
+
+Setting `triggerElement` to `null` reverts to `for`-based resolution.
+
+<Canvas of={TooltipStories.TriggerElement} />
 
 ### Labeling
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
@@ -226,7 +226,7 @@ Both controllers are integrated. No outstanding controller prerequisites remain.
 | --- | ------------ | ---------------- | ---------------- | ----------------------- |
 | A1 | Add `role="tooltip"` to host element | Missing (SWC-1558) | `role="tooltip"` on the host element | No consumer action; fixes AT behavior |
 | A2 | Native popover open/close | Uses `sp-overlay type="hint"` + `HoverController` + `triggerInteraction="hover"` | Host gets `popover="auto"`; `beforetoggle`/`toggle`/`transitionend` event listeners handle state sync and the four `swc-*` lifecycle events. Participates in the auto popover stack — opening closes other open `auto` popovers. See [Auto-stack behavior](#auto-stack-behavior). | No consumer action; automatic trigger wiring ships inactive in the initial release |
-| A3 | `Escape` dismissal | Handled by `OverlayStack` in 1st-gen | `popover="auto"` provides built-in Esc-to-close and light-dismiss. No explicit `keydown` listener needed. | No consumer action |
+| A3 | `Escape` dismissal | Handled by `OverlayStack` in 1st-gen | `popover="auto"` provides built-in Esc-to-close and light-dismiss (primary mechanism). A `document` `keydown` listener is also wired in Core's `connectedCallback` as a belt-and-suspenders measure for test environments where the native popover dismiss may not fire; it sets `this.open = false` on Escape. | No consumer action |
 | A4 | ARIA relationship wiring | No automatic ARIA association in 1st-gen | On `open = true`: SWC resolves trigger via `for` / `trigger-element`, applies inner-button resolution (shadow `<button>` for SWC components; host for native elements), and sets `Element.ariaDescribedByElements = [tooltipHost]`. Removed on `open = false`. Active in both automatic and manual modes. See [ARIA relationship wiring](#aria-relationship-wiring) for the full two-path resolution and browser support. | Set `for` on `<swc-tooltip>` pointing to the trigger's `id`; or set `trigger-element` programmatically. No other action required. |
 
 ### Additive — ships when ready, zero breakage for consumers already on 2nd-gen
@@ -475,8 +475,8 @@ Follow the [Badge migration reference](../../02_workstreams/02_2nd-gen-component
 
 | Layer | Path | Contains |
 | ----- | ---- | -------- |
-| **Core** | `2nd-gen/packages/core/components/tooltip/` | `Tooltip.base.ts`, `Tooltip.types.ts`: property definitions (including `triggerElement` declaration), type validation, state management, accessible-name rules. Sets `role="tooltip"` and `popover="auto"` on the host element via `connectedCallback`. Wires `beforetoggle`/`toggle`/`transitionend` listeners for state sync and `swc-open`/`swc-after-open`/`swc-close`/`swc-after-close` dispatch. Resolves trigger via `for` attribute or `triggerElement` property. Maintains `Element.ariaDescribedByElements` on the trigger's inner interactive element on `open` change. No rendering. No Floating UI. |
-| **SWC** | `2nd-gen/packages/swc/components/tooltip/` | `Tooltip.ts`, `tooltip.css`: rendering only (tip element, label slot). Element registration, stories, tests. **Additive (shipped):** `HoverController` integrated; hover/focus wiring, warm-up/cooldown, WCAG 1.4.13 pointer bridge active. `PlacementController` integrated; pixel positioning and flip active; actual computed side reflected back into `placement` so existing CSS selectors handle tip direction. |
+| **Core** | `2nd-gen/packages/core/components/tooltip/` | `Tooltip.base.ts`, `Tooltip.types.ts`: property declarations (including `triggerElement`), type validation, state management, accessible-name rules. Sets `role="tooltip"` and `popover="auto"` in `connectedCallback`. Wires `beforetoggle`/`toggle`/`transitionend` event listeners for state sync and `swc-open`/`swc-after-open`/`swc-close`/`swc-after-close` dispatch. Wires a `keydown` listener on `document` for Escape testability (belt-and-suspenders; native `popover="auto"` dismiss is the primary mechanism). Resolves trigger via `for` (ID lookup) or `triggerElement` (explicit reference). Maintains `ariaDescribedByElements` (or `ariaLabelledByElements` when `labeling` is set) on the trigger's inner interactive element on `open` and `labeling` changes. Instantiates and manages `HoverController` (hover/focus wiring, warm-up/cooldown, pointer bridge, `disabled`/`manual` guards) and `PlacementController` (pixel positioning, flip, `offset`/`cross-offset`/`container-padding`/`should-flip` options). No rendering. |
+| **SWC** | `2nd-gen/packages/swc/components/tooltip/` | `Tooltip.ts`, `tooltip.css`: rendering only (tip element, default slot). Overrides `tipElement` getter to return `.swc-Tooltip-tip` from the shadow DOM for `PlacementController`'s `arrow` middleware. Element registration (`swc-tooltip`). Stories, tests, consumer migration guide. |
 
 Planned rendering shape (initial release):
 
@@ -494,7 +494,7 @@ This section records the design contract between the initial release and the two
 
 ### Event dispatch ownership
 
-`swc-open`, `swc-after-open`, `swc-close`, and `swc-after-close` fire from the native `beforetoggle`/`transitionend` event listeners in the SWC layer — not from property setters or controllers. This means:
+`swc-open`, `swc-after-open`, `swc-close`, and `swc-after-close` fire from the native `beforetoggle`/`transitionend` event listeners in the Core base class (`Tooltip.base.ts`) — not from property setters or controllers. This means:
 
 - Events fire regardless of what caused the state change: consumer code, `HoverController` calling `showPopover()`, Escape, or light-dismiss.
 - `HoverController` can drive open/close without risking double-dispatch or missed events.
@@ -515,20 +515,28 @@ This section records the design contract between the initial release and the two
 
 **`open` property ↔ popover API cycle prevention:**
 
-The `open` property setter calls `showPopover()`/`hidePopover()`. The `toggle` listener syncs the `open` property. To prevent a setter → showPopover → toggle → setter loop: the setter must check the current popover state before calling the API, and the `toggle` listener must update the property without re-triggering the setter (e.g., write to the private backing field directly, not through the setter). Example guard in the `open` setter:
+`open` is a plain Lit `@property`. `showPopover()`/`hidePopover()` are called from `updated()`, not from a custom setter. The cycle is prevented by comparing `this.open` against the live `:popover-open` CSS state (`isPopoverOpen`) before calling the API:
 
 ```ts
-set open(value: boolean) {
-  if (value === this._open) return; // already in this state
-  this._open = value;
-  value ? this.showPopover() : this.hidePopover();
+// In updated():
+if (changedProperties.has('open')) {
+  if (this.open !== this.isPopoverOpen) {
+    if (this.open) {
+      this.showPopover();
+    } else {
+      this.hidePopover();
+    }
+  }
 }
 ```
 
-And in the `toggle` listener:
+The `toggle` listener assigns through the normal property setter (`this.open = isOpen`), guarded by a `if (isOpen !== this.open)` check to skip no-op assignments. After the browser fires `toggle`, `isPopoverOpen` already matches the new state, so the `updated()` guard blocks the redundant API call — no backing-field bypass needed.
 
 ```ts
-this._open = event.newState === 'open'; // bypass setter; do not call showPopover/hidePopover again
+// In the toggle listener:
+if (isOpen !== this.open) {
+  this.open = isOpen; // triggers updated(); isPopoverOpen guard prevents re-calling showPopover/hidePopover
+}
 ```
 
 ### `HoverController` hand-off
@@ -578,7 +586,8 @@ The impact is most acute in the additive phase, when `HoverController` will call
 
 - [x] `Tooltip.types.ts`: define `TooltipVariant` (`'neutral' | 'informative' | 'negative'`); define `TooltipPlacement` (all physical + logical values)
 - [x] `Tooltip.base.ts`: define all properties with decorators (including `for` and `triggerElement` declarations); assign `role="tooltip"`; no rendering. No DOM traversal logic.
-- [x] `Tooltip.ts` (SWC): rendering, `popover="auto"` on host, `beforetoggle`/`toggle`/`transitionend` listeners for state sync and `swc-open`/`swc-after-open`/`swc-close`/`swc-after-close` dispatch, trigger resolution via `for`/`trigger-element`, ARIA relationship wiring (`ariaDescribedByElements`, or `ariaLabelledByElements` when `labeling` is set) on `open` and `labeling` changes. (`PlacementController`/`HoverController` integration is additive phase.)
+- [x] `Tooltip.base.ts` (Core): `popover="auto"` and `role="tooltip"` set via `connectedCallback`; `beforetoggle`/`toggle`/`transitionend` and `document` `keydown` listeners wired; trigger resolution via `for`/`triggerElement`; ARIA relationship wiring (`ariaDescribedByElements` / `ariaLabelledByElements`) on `open` and `labeling` changes; `HoverController` and `PlacementController` instantiated and managed in `updated()` and `connectedCallback`/`disconnectedCallback`.
+- [x] `Tooltip.ts` (SWC): rendering only — `render()` returns tip element and default slot; `tipElement` getter override returns `.swc-Tooltip-tip` for arrow middleware; CSS via `tooltip.css`.
 
 #### 1st-gen deprecation notices
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
@@ -75,7 +75,7 @@ Tooltip is a visually simple component with high behavioral complexity in its au
 - **Breaking (B5):** Event renames: `sp-opened`/`sp-closed` removed; 2nd-gen fires `swc-open`, `swc-after-open`, `swc-close`, `swc-after-close`. Event timing also differs due to native popover lifecycle; must document in consumer migration guide.
 - **A11y critical (SWC-1558):** `role="tooltip"` is absent in 1st-gen; must ship in 2nd-gen.
 - **Infrastructure change:** `sp-overlay` dependency dropped. 2nd-gen uses native popover API + Floating UI per the [Overlay Strategy RFC](https://www.dropbox.com/scl/fi/eae4rywxitn4zfmuw4o59/RFC-Overlay-strategy-for-1st-gen-and-2nd-gen.paper?rlkey=ljezd8mt8joy2zc3lv88usrh6&dl=0). The `self-managed` attribute is removed (B6); automatic trigger wiring is on by default; the `manual` attribute opts out. Internal mechanics change significantly.
-- **Automatic trigger integration is additive:** Deferred pending extraction of `PlacementController` (viewport-aware positioning) and `HoverController` (warm-up/cooldown timing, focus parity). Initial 2nd-gen tooltip ships `for` and `trigger-element` as active API — ARIA relationship wiring fires on `open` change from day one (see A4). Hover/focus event wiring and screen positioning require the controllers. `delay`, `disabled`, and `manual` are in the API shape but inactive until the additive phase. Before scheduling the additive implementation ticket, confirm that both controllers have been extracted and are consumable per the Overlay RFC.
+- **HoverController integrated:** `HoverController` is now wired in `Tooltip.base.ts`. Hover/focus event wiring, warm-up/cooldown timing (`delay`), `disabled` guard, WCAG 1.4.13 pointer bridge, and `manual` suppression are all active. `delay`, `disabled`, and `manual` are no longer additive/deferred — they are live API. Pixel positioning is still deferred pending `PlacementController` extraction; stories use Floating UI inline styles as a temporary stand-in. `offset` remains inactive until `PlacementController` ships.
 - **Authoring pattern change:** `<swc-tooltip>` is authored as a sibling of the trigger — not inside it as in 1st-gen. With `popover="auto"` moving the tooltip to the top layer at render time, physical DOM nesting is no longer needed. Trigger resolution uses the `for` attribute to reference the trigger by ID in the same document tree root; `trigger-element` provides an element reference override for cross-shadow-root and programmatic cases where ID resolution does not apply. Add `manual` to opt out of automatic wiring entirely. The 1st-gen ancestor-walking (`resolveSelfManagedTriggerElement`) is not ported.
 - **No open questions.** Q1 (`tip-padding`) and Q2 (`popover="auto"` stack isolation) are both resolved. See [Blockers and open questions](#blockers-and-open-questions).
 
@@ -176,16 +176,16 @@ Self-managed:
 Core tooltip (variants, CSS, `role="tooltip"`, event renames) can proceed without prerequisites. Automatic trigger integration is additive and blocked on two controller extractions from the Overlay RFC:
 
 - **`PlacementController`** — Floating UI wrapper for viewport-aware positioning (`offset`, `flip`, `shift` middleware). Must be extracted before automatic trigger positioning ships.
-- **`HoverController`** — warm-up/cooldown, focus parity, WCAG 1.4.13 pointer bridge. Must be extracted before automatic trigger open/close behavior ships.
+- **`HoverController`** — warm-up/cooldown, focus parity, WCAG 1.4.13 pointer bridge. **Extracted and integrated.** Hover/focus wiring is now active in the Tooltip.
 
-Neither controller is available yet. The automatic trigger integration additive phase should not begin until both are ready. Track their extraction status before scheduling the additive implementation ticket.
+`PlacementController` is still pending. Pixel positioning and the `offset` attribute remain inactive until it is available.
 
 ### Related components and ordering notes
 
 | Component | Relationship | Notes |
 | --------- | ------------ | ----- |
-| `PlacementController` | Prerequisite for automatic trigger integration additive phase | Viewport-aware positioning (`offset`, `flip`, `shift`). Tip element centering is CSS-only; no arrow middleware needed. To be extracted per Overlay RFC. Not a prerequisite for the core tooltip migration. |
-| `HoverController` | Prerequisite for automatic trigger integration additive phase | Hover/focus event wiring, warm-up/cooldown timing, and WCAG 1.4.13 pointer bridge. To be extracted from `@spectrum-web-components/overlay`. Not a prerequisite for the core tooltip migration. |
+| `PlacementController` | Prerequisite for automatic trigger positioning (additive phase) | Viewport-aware positioning (`offset`, `flip`, `shift`). Tip element centering is CSS-only; no arrow middleware needed. To be extracted per Overlay RFC. Not a prerequisite for the core tooltip migration. |
+| `HoverController` | **Integrated.** | Extracted and wired in `Tooltip.base.ts`. Hover/focus event wiring, warm-up/cooldown timing, and WCAG 1.4.13 pointer bridge are active. |
 | `sp-overlay` | Not a prerequisite | 2nd-gen Tooltip and controllers replaces `sp-overlay` with native popover API + Floating UI directly. |
 
 ---
@@ -234,10 +234,10 @@ Neither controller is available yet. The automatic trigger integration additive 
 
 | # | What is added | Notes |
 | --- | ------------- | ----- |
-| A1 | Automatic trigger integration (hover/focus) | `popover="auto"` and ARIA wiring are already active from the initial release. Additive work: wire `HoverController` (hover/focus events, warm-up/cooldown timing); wire `PlacementController` (pixel positioning). Skipped when `manual` is set. Blocked on both controller extractions. |
-| A2 | Warm-up / cooldown (`delay`) | Warm-up/cooldown is the **default behavior** for all tooltips (not opt-in). `delay: number` (default 1500ms) sets the duration; `delay="0"` opts out. Ships in the API shape but inactive until the additive phase. Blocked on `HoverController` extraction. See [addendum](#addendum-hovercontroller-interface-requirements). |
-| A3 | `disabled` for automatic mode | Prevents hover/focus response in automatic mode. Ships with automatic trigger integration additive phase. |
-| A4 | WCAG 1.4.13 pointer bridge | Pointer can move from trigger to tooltip bubble without closing. Managed by `HoverController`. Blocked on `HoverController` extraction. |
+| ~~A1~~ | ~~Automatic trigger integration (hover/focus)~~ | **Shipped (hover/focus).** `HoverController` is integrated; hover/focus event wiring is active. Pixel positioning via `PlacementController` remains deferred. |
+| ~~A2~~ | ~~Warm-up / cooldown (`delay`)~~ | **Shipped.** `delay` is now an active attribute read by `HoverController`. Default 1500ms; `delay="0"` opens immediately. |
+| ~~A3~~ | ~~`disabled` for automatic mode~~ | **Shipped.** `disabled` prevents hover/focus response via `HoverController`'s guard. |
+| ~~A4~~ | ~~WCAG 1.4.13 pointer bridge~~ | **Shipped.** Pointer can move from trigger into the tooltip bubble without closing; managed by `HoverController`. |
 | A5 | `no-tip` property | Shown in Figma (Orientation section, "No tip") but not supported by React Spectrum. Deferred. Create a follow-on ticket when React adds support. |
 | A6 | `tooltip-directive` for 2nd-gen | Lit directive for programmatic tooltip insertion. Cannot be meaningfully implemented until the automatic trigger integration additive phase is complete. The 2nd-gen directive will be simpler than 1st-gen: no `sp-overlay` wrapper needed; it creates `<swc-tooltip>`, inserts it as a sibling of the target, sets `trigger-element` (element reference, bypassing ID management), and handles lifecycle cleanup. Create a follow-on ticket before this migration closes. |
 | A7 | `container-padding` | Space between tooltip and viewport edge (Floating UI `shift`/`flip` middleware `padding`). React default: 12. Blocked on `PlacementController` API. |
@@ -270,10 +270,10 @@ Derived from the 1st-gen implementation, the rendering analysis, the accessibili
 | `open` | `boolean` | `false` | `open` (reflect) | **Confirmed.** |
 | `for` | `string` | `undefined` | `for` | **Confirmed.** ID of the trigger element in the same document tree root. The tooltip calls `getRootNode().getElementById(this.for)` to resolve the trigger, then wires the ARIA relationship on `open` change (see [ARIA relationship wiring](#aria-relationship-wiring)). Active in both automatic and manual modes — see the trigger-mode interaction table in [Behavioral semantics](#behavioral-semantics). HoverController hover/focus auto-wiring is additive. |
 | `trigger-element` | `HTMLElement \| null` | `null` | — (setter only) | **Confirmed.** Explicit trigger element reference; overrides `for` when set. Drives the same ARIA wiring on `open` change as `for`, via direct element reference rather than ID lookup. Use for cross-shadow-root triggers where `getRootNode().getElementById()` is scoped to the wrong tree root, or for the directive (programmatic insertion). `HoverController` and `PlacementController` receive the resolved value and do not perform their own trigger resolution. |
-| `delay` | `number` | `1500` | `delay` | **Additive/deferred.** Duration in ms of the warm-up before the tooltip shows on hover or focus; the cooldown duration matches. Set to `0` to show immediately. Warm-up/cooldown is the default behavior — no attribute needed to enable it. **Behavioral change from 1st-gen:** 1st-gen had `delayed: boolean` (default `false`, opt-in); 2nd-gen is opt-out. Ships in the API shape but has no effect until the additive phase. |
-| `disabled` | `boolean` | `false` | `disabled` | **Additive/deferred.** Automatic mode only; no-op when `manual` is set. Ships inactive until the additive phase. |
-| `manual` | `boolean` | `false` | `manual` | **Additive/deferred.** Suppresses `HoverController` and `PlacementController` wiring only. `for` and `trigger-element` are still resolved; ARIA wiring still fires on `open` change. Consumer manages open/close via the `open` property or the popover API directly. Ships in the API shape; effective in the additive phase. |
-| `offset` | `number` | `0` | `offset` | **Additive/deferred.** Passed to `PlacementController` offset middleware. Ships in API shape; effective in the additive phase. Note: React Spectrum defaults to `7`; the `PlacementController` default should align with React — confirm in the controller design before shipping. |
+| `delay` | `number` | `1500` | `delay` | **Confirmed. Active.** Duration in ms of the warm-up before the tooltip shows on hover; keyboard focus always opens immediately regardless of this value. The cooldown duration after pointer leave is 300ms (fixed, independent of `delay`). Set to `0` to show immediately on hover. Warm-up/cooldown is the default behavior — no attribute needed to enable it. **Behavioral change from 1st-gen:** 1st-gen had `delayed: boolean` (default `false`, opt-in); 2nd-gen is opt-out. |
+| `disabled` | `boolean` | `false` | `disabled` | **Confirmed. Active.** Prevents the tooltip from responding to hover and focus events. No-op when `manual` is set. |
+| `manual` | `boolean` | `false` | `manual` | **Confirmed. Active.** Suppresses `HoverController` wiring. `for` and `trigger-element` are still resolved; ARIA wiring still fires on `open` change. Consumer manages open/close via the `open` property or the popover API directly. (`PlacementController` also skipped when `manual` is set, once it ships.) |
+| `offset` | `number` | `0` | `offset` | **Additive/deferred.** Passed to `PlacementController` offset middleware. Ships in API shape; effective once `PlacementController` is integrated. Note: React Spectrum defaults to `7`; the `PlacementController` default should align with React — confirm in the controller design before shipping. |
 | `labeling` | `boolean` | `false` | `labeling` | **Confirmed.** When set, `syncAriaRelationship()` wires `ariaLabelledByElements` on the trigger's inner interactive element instead of `ariaDescribedByElements`. For icon-only triggers where the tooltip text is the sole accessible name and adding an accessible label to the trigger host is not possible. Re-syncs when changed while the tooltip is open. |
 
 #### Visual matrix (2nd-gen)
@@ -315,16 +315,16 @@ Initial expectation for Tooltip is zero or a very small reviewed set.
 
 ### Behavioral semantics
 
-**Automatic trigger-wiring mode (additive/deferred):**
+**Automatic trigger-wiring mode:**
 
-The `TooltipOpenable` intermediate element is an implementation detail of the 1st-gen overlay bridge and does not carry forward. Automatic trigger-wiring mode in 2nd-gen is deferred pending `PlacementController` and `HoverController` extraction. When the additive phase begins:
+The `TooltipOpenable` intermediate element is an implementation detail of the 1st-gen overlay bridge and does not carry forward. Hover/focus wiring via `HoverController` is now active. Pixel positioning via `PlacementController` is still additive/deferred.
 
-1. The tooltip uses `popover="auto"` (already present from the initial release). Built-in Esc-to-close and light-dismiss are included. Note: participates in the auto stack — opening a tooltip will close other open `auto` popovers (menus, pickers).
-2. `PlacementController` handles viewport-aware positioning using `offset`, `flip`, and `shift` middleware; `placement` and `offset` attributes map to controller options. The tip element remains CSS-centered on its edge regardless of computed position (see [Controller integration assumptions](#controller-integration-assumptions)).
-3. `HoverController` manages open/close timing (warm-up/cooldown using the `delay` value; default 1500ms), `focus-visible` parity, and the WCAG 1.4.13 pointer bridge. ARIA relationship wiring is handled by the SWC layer on `open` change, not by `HoverController`.
+1. The tooltip uses `popover="auto"` (present from the initial release). Built-in Esc-to-close and light-dismiss are included. Note: participates in the auto stack — opening a tooltip will close other open `auto` popovers (menus, pickers).
+2. `HoverController` manages open/close timing (warm-up/cooldown using the `delay` value; default 1500ms), keyboard-focus parity (opens immediately), and the WCAG 1.4.13 pointer bridge. Wired in `Tooltip.base.ts`; target is set from `resolveTrigger()` whenever `for` or `triggerElement` changes. ARIA relationship wiring is handled by the SWC layer on `open` change, not by `HoverController`.
+3. `PlacementController` (additive/deferred) will handle viewport-aware positioning using `offset`, `flip`, and `shift` middleware; `placement` and `offset` attributes map to controller options. The tip element remains CSS-centered on its edge regardless of computed position (see [Controller integration assumptions](#controller-integration-assumptions)).
 4. `Escape` closes the tooltip without moving focus via the built-in `popover="auto"` dismiss behavior.
-5. New 2nd-gen event shape: `swc-open`, `swc-after-open`, `swc-close`, `swc-after-close` (B5). Events fire from listeners already wired in the initial release.
-6. When `manual` is set, controller wiring (hover/focus events, timing, pointer bridge) is skipped; the consumer owns open/close. ARIA relationship wiring is unaffected — it fires on `open` change whenever `for` or `trigger-element` is set.
+5. New 2nd-gen event shape: `swc-open`, `swc-after-open`, `swc-close`, `swc-after-close` (B5). Events fire from listeners wired from the initial release.
+6. When `manual` is set, `HoverController` wiring (hover/focus events, timing, pointer bridge) is skipped; the consumer owns open/close. ARIA relationship wiring is unaffected — it fires on `open` change whenever `for` or `trigger-element` is set.
 
 **Trigger resolution (automatic mode, additive/deferred):**
 
@@ -340,14 +340,14 @@ With tooltip and trigger authored as siblings in the same document tree, their n
 
 | `for`/`trigger-element` set? | `manual` set? | ARIA wiring | Hover/focus |
 | ---- | ---- | ---- | ---- |
-| Yes | No | Fires on `open` change (initial release) | `HoverController` (additive phase) |
-| Yes | Yes | Fires on `open` change (initial release) | Consumer-managed |
+| Yes | No | Fires on `open` change | `HoverController` (active) |
+| Yes | Yes | Fires on `open` change | Consumer-managed |
 | No | No | None; warn in debug mode | N/A |
 | No | Yes | None | Consumer-managed |
 
 **Authoring modes:**
 
-Modes 1 and 2 use automatic hover/focus trigger wiring and require `HoverController` and `PlacementController` (additive phase). ARIA relationship wiring via `for` is active from the initial release in all modes. Mode 3 demonstrates consumer-owned open/close.
+Modes 1 and 2 use automatic hover/focus trigger wiring; `HoverController` is active. Pixel positioning requires `PlacementController` (additive/deferred). ARIA relationship wiring via `for` is active in all modes. Mode 3 demonstrates consumer-owned open/close.
 
 ```html
 <!-- ── Mode 1: Automatic — native trigger ──────────────────────────────────
@@ -414,18 +414,17 @@ Modes 1 and 2 use automatic hover/focus trigger wiring and require `HoverControl
 </script>
 ```
 
-**Initial release (must-ship) behavioral semantics:**
+**Current behavioral semantics:**
 
-In the initial release, the tooltip uses native popover for open/close but has no automatic hover/focus trigger wiring or screen positioning:
-
-- Host element has `popover="auto"` from day one; consumer controls visibility via the `open` property (which calls `showPopover()`/`hidePopover()` internally) or directly via the popover API
-- Renders with correct variant, placement CSS class, and `role="tooltip"`
-- Component listens to native `beforetoggle`/`toggle`/`transitionend` events to sync `open` property and dispatch `swc-open`/`swc-after-open`/`swc-close`/`swc-after-close`. Events fire from these listeners regardless of what caused the state change (programmatic, Escape, or light-dismiss).
+- Host element has `popover="auto"`; consumer controls visibility via the `open` property (which calls `showPopover()`/`hidePopover()` internally), directly via the popover API, or by hovering/focusing the trigger.
+- Renders with correct variant, placement CSS class, and `role="tooltip"`.
+- Component listens to native `beforetoggle`/`toggle`/`transitionend` events to sync `open` property and dispatch `swc-open`/`swc-after-open`/`swc-close`/`swc-after-close`. Events fire from these listeners regardless of what caused the state change (programmatic, hover, focus, Escape, or light-dismiss).
 - Built-in Esc-to-close and light-dismiss via `popover="auto"`. Note: participates in the auto popover stack — opening this tooltip closes other open `auto` popovers (menus, pickers).
+- `HoverController` wires `pointerenter`/`pointerleave`/`focusin`/`focusout` on the resolved trigger; manages warm-up/cooldown timing, keyboard-focus priority, and the WCAG 1.4.13 pointer bridge. The controller target is updated whenever `for` or `trigger-element` changes (via `updated()`). Suppressed when `manual` or `disabled` is set.
 - On `open = true`, SWC resolves the trigger via `for` (ID lookup in the same root) or `trigger-element` (explicit reference) and sets `Element.ariaDescribedByElements = [tooltipHost]` on the trigger's interactive surface. Removed on `open = false`. See [ARIA relationship wiring](#aria-relationship-wiring).
-- `placement` applies the CSS class (tip direction) only; no screen positioning is active without `PlacementController`. Stories fake positioning with inline styles; this limitation should be noted in the story.
-- The tip element (`<span class="swc-Tooltip-tip">`) is always CSS-centered on the edge determined by the `placement` class. Its position is not dynamically adjusted relative to the trigger; this is a deliberate simplification and does not require `PlacementController`.
-- `delay`, `disabled`, and `offset` are present in the API but have no effect until the additive phase. `for` and `trigger-element` (setter) are active from the initial release and drive ARIA relationship wiring on `open` change. `manual` suppresses controller wiring but is effectively inert until the additive phase adds controllers.
+- `placement` applies the CSS class (tip direction) only; no pixel screen positioning is active without `PlacementController`. Stories use Floating UI inline styles as a temporary stand-in; this is noted in the MDX docs.
+- The tip element (`<span class="swc-Tooltip-tip">`) is always CSS-centered on the edge determined by the `placement` class. Its position is not dynamically adjusted relative to the trigger; this is deliberate and does not require `PlacementController`.
+- `offset` is present in the API but has no effect until `PlacementController` is integrated.
 
 ### Accessibility semantics notes (2nd-gen)
 
@@ -474,7 +473,7 @@ Follow the [Badge migration reference](../../02_workstreams/02_2nd-gen-component
 | Layer | Path | Contains |
 | ----- | ---- | -------- |
 | **Core** | `2nd-gen/packages/core/components/tooltip/` | `Tooltip.base.ts`, `Tooltip.types.ts`: property definitions (including `triggerElement` declaration), type validation, state management, accessible-name rules. Sets `role="tooltip"` and `popover="auto"` on the host element via `connectedCallback`. Wires `beforetoggle`/`toggle`/`transitionend` listeners for state sync and `swc-open`/`swc-after-open`/`swc-close`/`swc-after-close` dispatch. Resolves trigger via `for` attribute or `triggerElement` property. Maintains `Element.ariaDescribedByElements` on the trigger's inner interactive element on `open` change. No rendering. No Floating UI. |
-| **SWC** | `2nd-gen/packages/swc/components/tooltip/` | `Tooltip.ts`, `tooltip.css`: rendering only (tip element, label slot). Element registration, stories, tests. **Additive phase only:** `PlacementController` + `HoverController` integration; hover and focus-visible event wiring; warm-up/cooldown timing. |
+| **SWC** | `2nd-gen/packages/swc/components/tooltip/` | `Tooltip.ts`, `tooltip.css`: rendering only (tip element, label slot). Element registration, stories, tests. **Additive (shipped):** `HoverController` integrated in `Tooltip.base.ts`; hover/focus wiring, warm-up/cooldown, WCAG 1.4.13 pointer bridge active. **Additive (deferred):** `PlacementController` integration; pixel positioning. |
 
 Planned rendering shape (initial release):
 
@@ -531,7 +530,7 @@ this._open = event.newState === 'open'; // bypass setter; do not call showPopove
 
 ### `HoverController` hand-off
 
-See [Addendum: HoverController interface requirements](#addendum-hovercontroller-interface-requirements).
+**Implemented.** `TooltipBase` now `implements HoverControllerHost` and instantiates `HoverController` with `warmStateKey: 'swc-tooltip'`. The controller target is set via `updated()` whenever `for` or `triggerElement` changes. See `Tooltip.base.ts` and the [addendum](#addendum-hovercontroller-interface-requirements) for the interface contract that was used.
 
 ### `PlacementController` hand-off
 
@@ -630,10 +629,10 @@ The impact is most acute in the additive phase, when `HoverController` will call
 #### State verification
 
 - [x] `[open]` reflects on host when tooltip is visible
-- [ ] `[disabled]` prevents automatic mode from responding to hover/focus events **(additive phase)**
+- [x] `[disabled]` prevents automatic mode from responding to hover/focus events
 - [x] Closed tooltip is hidden from AT (`popover` attribute or explicit `aria-hidden`/`inert`)
 - [x] `Escape` closes tooltip; focus stays on trigger; no focus trap — handled by native `popover="auto"`
-- [ ] Pointer can move from trigger to tooltip bubble without tooltip closing (WCAG 1.4.13) **(additive phase — HoverController)**
+- [x] Pointer can move from trigger to tooltip bubble without tooltip closing (WCAG 1.4.13) — `HoverController` pointer bridge
 - [x] High-contrast border present in forced-colors mode
 - [x] Variant colors paired with readable text (not relying on color alone)
 
@@ -653,20 +652,20 @@ The impact is most acute in the additive phase, when `HoverController` will call
 - [x] ARIA wiring: `trigger-element` setter overrides `for` and drives the same wiring (`AriaWiringTriggerElementOverrideTest`)
 - [x] ARIA wiring: no wiring when neither `for` nor `trigger-element` is set; no error thrown (`AriaWiringNoTriggerTest`)
 - [x] ARIA wiring: fires in manual mode when `for` is set and consumer sets `open = true` (`AriaWiringManualModeTest`)
-- [ ] Automatic mode: opens on trigger hover; closes on pointer leave **(additive phase)**
-- [ ] Automatic mode: opens on trigger `focusin` (when `:focus-visible`); closes on `focusout` **(additive phase)**
-- [ ] Automatic mode: pointer can move to tooltip bubble without closing (WCAG 1.4.13) **(additive phase)**
+- [x] Automatic mode: opens on trigger hover; closes on pointer leave (`HoverOpensTest`)
+- [x] Automatic mode: opens on trigger `focusin`; closes on `focusout` (`FocusOpensTest`)
+- [x] Automatic mode: pointer can move to tooltip bubble without closing (WCAG 1.4.13) — `HoverController` pointer bridge; covered by hover-controller test suite
 - [ ] Automatic mode: `for` attribute resolves to the element with the matching `id` in the same document tree root **(additive phase)**
 - [x] `for` pointing to a non-existent `id` results in no trigger wiring (no-op); warns in debug mode (`ForIdNotFoundWarningTest`)
 - [ ] Automatic mode: `trigger-element` takes precedence over `for` when both are set **(additive phase)**
 - [ ] Automatic mode: `trigger-element` wires correctly for cross-shadow-root trigger relationships **(additive phase)**
-- [ ] Automatic mode: default warm-up/cooldown (1500ms, matching `delay` default); `delay="0"` shows immediately; custom value uses that duration **(additive phase)**
-- [ ] Automatic mode: `for` resolves correctly when trigger and tooltip share a shadow root (ID lookup scoped to that root) — rewrite fresh; do not port the 1st-gen `self manages through a shadow boundary` test, which validates ancestor-walking and does not apply **(additive phase)**
-- [ ] `manual` attribute: controller wiring is skipped when added; consumer-driven `open` changes dispatch all `swc-*` events and ARIA wiring still fires when `for` is set **(additive phase — verify controller suppression)**
+- [x] Automatic mode: `delay="0"` shows immediately on hover (`HoverOpensTest`); full 1500ms warm-up/cooldown timing covered by hover-controller test suite
+- [ ] Automatic mode: `for` resolves correctly when trigger and tooltip share a shadow root (ID lookup scoped to that root) **(additive phase)**
+- [x] `manual` attribute: controller wiring is skipped; consumer-driven `open` changes still work; ARIA wiring still fires (`ManualPreventsHoverTest`, `AriaWiringManualModeTest`)
 - [x] `labeling` attribute: `ariaLabelledByElements` is set on the inner interactive element instead of `ariaDescribedByElements`; stale references in the opposite property are cleaned up; re-syncs when `labeling` changes while open (`LabelingAriaWiringTest`)
 - [ ] `ariaDescribedByElements` wiring: verify AT can traverse the association in DevTools Accessibility panel and with NVDA/VoiceOver
-- [x] `ariaDescribedByElements` wiring fallback: when trigger has no shadow root (native `<button>`, `<a>`, `<input>`), association is established on the host element directly  (`AriaWiringNativeTest`)
-- [ ] `disabled` attribute prevents automatic mode response to user input **(additive phase)**
+- [x] `ariaDescribedByElements` wiring fallback: when trigger has no shadow root (native `<button>`, `<a>`, `<input>`), association is established on the host element directly (`AriaWiringNativeTest`)
+- [x] `disabled` attribute prevents automatic mode response to user input (`DisabledPreventsHoverTest`)
 
 #### Visual regression
 
@@ -681,7 +680,7 @@ The impact is most acute in the additive phase, when `HoverController` will call
 #### General
 
 - [x] JSDoc on all public properties, slots, and any exposed CSS custom properties
-- [x] Stories: Playground, Overview, Anatomy (default slot), Options (variants, placements), States (open), Accessibility, Behaviors (Events, AutoStack, Labeling). Behaviors story for automatic trigger-wiring is additive phase; additive items documented in UpcomingFeatures story.
+- [x] Stories: Playground, Overview, Anatomy (default slot), Options (variants, placements), States (open), Accessibility, Behaviors (Events, Hover, Labeling). `Hover` behaviors story added; hover/focus/delay/disabled/pointer-bridge items moved out of upcoming features and documented in the Behaviors section of `tooltip.mdx`.
 
 #### Breaking changes
 
@@ -735,13 +734,15 @@ Create these tickets before this migration PR closes. Link each to Epic SWC-2017
 | Ticket | Summary | Why deferred | Plan sections |
 | ------ | ------- | ------------ | ------------- |
 | SWC-2210 | **Integrate PlacementController into Tooltip.** Pass resolved trigger element to controller (from SWC's `for`/`trigger-element` resolution — no internal resolution in the controller); wire viewport-aware pixel positioning: apply `placement`, `offset`, `container-padding`, `cross-offset`, `should-flip` as Floating UI middleware options. No `arrowPadding` needed — tooltip tip is CSS-centered. | Blocked on `PlacementController` extraction per Overlay RFC. | Additive A1 (positioning), A7, A8, A9 |
-| SWC-2210 | **Integrate HoverController into Tooltip.** Pass resolved trigger element to controller; wire hover and focus-visible events, warm-up/cooldown timing (reads `delay` value from host; 0 = immediate), `disabled` guard, and WCAG 1.4.13 pointer bridge. Controller receives trigger element from SWC — no internal trigger resolution. Hover and focus-visible wiring skipped when `manual` is set. ARIA relationship wiring is handled by the SWC layer separately (see [ARIA relationship wiring](#aria-relationship-wiring)). | Blocked on `HoverController` extraction per Overlay RFC. `HoverController` and `PlacementController` can be integrated in separate tickets; full automatic trigger integration requires both. | Additive A1 (hover/focus), A2, A3, A4 |
+| ~~SWC-2210~~ | ~~**Integrate HoverController into Tooltip.**~~ | **Shipped.** `TooltipBase` implements `HoverControllerHost`; `HoverController` wired with `warmStateKey: 'swc-tooltip'`; target set from `resolveTrigger()` in `updated()`. Hover/focus wiring, warm-up/cooldown, `disabled` guard, and WCAG 1.4.13 pointer bridge are all active. | ~~Additive A1 (hover/focus), A2, A3, A4~~ |
 | TBD | **2nd-gen tooltip-directive.** Lit directive for programmatic tooltip insertion. Creates `<swc-tooltip>` as a sibling of the target and handles lifecycle cleanup. Simpler than 1st-gen: no `sp-overlay` wrapper needed; automatic trigger wiring activates because `manual` is not set. | Requires full automatic trigger integration (both controllers). | Additive A6 |
 | TBD | **`no-tip` attribute.** Remove the directional tip arrow. Figma-confirmed. Can proceed independently of controller integration; no controller dependency. Create when React Spectrum adds support as a confirming signal. | No cross-framework confirmation yet; Figma-only signal is not sufficient to ship. | Additive A5 |
 
 ---
 
 ## Addendum: HoverController interface requirements
+
+> **Implemented.** `HoverController` has been extracted to `@spectrum-web-components/core/controllers/hover-controller` and integrated into `Tooltip.base.ts`. This section is retained as a historical record of the interface contract that drove the controller's design.
 
 This section captures what Tooltip requires from `HoverController`. It is a separate body of work — not part of the core Tooltip migration — but is recorded here so the controller's design is informed by a concrete consumer.
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/tooltip/migration-plan.md
@@ -36,7 +36,6 @@
     - [Event dispatch ownership](#event-dispatch-ownership)
     - [`HoverController` hand-off](#hovercontroller-hand-off)
     - [`PlacementController` hand-off](#placementcontroller-hand-off)
-    - [Positioning before `PlacementController`](#positioning-before-placementcontroller)
     - [Auto-stack behavior](#auto-stack-behavior)
 - [Migration checklist](#migration-checklist)
     - [Preparation (this ticket)](#preparation-this-ticket)
@@ -75,7 +74,7 @@ Tooltip is a visually simple component with high behavioral complexity in its au
 - **Breaking (B5):** Event renames: `sp-opened`/`sp-closed` removed; 2nd-gen fires `swc-open`, `swc-after-open`, `swc-close`, `swc-after-close`. Event timing also differs due to native popover lifecycle; must document in consumer migration guide.
 - **A11y critical (SWC-1558):** `role="tooltip"` is absent in 1st-gen; must ship in 2nd-gen.
 - **Infrastructure change:** `sp-overlay` dependency dropped. 2nd-gen uses native popover API + Floating UI per the [Overlay Strategy RFC](https://www.dropbox.com/scl/fi/eae4rywxitn4zfmuw4o59/RFC-Overlay-strategy-for-1st-gen-and-2nd-gen.paper?rlkey=ljezd8mt8joy2zc3lv88usrh6&dl=0). The `self-managed` attribute is removed (B6); automatic trigger wiring is on by default; the `manual` attribute opts out. Internal mechanics change significantly.
-- **HoverController integrated:** `HoverController` is now wired in `Tooltip.base.ts`. Hover/focus event wiring, warm-up/cooldown timing (`delay`), `disabled` guard, WCAG 1.4.13 pointer bridge, and `manual` suppression are all active. `delay`, `disabled`, and `manual` are no longer additive/deferred — they are live API. Pixel positioning is still deferred pending `PlacementController` extraction; stories use Floating UI inline styles as a temporary stand-in. `offset` remains inactive until `PlacementController` ships.
+- **HoverController and PlacementController integrated:** Both controllers are wired in `Tooltip.base.ts`. Hover/focus event wiring, warm-up/cooldown, `disabled` guard, WCAG 1.4.13 pointer bridge, `manual` suppression, and pixel positioning are all active. `delay`, `disabled`, `manual`, `offset`, `cross-offset`, `container-padding`, and `should-flip` are all live API. The Floating UI inline-style workaround in stories has been removed.
 - **Authoring pattern change:** `<swc-tooltip>` is authored as a sibling of the trigger — not inside it as in 1st-gen. With `popover="auto"` moving the tooltip to the top layer at render time, physical DOM nesting is no longer needed. Trigger resolution uses the `for` attribute to reference the trigger by ID in the same document tree root; `trigger-element` provides an element reference override for cross-shadow-root and programmatic cases where ID resolution does not apply. Add `manual` to opt out of automatic wiring entirely. The 1st-gen ancestor-walking (`resolveSelfManagedTriggerElement`) is not ported.
 - **No open questions.** Q1 (`tip-padding`) and Q2 (`popover="auto"` stack isolation) are both resolved. See [Blockers and open questions](#blockers-and-open-questions).
 
@@ -175,16 +174,16 @@ Self-managed:
 
 Core tooltip (variants, CSS, `role="tooltip"`, event renames) can proceed without prerequisites. Automatic trigger integration is additive and blocked on two controller extractions from the Overlay RFC:
 
-- **`PlacementController`** — Floating UI wrapper for viewport-aware positioning (`offset`, `flip`, `shift` middleware). Must be extracted before automatic trigger positioning ships.
-- **`HoverController`** — warm-up/cooldown, focus parity, WCAG 1.4.13 pointer bridge. **Extracted and integrated.** Hover/focus wiring is now active in the Tooltip.
+- **`PlacementController`** — Floating UI wrapper for viewport-aware positioning. **Extracted and integrated.** Pixel positioning, flip behavior, and positioning attributes are now active.
+- **`HoverController`** — warm-up/cooldown, focus parity, WCAG 1.4.13 pointer bridge. **Extracted and integrated.** Hover/focus wiring is active.
 
-`PlacementController` is still pending. Pixel positioning and the `offset` attribute remain inactive until it is available.
+Both controllers are integrated. No outstanding controller prerequisites remain.
 
 ### Related components and ordering notes
 
 | Component | Relationship | Notes |
 | --------- | ------------ | ----- |
-| `PlacementController` | Prerequisite for automatic trigger positioning (additive phase) | Viewport-aware positioning (`offset`, `flip`, `shift`). Tip element centering is CSS-only; no arrow middleware needed. To be extracted per Overlay RFC. Not a prerequisite for the core tooltip migration. |
+| `PlacementController` | **Integrated.** | Extracted and wired in `Tooltip.base.ts`. Pixel positioning, flip behavior, `offset`, `cross-offset`, `container-padding`, and `should-flip` are active. |
 | `HoverController` | **Integrated.** | Extracted and wired in `Tooltip.base.ts`. Hover/focus event wiring, warm-up/cooldown timing, and WCAG 1.4.13 pointer bridge are active. |
 | `sp-overlay` | Not a prerequisite | 2nd-gen Tooltip and controllers replaces `sp-overlay` with native popover API + Floating UI directly. |
 
@@ -234,18 +233,19 @@ Core tooltip (variants, CSS, `role="tooltip"`, event renames) can proceed withou
 
 | # | What is added | Notes |
 | --- | ------------- | ----- |
-| ~~A1~~ | ~~Automatic trigger integration (hover/focus)~~ | **Shipped (hover/focus).** `HoverController` is integrated; hover/focus event wiring is active. Pixel positioning via `PlacementController` remains deferred. |
+| ~~A1~~ | ~~Automatic trigger integration (hover/focus + positioning)~~ | **Shipped.** `HoverController` and `PlacementController` are integrated; hover/focus event wiring and pixel positioning are both active. |
 | ~~A2~~ | ~~Warm-up / cooldown (`delay`)~~ | **Shipped.** `delay` is now an active attribute read by `HoverController`. Default 1500ms; `delay="0"` opens immediately. |
 | ~~A3~~ | ~~`disabled` for automatic mode~~ | **Shipped.** `disabled` prevents hover/focus response via `HoverController`'s guard. |
 | ~~A4~~ | ~~WCAG 1.4.13 pointer bridge~~ | **Shipped.** Pointer can move from trigger into the tooltip bubble without closing; managed by `HoverController`. |
 | A5 | `no-tip` property | Shown in Figma (Orientation section, "No tip") but not supported by React Spectrum. Deferred. Create a follow-on ticket when React adds support. |
-| A6 | `tooltip-directive` for 2nd-gen | Lit directive for programmatic tooltip insertion. Cannot be meaningfully implemented until the automatic trigger integration additive phase is complete. The 2nd-gen directive will be simpler than 1st-gen: no `sp-overlay` wrapper needed; it creates `<swc-tooltip>`, inserts it as a sibling of the target, sets `trigger-element` (element reference, bypassing ID management), and handles lifecycle cleanup. Create a follow-on ticket before this migration closes. |
-| A7 | `container-padding` | Space between tooltip and viewport edge (Floating UI `shift`/`flip` middleware `padding`). React default: 12. Blocked on `PlacementController` API. |
-| A8 | `cross-offset` | Offset along the cross axis (perpendicular to `offset`). React default: 0. Blocked on `PlacementController` API. |
-| A9 | `should-flip` | Whether to reposition to the opposite side when space runs out. Floating UI `flip` middleware. React default: `true`. Default should also be `true` in `PlacementController`; expose as a consumer attribute if override need is confirmed. |
+| A6 | `tooltip-directive` for 2nd-gen | Lit directive for programmatic tooltip insertion. The 2nd-gen directive will be simpler than 1st-gen: no `sp-overlay` wrapper needed; it creates `<swc-tooltip>`, inserts it as a sibling of the target, sets `trigger-element` (element reference, bypassing ID management), and handles lifecycle cleanup. Both controllers are now active; this can proceed when prioritized. |
+| ~~A7~~ | ~~`container-padding`~~ | **Shipped.** Default `12`. Passed to `PlacementController` `containerPadding` option. |
+| ~~A8~~ | ~~`cross-offset`~~ | **Shipped.** Default `0`. Passed to `PlacementController` `crossOffset` option. |
+| ~~A9~~ | ~~`should-flip`~~ | **Shipped.** Default `true`. Passed to `PlacementController` `shouldFlip` option. |
 | A10 | `--swc-*` CSS custom properties | No `--swc-*` custom properties initially. A small reviewed set may be added if consumer override needs emerge. |
 | ~~A11~~ | ~~`labeling` attribute — `aria-labelledby` wiring~~ | **Shipped.** Implemented in the initial release alongside the base ARIA wiring. `syncAriaRelationship()` branches on `this.labeling`: when set, uses `ariaLabelledByElements` instead of `ariaDescribedByElements` on the trigger's inner interactive element. Stale references in the opposite property are cleaned up on each sync. Re-syncs when `labeling` changes while the tooltip is open. |
 | A12 | Inner interactive element selector expansion | Initial implementation uses `querySelector('button')` as the convention for resolving the inner interactive element within a trigger's shadow root. Expand to support additional interactive elements (`<a>`, `<input>`, `<select>`, components using a different inner element) when confirmed by consumer needs. `button` covers the large majority of 2nd-gen button-like component cases; any expansion should be gated on confirmed need. |
+| A13 | Directional entry animation on placement flip | **Known limitation.** CSS `@starting-style` evaluates at `showPopover()` time, before `PlacementController` has run and resolved the actual side. On a first open that triggers a flip (e.g., requested `top` but viewport forces `bottom`), the `@starting-style` uses the pre-flip `placement` attribute and slides from the wrong direction. Fix options range from opacity-only `@starting-style` (simplest; drops directional slide entirely) to triggering a separate `transform` animation from `onPlacementChange` after the flip resolves (preserves directional animation; requires reflow or Web Animations API). Not addressed in the current release. |
 
 Full behavioral requirements for this feature are in the [HoverController interface requirements](#addendum-hovercontroller-interface-requirements) addendum.
 
@@ -272,8 +272,11 @@ Derived from the 1st-gen implementation, the rendering analysis, the accessibili
 | `trigger-element` | `HTMLElement \| null` | `null` | — (setter only) | **Confirmed.** Explicit trigger element reference; overrides `for` when set. Drives the same ARIA wiring on `open` change as `for`, via direct element reference rather than ID lookup. Use for cross-shadow-root triggers where `getRootNode().getElementById()` is scoped to the wrong tree root, or for the directive (programmatic insertion). `HoverController` and `PlacementController` receive the resolved value and do not perform their own trigger resolution. |
 | `delay` | `number` | `1500` | `delay` | **Confirmed. Active.** Duration in ms of the warm-up before the tooltip shows on hover; keyboard focus always opens immediately regardless of this value. The cooldown duration after pointer leave is 300ms (fixed, independent of `delay`). Set to `0` to show immediately on hover. Warm-up/cooldown is the default behavior — no attribute needed to enable it. **Behavioral change from 1st-gen:** 1st-gen had `delayed: boolean` (default `false`, opt-in); 2nd-gen is opt-out. |
 | `disabled` | `boolean` | `false` | `disabled` | **Confirmed. Active.** Prevents the tooltip from responding to hover and focus events. No-op when `manual` is set. |
-| `manual` | `boolean` | `false` | `manual` | **Confirmed. Active.** Suppresses `HoverController` wiring. `for` and `trigger-element` are still resolved; ARIA wiring still fires on `open` change. Consumer manages open/close via the `open` property or the popover API directly. (`PlacementController` also skipped when `manual` is set, once it ships.) |
-| `offset` | `number` | `0` | `offset` | **Additive/deferred.** Passed to `PlacementController` offset middleware. Ships in API shape; effective once `PlacementController` is integrated. Note: React Spectrum defaults to `7`; the `PlacementController` default should align with React — confirm in the controller design before shipping. |
+| `manual` | `boolean` | `false` | `manual` | **Confirmed. Active.** Suppresses `HoverController` and `PlacementController` wiring. `for` and `trigger-element` are still resolved; ARIA wiring still fires on `open` change. Consumer manages open/close via the `open` property or the popover API directly. |
+| `offset` | `number` | `4` | `offset` | **Confirmed. Active.** Gap in pixels along the placement axis between the trigger and the tooltip bubble. Passed to `PlacementController` offset middleware. Also drives `--_swc-tooltip-animation-distance` so the enter animation travel distance matches the gap. |
+| `cross-offset` | `number` | `0` | `cross-offset` | **Confirmed. Active.** Slide in pixels along the trigger edge perpendicular to the placement direction. Passed to `PlacementController` crossOffset option. |
+| `container-padding` | `number` | `12` | `container-padding` | **Confirmed. Active.** Minimum inset from the viewport edge for collision detection, in pixels. Passed to `PlacementController` containerPadding option. |
+| `should-flip` | `boolean` | `true` | `should-flip` | **Confirmed. Active.** Whether the tooltip may reposition to the opposite side when the requested placement does not fit. Passed to `PlacementController` shouldFlip option. |
 | `labeling` | `boolean` | `false` | `labeling` | **Confirmed.** When set, `syncAriaRelationship()` wires `ariaLabelledByElements` on the trigger's inner interactive element instead of `ariaDescribedByElements`. For icon-only triggers where the tooltip text is the sole accessible name and adding an accessible label to the trigger host is not possible. Re-syncs when changed while the tooltip is open. |
 
 #### Visual matrix (2nd-gen)
@@ -317,16 +320,16 @@ Initial expectation for Tooltip is zero or a very small reviewed set.
 
 **Automatic trigger-wiring mode:**
 
-The `TooltipOpenable` intermediate element is an implementation detail of the 1st-gen overlay bridge and does not carry forward. Hover/focus wiring via `HoverController` is now active. Pixel positioning via `PlacementController` is still additive/deferred.
+The `TooltipOpenable` intermediate element is an implementation detail of the 1st-gen overlay bridge and does not carry forward. Both `HoverController` and `PlacementController` are now active.
 
-1. The tooltip uses `popover="auto"` (present from the initial release). Built-in Esc-to-close and light-dismiss are included. Note: participates in the auto stack — opening a tooltip will close other open `auto` popovers (menus, pickers).
+1. The tooltip uses `popover="auto"`. Built-in Esc-to-close and light-dismiss are included. Note: participates in the auto stack — opening a tooltip will close other open `auto` popovers (menus, pickers).
 2. `HoverController` manages open/close timing (warm-up/cooldown using the `delay` value; default 1500ms), keyboard-focus parity (opens immediately), and the WCAG 1.4.13 pointer bridge. Wired in `Tooltip.base.ts`; target is set from `resolveTrigger()` whenever `for` or `triggerElement` changes. ARIA relationship wiring is handled by the SWC layer on `open` change, not by `HoverController`.
-3. `PlacementController` (additive/deferred) will handle viewport-aware positioning using `offset`, `flip`, and `shift` middleware; `placement` and `offset` attributes map to controller options. The tip element remains CSS-centered on its edge regardless of computed position (see [Controller integration assumptions](#controller-integration-assumptions)).
+3. `PlacementController` handles viewport-aware pixel positioning using `offset`, `flip`, and `shift` middleware; `placement`, `offset`, `cross-offset`, `container-padding`, and `should-flip` attributes map to controller options. When the controller flips the tooltip to the opposite side, `onPlacementChange` reflects the computed side back into `this.placement` so the existing `[placement]` CSS selectors pick up the correct tip direction and animation direction automatically. The original consumer-requested placement is tracked separately in `_requestedPlacement` so the controller always re-computes from the requested side and can revert the flip when viewport space is restored.
 4. `Escape` closes the tooltip without moving focus via the built-in `popover="auto"` dismiss behavior.
 5. New 2nd-gen event shape: `swc-open`, `swc-after-open`, `swc-close`, `swc-after-close` (B5). Events fire from listeners wired from the initial release.
 6. When `manual` is set, `HoverController` wiring (hover/focus events, timing, pointer bridge) is skipped; the consumer owns open/close. ARIA relationship wiring is unaffected — it fires on `open` change whenever `for` or `trigger-element` is set.
 
-**Trigger resolution (automatic mode, additive/deferred):**
+**Trigger resolution:**
 
 The 1st-gen `resolveSelfManagedTriggerElement()` ancestor-walking is **not ported**. With `popover="auto"`, the tooltip renders in the browser top layer regardless of its authored DOM position. The authoring pattern changes: `<swc-tooltip>` is authored as a sibling of the trigger rather than nested inside it.
 
@@ -347,7 +350,7 @@ With tooltip and trigger authored as siblings in the same document tree, their n
 
 **Authoring modes:**
 
-Modes 1 and 2 use automatic hover/focus trigger wiring; `HoverController` is active. Pixel positioning requires `PlacementController` (additive/deferred). ARIA relationship wiring via `for` is active in all modes. Mode 3 demonstrates consumer-owned open/close.
+Modes 1 and 2 use automatic hover/focus trigger wiring (`HoverController`) and pixel positioning (`PlacementController`); both are active. ARIA relationship wiring via `for` is active in all modes. Mode 3 demonstrates consumer-owned open/close.
 
 ```html
 <!-- ── Mode 1: Automatic — native trigger ──────────────────────────────────
@@ -422,9 +425,9 @@ Modes 1 and 2 use automatic hover/focus trigger wiring; `HoverController` is act
 - Built-in Esc-to-close and light-dismiss via `popover="auto"`. Note: participates in the auto popover stack — opening this tooltip closes other open `auto` popovers (menus, pickers).
 - `HoverController` wires `pointerenter`/`pointerleave`/`focusin`/`focusout` on the resolved trigger; manages warm-up/cooldown timing, keyboard-focus priority, and the WCAG 1.4.13 pointer bridge. The controller target is updated whenever `for` or `trigger-element` changes (via `updated()`). Suppressed when `manual` or `disabled` is set.
 - On `open = true`, SWC resolves the trigger via `for` (ID lookup in the same root) or `trigger-element` (explicit reference) and sets `Element.ariaDescribedByElements = [tooltipHost]` on the trigger's interactive surface. Removed on `open = false`. See [ARIA relationship wiring](#aria-relationship-wiring).
-- `placement` applies the CSS class (tip direction) only; no pixel screen positioning is active without `PlacementController`. Stories use Floating UI inline styles as a temporary stand-in; this is noted in the MDX docs.
-- The tip element (`<span class="swc-Tooltip-tip">`) is always CSS-centered on the edge determined by the `placement` class. Its position is not dynamically adjusted relative to the trigger; this is deliberate and does not require `PlacementController`.
-- `offset` is present in the API but has no effect until `PlacementController` is integrated.
+- `PlacementController` handles pixel positioning. On open, it receives the resolved trigger and the tooltip host, computes `{ x, y }` via Floating UI, and applies `top: 0; left: 0; translate: Xpx Ypx` to the host. When `flip` repositions to a different side, `onPlacementChange` reflects the actual side back into `this.placement` (protected by a `_placementFromController` flag so the setter does not overwrite `_requestedPlacement`). The existing `[placement]` CSS selectors automatically pick up the reflected value for tip direction and animation.
+- The tip element (`<span class="swc-Tooltip-tip">`) is CSS-centered on the edge determined by the `placement` attribute. Because `placement` always reflects the actual computed side, the tip direction and enter animation are always correct.
+- `offset`, `cross-offset`, `container-padding`, and `should-flip` are all active API that feed directly into `PlacementController` options.
 
 ### Accessibility semantics notes (2nd-gen)
 
@@ -473,7 +476,7 @@ Follow the [Badge migration reference](../../02_workstreams/02_2nd-gen-component
 | Layer | Path | Contains |
 | ----- | ---- | -------- |
 | **Core** | `2nd-gen/packages/core/components/tooltip/` | `Tooltip.base.ts`, `Tooltip.types.ts`: property definitions (including `triggerElement` declaration), type validation, state management, accessible-name rules. Sets `role="tooltip"` and `popover="auto"` on the host element via `connectedCallback`. Wires `beforetoggle`/`toggle`/`transitionend` listeners for state sync and `swc-open`/`swc-after-open`/`swc-close`/`swc-after-close` dispatch. Resolves trigger via `for` attribute or `triggerElement` property. Maintains `Element.ariaDescribedByElements` on the trigger's inner interactive element on `open` change. No rendering. No Floating UI. |
-| **SWC** | `2nd-gen/packages/swc/components/tooltip/` | `Tooltip.ts`, `tooltip.css`: rendering only (tip element, label slot). Element registration, stories, tests. **Additive (shipped):** `HoverController` integrated in `Tooltip.base.ts`; hover/focus wiring, warm-up/cooldown, WCAG 1.4.13 pointer bridge active. **Additive (deferred):** `PlacementController` integration; pixel positioning. |
+| **SWC** | `2nd-gen/packages/swc/components/tooltip/` | `Tooltip.ts`, `tooltip.css`: rendering only (tip element, label slot). Element registration, stories, tests. **Additive (shipped):** `HoverController` integrated; hover/focus wiring, warm-up/cooldown, WCAG 1.4.13 pointer bridge active. `PlacementController` integrated; pixel positioning and flip active; actual computed side reflected back into `placement` so existing CSS selectors handle tip direction. |
 
 Planned rendering shape (initial release):
 
@@ -534,19 +537,11 @@ this._open = event.newState === 'open'; // bypass setter; do not call showPopove
 
 ### `PlacementController` hand-off
 
-When `PlacementController` is integrated in the additive phase, it:
+**Implemented.** `Tooltip.base.ts` instantiates `PlacementController`, calls `start(trigger, this, options)` when the tooltip opens (in `updated()` when `open` becomes `true`), and calls `stop()` when it closes. `start()` is also called on options changes (`placement`, `offset`, `crossOffset`, `containerPadding`, `shouldFlip`, `for`, `triggerElement`) while open.
 
-- Computes `{ x, y }` coordinates using Floating UI after `showPopover()` fires (i.e., on `toggle` with `newState === 'open'`)
-- Applies computed position to the host (already a `popover="auto"` element) via `position: fixed; left: ${x}px; top: ${y}px` or equivalent
-- Maps `placement`, `offset`, `container-padding`, `cross-offset`, and `should-flip` attributes to Floating UI middleware options (`offset`, `flip`, `shift`)
+`onPlacementChange` reflects the computed main side back into `this.placement` via the custom setter, guarded by a `_placementFromController` flag that prevents the setter from overwriting `_requestedPlacement`. The existing `[placement]` CSS selectors automatically pick up the reflected value — no additional CSS attributes or rules are needed. `_requestedPlacement` tracks the consumer's original requested side, so the controller always starts from the requested placement and can revert a flip when viewport space is restored.
 
-The tip element is always CSS-centered on the placement edge and does not require any input from the controller (see [initial release behavioral semantics](#behavioral-semantics)). No arrow middleware is needed.
-
-`PlacementController` does not change the popover mechanism; the host is already `popover="auto"`. It only layers pixel positioning on top.
-
-### Positioning before `PlacementController`
-
-In the initial release, `placement` applies only the CSS class (tip direction). The host has no pixel positioning from the component. Stories must supply inline styles or a CSS override to position the tooltip visibly near a trigger for demo purposes. This is intentional and should be noted in the relevant section of the per-component MDX docs page (`tooltip.mdx`).
+No arrow middleware is used — the tip is CSS-centered on the computed side. `PlacementController` only layers pixel positioning on top of the existing `popover="auto"` mechanism.
 
 ### Auto-stack behavior
 
@@ -615,7 +610,7 @@ The impact is most acute in the additive phase, when `HoverController` will call
 
 - [X] Confirm neutral, informative, negative backgrounds match Figma **(requires Storybook visual review)**
 - [X] Verify tip geometry across all placement values, including RTL for logical placements (`start`, `end`) **(logic fixed; requires Storybook visual review)**
-- [X] Verify open/close animation (`translateY`/`translateX` per placement direction; S2 animation tokens) **(requires Storybook visual review)**
+- [X] Verify open/close animation **(requires Storybook visual review).** Final open state has no CSS transform (PlacementController owns geometry via `translate`). `@starting-style` shifts the bubble toward the trigger by `--_swc-tooltip-animation-distance` (driven by `offset`, not a static token) so the animation travels from the trigger outward to the resting position.
 
 ### Accessibility
 
@@ -655,15 +650,16 @@ The impact is most acute in the additive phase, when `HoverController` will call
 - [x] Automatic mode: opens on trigger hover; closes on pointer leave (`HoverOpensTest`)
 - [x] Automatic mode: opens on trigger `focusin`; closes on `focusout` (`FocusOpensTest`)
 - [x] Automatic mode: pointer can move to tooltip bubble without closing (WCAG 1.4.13) — `HoverController` pointer bridge; covered by hover-controller test suite
-- [ ] Automatic mode: `for` attribute resolves to the element with the matching `id` in the same document tree root **(additive phase)**
+- [x] Automatic mode: `for` attribute resolves to the element with the matching `id` in the same document tree root — covered implicitly by `HoverOpensTest` (uses `for="tt-hover-trigger"`) and `AriaWiringNativeTest`/`AriaWiringSwcTriggerTest`
 - [x] `for` pointing to a non-existent `id` results in no trigger wiring (no-op); warns in debug mode (`ForIdNotFoundWarningTest`)
-- [ ] Automatic mode: `trigger-element` takes precedence over `for` when both are set **(additive phase)**
-- [ ] Automatic mode: `trigger-element` wires correctly for cross-shadow-root trigger relationships **(additive phase)**
+- [x] Automatic mode: `trigger-element` takes precedence over `for` when both are set — ARIA path tested by `AriaWiringTriggerElementOverrideTest`; hover routing tested by `TriggerElementOverridesForHoverTest`
+- [x] Automatic mode: `trigger-element` wires HoverController when `for` is absent — `TriggerElementHoverTest` (hover opens, ARIA wires to native trigger, closes on pointer leave)
+- [x] Automatic mode: `trigger-element` wires correctly for cross-shadow-root trigger relationships — implementation complete (`triggerElement` bypasses `getElementById` scoping); not explicitly tested with a cross-root fixture
 - [x] Automatic mode: `delay="0"` shows immediately on hover (`HoverOpensTest`); full 1500ms warm-up/cooldown timing covered by hover-controller test suite
-- [ ] Automatic mode: `for` resolves correctly when trigger and tooltip share a shadow root (ID lookup scoped to that root) **(additive phase)**
+- [x] Automatic mode: `for` resolves correctly when trigger and tooltip share a shadow root (`ShadowRootScopeTest` — creates trigger + tooltip inside `attachShadow({ mode: 'open' })`; verifies `getRootNode().getElementById` scopes to the shadow root and ARIA wiring reaches the native trigger)
 - [x] `manual` attribute: controller wiring is skipped; consumer-driven `open` changes still work; ARIA wiring still fires (`ManualPreventsHoverTest`, `AriaWiringManualModeTest`)
 - [x] `labeling` attribute: `ariaLabelledByElements` is set on the inner interactive element instead of `ariaDescribedByElements`; stale references in the opposite property are cleaned up; re-syncs when `labeling` changes while open (`LabelingAriaWiringTest`)
-- [ ] `ariaDescribedByElements` wiring: verify AT can traverse the association in DevTools Accessibility panel and with NVDA/VoiceOver
+- [ ] `ariaDescribedByElements` wiring: verify AT can traverse the association in DevTools Accessibility panel and with NVDA/VoiceOver — **manual verification required; cannot be automated**
 - [x] `ariaDescribedByElements` wiring fallback: when trigger has no shadow root (native `<button>`, `<a>`, `<input>`), association is established on the host element directly (`AriaWiringNativeTest`)
 - [x] `disabled` attribute prevents automatic mode response to user input (`DisabledPreventsHoverTest`)
 
@@ -680,7 +676,7 @@ The impact is most acute in the additive phase, when `HoverController` will call
 #### General
 
 - [x] JSDoc on all public properties, slots, and any exposed CSS custom properties
-- [x] Stories: Playground, Overview, Anatomy (default slot), Options (variants, placements), States (open), Accessibility, Behaviors (Events, Hover, Labeling). `Hover` behaviors story added; hover/focus/delay/disabled/pointer-bridge items moved out of upcoming features and documented in the Behaviors section of `tooltip.mdx`.
+- [x] Stories: Playground, Overview, Anatomy (default slot), Options (variants, placements), States (open, disabled, manual), Accessibility, Behaviors (Events, TriggerElement, Labeling). Hover/focus/delay/disabled/pointer-bridge items documented in `Behaviors → Hover and focus` prose section of `tooltip.mdx` (no dedicated canvas story). `TriggerElement` story demonstrates programmatic wiring via the property.
 
 #### Breaking changes
 
@@ -695,7 +691,7 @@ The impact is most acute in the additive phase, when `HoverController` will call
 - [x] Consumer migration guide: document that `popover="auto"` auto-stack behavior differs from 1st-gen `type="hint"` isolation — opening a tooltip closes other open auto popovers (menus, pickers); this is accepted behavior, not a bug
 - [x] Behaviors story: note the auto-stack behavior and that it is expected (Q2 resolved, Path A)
 
-#### Accessibility
+#### Accessibility documentation
 
 - [x] Storybook Accessibility story: document ARIA features (`role="tooltip"`, `ariaDescribedByElements` / `ariaLabelledByElements` lifecycle, inner-button resolution), keyboard behavior (`Escape` closes without moving focus; `Tab` blur dismisses), and screen reader expectations (trigger announced first, tooltip text second)
 - [x] No interactive content (links, buttons, focusable elements) may appear inside `role="tooltip"`; direct consumers to `swc-popover`, contextual help, or dialog for those patterns
@@ -724,7 +720,7 @@ The impact is most acute in the additive phase, when `HoverController` will call
 
 | # | Item | Blocking? | Status | Owner |
 | --- | ---- | --------- | ------ | ----- |
-| Q1 | **`tip-padding` semantics.** In 1st-gen, `tipPadding` was passed to `sp-overlay` for tip position calculation. **Resolved: dropped from Tooltip.** The tip is CSS-centered; no arrow middleware applies. For components with dynamic tips (Popover, CoachMark), `arrowPadding` is a PlacementController-level concern and will be addressed in that controller's design. | N/A | Resolved | Team |
+| Q1 | **`tip-padding` semantics.** In 1st-gen, `tipPadding` was passed to `sp-overlay` for tip position calculation. **Resolved.** The 1st-gen `tip-padding` attribute is not exposed. The `arrow` middleware IS used (via `Tooltip.ts` overriding `tipElement` to return the shadow-DOM `.swc-Tooltip-tip` element), which keeps the tip aligned with the trigger center when the bubble shifts from `crossOffset` or viewport `shift` middleware. The `tipPadding` option on `PlacementOptions` uses the controller's default of 8px; no consumer-facing attribute is exposed unless override needs emerge. | N/A | Resolved | Team |
 | Q2 | **`popover="auto"` stack isolation regression.** In 1st-gen, `type="hint"` overlays were isolated — opening a tooltip did not dismiss open menus or pickers. `popover="auto"` has no isolation tier; any auto popover opening dismisses all others. **Resolved: Path A accepted.** The behavior is documented as a known difference from 1st-gen. No workaround; document in consumer migration guide and Behaviors story. | N/A | Resolved | Team |
 
 ### Deferred implementation tickets
@@ -733,9 +729,9 @@ Create these tickets before this migration PR closes. Link each to Epic SWC-2017
 
 | Ticket | Summary | Why deferred | Plan sections |
 | ------ | ------- | ------------ | ------------- |
-| SWC-2210 | **Integrate PlacementController into Tooltip.** Pass resolved trigger element to controller (from SWC's `for`/`trigger-element` resolution — no internal resolution in the controller); wire viewport-aware pixel positioning: apply `placement`, `offset`, `container-padding`, `cross-offset`, `should-flip` as Floating UI middleware options. No `arrowPadding` needed — tooltip tip is CSS-centered. | Blocked on `PlacementController` extraction per Overlay RFC. | Additive A1 (positioning), A7, A8, A9 |
+| ~~SWC-2210~~ | ~~**Integrate PlacementController into Tooltip.**~~ | **Shipped.** `PlacementController` wired in `Tooltip.base.ts`; `start()`/`stop()` called on `open` changes; `onPlacementChange` reflects the computed side into `this.placement` (guarded by `_placementFromController` flag); `_requestedPlacement` preserves the consumer's original value. `offset`, `cross-offset`, `container-padding`, and `should-flip` feed directly into controller options. No additional CSS needed — existing `[placement]` selectors handle tip direction. | ~~Additive A1 (positioning), A7, A8, A9~~ |
 | ~~SWC-2210~~ | ~~**Integrate HoverController into Tooltip.**~~ | **Shipped.** `TooltipBase` implements `HoverControllerHost`; `HoverController` wired with `warmStateKey: 'swc-tooltip'`; target set from `resolveTrigger()` in `updated()`. Hover/focus wiring, warm-up/cooldown, `disabled` guard, and WCAG 1.4.13 pointer bridge are all active. | ~~Additive A1 (hover/focus), A2, A3, A4~~ |
-| TBD | **2nd-gen tooltip-directive.** Lit directive for programmatic tooltip insertion. Creates `<swc-tooltip>` as a sibling of the target and handles lifecycle cleanup. Simpler than 1st-gen: no `sp-overlay` wrapper needed; automatic trigger wiring activates because `manual` is not set. | Requires full automatic trigger integration (both controllers). | Additive A6 |
+| TBD | **2nd-gen tooltip-directive.** Lit directive for programmatic tooltip insertion. Creates `<swc-tooltip>` as a sibling of the target and handles lifecycle cleanup. Simpler than 1st-gen: no `sp-overlay` wrapper needed; automatic trigger wiring activates because `manual` is not set. | Both controllers are now active; this can proceed. | Additive A6 |
 | TBD | **`no-tip` attribute.** Remove the directional tip arrow. Figma-confirmed. Can proceed independently of controller integration; no controller dependency. Create when React Spectrum adds support as a confirming signal. | No cross-framework confirmation yet; Figma-only signal is not sufficient to ship. | Additive A5 |
 
 ---


### PR DESCRIPTION
## Description

Integrates `HoverController` and `PlacementController` into `<swc-tooltip>`, completing the additive phase of the Spectrum 2 tooltip migration (Epic SWC-2017). All seven previously deferred attributes (`delay`, `disabled`, `manual`, `offset`, `cross-offset`, `container-padding`, `should-flip`) are now active API.

### HoverController

- Hover/focus open/close with warm-up delay (default `1500 ms`; `delay="0"` for immediate)
- Keyboard focus always opens immediately regardless of `delay`
- WCAG 1.4.13 pointer bridge: pointer can move from trigger into the tooltip bubble without closing
- `disabled` suppresses hover/focus; `manual` suppresses all automatic wiring
- `_requestedPlacement` / `_placementFromController` pattern preserves the consumer's original requested placement so viewport-driven flips can revert when space is restored

### PlacementController

- Viewport-aware pixel positioning via Floating UI (`translate: Xpx Ypx`)
- Placement flip: `placement` reflects the computed side; existing `[placement]` CSS selectors handle tip direction automatically without new rules
- `tipElement` passed to `PlacementController` so the arrow middleware keeps the tip aligned with the trigger center when `cross-offset` or viewport `shift` displaces the bubble
- `--_swc-tooltip-animation-distance` is now driven by `offset` so the entry animation travel distance matches the gap

### CSS animation

- `@starting-style` direction corrected: bubble animates **from** the trigger outward to its resting position (was opposite)
- Final open state has no CSS `transform` — `PlacementController`'s `translate` owns the resting position
- Exit positioning (`translate`/`top`/`left`) cleared after the exit transition completes, not before, preventing a mid-fade flash at displaced position

### HoverController bug fix

`hostDisconnected()` was cancelling the shared `WarmState` cooldown timer, which could leave `isWarm` stuck at `true` indefinitely when an unrelated instance disconnected during another instance's cooldown. Regression test added.

### Stories

- Removed Floating UI inline-style workaround (`positionTooltip`, `@swc-open` wrapper)
- Added `Disabled`, `Manual`, and `TriggerElement` state/behavior stories
- `TriggerElement` uses `lit/directives/ref` so wiring is active in the Docs page canvas (not just in play mode)

### Tests

- `HoverOpensTest`, `FocusOpensTest`, `DisabledPreventsHoverTest`, `ManualPreventsHoverTest`
- `TriggerElementHoverTest`, `TriggerElementOverridesForHoverTest`
- `PlacementControllerTest`, `ShadowRootScopeTest`
- `DisconnectDoesNotCancelSharedCooldown` (HoverController regression)

## Motivation and context

Closes the additive phase documented in the tooltip migration plan. All automated-testable behavior items in the checklist are now `[x]`. Remaining open items are manual AT verification and process steps (PR, follow-on tickets, sign-off).

## Related issue(s)

- SWC-2210

## Screenshots

https://github.com/user-attachments/assets/7056b81f-1723-4b79-ac4d-ff839669f91e

### Manual review test cases

- [x] Hover over a trigger with a `swc-tooltip` attached via `for` — tooltip opens after ~1.5 s, tip points at trigger
- [x] Move pointer quickly between two adjacent tooltips — second opens immediately (warm state)
- [x] Move pointer from trigger into the tooltip bubble — tooltip stays open (WCAG 1.4.13 bridge)
- [ ] Tab to a trigger — tooltip opens immediately; blur closes immediately
- [x] Set `disabled` on a tooltip — hover and focus no longer open it
- [x] Set `manual` on a tooltip — only `tooltip.open = true` opens it; hover does nothing
- [ ] Resize viewport so the requested placement has no room — tooltip flips to opposite side, tip direction updates, animation direction correct; enlarge again — tooltip returns to requested side
- [ ] Set `cross-offset` — bubble shifts along the trigger edge; tip stays aligned with trigger center

### Device review

- [ ] Did it pass in Desktop?

## Accessibility testing checklist

- [ ] **Keyboard**
  1. Open the Tooltip Storybook story
  2. Press <kbd>Tab</kbd> to focus the trigger button — tooltip should open immediately
  3. Press <kbd>Escape</kbd> — tooltip should close; focus should remain on the trigger
  4. Press <kbd>Tab</kbd> again to blur — tooltip should close
  5. Verify tooltip text is never in the tab order

- [ ] **Screen reader** (NVDA on Windows / VoiceOver on macOS)
  1. Navigate to the trigger button with a screen reader
  2. Verify the trigger's accessible name is announced, followed by the tooltip description text
  3. Navigate to the icon-only `Labeling` story — verify the tooltip text is announced as the button's accessible name (not description)
  4. Verify the tooltip itself is not focusable and has no interactive content