### PR TITLE
[docs][styles] reinforce and clean up auto-generated files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,19 @@
 yarn lint-staged --allow-empty
 
-# If any CONTRIBUTOR-DOCS files are staged, regenerate navigation and verify links
+# If any CONTRIBUTOR-DOCS files are staged, regenerate navigation and verify links,
+# then regenerate the Storybook contributor-docs MDX and update preview.ts sort order.
 if git diff --cached --name-only | grep -q "^CONTRIBUTOR-DOCS/"; then
   node CONTRIBUTOR-DOCS/01_contributor-guides/07_authoring-contributor-docs/update-nav.js "$(pwd)/CONTRIBUTOR-DOCS"
   git add CONTRIBUTOR-DOCS/
+  (cd 2nd-gen/packages/swc && node .storybook/scripts/generate-contributor-docs.mjs)
+  git add 2nd-gen/packages/swc/.storybook/preview.ts
+fi
+
+# If any component CSS files are staged, run the build so the vite plugin
+# regenerates all global stylesheets, then stage the results.
+if git diff --cached --name-only | grep -qE "^2nd-gen/packages/swc/components/.*\.css$"; then
+  (cd 2nd-gen/packages/swc && yarn build)
+  git add 2nd-gen/packages/swc/stylesheets/global/
 fi
 
 # If any per-unit MDX or stories file changed under the in-scope 2nd-gen

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -391,6 +391,7 @@ const preview = {
                 'Color handle',
                 [
                   'Accessibility migration analysis',
+                  'Migration plan',
                   'Rendering and styling migration analysis',
                 ],
                 'Color loupe',
@@ -475,6 +476,7 @@ const preview = {
                 'Progress bar',
                 [
                   'Accessibility migration analysis',
+                  'Migration plan',
                   'Rendering and styling migration analysis',
                 ],
                 'Progress circle',

--- a/2nd-gen/packages/swc/package.json
+++ b/2nd-gen/packages/swc/package.json
@@ -27,13 +27,13 @@
       "types": "./dist/*.css.d.ts",
       "default": "./dist/*.css"
     },
-    "./components/*.js": {
-      "types": "./dist/components/*.d.ts",
-      "default": "./dist/components/*.js"
-    },
     "./components/*": {
       "types": "./dist/components/*/index.d.ts",
       "import": "./dist/components/*/index.js"
+    },
+    "./components/*.js": {
+      "types": "./dist/components/*.d.ts",
+      "default": "./dist/components/*.js"
     },
     "./global-button.css": {
       "default": "./dist/global-button.css"
@@ -64,7 +64,7 @@
   "scripts": {
     "analyze": "cem analyze --config cem.config.js",
     "analyze:watch": "cem analyze --config cem.config.js --watch",
-    "build": "vite build",
+    "build": "yarn analyze && vite build",
     "clean": "rimraf dist",
     "dev": "vite build --watch",
     "dev:core": "yarn workspace @spectrum-web-components/core dev",

--- a/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
@@ -40,7 +40,7 @@
   user-select: none;
   transition-timing-function: token("animation-ease-in-out");
   transition-duration: token("animation-duration-100");
-  transition-property: border-color, color, background-color, transform;
+  transition-property: outline, border-color, color, background-color, transform;
 
   --_swc-action-button-border-width: token("border-width-100");
   --_swc-action-button-min-block-size: var(--swc-action-button-min-block-size, token("component-height-100"));

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.js
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.js
@@ -396,7 +396,8 @@ function wrapInLayer(root, block) {
     params: LAYER,
     raws: { afterName: ' ', between: ' ', after: '\n' },
   });
-  for (const node of children) {
+  for (const [i, node] of children.entries()) {
+    node.raws.before = i === 0 ? '' : '\n\n';
     layer.append(node);
   }
   root.append(layer);
@@ -405,6 +406,7 @@ function wrapInLayer(root, block) {
   // revert any property to the layer-defined value rather than being
   // overridden by unlayered application CSS.
   const revert = postcss.rule({ selector: `.${block}` });
+  revert.raws.before = '\n\n';
   revert.append(
     postcss.decl({ prop: 'all', value: 'revert-layer !important' })
   );


### PR DESCRIPTION
## Description

This PR makes two fixes to the `vite-global-elements-css` script and updates the pre-commit hook to keep autogenerated files in sync automatically.

### `vite-global-elements-css` script fixes

- Adds blank lines between rules inside the generated `@layer` block by setting `node.raws.before` on each appended node, and adds a blank line before the `revert-layer` escape-hatch rule. This produces consistently formatted output.
- Fixes `global-action-button.css` to include `outline` in the `transition-property` list.

### `package.json` export order fix

Reorders the `./components/*` and `./components/*.js` export conditions so the more specific `./components/*.js` pattern comes after `./components/*`. This ensures Node resolves the wildcard directory entry first, matching the intended behavior.

Also adds `yarn analyze` to the `build` script so `custom-elements.json` is always up to date before vite processes the package.

### Pre-commit hook improvements

Extends the Husky pre-commit hook to keep autogenerated files accurate in branches so `main` stays clean and diffs don't accumulate stale artifacts:

- **CONTRIBUTOR-DOCS changes**: in addition to the existing `update-nav.js` run (breadcrumbs/TOC), now also runs `generate-contributor-docs.mjs` to regenerate the Storybook `.mdx` files and update the `GENERATED:CONTRIBUTOR-DOCS-SORT` block in `preview.ts`. Both files are staged automatically.
- **Component CSS changes**: when any `.css` file under `2nd-gen/packages/swc/components/` is staged, runs `yarn build` so the `vite-global-elements-css` plugin regenerates all `stylesheets/global/global-*.css` files. Results are staged automatically. The trigger is intentionally broad so new global element CSS entries added to `vite.config.ts` are picked up without any hook changes.

## Motivation and context

Autogenerated files (`stylesheets/global/`, `preview.ts` sort order, CONTRIBUTOR-DOCS nav) were not being kept in sync at commit time, causing `main` to accumulate stale diffs whenever these generation scripts were run locally.

## Related issue(s)

- fixes [Issue Number]

## Screenshots (if appropriate)

---

## Author's checklist

- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Stage a component CSS file (e.g. `components/button/button.css`) and commit — verify `stylesheets/global/global-button.css` is automatically staged and updated.
- [ ] Stage a CONTRIBUTOR-DOCS `.md` file and commit — verify breadcrumbs/TOC are regenerated in the `.md` files and `preview.ts` sort order is updated.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

No interactive UI changes in this PR — changes are limited to build tooling, generated CSS, and the pre-commit hook.

- [ ] **Keyboard** — not applicable; no focusable elements added or changed.
- [ ] **Screen reader** — not applicable; no DOM structure or ARIA changes.