### PR TITLE
fix(action-menu): additional action menu test fixes

### DIFF
--- a/1st-gen/packages/action-menu/test/index.ts
+++ b/1st-gen/packages/action-menu/test/index.ts
@@ -292,6 +292,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
       `);
       const opened = oneEvent(el, 'sp-opened');
       el.focus();
+      await elementUpdated(el);
       await sendKeys({ press: 'Enter' });
       await opened;
       await nextFrame();
@@ -636,6 +637,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
       expect(el.value).to.not.equal(thirdItem.value);
       const opened = oneEvent(el, 'sp-opened');
       el.focus();
+      await elementUpdated(el);
       await sendKeys({ press: 'Enter' });
       await opened;
 
@@ -654,6 +656,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
       expect(el.value).to.not.equal(thirdItem.value);
       const opened = oneEvent(el, 'sp-opened');
       el.focus();
+      await elementUpdated(el);
       await sendKeys({ press: 'Enter' });
       await opened;
 


### PR DESCRIPTION
## Description

In three tests — "has menuitems in accessibility tree", "returns focus on Escape", and "returns focus on select" — `sendKeys({ press: 'Enter' })` was called immediately after `el.focus()` with no Lit update cycle between them. `sp-action-menu` inherits `delegatesFocus: true` from its Picker base, so focus delegation into the shadow root's internal button happens asynchronously during Lit's update cycle. Without `await elementUpdated(el)`, the Enter keydown handler on the internal button was never reached, the menu never opened, and `await oneEvent(el, 'sp-opened')` hung indefinitely.

Added `await elementUpdated(el)` after `el.focus()` in each of the three affected tests to allow Lit to complete the update cycle (and shadow focus delegation) before the key event fires.

## Motivation and context

Both `action-menu.test.js` and `action-menu-sync.test.js` were timing out after 60 seconds consistently across all three browsers. `sendKeys` is a server command that targets `document.activeElement` in the browser — if focus delegation hasn't completed, the key lands nowhere useful and the test hangs on the `sp-opened` event.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.

## Accessibility testing checklist

- [x] **Keyboard** — This is a test-only fix. The production keyboard behavior of `sp-action-menu` is unchanged. Keyboard tests that previously hung now exercise <kbd>Enter</kbd> to open, <kbd>Escape</kbd> to dismiss, and item selection via click — all verified passing across Chromium, Firefox, and WebKit.

- [x] **Screen reader** — No production code changed; screen reader behavior is unaffected. The accessibility tree snapshot test ("has menuitems in accessibility tree") now runs to completion and verifies that menu items are correctly exposed in the a11y tree after keyboard activation.