### PR TITLE
feat(close-button): S2 styling and Storybook docs

### DIFF
--- a/2nd-gen/packages/swc/components/close-button/CloseButton.ts
+++ b/2nd-gen/packages/swc/components/close-button/CloseButton.ts
@@ -61,6 +61,20 @@ const crossIconBySize: Record<ButtonSize, () => TemplateResult> = {
  * ```html
  * <swc-close-button static-color="white" accessible-label="Close"></swc-close-button>
  * ```
+ *
+ * @cssprop --swc-close-button-size - Inline and block size of the close button. Defaults to the medium component height token.
+ * @cssprop --swc-close-button-icon-size - Size of the cross icon. Defaults to the medium cross icon token.
+ * @cssprop --swc-close-button-border-radius - Corner radius. Defaults to the full corner radius token.
+ * @cssprop --swc-close-button-icon-color-default - Cross icon color in the default state.
+ * @cssprop --swc-close-button-icon-color-hover - Cross icon color when hovered.
+ * @cssprop --swc-close-button-icon-color-down - Cross icon color when pressed.
+ * @cssprop --swc-close-button-icon-color-focus - Cross icon color when keyboard focused.
+ * @cssprop --swc-close-button-icon-color-disabled - Cross icon color when disabled.
+ * @cssprop --swc-close-button-background-color-default - Background color in the default state.
+ * @cssprop --swc-close-button-background-color-hover - Background color when hovered.
+ * @cssprop --swc-close-button-background-color-down - Background color when pressed.
+ * @cssprop --swc-close-button-background-color-focus - Background color when keyboard focused.
+ * @cssprop --swc-close-button-focus-indicator-color - Focus ring color. Defaults to the focus indicator color token.
  */
 export class CloseButton extends ButtonBase {
   /**

--- a/2nd-gen/packages/swc/components/close-button/CloseButton.ts
+++ b/2nd-gen/packages/swc/components/close-button/CloseButton.ts
@@ -11,7 +11,6 @@
  */
 
 import { CSSResultArray, html, TemplateResult } from 'lit';
-import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import {
@@ -100,11 +99,7 @@ export class CloseButton extends ButtonBase {
 
     return html`
       <button
-        class=${classMap({
-          'swc-CloseButton': true,
-          'swc-CloseButton--staticWhite': this.staticColor === 'white',
-          'swc-CloseButton--staticBlack': this.staticColor === 'black',
-        })}
+        class="swc-CloseButton"
         type="button"
         @click=${this.handleActivationClick}
         ?disabled=${this.disabled}

--- a/2nd-gen/packages/swc/components/close-button/close-button.css
+++ b/2nd-gen/packages/swc/components/close-button/close-button.css
@@ -12,48 +12,122 @@
 
 :host {
   display: inline-flex;
+  vertical-align: top;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:host([size="s"]) {
+  --swc-close-button-icon-size: token("cross-icon-size-200");
+  --swc-close-button-size: token("component-height-75");
+}
+
+:host([size="l"]) {
+  --swc-close-button-icon-size: token("cross-icon-size-400");
+  --swc-close-button-size: token("component-height-200");
+}
+
+:host([size="xl"]) {
+  --swc-close-button-icon-size: token("cross-icon-size-500");
+  --swc-close-button-size: token("component-height-300");
+}
+
+:host([static-color="white"]) {
+  --swc-close-button-background-color-default: transparent;
+  --swc-close-button-background-color-down: token("transparent-white-100");
+  --swc-close-button-background-color-focus: token("transparent-white-100");
+  --swc-close-button-background-color-hover: token("transparent-white-100");
+  --swc-close-button-focus-indicator-color: token("static-white-focus-indicator-color");
+  --swc-close-button-icon-color-default: token("transparent-white-800");
+  --swc-close-button-icon-color-disabled: token("disabled-static-white-background-color");
+  --swc-close-button-icon-color-down: token("transparent-white-900");
+  --swc-close-button-icon-color-focus: token("transparent-white-900");
+  --swc-close-button-icon-color-hover: token("transparent-white-900");
+}
+
+:host([static-color="black"]) {
+  --swc-close-button-background-color-default: transparent;
+  --swc-close-button-background-color-down: token("transparent-black-100");
+  --swc-close-button-background-color-focus: token("transparent-black-100");
+  --swc-close-button-background-color-hover: token("transparent-black-100");
+  --swc-close-button-focus-indicator-color: token("static-black-focus-indicator-color");
+  --swc-close-button-icon-color-default: token("transparent-black-800");
+  --swc-close-button-icon-color-disabled: token("disabled-static-black-background-color");
+  --swc-close-button-icon-color-down: token("transparent-black-900");
+  --swc-close-button-icon-color-focus: token("transparent-black-900");
+  --swc-close-button-icon-color-hover: token("transparent-black-900");
 }
 
 .swc-CloseButton {
-  --_swc-close-button-block-size: token("component-height-100");
-  --_swc-close-button-icon-size: token("cross-icon-size-300");
+  --_swc-close-button-focus-indicator-gap: token("focus-indicator-gap");
+  --_swc-close-button-focus-indicator-thickness: token("focus-indicator-thickness");
 
+  -webkit-tap-highlight-color: transparent;
   display: inline-flex;
+  position: relative;
   align-items: center;
   justify-content: center;
-  inline-size: var(--_swc-close-button-block-size);
-  block-size: var(--_swc-close-button-block-size);
+  inline-size: var(--swc-close-button-size, token("component-height-100"));
+  block-size: var(--swc-close-button-size, token("component-height-100"));
   padding: 0;
-  color: token("neutral-content-color-default");
-  background: transparent;
-  border: none;
+  margin: 0;
+  color: var(--swc-close-button-icon-color-default, token("neutral-content-color-default"));
+  background-color: var(--swc-close-button-background-color-default, transparent);
+  border: 0;
+  border-radius: var(--swc-close-button-border-radius, token("corner-radius-full"));
+  overflow: visible;
   cursor: pointer;
+  user-select: none;
+  transition: background-color token("animation-duration-100") ease-in-out;
+}
+
+.swc-CloseButton:focus {
+  outline: none;
+}
+
+.swc-CloseButton::after {
+  position: absolute;
+  inset-block: 0;
+  inset-inline: 0;
+  margin: calc(var(--_swc-close-button-focus-indicator-gap) * -1);
+  border-radius: calc(var(--swc-close-button-border-radius, token("corner-radius-full")) + var(--_swc-close-button-focus-indicator-gap));
+  pointer-events: none;
+  content: "";
+  transition: box-shadow token("animation-duration-100") ease-in-out;
 }
 
 .swc-CloseButton:disabled {
+  color: var(--swc-close-button-icon-color-disabled, token("disabled-content-color"));
+  background-color: var(--swc-close-button-background-color-default, transparent);
   cursor: default;
 }
 
-:host([size="s"]) .swc-CloseButton {
-  --_swc-close-button-block-size: token("component-height-75");
-  --_swc-close-button-icon-size: token("cross-icon-size-200");
+.swc-CloseButton:focus-visible {
+  color: var(--swc-close-button-icon-color-focus, token("neutral-content-color-key-focus"));
+  background-color: var(--swc-close-button-background-color-focus, token("gray-100"));
 }
 
-:host([size="l"]) .swc-CloseButton {
-  --_swc-close-button-block-size: token("component-height-200");
-  --_swc-close-button-icon-size: token("cross-icon-size-400");
+.swc-CloseButton:focus-visible::after {
+  box-shadow: 0 0 0 var(--_swc-close-button-focus-indicator-thickness) var(--swc-close-button-focus-indicator-color, token("focus-indicator-color"));
 }
 
-:host([size="xl"]) .swc-CloseButton {
-  --_swc-close-button-block-size: token("component-height-300");
-  --_swc-close-button-icon-size: token("cross-icon-size-500");
+.swc-CloseButton:hover:not(:disabled) {
+  color: var(--swc-close-button-icon-color-hover, token("neutral-content-color-hover"));
+  background-color: var(--swc-close-button-background-color-hover, token("gray-100"));
+}
+
+.swc-CloseButton:active:not(:disabled) {
+  color: var(--swc-close-button-icon-color-down, token("neutral-content-color-down"));
+  background-color: var(--swc-close-button-background-color-down, token("gray-100"));
 }
 
 .swc-CloseButton-icon {
   display: block;
   flex-shrink: 0;
-  inline-size: var(--_swc-close-button-icon-size);
-  block-size: var(--_swc-close-button-icon-size);
+  inline-size: var(--swc-close-button-icon-size, token("cross-icon-size-300"));
+  block-size: var(--swc-close-button-icon-size, token("cross-icon-size-300"));
 }
 
 .swc-CloseButton-icon svg {
@@ -76,4 +150,46 @@
   border: 0;
   overflow: hidden;
   clip-path: inset(50%);
+}
+
+@media (forced-colors: active) {
+  .swc-CloseButton {
+    --_swc-close-button-background-color-default: ButtonFace;
+    --_swc-close-button-focus-indicator-color: ButtonText;
+    --_swc-close-button-icon-color-disabled: GrayText;
+    --_swc-close-button-icon-color-down: Highlight;
+    --_swc-close-button-icon-color-focus: Highlight;
+    --_swc-close-button-icon-color-hover: Highlight;
+  }
+
+  .swc-CloseButton:disabled {
+    color: var(--_swc-close-button-icon-color-disabled);
+    background-color: var(--_swc-close-button-background-color-default);
+  }
+
+  .swc-CloseButton:focus-visible {
+    color: var(--_swc-close-button-icon-color-focus);
+    background-color: var(--_swc-close-button-background-color-default);
+  }
+
+  .swc-CloseButton:focus-visible::after {
+    margin: calc(var(--_swc-close-button-focus-indicator-gap) * -1);
+    box-shadow: 0 0 0 var(--_swc-close-button-focus-indicator-thickness) var(--_swc-close-button-focus-indicator-color);
+    forced-color-adjust: none;
+    transition:
+      opacity token("animation-duration-100") ease-out,
+      margin token("animation-duration-100") ease-out;
+  }
+
+  .swc-CloseButton:hover:not(:disabled) {
+    color: var(--_swc-close-button-icon-color-hover);
+  }
+
+  .swc-CloseButton:active:not(:disabled) {
+    color: var(--_swc-close-button-icon-color-down);
+  }
+
+  :host([static-color="white"]) .swc-CloseButton:disabled {
+    --_swc-close-button-icon-color-disabled: Highlight;
+  }
 }

--- a/2nd-gen/packages/swc/components/close-button/close-button.css
+++ b/2nd-gen/packages/swc/components/close-button/close-button.css
@@ -61,8 +61,7 @@
 }
 
 .swc-CloseButton {
-  --_swc-close-button-focus-indicator-gap: token("focus-indicator-gap");
-  --_swc-close-button-focus-indicator-thickness: token("focus-indicator-thickness");
+  --_swc-close-button-border-width: token("border-width-200");
 
   -webkit-tap-highlight-color: transparent;
   display: inline-flex;
@@ -75,42 +74,34 @@
   margin: 0;
   color: var(--swc-close-button-icon-color-default, token("neutral-content-color-default"));
   background-color: var(--swc-close-button-background-color-default, transparent);
-  border: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: var(--_swc-close-button-border-width);
   border-radius: var(--swc-close-button-border-radius, token("corner-radius-full"));
   overflow: visible;
   cursor: pointer;
   user-select: none;
-  transition: background-color token("animation-duration-100") ease-in-out;
+  transition-timing-function: token("animation-ease-in-out");
+  transition-duration: token("animation-duration-100");
+  transition-property: outline, border-color, color, background-color, transform;
 }
 
 .swc-CloseButton:focus {
-  outline: none;
-}
-
-.swc-CloseButton::after {
-  position: absolute;
-  inset-block: 0;
-  inset-inline: 0;
-  margin: calc(var(--_swc-close-button-focus-indicator-gap) * -1);
-  border-radius: calc(var(--swc-close-button-border-radius, token("corner-radius-full")) + var(--_swc-close-button-focus-indicator-gap));
-  pointer-events: none;
-  content: "";
-  transition: box-shadow token("animation-duration-100") ease-in-out;
+  outline: transparent;
 }
 
 .swc-CloseButton:disabled {
   color: var(--swc-close-button-icon-color-disabled, token("disabled-content-color"));
   background-color: var(--swc-close-button-background-color-default, transparent);
   cursor: default;
+  transform: none;
 }
 
 .swc-CloseButton:focus-visible {
   color: var(--swc-close-button-icon-color-focus, token("neutral-content-color-key-focus"));
   background-color: var(--swc-close-button-background-color-focus, token("gray-100"));
-}
-
-.swc-CloseButton:focus-visible::after {
-  box-shadow: 0 0 0 var(--_swc-close-button-focus-indicator-thickness) var(--swc-close-button-focus-indicator-color, token("focus-indicator-color"));
+  outline: var(--swc-close-button-focus-indicator-thickness, token("focus-indicator-thickness")) solid var(--swc-close-button-focus-indicator-color, token("focus-indicator-color"));
+  outline-offset: var(--swc-close-button-focus-indicator-gap, token("focus-indicator-gap"));
 }
 
 .swc-CloseButton:hover:not(:disabled) {
@@ -121,6 +112,8 @@
 .swc-CloseButton:active:not(:disabled) {
   color: var(--swc-close-button-icon-color-down, token("neutral-content-color-down"));
   background-color: var(--swc-close-button-background-color-down, token("gray-100"));
+  transform: perspective(var(--swc-close-button-size, token("component-height-100"))) translate3d(0, 0, token("component-size-difference-down"));
+  will-change: transform;
 }
 
 .swc-CloseButton-icon {
@@ -150,46 +143,4 @@
   border: 0;
   overflow: hidden;
   clip-path: inset(50%);
-}
-
-@media (forced-colors: active) {
-  .swc-CloseButton {
-    --_swc-close-button-background-color-default: ButtonFace;
-    --_swc-close-button-focus-indicator-color: ButtonText;
-    --_swc-close-button-icon-color-disabled: GrayText;
-    --_swc-close-button-icon-color-down: Highlight;
-    --_swc-close-button-icon-color-focus: Highlight;
-    --_swc-close-button-icon-color-hover: Highlight;
-  }
-
-  .swc-CloseButton:disabled {
-    color: var(--_swc-close-button-icon-color-disabled);
-    background-color: var(--_swc-close-button-background-color-default);
-  }
-
-  .swc-CloseButton:focus-visible {
-    color: var(--_swc-close-button-icon-color-focus);
-    background-color: var(--_swc-close-button-background-color-default);
-  }
-
-  .swc-CloseButton:focus-visible::after {
-    margin: calc(var(--_swc-close-button-focus-indicator-gap) * -1);
-    box-shadow: 0 0 0 var(--_swc-close-button-focus-indicator-thickness) var(--_swc-close-button-focus-indicator-color);
-    forced-color-adjust: none;
-    transition:
-      opacity token("animation-duration-100") ease-out,
-      margin token("animation-duration-100") ease-out;
-  }
-
-  .swc-CloseButton:hover:not(:disabled) {
-    color: var(--_swc-close-button-icon-color-hover);
-  }
-
-  .swc-CloseButton:active:not(:disabled) {
-    color: var(--_swc-close-button-icon-color-down);
-  }
-
-  :host([static-color="white"]) .swc-CloseButton:disabled {
-    --_swc-close-button-icon-color-disabled: Highlight;
-  }
 }

--- a/2nd-gen/packages/swc/components/close-button/close-button.mdx
+++ b/2nd-gen/packages/swc/components/close-button/close-button.mdx
@@ -49,7 +49,7 @@ Use the `static-color` attribute when displaying over images or colored backgrou
 - **white** — use on dark or colored backgrounds for better contrast
 - **black** — use on light backgrounds for better contrast
 
-The canvas below uses the Storybook static-color demo layout: **white** on a dark gradient panel, then **default** and **black** on a light gradient panel.
+The canvas below uses the Storybook static-color demo layout: **white** on a dark gradient panel and **black** on a light gradient panel.
 
 > **Migration note:** replace legacy `variant="white"` or `variant="black"` with `static-color`. The `variant` attribute is not supported on `<swc-close-button>`.
 
@@ -84,7 +84,7 @@ The `<swc-close-button>` element implements several accessibility features:
 
 - Hit target size scales with the `size` attribute
 - Static color variants maintain contrast on colored backgrounds
-- High contrast mode overrides icon, background, and focus ring colors
+- Transparent border and outline focus treatment support high contrast mode without custom forced-color overrides
 
 ### Best practices
 

--- a/2nd-gen/packages/swc/components/close-button/close-button.mdx
+++ b/2nd-gen/packages/swc/components/close-button/close-button.mdx
@@ -7,27 +7,91 @@ import * as CloseButtonStories from './stories/close-button.stories';
 
 <DocsHeader />
 
+## Anatomy
+
+A close button consists of:
+
+1. **Button** — native `<button type="button">` with delegated focus; handles pointer and keyboard activation
+2. **Icon** — cross icon (`aria-hidden="true"`); size follows the `size` attribute
+3. **Label** — visually hidden default slot text used for the accessible name when `accessible-label` is omitted
+
+#### Slots
+
+- **Default slot** — accessible text label rendered visually hidden next to the cross icon
+
+#### Properties
+
+- **`accessible-label`** — accessible name forwarded to the inner button as `aria-label` when set
+- **`size`** — visual size of the hit target and icon scale (`s`, `m`, `l`, `xl`)
+- **`static-color`** — static color treatment for display over colored or image backgrounds (`white`, `black`)
+
+<Canvas of={CloseButtonStories.Anatomy} />
+
 ## Options
 
 ### Sizes
 
-Close buttons use the same size scale as `swc-button`: `s`, `m`, `l`, and `xl`. Medium is the default.
+Close buttons come in four sizes to fit various contexts:
+
+- **Small (`s`)** — compact chrome such as dense toolbars or inline banners
+- **Medium (`m`)** — default size for dialogs, toasts, and most dismiss affordances
+- **Large (`l`)** — larger hit target when space allows
+- **Extra large (`xl`)** — maximum visibility for prominent dismiss controls
+
+> **Migration note:** `<swc-close-button>` reflects **`size="m"`** on the host when omitted. Spectrum 1 did not reflect a default `size` attribute, though the visual default was still medium.
 
 <Canvas of={CloseButtonStories.Sizes} />
 
 ### Static colors
 
-Use `static-color="white"` or `static-color="black"` when the dismiss control sits on a colored or image background.
+Use the `static-color` attribute when displaying over images or colored backgrounds:
+
+- **white** — use on dark or colored backgrounds for better contrast
+- **black** — use on light backgrounds for better contrast
+
+The canvas below uses the Storybook static-color demo layout: **white** on a dark gradient panel, then **default** and **black** on a light gradient panel.
+
+> **Migration note:** replace legacy `variant="white"` or `variant="black"` with `static-color`. The `variant` attribute is not supported on `<swc-close-button>`.
 
 <Canvas of={CloseButtonStories.StaticColors} />
 
 ## States
 
+Close buttons support enabled and disabled states. Hover, active, and keyboard focus styles apply only when the control is not disabled.
+
 <Canvas of={CloseButtonStories.States} />
 
 ## Accessibility
 
-Every close button needs a discernible name via `accessible-label` or default slot text. The cross icon is decorative.
+### Features
+
+The `<swc-close-button>` element implements several accessibility features:
+
+#### Keyboard navigation
+
+- **Tab** — moves focus to the inner dismiss button via delegated focus
+- **Enter** or **Space** — activates the dismiss action
+- **Focus indicator** — visible `:focus-visible` ring on keyboard focus
+
+#### ARIA implementation
+
+1. **Native button** — renders a real `<button type="button">` inside the shadow root
+2. **Accessible name** — resolved from `accessible-label` or visually hidden default slot text, forwarded as `aria-label` on the inner button
+3. **Decorative icon** — cross icon is marked `aria-hidden="true"` so screen readers announce the button name only
+4. **Disabled state** — `disabled` removes activation and applies disabled visuals on the inner button
+
+#### Visual accessibility
+
+- Hit target size scales with the `size` attribute
+- Static color variants maintain contrast on colored backgrounds
+- High contrast mode overrides icon, background, and focus ring colors
+
+### Best practices
+
+- Always provide a descriptive accessible name such as "Close" or "Close dialog" — not a clear/reset verb
+- Prefer `accessible-label` for icon-only dismiss controls in dialog chrome
+- Use `static-color="white"` or `static-color="black"` when the default neutral icon lacks contrast on the background
+- Test keyboard focus order when placing close buttons in dialog headers or banner corners
 
 <Canvas of={CloseButtonStories.Accessibility} />
 

--- a/2nd-gen/packages/swc/components/close-button/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/close-button/migration-guide.mdx
@@ -1,0 +1,152 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Close Button/Migration guide" />
+
+# Close button migration guide
+
+Replace `<sp-close-button>` with `<swc-close-button>` and update imports, accessible naming, and styling overrides.
+
+## Installation
+
+```bash
+# Remove
+yarn remove @spectrum-web-components/button
+
+# Add
+yarn add @adobe/spectrum-wc
+```
+
+Update your import:
+
+```js
+// Before
+import '@spectrum-web-components/button/sp-close-button.js';
+
+// After
+import '@adobe/spectrum-wc/components/close-button/swc-close-button.js';
+```
+
+> `@adobe/spectrum-wc` is a monolithic package. Importing via subpath registers and loads only that component's bundle.
+
+## What changed
+
+### Renamed
+
+| Area             | Spectrum 1 (`sp-close-button`)        | Spectrum 2 (`swc-close-button`)                                  |
+| ---------------- | ------------------------------------- | ---------------------------------------------------------------- |
+| Tag              | `sp-close-button`                     | `swc-close-button`                                               |
+| Import path      | `@spectrum-web-components/button/...` | `@adobe/spectrum-wc/components/close-button/swc-close-button.js` |
+| Accessible name  | `label` attribute                     | `accessible-label` attribute                                     |
+| CSS custom props | `--mod-closebutton-*`                 | `--swc-close-button-*` (see [Styling](#styling))                 |
+
+### Removed in Spectrum 2
+
+| Removed                         | Replacement                                                                 |
+| ------------------------------- | --------------------------------------------------------------------------- |
+| `variant="white"` / `"black"`   | `static-color="white"` / `"black"`                                          |
+| `label` attribute               | `accessible-label` attribute                                                |
+| `--mod-closebutton-*` overrides | `--swc-close-button-*` equivalents (see [Styling](#styling))                |
+| Host-level button semantics     | Inner `<button type="button">` with delegated focus — update DOM assertions |
+
+## Update your code
+
+### 1. Rename the tag and accessible name
+
+```html
+<!-- Before -->
+<sp-close-button label="Close"></sp-close-button>
+
+<!-- After -->
+<swc-close-button accessible-label="Close"></swc-close-button>
+```
+
+Slotted text still works when `accessible-label` is omitted:
+
+```html
+<swc-close-button>Close</swc-close-button>
+```
+
+### 2. Replace `variant` with `static-color`
+
+```html
+<!-- Before -->
+<sp-close-button variant="white" label="Close"></sp-close-button>
+
+<!-- After -->
+<swc-close-button
+  static-color="white"
+  accessible-label="Close"
+></swc-close-button>
+```
+
+### 3. Default `size` reflection
+
+If you omit `size`, `<swc-close-button>` reflects **`size="m"`** on the host. Spectrum 1 did not reflect a default attribute, though the visual default was medium. Update DOM selectors or snapshots that assumed no `size` attribute.
+
+## Accessibility
+
+`<swc-close-button>` renders a native inner `<button>` with delegated focus. Keyboard and screen reader behavior matches a standard dismiss control when a discernible name is provided via `accessible-label` or default slot text.
+
+Update tests that asserted host-level button semantics or shadow DOM structure from Spectrum 1.
+
+## Styling
+
+Spectrum 2 exposes reviewed `--swc-close-button-*` custom properties on `<swc-close-button>`.
+
+<div
+  style={{
+    borderLeft: '4px solid #dba842',
+    background: 'rgba(219, 168, 66, 0.12)',
+    padding: '12px 16px',
+    margin: '16px 0',
+    borderRadius: '4px',
+  }}
+>
+  <strong>⚠️ Breaking change.</strong> Spectrum 1{' '}
+  <code>{'--mod-closebutton-*'}</code> properties <strong>do not apply</strong>{' '}
+  to <code>{'<swc-close-button>'}</code>. Remove or replace every{' '}
+  <code>{'--mod-closebutton-*'}</code> override with the{' '}
+  <code>{'--swc-close-button-*'}</code> equivalents below.
+</div>
+
+### Public custom properties
+
+| Custom property                               | Description                               |
+| --------------------------------------------- | ----------------------------------------- |
+| `--swc-close-button-size`                     | Inline and block size of the close button |
+| `--swc-close-button-icon-size`                | Size of the cross icon                    |
+| `--swc-close-button-border-radius`            | Corner radius                             |
+| `--swc-close-button-icon-color-default`       | Cross icon color in the default state     |
+| `--swc-close-button-icon-color-hover`         | Cross icon color when hovered             |
+| `--swc-close-button-icon-color-down`          | Cross icon color when pressed             |
+| `--swc-close-button-icon-color-focus`         | Cross icon color when keyboard focused    |
+| `--swc-close-button-icon-color-disabled`      | Cross icon color when disabled            |
+| `--swc-close-button-background-color-default` | Background color in the default state     |
+| `--swc-close-button-background-color-hover`   | Background color when hovered             |
+| `--swc-close-button-background-color-down`    | Background color when pressed             |
+| `--swc-close-button-background-color-focus`   | Background color when keyboard focused    |
+| `--swc-close-button-focus-indicator-color`    | Focus ring color                          |
+
+<div
+  style={{
+    borderLeft: '4px solid #e34850',
+    background: 'rgba(227, 72, 80, 0.10)',
+    padding: '12px 16px',
+    margin: '16px 0',
+    borderRadius: '4px',
+  }}
+>
+  <strong>🚫 Do not target internals.</strong> Internal classes,{' '}
+  <code>{'--_swc-close-button-*'}</code> private properties, and shadow DOM are{' '}
+  <strong>not public API</strong>. Styling applied to them will break without
+  warning on minor releases.
+</div>
+
+## Checklist
+
+- [ ] Update imports
+- [ ] Rename all `<sp-close-button>` to `<swc-close-button>`
+- [ ] Rename `label` to `accessible-label`
+- [ ] Replace `variant="white|black"` with `static-color="white|black"`
+- [ ] Replace `--mod-closebutton-*` overrides with `--swc-close-button-*` equivalents
+- [ ] Update tests for inner `<button>` semantics and default `size="m"` reflection

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -144,7 +144,6 @@ export const StaticColors: Story = {
       })}
     </div>
     <div style="display: flex; align-items: center; gap: 16px;">
-      ${template({ ...args, 'accessible-label': 'Close (default)' })}
       ${template({
         ...args,
         'static-color': 'black',

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -95,6 +95,23 @@ export const Overview: Story = {
 };
 
 // ──────────────────────────
+//    ANATOMY STORY
+// ──────────────────────────
+
+export const Anatomy: Story = {
+  render: (args) => html`
+    <swc-close-button
+      size=${args.size}
+      static-color=${args['static-color'] ?? ''}
+      accessible-label="Close"
+    >
+      Close
+    </swc-close-button>
+  `,
+  tags: ['anatomy'],
+};
+
+// ──────────────────────────
 //    OPTIONS STORIES
 // ──────────────────────────
 

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -54,7 +54,8 @@ args['accessible-label'] = 'Close';
 /**
  * Close buttons dismiss dialogs, banners, toasts, and similar surfaces. They
  * are compact, icon-forward controls that require an accessible name describing
- * the dismiss action.
+ * the dismiss action. For primary actions, see
+ * [Button](../?path=/docs/components-button--docs).
  */
 const meta: Meta = {
   title: 'Close Button',
@@ -65,6 +66,10 @@ const meta: Meta = {
   parameters: {
     docs: {
       subtitle: 'Compact dismiss control for overlays and chrome regions',
+    },
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/Mngz9H7WZLbrCvGQf3GnsY/S2---Web--Desktop-scale-?node-id=125265-577',
     },
   },
   tags: ['migrated'],
@@ -99,14 +104,8 @@ export const Overview: Story = {
 // ──────────────────────────
 
 export const Anatomy: Story = {
-  render: (args) => html`
-    <swc-close-button
-      size=${args.size}
-      static-color=${args['static-color'] ?? ''}
-      accessible-label="Close"
-    >
-      Close
-    </swc-close-button>
+  render: () => html`
+    <swc-close-button accessible-label="Close">Close</swc-close-button>
   `,
   tags: ['anatomy'],
 };
@@ -130,19 +129,22 @@ export const Sizes: Story = {
     </div>
   `,
   tags: ['options'],
+  parameters: {
+    flexLayout: 'row-wrap',
+  },
 };
 
 export const StaticColors: Story = {
   render: (args) => html`
-    <div
-      style="display: flex; align-items: center; gap: 16px; padding: 16px; background: var(--spectrum-gray-800, #222);"
-    >
-      ${template({ ...args, 'accessible-label': 'Close (default)' })}
+    <div style="display: flex; align-items: center; gap: 16px;">
       ${template({
         ...args,
         'static-color': 'white',
         'accessible-label': 'Close (white)',
       })}
+    </div>
+    <div style="display: flex; align-items: center; gap: 16px;">
+      ${template({ ...args, 'accessible-label': 'Close (default)' })}
       ${template({
         ...args,
         'static-color': 'black',
@@ -151,7 +153,12 @@ export const StaticColors: Story = {
     </div>
   `,
   tags: ['options'],
+  parameters: {
+    flexLayout: false,
+    staticColorsDemo: true,
+  },
 };
+StaticColors.storyName = 'Static colors';
 
 // ──────────────────────────
 //    STATES STORIES
@@ -165,6 +172,9 @@ export const States: Story = {
     </div>
   `,
   tags: ['states'],
+  parameters: {
+    flexLayout: 'row-wrap',
+  },
 };
 
 // ────────────────────────────────

--- a/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
@@ -371,8 +371,8 @@ export const StaticColorsStoryTest: Story = {
       const closeButtons = canvasElement.querySelectorAll('swc-close-button');
       expect(
         closeButtons.length,
-        'default and static color examples render'
-      ).toBe(3);
+        'static color examples render'
+      ).toBe(2);
     });
   },
 };

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/close-button/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/close-button/migration-plan.md
@@ -55,7 +55,7 @@
 
 ## TL;DR
 
-- `swc-close-button` should ship as a dedicated 2nd-gen component in both `core` and `swc` layers, not as an extension point buried inside `swc-button`.
+- `swc-close-button` should ship as a dedicated 2nd-gen SWC component extending `ButtonBase`, not as an extension point buried inside `swc-button`.
 - API should align with modern button conventions: `accessible-label` (consumer-facing), `static-color`, and `size` (`s|m|l|xl`).
 - 2nd-gen does not ship the 1st-gen `variant="white|black"` alias; use `static-color` only. Deprecation of `variant` is a 1st-gen (`sp-close-button`) concern.
 - Styling source of truth is Spectrum CSS `spectrum-two` `components/closebutton`; 2nd-gen should not re-expose the 1st-gen `--mod-closebutton-*` surface.
@@ -63,7 +63,7 @@
 
 ### Most blocking open questions
 
-- [Q1](#architecture-and-behavior): Confirm whether `icon-size` should be a public API in SWC or kept internal.
+None at this time. [Q1](#architecture-and-behavior) (icon scale) is resolved: no `icon-size` attribute; scale follows `size`, with optional `--swc-close-button-icon-size` CSS override only.
 
 ---
 
@@ -129,7 +129,7 @@ No close-button-specific custom events.
 `close-button` should follow this order:
 
 1. Finish this plan and rendering analysis.
-2. Scaffold 2nd-gen `core` and `swc` close-button files.
+2. Scaffold `swc-close-button` (reuse `ButtonBase` from core).
 3. Land API + accessibility behavior before visual parity.
 4. Land S2 styling and then tests/docs.
 
@@ -169,7 +169,7 @@ Prerequisite dependency:
 
 | # | What is added | Notes |
 | --- | --- | --- |
-| A1 | Optional icon-scale API (`icon-size`) | Add only if design and implementation both require it. |
+| A1 | Optional icon-scale API (`icon-size`) | Resolved: no attribute; icon scale follows `size`. Consumers may override via `--swc-close-button-icon-size` only. |
 | A2 | Expanded public custom property set | Keep minimal initially; expand only for proven consumer needs. |
 
 ---
@@ -263,7 +263,7 @@ Prerequisite dependency:
 
 | # | Item | Blocking? | Status | Owner |
 | --- | --- | --- | --- | --- |
-| Q1 | Should `icon-size` be exposed in public API, or remain internal visual implementation detail? | Yes | Open | Design + implementation |
+| Q1 | Should `icon-size` be exposed in public API, or remain internal visual implementation detail? | No | Resolved — no `icon-size` attribute; scale follows `size` with optional `--swc-close-button-icon-size` CSS override | Design + implementation |
 
 ### Scope and prerequisites
 


### PR DESCRIPTION
## Description
  Phases **5 (Styling)** and **7 (Documentation)** for the `swc-close-button` 2nd-gen migration. Replaces stub CSS with 
  Spectrum 2 close-button visuals ported from `spectrum-css` `spectrum-two` `components/closebutton/index.css`, and adds the 
  Storybook docs surface reviewers need to verify visuals.

  **SWC (`2nd-gen/packages/swc/components/close-button/`)**
  - `close-button.css` — S2 token mapping for size (`s|m|l|xl`), default and static-color treatments (`white|black` via 
  `:host([static-color])`), hover/active/focus/disabled states, pseudo-element focus ring, and `forced-colors` overrides
  - Exposes reviewed `--swc-close-button-*` custom properties (size, icon size, border radius, icon/background colors per 
  state, focus indicator color)
  - `CloseButton.ts` — `@cssprop` JSDoc for exposed custom properties; static-color styling is host-driven (removed unused 
  `--staticWhite` / `--staticBlack` modifier classes on the inner button)
  - `close-button.mdx` — component docs (Anatomy, Options, States, Accessibility)
  - `migration-guide.mdx` — consumer migration guide (`sp-close-button` → `swc-close-button`, `label` → `accessible-label`, 
  drop `variant`, `--mod-closebutton-*` → `--swc-close-button-*`)
  - `stories/close-button.stories.ts` — Anatomy story, Figma design link, `flexLayout` / `staticColorsDemo` params, 
  static-color demo panels (white on dark gradient; default + black on light)
  **Also:** `migration-plan.md` — TL;DR/architecture/Q1 (`icon-size`) aligned with `ButtonBase`-only setup.
  No API contract changes in this PR.
  ## Motivation and context
  Close-button previously shipped with layout-only stub styles and a minimal docs page, which made visual review difficult. 
  This PR brings Spectrum 2 visual parity (hit target sizing, interactive feedback, static-color treatments, keyboard focus
  ring) and the Storybook docs/migration guide needed to review and adopt those visuals.
  Part of the close-button washing-machine migration (Epic SWC-2087).
  ## Related issue(s)
  - Epic SWC-2087 (2nd-gen close-button migration)
  ## Screenshots (if appropriate)
  _Storybook → Close Button → Docs — verify Anatomy, Sizes, Static colors, States, and Accessibility canvases. Also check 
  Close Button/Migration guide._
  ## Notes for reviewers
  - **`pending` / `pending-label` in the API table** — inherited from `ButtonBase` for now; close-button does not implement 
  pending visuals. Expected to clear when pending moves off `ButtonBase` (separate button workstream).
  - **`size` description blank in API table** — CEM inherits `size` from `SizedMixin` without field-level JSDoc; known docs 
  quirk, not a functional gap.
  ---
  ## Author's checklist
  - [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and 
  **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
  - [x] I have reviewed the Accessibility Practices for this feature, see: [Aria 
  Practices](https://www.w3.org/TR/wai-aria-practices/)
  - [ ] I have added automated tests to cover my changes. _(Existing Storybook interaction tests pass; expanded Playwright 
  a11y snapshots deferred to next PR.)_
  - [ ] I have included a well-written changeset if my change needs to be published. _(Planned for merge-ready / Phase 8 
  pass.)_
  - [x] I have included updated documentation if my change required it. _(Component MDX + consumer migration guide.)_
  ---
  ## Reviewer's checklist
  - [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
  - [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
  - [ ] Automated tests cover all use cases and follow best practices for writing
  - [ ] Validated on all supported browsers
  - [ ] All VRTs are approved before the author can update Golden Hash
  ### Manual review test cases
  - [ ] **Docs page**
    1. Open Storybook → Close Button → Docs
    2. Walk Anatomy, Options (Sizes, Static colors), States, and Accessibility sections
    3. Expect prose + canvases to render; API table shows `@cssprop` entries
  - [ ] **Migration guide**
    1. Open Storybook → Close Button/Migration guide
    2. Review renamed API, removed `variant`, and CSS custom property table
    3. Expect checklist and code samples to match shipped API
  - [ ] **Size scale**
    1. Open Storybook → Close Button → Sizes (Docs or story)
    2. Compare `s`, `m`, `l`, `xl` hit targets and cross icon scale
    3. Expect progressively larger square buttons with matching icon sizes; medium is the default when `size` is omitted
  - [ ] **Static colors**
    1. Open Storybook → Close Button → Static colors
    2. Compare `static-color="white"` on the dark gradient panel, then default and `static-color="black"` on the light panel
    3. Expect readable icon contrast; hover/active/focus show subtle background fills per S2
  - [ ] **Interactive states**
    1. Open Storybook → Close Button → States
    2. Hover, press, and Tab-focus the enabled button; compare disabled example
    3. Expect hover/active background on enabled only; visible focus ring on keyboard focus; disabled is faded and 
  non-interactive
  - [ ] **Focus ring**
    1. Open Storybook → Close Button → Playground
    2. Tab to the close button (keyboard only, not mouse click)
    3. Expect pseudo-element focus ring outside the circular hit target; ring color follows default or static-color treatment
  ### Device review
  - [ ] Did it pass in Desktop?
  - [ ] Did it pass in (emulated) Mobile?
  - [ ] Did it pass in (emulated) iPad?
  ## Accessibility testing checklist
  Close button a11y **behavior** (inner button, accessible name, keyboard activation) landed in the stacked API PR. This PR 
  affects **visual** focus/state presentation and **documents** accessible usage patterns.
  - [ ] **Keyboard** (required)
    1. Open Storybook → Close Button → Accessibility (Docs canvas)
    2. Tab to each close button example
    3. Expect focus on the dismiss control via delegated focus; Enter/Space activate; disabled example does not activate; 
  focus ring visible on `:focus-visible`
  - [ ] **Screen reader** (required)
    1. Open Storybook → Close Button → Accessibility with VoiceOver or NVDA
    2. Navigate to the `accessible-label` and slot-label examples
    3. Expect role "button" with name "Close" / "Dismiss" / "Close dialog"; cross icon not announced separately 
  (`aria-hidden`)