### PR TITLE
fix(testing): stored timing data when running tests can't match paths correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,7 @@ jobs:
       - run:
           name: Run chromium tests
           command: |
-            TEST=$(circleci tests glob "1st-gen/{packages,tools}/*/test/*.test.js" | grep -v ".*-memory\.test\.js$" | circleci tests split --split-by=timings | sed 's/1st-gen\///')
+            TEST=$(circleci tests glob "1st-gen/{packages,tools}/*/test/*.test.js" | grep -v ".*-memory\.test\.js$" | sed 's/1st-gen\///' | circleci tests split --split-by=timings)
             yarn workspace @spectrum-web-components/1st-gen test:start --files $TEST --config ./web-test-runner.config.ci-chromium.js --group unit-ci
       - store_test_results:
           path: /root/project/1st-gen/results/
@@ -368,7 +368,7 @@ jobs:
       - run:
           name: Run memory tests
           command: |
-            TEST=$(circleci tests glob "1st-gen/{packages,tools}/*/test/*-memory.test.js" | grep -v "packages/color-.*/test/.*-memory\.test\.js" | grep -v "tools/grid/test/.*-memory\.test\.js" | circleci tests split --split-by=timings | sed 's/1st-gen\///')
+            TEST=$(circleci tests glob "1st-gen/{packages,tools}/*/test/*-memory.test.js" | grep -v "packages/color-.*/test/.*-memory\.test\.js" | grep -v "tools/grid/test/.*-memory\.test\.js" | sed 's/1st-gen\///' | circleci tests split --split-by=timings)
             echo $TEST
             yarn workspace @spectrum-web-components/1st-gen test:start --files $TEST --config web-test-runner.config.ci-chromium-memory.js --group unit-ci
       - store_test_results:
@@ -385,7 +385,7 @@ jobs:
       - run:
           name: Run firefox tests
           command: |
-            TEST=$(circleci tests glob "1st-gen/{packages,tools}/*/test/*.test.js" | grep -v ".*-memory\.test\.js$" | circleci tests split --split-by=timings | sed 's/1st-gen\///')
+            TEST=$(circleci tests glob "1st-gen/{packages,tools}/*/test/*.test.js" | grep -v ".*-memory\.test\.js$" | sed 's/1st-gen\///' | circleci tests split --split-by=timings)
             yarn workspace @spectrum-web-components/1st-gen test:start --files $TEST --config web-test-runner.config.ci-firefox.js --group unit-ci
       - store_test_results:
           path: /root/project/results/
@@ -401,7 +401,7 @@ jobs:
       - run:
           name: Run webkit tests
           command: |
-            TEST=$(circleci tests glob "1st-gen/{packages,tools}/*/test/*.test.js" | grep -v ".*-memory\.test\.js$" | circleci tests split --split-by=timings | sed 's/1st-gen\///')
+            TEST=$(circleci tests glob "1st-gen/{packages,tools}/*/test/*.test.js" | grep -v ".*-memory\.test\.js$" | sed 's/1st-gen\///' | circleci tests split --split-by=timings)
             yarn workspace @spectrum-web-components/1st-gen test:start --files $TEST --config web-test-runner.config.ci-webkit.js --group unit-ci
       - store_test_results:
           path: /root/project/results/


### PR DESCRIPTION
## Description

In four CircleCI test jobs (chromium, chromium-memory, firefox, webkit), the `sed 's/1st-gen\///'` strip was applied _after_ `circleci tests split --split-by=timings`. This meant CircleCI received paths like `1st-gen/packages/accordion/test/a11y-tree.test.js` during the split, but stored timing data uses paths like `packages/action-menu/test/action-menu-directive.test.js` (no `1st-gen/` prefix). CircleCI couldn't match them and fell back to weighting by filename, making timing-based sharding a no-op.

The fix moves `sed` before `circleci tests split` so the paths are stripped before timing lookup, restoring accurate test distribution across parallel runners.

## Motivation and context

CircleCI logs the following warning on every parallel test run:

```
Error autodetecting timing type, falling back to weighting by name. Autodetect no matching filename or classname.
Example input file: "1st-gen/packages/accordion/test/a11y-tree.test.js"
Example file from timings: "packages/action-menu/test/action-menu-directive.test.js"
```

This silently degrades CI efficiency: tests are distributed by name hash rather than historical duration, so some parallel runners finish much earlier than others. No test failures result, but CI time is wasted.

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/) — not applicable (CI config only)
- [x] I have added automated tests to cover my changes — not applicable (CI config only)
- [x] I have included a well-written changeset if my change needs to be published — not applicable (CI config only)
- [x] I have included updated documentation if my change required it — not applicable

---

## Reviewer's checklist

- [ ] Four `circleci tests split --split-by=timings` invocations each have `sed 's/1st-gen\///'` piped _before_ the split, not after

### Manual review test cases

- [ ] Verify the warning no longer appears in CircleCI logs after this merges
  1. Open a CircleCI run for any of the four affected jobs (test-chromium, test-chromium-memory, test-firefox, test-webkit)
  2. Expand the "Run ... tests" step
  3. Confirm the "Error autodetecting timing type" line is absent