### PR TITLE
docs(opacity-checkerboard): fixed missing docs section

### DIFF
--- a/2nd-gen/packages/swc/components/opacity-checkerboard/opacity-checkerboard.internal.mdx
+++ b/2nd-gen/packages/swc/components/opacity-checkerboard/opacity-checkerboard.internal.mdx
@@ -21,6 +21,72 @@ Apply `.swc-OpacityCheckerboard` to a decorative element rendered behind transpa
 2. Add the styles to your styles array.
 3. Add the `swc-OpacityCheckerboard` class to the `span` or `div` element where you want the checkerboard to appear, and make sure the element is `aria-hidden="true"`.
 
+```typescript
+import { css, html, LitElement, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import opacityCheckerboardStyles from '@spectrum-web-components//stylesheets/shared/opacity-checkerboard.css';
+export class DemoOpacityCheckerboardSwatch extends LitElement {
+  /**
+   * Adopt the shared fragment into this element's shadow root, then layer the
+   * component-local styles on top.
+   */
+  static override styles = [
+    opacityCheckerboardStyles,
+    css`
+      :host {
+        display: inline-block;
+      }
+      .swatch {
+        position: relative;
+        inline-size: 120px;
+        block-size: 120px;
+        border: 1px solid var(--swc-gray-300, #ccc);
+        border-radius: 4px;
+        overflow: hidden;
+      }
+      /* Decorative checkerboard and the color fill share the swatch box. */
+      .swc-OpacityCheckerboard,
+      .fill {
+        position: absolute;
+        inset: 0;
+      }
+      .fill {
+        background: var(--demo-fill, transparent);
+      }
+    `,
+  ];
+  /** Human-readable name including opacity; lives on the control, not the pattern. */
+  @property()
+  public label = '';
+  /** CSS color for the fill layer, e.g. `rgba(255, 0, 0, 0.4)` or `transparent`. */
+  @property()
+  public color = 'transparent';
+  /** Checkerboard square size: medium (default, no modifier) or small. */
+  @property({ reflect: true })
+  public size: 'm' | 's' = 'm';
+  protected override render(): TemplateResult {
+    const sizeClass = this.size === 's' ? 'swc-OpacityCheckerboard--sizeS' : '';
+    return html`
+      <div
+        class="swatch"
+        role="img"
+        aria-label=${this.label || 'Color preview'}
+        style="--demo-fill: ${this.color}"
+      >
+        <!-- Decoration only: hidden from assistive technologies, never focusable. -->
+        <span
+          class="swc-OpacityCheckerboard ${sizeClass}"
+          aria-hidden="true"
+        ></span>
+        <span class="fill" aria-hidden="true"></span>
+      </div>
+    `;
+  }
+}
+```
+
+## Options
+
 ### Sizes
 
 The default square size uses the medium token. The `.swc-OpacityCheckerboard--sizeS` modifier switches to the small token, halving the square size.
@@ -54,3 +120,4 @@ The shared `css` fragment sets no ARIA. It only keeps `forced-color-adjust: none
 <Canvas of={Stories.Accessibility} />
 
 <DocsFooter />
+```


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

Fixes missing content from opacity-checkerboard docs in 2nd-gen PR that was merged (https://github.com/adobe/spectrum-web-components/pull/6378)

<!--- Describe your changes in detail -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
I had a syntax error in my suggested code for my review. When it got applied, my re-review was requested (dismissing my prior review) and the PR was set to automerge, it merged before my re-reviews since it already had 2 acceptances.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- fixes PR#6378

## Screenshots (if appropriate)
<img width="1418" height="947" alt="Screenshot 2026-06-10 at 2 37 30 PM" src="https://github.com/user-attachments/assets/63673009-53b5-4efd-85d5-ae3e13dfd45b" />
Notice that the Options heading is missing, and there is no demo doc in the Usage section.
---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

- [ ] _Descriptive Test Statement_
  1. Checkout the branch (opacity checkerboard docs only show in internally dev mode).
  2. Start second gen storybook locally.
  3. Verify that the usage heading is back and that there is a code sample in the Usage section above it.