### PR TITLE
feat(button): extract pending state into a reusable PendingController

### DIFF
--- a/2nd-gen/packages/core/components/button/Button.base.ts
+++ b/2nd-gen/packages/core/components/button/Button.base.ts
@@ -11,7 +11,7 @@
  */
 
 import { PropertyValues } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
 
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
 import {
@@ -61,41 +61,15 @@ export abstract class ButtonBase extends SizedMixin(
   public disabled: boolean = false;
 
   /**
-   * Whether the button is in a pending (busy) state. The button remains
-   * focusable but activation is suppressed.
-   */
-  @property({ type: Boolean, reflect: true })
-  public pending: boolean = false;
-
-  /**
    * Accessible label forwarded to the internal `<button>` element as
    * `aria-label`. Required for icon-only buttons, which have no visible text.
    */
   @property({ type: String, attribute: 'accessible-label' })
   public accessibleLabel?: string;
 
-  /**
-   * Custom accessible label used during the pending state. When omitted,
-   * the pending label is derived from the resolved non-busy accessible name
-   * plus a busy suffix (e.g. "Save, busy").
-   */
-  @property({ type: String, attribute: 'pending-label' })
-  public pendingLabel?: string;
-
-  /**
-   * Tracks whether the pending visual (disabled colors + spinner) is currently
-   * active. Set to `true` after a 1-second delay once `pending` becomes true,
-   * so the button does not immediately flash to its unavailable appearance.
-   * Protected so subclasses can reference it in their `classMap` binding.
-   */
-  @state()
-  protected pendingActive: boolean = false;
-
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────
-
-  private _pendingTimer: ReturnType<typeof setTimeout> | null = null;
 
   protected get hasIcon(): boolean {
     return this.slotContentIsPresent;
@@ -117,21 +91,6 @@ export abstract class ButtonBase extends SizedMixin(
   }
 
   /**
-   * Derives the pending-state accessible label. Prefers an explicit
-   * `pendingLabel`, then falls back to the resolved non-busy accessible
-   * name plus a ", busy" suffix, then a fixed "Busy" fallback.
-   *
-   * @internal
-   */
-  protected getPendingAccessibleName(): string {
-    if (this.pendingLabel) {
-      return this.pendingLabel;
-    }
-    const resolvedName = this.getResolvedAccessibleName();
-    return resolvedName ? `${resolvedName}, busy` : 'Busy';
-  }
-
-  /**
    * Returns the set of attributes that should be forwarded to the internal
    * semantic `<button>` element, if not otherwise directly managed.
    *
@@ -143,8 +102,17 @@ export abstract class ButtonBase extends SizedMixin(
   > {
     return {
       disabled: this.disabled,
-      'aria-disabled': this.pending && !this.disabled ? 'true' : undefined,
     };
+  }
+
+  /**
+   * Whether activation (click) should be suppressed. Subclasses extend this to
+   * add their own unavailable conditions (e.g. a pending state).
+   *
+   * @internal
+   */
+  protected isActivationSuppressed(): boolean {
+    return this.disabled;
   }
 
   public override connectedCallback(): void {
@@ -156,65 +124,27 @@ export abstract class ButtonBase extends SizedMixin(
 
   public override disconnectedCallback(): void {
     this.removeEventListener('click', this.handleClick, true);
-    if (this._pendingTimer !== null) {
-      clearTimeout(this._pendingTimer);
-      this._pendingTimer = null;
-    }
-    this.pendingActive = false;
     super.disconnectedCallback();
   }
 
   /**
-   * Suppresses click activation while the button is `disabled` or `pending`.
+   * Suppresses click activation while the button is unavailable (see
+   * {@link isActivationSuppressed}).
    *
    * Slotted icon content lives in the light DOM, so pointer clicks on icons
    * bypass the disabled inner `<button>` and bubble on the host. The host
    * listener (capture) and inner `@click` binding both call this handler.
    */
   protected readonly handleClick = (event: Event): void => {
-    if (this.disabled || this.pending) {
+    if (this.isActivationSuppressed()) {
       event.preventDefault();
       event.stopImmediatePropagation();
     }
   };
 
   protected override update(changedProperties: PropertyValues): void {
-    if (changedProperties.has('pending')) {
-      if (this.pending) {
-        this._pendingTimer = setTimeout(() => {
-          if (this.pending) {
-            const internalButton = this.renderRoot.querySelector('button');
-            if (internalButton) {
-              internalButton.style.setProperty(
-                '--_swc-button-pending-inline-size',
-                `${internalButton.offsetWidth}px`
-              );
-            }
-            this.pendingActive = true;
-          }
-          this._pendingTimer = null;
-        }, 1000);
-      } else {
-        if (this._pendingTimer !== null) {
-          clearTimeout(this._pendingTimer);
-          this._pendingTimer = null;
-        }
-        this.renderRoot
-          .querySelector('button')
-          ?.style.removeProperty('--_swc-button-pending-inline-size');
-        this.pendingActive = false;
-      }
-    }
     super.update(changedProperties);
     if (window.__swc?.DEBUG) {
-      if (this.pending && this.disabled) {
-        window.__swc.warn(
-          this,
-          `<${this.localName}> should not set both "pending" and "disabled" simultaneously. Use "pending" to keep the button focusable while unavailable, or "disabled" to fully remove it from the tab order.`,
-          'https://opensource.adobe.com/spectrum-web-components/components/button/#pending',
-          { issues: ['pending + disabled'] }
-        );
-      }
       if (this.hasIcon && !this.hasLabel && !this.accessibleLabel) {
         window.__swc.warn(
           this,

--- a/2nd-gen/packages/core/controllers/index.ts
+++ b/2nd-gen/packages/core/controllers/index.ts
@@ -31,6 +31,12 @@ export {
   languageResolverUpdatedSymbol,
 } from './language-resolution.js';
 export {
+  PendingController,
+  pendingControllerStyles,
+  type PendingControllerHost,
+  type PendingControllerOptions,
+} from './pending-controller/index.js';
+export {
   ALL_PLACEMENTS,
   fromFloatingPlacement,
   PlacementController,

--- a/2nd-gen/packages/core/controllers/pending-controller/index.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export {
+  PendingController,
+  pendingControllerStyles,
+  type PendingControllerHost,
+  type PendingControllerOptions,
+} from './src/pending-controller.js';

--- a/2nd-gen/packages/core/controllers/pending-controller/pending-controller.mdx
+++ b/2nd-gen/packages/core/controllers/pending-controller/pending-controller.mdx
@@ -93,6 +93,14 @@ A `pendingLabel` on the host overrides the derived name and is used verbatim as 
 
 <Canvas of={Stories.ExplicitPendingLabel} />
 
+### Focus retained on re-render
+
+When `pendingActive` transitions from `false` to `true`, the controller calls `host.requestUpdate()`, which triggers a Lit re-render. Because lit-html patches the DOM in place rather than replacing elements, the focused `<button>` element is not destroyed; its class and content are updated around it. Focus remains on the button throughout the re-render.
+
+Click the button below to start a pending operation. The button receives focus via the click and re-renders after the controller's delay. Focus is preserved.
+
+<Canvas of={Stories.FocusRetained} />
+
 ## Accessibility
 
 ### Features

--- a/2nd-gen/packages/core/controllers/pending-controller/pending-controller.mdx
+++ b/2nd-gen/packages/core/controllers/pending-controller/pending-controller.mdx
@@ -1,0 +1,153 @@
+{/* Copyright 2026 Adobe. All rights reserved. This file is licensed to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */}
+
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { DocsFooter, DocsHeader } from '../../../swc/.storybook/blocks';
+
+import * as Stories from './stories/pending-controller.stories';
+
+<Meta of={Stories} />
+
+<DocsHeader />
+
+## Usage
+
+`PendingController` encapsulates the pending (busy) state so consuming components do not duplicate the timing, layout, accessibility-name, and spinner logic. It is used by [Button](../?path=/docs/button--docs) and is reusable by any component that exposes a `pending` property.
+
+### What it does
+
+- **Delayed activation** — the busy visual (`pendingActive`) turns on only after a `delay` (1000 ms by default) so operations that complete quickly never flash to a busy appearance.
+- **Inline-size freeze** — just before activating, it measures the target element's width and locks it via the `--swc-pending-inline-size` custom property, so the host does not collapse when its label and icon are hidden.
+- **Derived busy name** — `getPendingAccessibleName()` returns the explicit `pendingLabel`, otherwise the resolved non-busy name plus a `", busy"` suffix, otherwise `"Busy"`.
+- **Spinner rendering** — `renderPendingState()` renders an animated SVG spinner while `pendingActive` is true. Its structure and animation ship in `pendingControllerStyles`; colors and size are themeable via custom properties so the controller carries no design-token dependency.
+
+### What the host owns
+
+- The `pending` and `pendingLabel` reactive properties.
+- Applying `aria-disabled` and the pending `aria-label` in its own template, keyed off `pending` for an immediate (non-delayed) response.
+- Theming the spinner (`--swc-pending-spinner-*`) and consuming `--swc-pending-inline-size`.
+
+### Basic usage
+
+1. Add `pendingControllerStyles` to the host's `static styles`.
+2. Construct the controller, passing a `resolveAccessibleName` callback so it can derive the busy name without coupling to the host's naming logic.
+3. Apply `pendingController.pendingActive` and `pendingController.renderPendingState()` in `render()`.
+
+```typescript
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import {
+  PendingController,
+  pendingControllerStyles,
+} from '@spectrum-web-components/core/controllers/pending-controller';
+
+class SwcButton extends LitElement {
+  @property({ type: Boolean, reflect: true }) pending = false;
+  @property({ attribute: 'pending-label' }) pendingLabel?: string;
+
+  static styles = [pendingControllerStyles];
+
+  private readonly pendingController = new PendingController(this, {
+    resolveAccessibleName: () => this.textContent?.trim() ?? null,
+  });
+
+  render() {
+    return html`
+      <button
+        class=${classMap({
+          active: this.pendingController.pendingActive,
+        })}
+        aria-disabled=${ifDefined(this.pending ? 'true' : undefined)}
+        aria-label=${ifDefined(
+          this.pending
+            ? this.pendingController.getPendingAccessibleName()
+            : undefined
+        )}
+      >
+        <slot></slot>
+        ${this.pendingController.renderPendingState()}
+      </button>
+    `;
+  }
+}
+```
+
+## Behaviors
+
+### Delayed activation
+
+Setting `pending` does not immediately change the host's appearance. The controller waits `delay` milliseconds, then measures the target, freezes its inline size, sets `pendingActive`, and requests a host update. If `pending` returns to `false` before the delay elapses, the timer is cancelled and nothing flashes. The demo below uses a shortened 250 ms delay.
+
+<Canvas of={Stories.DelayedActivation} />
+
+### Derived busy name
+
+When no explicit `pendingLabel` is set, the controller derives the busy accessible name from the `resolveAccessibleName` callback plus a `", busy"` suffix (for example, `"Save, busy"`). When the callback returns nothing, it falls back to `"Busy"`.
+
+<Canvas of={Stories.DerivedBusyName} />
+
+### Explicit pending label
+
+A `pendingLabel` on the host overrides the derived name and is used verbatim as the pending accessible label.
+
+<Canvas of={Stories.ExplicitPendingLabel} />
+
+## Accessibility
+
+### Features
+
+- The host stays focusable while busy; the controller never sets the native `disabled` attribute. The host applies `aria-disabled="true"` so assistive technology announces the control as unavailable while it remains in the tab order.
+- The pending accessible name (`getPendingAccessibleName()`) communicates the busy state by name rather than relying on the spinner, which is rendered `aria-hidden`.
+- The spinner respects `prefers-reduced-motion`: its animation slows to a steady 15 s linear rotation with no dash-offset pulsing.
+
+### Best practices
+
+- Apply `aria-disabled` and the pending `aria-label` in the host template keyed off `pending` (not `pendingActive`) so the busy state is announced immediately, before the visual delay.
+- Provide a `resolveAccessibleName` callback that returns the control's normal name so the derived busy label is meaningful.
+- Theme `--swc-pending-spinner-track-color` and `--swc-pending-spinner-fill-color` to maintain sufficient contrast against the host's busy background.
+
+<Canvas of={Stories.Accessibility} />
+
+## API
+
+### Methods
+
+| Member                       | Returns                            | Description                                                                                                       |
+| ---------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `pendingActive`              | `boolean` (getter)                 | Whether the busy visual is active. Becomes `true` after `delay` once `pending` turns true. Read this in `render`. |
+| `getPendingAccessibleName()` | `string`                           | The pending accessible name: `pendingLabel`, else `"<name>, busy"`, else `"Busy"`.                                |
+| `renderPendingState()`       | `TemplateResult \| typeof nothing` | The animated spinner while `pendingActive`, otherwise `nothing`.                                                  |
+
+### Exports
+
+| Export                    | Description                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------------ |
+| `pendingControllerStyles` | A `CSSResult` with the spinner structure and animation. Add to the host's `static styles` array. |
+
+### Constructor options (`PendingControllerOptions`)
+
+| Option                  | Type                   | Default      | Description                                                                                                            |
+| ----------------------- | ---------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `delay`                 | `number`               | `1000`       | Milliseconds to wait after `pending` becomes true before activating the busy visual.                                   |
+| `targetSelector`        | `string \| null`       | `'button'`   | Selector (within the host's `renderRoot`) for the element whose inline size is frozen. Pass `null` to skip the freeze. |
+| `resolveAccessibleName` | `() => string \| null` | `() => null` | Returns the host's non-busy accessible name, used to derive the default busy label.                                    |
+
+### Host interface (`PendingControllerHost`)
+
+| Member         | Type      | Description                                                                             |
+| -------------- | --------- | --------------------------------------------------------------------------------------- |
+| `pending`      | `boolean` | Whether the host is in a pending (busy) state.                                          |
+| `pendingLabel` | `string`  | Optional explicit accessible label used while pending; overrides the derived busy name. |
+
+### Spinner theming custom properties
+
+| Custom property                     | Default        | Description                                                                      |
+| ----------------------------------- | -------------- | -------------------------------------------------------------------------------- |
+| `--swc-pending-spinner-size`        | `1em`          | Inline and block size of the spinner.                                            |
+| `--swc-pending-spinner-track-color` | `currentColor` | Color of the static track ring.                                                  |
+| `--swc-pending-spinner-fill-color`  | `currentColor` | Color of the animated fill arc.                                                  |
+| `--swc-pending-spinner-thickness`   | `2px`          | Stroke width of both rings.                                                      |
+| `--swc-pending-inline-size`         | —              | Set by the controller on the freeze target; consume via `inline-size: var(...)`. |
+
+<DocsFooter />

--- a/2nd-gen/packages/core/controllers/pending-controller/src/pending-controller.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/src/pending-controller.ts
@@ -1,0 +1,352 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  css,
+  html,
+  nothing,
+  type ReactiveController,
+  type ReactiveElement,
+  type TemplateResult,
+} from 'lit';
+
+// ─────────────────────────
+//     TYPES
+// ─────────────────────────
+
+/** Minimum interface required from any element that hosts a {@link PendingController}. */
+export interface PendingControllerHost extends ReactiveElement {
+  /** Whether the host is in a pending (busy) state. */
+  pending: boolean;
+
+  /**
+   * Optional explicit accessible label used during the pending state. When
+   * omitted, the controller derives a busy label from
+   * {@link PendingControllerOptions.resolveAccessibleName}.
+   */
+  pendingLabel?: string;
+}
+
+/** Configuration options for {@link PendingController}. */
+export interface PendingControllerOptions {
+  /**
+   * Milliseconds to wait after `pending` becomes true before activating the
+   * pending visual, so the host does not flash to its busy appearance for
+   * operations that complete quickly. Defaults to `1000`.
+   */
+  delay?: number;
+
+  /**
+   * CSS selector, resolved within the host's `renderRoot`, for the element
+   * whose inline size should be frozen while pending (via
+   * `--swc-pending-inline-size`) so the host does not resize when its label or
+   * icon is hidden. Defaults to `'button'`. Pass `null` to skip the freeze.
+   */
+  targetSelector?: string | null;
+
+  /**
+   * Returns the host's non-busy accessible name, used to derive the default
+   * busy label (`"<name>, busy"`). Keeps the controller decoupled from how the
+   * host resolves its own name.
+   */
+  resolveAccessibleName?: () => string | null;
+}
+
+const DEFAULT_DELAY = 1000;
+
+/**
+ * Custom property the controller sets on the freeze target to lock its measured
+ * inline size while pending. Consumers apply it via `inline-size: var(...)`.
+ */
+const INLINE_SIZE_PROPERTY = '--swc-pending-inline-size';
+
+// ─────────────────────────────────────────────────
+//     STYLES
+// ─────────────────────────────────────────────────
+
+/**
+ * Structural and animation styles for the spinner rendered by
+ * {@link PendingController.renderPendingState}. Add to the host's `static
+ * styles` array. Colors and size are themeable via custom properties so the
+ * controller carries no design-token dependency and can be reused by any
+ * component:
+ *
+ * - `--swc-pending-spinner-size` — inline and block size of the spinner. Defaults to `1em`.
+ * - `--swc-pending-spinner-track-color` — color of the static track ring. Defaults to `currentColor`.
+ * - `--swc-pending-spinner-fill-color` — color of the animated fill arc. Defaults to `currentColor`.
+ * - `--swc-pending-spinner-thickness` — stroke width of both rings. Defaults to `2px`.
+ */
+export const pendingControllerStyles = css`
+  @keyframes swc-pending-spinner-rotate {
+    0% {
+      transform: rotate(var(--swc-pending-spinner-rotate-start, -90deg));
+    }
+
+    100% {
+      transform: rotate(var(--swc-pending-spinner-rotate-end, 270deg));
+    }
+  }
+
+  @keyframes swc-pending-spinner-dashoffset {
+    0%,
+    100% {
+      stroke-dashoffset: 75px;
+    }
+
+    30% {
+      stroke-dashoffset: var(--swc-pending-spinner-dashoffset-30, 20px);
+    }
+  }
+
+  .swc-PendingSpinner {
+    flex-shrink: 0;
+    display: inline-block;
+    inline-size: var(--swc-pending-spinner-size, 1em);
+    block-size: var(--swc-pending-spinner-size, 1em);
+  }
+
+  .swc-PendingSpinner-track {
+    stroke: var(--swc-pending-spinner-track-color, currentColor);
+    stroke-width: var(--swc-pending-spinner-thickness, 2px);
+  }
+
+  .swc-PendingSpinner-fill {
+    stroke: var(--swc-pending-spinner-fill-color, currentColor);
+    stroke-width: var(--swc-pending-spinner-thickness, 2px);
+    transform: rotate(-90deg);
+    transform-origin: center;
+    animation:
+      swc-pending-spinner-rotate 1s cubic-bezier(0.6, 0.1, 0.3, 0.9) infinite,
+      swc-pending-spinner-dashoffset 1s cubic-bezier(0.25, 0.1, 0.25, 1.3)
+        infinite;
+    will-change: transform;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .swc-PendingSpinner-fill {
+      --swc-pending-spinner-dashoffset-30: 0;
+      --swc-pending-spinner-rotate-start: 0deg;
+      --swc-pending-spinner-rotate-end: 360deg;
+
+      animation-duration: 15s;
+      animation-timing-function: linear, linear;
+    }
+  }
+`;
+
+// ─────────────────────────────────────────────────
+//     CONTROLLER
+// ─────────────────────────────────────────────────
+
+/**
+ * A Lit {@link ReactiveController} that manages the pending (busy) state of a
+ * host element: the delayed visual activation, freezing the host's inline size
+ * while busy, deriving the pending accessible name, and rendering an animated
+ * spinner.
+ *
+ * The accessible name and `aria-disabled` are applied by the host's own
+ * template (keyed off `host.pending` for an immediate response); this
+ * controller exposes {@link getPendingAccessibleName} for the host to read.
+ * Pair {@link renderPendingState} with {@link pendingControllerStyles}.
+ *
+ * @example
+ * ```ts
+ * class SwcButton extends LitElement implements PendingControllerHost {
+ *   @property({ type: Boolean, reflect: true }) pending = false;
+ *   @property({ attribute: 'pending-label' }) pendingLabel?: string;
+ *
+ *   static styles = [styles, pendingControllerStyles];
+ *
+ *   private pendingController = new PendingController(this, {
+ *     resolveAccessibleName: () => this.getResolvedAccessibleName(),
+ *   });
+ *
+ *   render() {
+ *     return html`
+ *       <button
+ *         class=${classMap({ active: this.pendingController.pendingActive })}
+ *         aria-label=${ifDefined(
+ *           this.pending
+ *             ? this.pendingController.getPendingAccessibleName()
+ *             : undefined
+ *         )}
+ *       >
+ *         <slot></slot>
+ *         ${this.pendingController.renderPendingState()}
+ *       </button>
+ *     `;
+ *   }
+ * }
+ * ```
+ */
+export class PendingController implements ReactiveController {
+  private readonly host: PendingControllerHost;
+  private readonly delay: number;
+  private readonly targetSelector: string | null;
+  private readonly resolveAccessibleName: () => string | null;
+
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Tracks the last-seen `pending` value so transitions can be detected in `hostUpdated`. */
+  private wasPending = false;
+
+  /**
+   * Whether the pending visual is currently active. Becomes `true` only after
+   * the configured delay so the host does not flash to its busy appearance for
+   * operations that complete quickly. Read this from the host's `render` to
+   * apply the busy styling.
+   */
+  public get pendingActive(): boolean {
+    return this._pendingActive;
+  }
+  private _pendingActive = false;
+
+  constructor(
+    host: PendingControllerHost,
+    options: PendingControllerOptions = {}
+  ) {
+    this.host = host;
+    this.delay = options.delay ?? DEFAULT_DELAY;
+    this.targetSelector =
+      options.targetSelector === undefined ? 'button' : options.targetSelector;
+    this.resolveAccessibleName = options.resolveAccessibleName ?? (() => null);
+    host.addController(this);
+  }
+
+  // ─────────────────────────────────────────────────
+  //     PUBLIC API
+  // ─────────────────────────────────────────────────
+
+  /**
+   * Derives the pending-state accessible label. Prefers an explicit
+   * `pendingLabel`, then the resolved non-busy name plus a ", busy" suffix,
+   * then a fixed "Busy" fallback.
+   */
+  public getPendingAccessibleName(): string {
+    if (this.host.pendingLabel) {
+      return this.host.pendingLabel;
+    }
+    const resolvedName = this.resolveAccessibleName();
+    return resolvedName ? `${resolvedName}, busy` : 'Busy';
+  }
+
+  /**
+   * Renders the animated pending spinner while {@link pendingActive} is true,
+   * otherwise renders nothing. Style it via {@link pendingControllerStyles}.
+   */
+  public renderPendingState(): TemplateResult | typeof nothing {
+    if (!this._pendingActive) {
+      return nothing;
+    }
+    return html`
+      <svg
+        class="swc-PendingSpinner"
+        width="100%"
+        height="100%"
+        fill="none"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <circle
+          class="swc-PendingSpinner-track"
+          cx="50%"
+          cy="50%"
+          r="calc(50% - 1px)"
+        />
+        <circle
+          class="swc-PendingSpinner-fill"
+          cx="50%"
+          cy="50%"
+          r="calc(50% - 1px)"
+          pathLength="100"
+          stroke-dasharray="100 200"
+          stroke-dashoffset="75"
+          stroke-linecap="round"
+        />
+      </svg>
+    `;
+  }
+
+  // ─────────────────────────────────────────────────
+  //     LIFECYCLE
+  // ─────────────────────────────────────────────────
+
+  public hostUpdated(): void {
+    if (this.host.pending === this.wasPending) {
+      return;
+    }
+    this.wasPending = this.host.pending;
+    if (this.host.pending) {
+      this.activateAfterDelay();
+    } else {
+      this.deactivate();
+    }
+  }
+
+  public hostDisconnected(): void {
+    this.clearTimer();
+    this.wasPending = false;
+    this._pendingActive = false;
+  }
+
+  // ─────────────────────────────────────────────────
+  //     IMPLEMENTATION
+  // ─────────────────────────────────────────────────
+
+  private activateAfterDelay(): void {
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      // Guard against `pending` flipping back to false after the timer fired
+      // but before this callback ran.
+      if (!this.host.pending) {
+        return;
+      }
+      this.freezeInlineSize();
+      this._pendingActive = true;
+      this.host.requestUpdate();
+    }, this.delay);
+  }
+
+  private deactivate(): void {
+    this.clearTimer();
+    this.releaseInlineSize();
+    if (this._pendingActive) {
+      this._pendingActive = false;
+      this.host.requestUpdate();
+    }
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private get freezeTarget(): HTMLElement | null {
+    if (!this.targetSelector) {
+      return null;
+    }
+    return this.host.renderRoot.querySelector<HTMLElement>(this.targetSelector);
+  }
+
+  private freezeInlineSize(): void {
+    const target = this.freezeTarget;
+    if (target) {
+      target.style.setProperty(INLINE_SIZE_PROPERTY, `${target.offsetWidth}px`);
+    }
+  }
+
+  private releaseInlineSize(): void {
+    this.freezeTarget?.style.removeProperty(INLINE_SIZE_PROPERTY);
+  }
+}

--- a/2nd-gen/packages/core/controllers/pending-controller/stories/demo-hosts.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/stories/demo-hosts.ts
@@ -90,11 +90,13 @@ export class DemoPendingHost extends LitElement {
     pending: { type: Boolean, reflect: true },
     pendingLabel: { type: String, attribute: 'pending-label' },
     label: { type: String },
+    clickPending: { type: Boolean, attribute: 'click-pending' },
   };
 
   declare pending: boolean;
   declare pendingLabel?: string;
   declare label: string;
+  declare clickPending: boolean;
 
   private readonly pendingController = new PendingController(this, {
     delay: 250,
@@ -103,10 +105,32 @@ export class DemoPendingHost extends LitElement {
       this.label || (this.textContent?.trim() ?? null),
   });
 
+  private resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private readonly onButtonClick = (): void => {
+    if (this.pending) {
+      return;
+    }
+    this.pending = true;
+    this.resetTimer = setTimeout(() => {
+      this.resetTimer = null;
+      this.pending = false;
+    }, 2000);
+  };
+
   constructor() {
     super();
     this.pending = false;
     this.label = 'Save';
+    this.clickPending = false;
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback?.();
+    if (this.resetTimer !== null) {
+      clearTimeout(this.resetTimer);
+      this.resetTimer = null;
+    }
   }
 
   protected override render(): TemplateResult {
@@ -123,6 +147,7 @@ export class DemoPendingHost extends LitElement {
             ? this.pendingController.getPendingAccessibleName()
             : undefined
         )}
+        @click=${this.clickPending ? this.onButtonClick : null}
       >
         <span class="demo-button-label">${this.label}</span>
         ${this.pendingController.renderPendingState()}

--- a/2nd-gen/packages/core/controllers/pending-controller/stories/demo-hosts.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/stories/demo-hosts.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { css, html, LitElement, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+import { PendingController, pendingControllerStyles } from '../index.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'demo-pending-host': DemoPendingHost;
+  }
+}
+
+// ────────────────────────────────────────
+//     DEMO HOST
+// ────────────────────────────────────────
+
+/**
+ * @internal
+ *
+ * Storybook-only host that wires `PendingController` onto a minimal `<button>`.
+ * It mirrors how a real component consumes the controller: it owns the `pending`
+ * and `pendingLabel` reactive properties, includes `pendingControllerStyles`,
+ * applies the busy class from `pendingController.pendingActive`, keeps
+ * `aria-disabled` / `aria-label` synchronous with `pending`, and renders the
+ * spinner via `renderPendingState()`.
+ *
+ * A short demo `delay` (250 ms) keeps the visual transition responsive for the
+ * stories without multi-second waits; production hosts use the 1000 ms default.
+ */
+@customElement('demo-pending-host')
+export class DemoPendingHost extends LitElement {
+  static override styles = [
+    pendingControllerStyles,
+    css`
+      :host {
+        display: inline-flex;
+      }
+
+      .demo-button {
+        display: inline-flex;
+        gap: 8px;
+        align-items: center;
+        justify-content: center;
+        min-block-size: 32px;
+        padding-inline: 16px;
+        color: var(--swc-white, #fff);
+        background: var(--swc-blue-900, #2680eb);
+        border: none;
+        border-radius: 16px;
+        font: inherit;
+        cursor: pointer;
+      }
+
+      .demo-button--pendingActive {
+        /* Freeze the measured width so hiding the label does not collapse the
+           button, and swap to an unavailable appearance. */
+        inline-size: var(--swc-pending-inline-size);
+        background: var(--swc-gray-300, #b3b3b3);
+        cursor: default;
+      }
+
+      .demo-button--pendingActive .demo-button-label {
+        display: none;
+      }
+
+      /* Theme the controller-rendered spinner. */
+      .swc-PendingSpinner {
+        --swc-pending-spinner-size: 18px;
+        --swc-pending-spinner-track-color: var(--swc-gray-500, #747474);
+        --swc-pending-spinner-fill-color: var(--swc-white, #fff);
+        --swc-pending-spinner-thickness: 2px;
+      }
+    `,
+  ];
+
+  static override properties = {
+    pending: { type: Boolean, reflect: true },
+    pendingLabel: { type: String, attribute: 'pending-label' },
+    label: { type: String },
+  };
+
+  declare pending: boolean;
+  declare pendingLabel?: string;
+  declare label: string;
+
+  private readonly pendingController = new PendingController(this, {
+    delay: 250,
+    targetSelector: '.demo-button',
+    resolveAccessibleName: () =>
+      this.label || (this.textContent?.trim() ?? null),
+  });
+
+  constructor() {
+    super();
+    this.pending = false;
+    this.label = 'Save';
+  }
+
+  protected override render(): TemplateResult {
+    return html`
+      <button
+        class=${classMap({
+          'demo-button': true,
+          'demo-button--pendingActive': this.pendingController.pendingActive,
+        })}
+        type="button"
+        aria-disabled=${ifDefined(this.pending ? 'true' : undefined)}
+        aria-label=${ifDefined(
+          this.pending
+            ? this.pendingController.getPendingAccessibleName()
+            : undefined
+        )}
+      >
+        <span class="demo-button-label">${this.label}</span>
+        ${this.pendingController.renderPendingState()}
+      </button>
+    `;
+  }
+}

--- a/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.stories.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.stories.ts
@@ -131,6 +131,14 @@ export const ExplicitPendingLabel: Story = {
 };
 ExplicitPendingLabel.storyName = 'Explicit pending label';
 
+export const FocusRetained: Story = {
+  render: () => html`
+    <demo-pending-host click-pending .label=${'Save'}></demo-pending-host>
+  `,
+  tags: ['behaviors'],
+};
+FocusRetained.storyName = 'Focus retained on re-render';
+
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────

--- a/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.stories.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.stories.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import './demo-hosts.js';
+
+// ────────────────
+//    METADATA
+// ────────────────
+
+const args = {
+  pending: true,
+  pendingLabel: '',
+  label: 'Save',
+};
+
+const argTypes = {
+  pending: {
+    control: 'boolean',
+    description:
+      'Whether the host is in a pending (busy) state. The host stays focusable but activation is suppressed.',
+    table: { category: 'Options', defaultValue: { summary: 'false' } },
+  },
+  pendingLabel: {
+    control: 'text',
+    description:
+      'Explicit accessible label used while pending. When empty, the controller derives `"<name>, busy"` from the resolved non-busy name.',
+    table: { category: 'Options', defaultValue: { summary: '""' } },
+  },
+  label: {
+    control: 'text',
+    description: 'Visible label of the demo button.',
+    table: { category: 'Options', defaultValue: { summary: 'Save' } },
+  },
+};
+
+/**
+ * `PendingController` is a Lit `ReactiveController` that manages the pending
+ * (busy) state of a host element: it activates the busy visual after a short
+ * delay so quick operations do not flash, freezes the host's inline size while
+ * busy, derives the pending accessible name, and renders an animated spinner.
+ *
+ * It is used by [Button](../?path=/docs/button--docs) and is reusable by any
+ * component that exposes a `pending` state. The accessible name and
+ * `aria-disabled` are applied by the host's own template (keyed off `pending`)
+ * for an immediate response; the controller exposes `getPendingAccessibleName()`
+ * for the host to read.
+ */
+const meta: Meta = {
+  title: 'Controllers/Pending controller',
+  component: 'demo-pending-host',
+  args,
+  argTypes,
+  render: (args) => html`
+    <demo-pending-host
+      ?pending=${args.pending}
+      pending-label=${args.pendingLabel}
+      .label=${args.label}
+    ></demo-pending-host>
+  `,
+  parameters: {
+    docs: {
+      subtitle:
+        'Delayed busy visual, inline-size freeze, derived busy label, and animated spinner.',
+    },
+    layout: 'centered',
+  },
+  tags: ['migrated', 'controller'],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// ────────────────────
+//    PLAYGROUND STORY
+// ────────────────────
+
+export const Playground: Story = {
+  tags: ['dev'],
+};
+
+// ──────────────────────────
+//    OVERVIEW STORY
+// ──────────────────────────
+
+export const Overview: Story = {
+  tags: ['overview'],
+};
+
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+export const DelayedActivation: Story = {
+  render: () => html`
+    <demo-pending-host pending .label=${'Uploading'}></demo-pending-host>
+  `,
+  tags: ['behaviors'],
+};
+DelayedActivation.storyName = 'Delayed activation';
+
+export const DerivedBusyName: Story = {
+  render: () => html`
+    <demo-pending-host pending .label=${'Save'}></demo-pending-host>
+  `,
+  tags: ['behaviors'],
+};
+DerivedBusyName.storyName = 'Derived busy name';
+
+export const ExplicitPendingLabel: Story = {
+  render: () => html`
+    <demo-pending-host
+      pending
+      .label=${'Save'}
+      pending-label="Processing your request"
+    ></demo-pending-host>
+  `,
+  tags: ['behaviors'],
+};
+ExplicitPendingLabel.storyName = 'Explicit pending label';
+
+// ────────────────────────────────
+//    ACCESSIBILITY STORIES
+// ────────────────────────────────
+
+export const Accessibility: Story = {
+  render: () => html`
+    <demo-pending-host pending .label=${'Save'}></demo-pending-host>
+  `,
+  tags: ['a11y'],
+};

--- a/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.test.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * These Storybook play tests verify observable `PendingController` behavior using
+ * real browser timers and programmatic property changes.
+ *
+ * ### Timing
+ *
+ * The `demo-pending-host` element uses a 250 ms controller delay (shortened from
+ * the 1000 ms production default) so tests are responsive without multi-second
+ * waits. All `wait()` calls include a buffer beyond the configured delay.
+ *
+ * ### Focus-retention contract
+ *
+ * When `pendingActive` transitions from `false` to `true`, the controller calls
+ * `host.requestUpdate()`, which triggers a Lit re-render. Because lit-html patches
+ * the DOM in place rather than replacing elements, the focused `<button>` is not
+ * destroyed. The test verifies that `shadowRoot.activeElement` still points to the
+ * same internal button after the re-render.
+ */
+
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import './demo-hosts.js';
+
+import type { DemoPendingHost } from './demo-hosts.js';
+import pendingMeta, { FocusRetained } from './pending-controller.stories.js';
+
+// ─────────────────────────
+//     HELPERS
+// ─────────────────────────
+
+/** Waits `ms` milliseconds for async timers to settle. */
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─────────────────────────
+//     META
+// ─────────────────────────
+
+export default {
+  ...pendingMeta,
+  title: 'Controllers/Pending controller/Tests',
+  parameters: {
+    ...pendingMeta.parameters,
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+// ──────────────────────────────────────────────────────────────────────────
+//     Focus retained through controller-triggered re-render
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Verifies that when `pendingActive` becomes `true` (after the controller's 250 ms
+ * delay following a mouse-focus-style interaction), Lit's in-place DOM patch does
+ * not move focus away from the internal `<button>`.
+ *
+ * Sequence:
+ * 1. Focus the internal button (simulating mouse-click focus).
+ * 2. Verify focus is on the button before any pending state.
+ * 3. Set `pending = true` — immediately applies `aria-disabled` and `aria-label`.
+ * 4. Wait for the controller's 250 ms delay (plus a buffer).
+ * 5. Verify `pendingActive` visual is active (spinner present, CSS class applied).
+ * 6. Verify focus is still on the same button element after the re-render.
+ */
+export const FocusRetainedTest: Story = {
+  ...FocusRetained,
+  play: async ({ canvasElement, step }) => {
+    const host =
+      canvasElement.querySelector<DemoPendingHost>('demo-pending-host');
+    if (!host) {
+      throw new Error('demo-pending-host not found');
+    }
+
+    const shadowRoot = host.shadowRoot as ShadowRoot;
+    const internalButton =
+      shadowRoot.querySelector<HTMLButtonElement>('button');
+    if (!internalButton) {
+      throw new Error('Internal <button> not found');
+    }
+
+    await step('button is not pending in initial state', async () => {
+      expect(host.pending, 'pending defaults to false').toBe(false);
+      expect(
+        internalButton.getAttribute('aria-disabled'),
+        'aria-disabled is absent in default state'
+      ).toBeNull();
+    });
+
+    await step(
+      'mouse-focus-style interaction: button receives focus',
+      async () => {
+        // Dispatch pointerdown before focus to mirror the sequence a real
+        // mouse click produces (pointer-click focus, not keyboard focus).
+        internalButton.dispatchEvent(
+          new PointerEvent('pointerdown', { bubbles: true, composed: true })
+        );
+        internalButton.focus();
+        expect(
+          shadowRoot.activeElement,
+          'internal button is the active element in the shadow root'
+        ).toBe(internalButton);
+      }
+    );
+
+    await step(
+      'setting pending=true immediately applies aria attributes; focus is preserved',
+      async () => {
+        host.pending = true;
+        await host.updateComplete;
+
+        expect(
+          internalButton.getAttribute('aria-disabled'),
+          'aria-disabled is set to true immediately when pending'
+        ).toBe('true');
+        expect(
+          internalButton.getAttribute('aria-label'),
+          'aria-label is set to the derived busy name immediately'
+        ).toBe('Save, busy');
+        expect(
+          shadowRoot.activeElement,
+          'focus is still on the internal button after the immediate aria update'
+        ).toBe(internalButton);
+      }
+    );
+
+    await step(
+      'after the controller delay, pendingActive re-renders the button; focus is preserved',
+      async () => {
+        // The demo host uses delay=250 ms. Wait 350 ms to include a buffer.
+        await wait(350);
+        await host.updateComplete;
+
+        const spinner = shadowRoot.querySelector('.swc-PendingSpinner');
+        expect(
+          spinner,
+          'spinner is rendered once pendingActive is true'
+        ).toBeTruthy();
+        expect(
+          internalButton.classList.contains('demo-button--pendingActive'),
+          'pendingActive CSS class is applied after the controller delay'
+        ).toBe(true);
+        expect(
+          shadowRoot.activeElement,
+          'focus is still on the same button element after the controller-triggered re-render'
+        ).toBe(internalButton);
+      }
+    );
+
+    await step(
+      'clearing pending removes the busy visual; focus is preserved',
+      async () => {
+        host.pending = false;
+        await host.updateComplete;
+        // Allow the deactivation re-render to settle.
+        await wait(50);
+        await host.updateComplete;
+
+        expect(
+          shadowRoot.querySelector('.swc-PendingSpinner'),
+          'spinner is removed after pending clears'
+        ).toBeNull();
+        expect(
+          internalButton.classList.contains('demo-button--pendingActive'),
+          'pendingActive class is removed after pending clears'
+        ).toBe(false);
+        expect(
+          shadowRoot.activeElement,
+          'focus is still on the button after pending clears'
+        ).toBe(internalButton);
+      }
+    );
+  },
+};
+FocusRetainedTest.storyName = 'Focus retained on re-render (test)';

--- a/2nd-gen/packages/core/package.json
+++ b/2nd-gen/packages/core/package.json
@@ -103,6 +103,14 @@
       "types": "./dist/controllers/language-resolution.d.ts",
       "import": "./dist/controllers/language-resolution.js"
     },
+    "./controllers/pending-controller": {
+      "types": "./dist/controllers/pending-controller/index.d.ts",
+      "import": "./dist/controllers/pending-controller/index.js"
+    },
+    "./controllers/pending-controller/index.js": {
+      "types": "./dist/controllers/pending-controller/index.d.ts",
+      "import": "./dist/controllers/pending-controller/index.js"
+    },
     "./controllers/placement-controller": {
       "types": "./dist/controllers/placement-controller/index.d.ts",
       "import": "./dist/controllers/placement-controller/index.js"
@@ -246,6 +254,12 @@
       ],
       "controllers/language-resolution.js": [
         "dist/controllers/language-resolution.d.ts"
+      ],
+      "controllers/pending-controller": [
+        "dist/controllers/pending-controller/index.d.ts"
+      ],
+      "controllers/pending-controller/index.js": [
+        "dist/controllers/pending-controller/index.d.ts"
       ],
       "controllers/placement-controller": [
         "dist/controllers/placement-controller/index.d.ts"

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -361,6 +361,7 @@ const preview = {
                 [
                   'Accessibility migration analysis',
                   'Migration plan',
+                  'Pending controller extraction',
                   'Rendering and styling migration analysis',
                 ],
                 'Button group',

--- a/2nd-gen/packages/swc/components/button/Button.ts
+++ b/2nd-gen/packages/swc/components/button/Button.ts
@@ -10,13 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {
-  CSSResultArray,
-  html,
-  nothing,
-  PropertyValues,
-  TemplateResult,
-} from 'lit';
+import { CSSResultArray, html, PropertyValues, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -29,6 +23,10 @@ import {
   type ButtonStaticColor,
   type ButtonVariant,
 } from '@spectrum-web-components/core/components/button';
+import {
+  PendingController,
+  pendingControllerStyles,
+} from '@spectrum-web-components/core/controllers/pending-controller';
 
 import styles from './button.css';
 import baseStyles from './button-base.css';
@@ -119,12 +117,36 @@ export class Button extends ButtonBase {
   @property({ type: Boolean, reflect: true })
   public justified: boolean = false;
 
+  /**
+   * Whether the button is in a pending (busy) state. The button remains
+   * focusable but activation is suppressed.
+   */
+  @property({ type: Boolean, reflect: true })
+  public pending: boolean = false;
+
+  /**
+   * Custom accessible label used during the pending state. When omitted, the
+   * pending label is derived from the resolved non-busy accessible name plus a
+   * busy suffix (e.g. "Save, busy").
+   */
+  @property({ type: String, attribute: 'pending-label' })
+  public pendingLabel?: string;
+
   // ──────────────────────────────
   //     RENDERING & STYLING
   // ──────────────────────────────
 
+  /**
+   * Manages the pending (busy) state: the delayed visual activation, freezing
+   * the button's inline size while busy, the derived busy accessible name, and
+   * rendering the animated spinner.
+   */
+  private readonly pendingController = new PendingController(this, {
+    resolveAccessibleName: () => this.getResolvedAccessibleName(),
+  });
+
   public static override get styles(): CSSResultArray {
-    return [baseStyles, styles];
+    return [baseStyles, styles, pendingControllerStyles];
   }
 
   // @todo SWC-2034: handle form-associated types reset / submit
@@ -135,7 +157,7 @@ export class Button extends ButtonBase {
           'swc-Button': true,
           'swc-Button--hasIcon': this.hasIcon,
           'swc-Button--iconOnly': this.hasIcon && !this.hasLabel,
-          'swc-Button--pendingActive': this.pendingActive,
+          'swc-Button--pendingActive': this.pendingController.pendingActive,
         })}
         type="button"
         @click=${this.handleClick}
@@ -144,49 +166,36 @@ export class Button extends ButtonBase {
           this.pending && !this.disabled ? 'true' : undefined
         )}
         aria-label=${ifDefined(
-          this.pending ? this.getPendingAccessibleName() : this.accessibleLabel
+          this.pending
+            ? this.pendingController.getPendingAccessibleName()
+            : this.accessibleLabel
         )}
       >
         <slot name="icon"></slot>
         <span class="swc-Button-label">
           <slot></slot>
         </span>
-        ${this.pending
-          ? html`
-              <svg
-                class="swc-Button-pendingSpinner"
-                width="100%"
-                height="100%"
-                fill="none"
-                aria-hidden="true"
-                focusable="false"
-              >
-                <circle
-                  class="swc-Button-pendingSpinner-track"
-                  cx="50%"
-                  cy="50%"
-                  r="calc(50% - 1px)"
-                />
-                <circle
-                  class="swc-Button-pendingSpinner-fill"
-                  cx="50%"
-                  cy="50%"
-                  r="calc(50% - 1px)"
-                  pathLength="100"
-                  stroke-dasharray="100 200"
-                  stroke-dashoffset="75"
-                  stroke-linecap="round"
-                />
-              </svg>
-            `
-          : nothing}
+        ${this.pendingController.renderPendingState()}
       </button>
     `;
+  }
+
+  /** Also suppress activation while pending, on top of the base `disabled` rule. */
+  protected override isActivationSuppressed(): boolean {
+    return super.isActivationSuppressed() || this.pending;
   }
 
   protected override update(changedProperties: PropertyValues): void {
     super.update(changedProperties);
     if (window.__swc?.DEBUG) {
+      if (this.pending && this.disabled) {
+        window.__swc.warn(
+          this,
+          `<${this.localName}> should not set both "pending" and "disabled" simultaneously. Use "pending" to keep the button focusable while unavailable, or "disabled" to fully remove it from the tab order.`,
+          'https://opensource.adobe.com/spectrum-web-components/components/button/#pending',
+          { issues: ['pending + disabled'] }
+        );
+      }
       if (!BUTTON_VARIANTS.includes(this.variant)) {
         window.__swc.warn(
           this,

--- a/2nd-gen/packages/swc/components/button/button.css
+++ b/2nd-gen/packages/swc/components/button/button.css
@@ -10,30 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* @global-exclude: pending spinner animations require JS runtime */
-@keyframes swc-pending-spinner-rotate {
-  0% {
-    transform: rotate(var(--swc-pending-spinner-rotate-start, -90deg));
-  }
-
-  100% {
-    transform: rotate(var(--swc-pending-spinner-rotate-end, 270deg));
-  }
-}
-
-@keyframes swc-pending-spinner-dashoffset {
-  0%,
-  100% {
-    stroke-dashoffset: 75px;
-  }
-
-  30% {
-    stroke-dashoffset: var(--swc-pending-spinner-dashoffset-30, 20px);
-  }
-}
-
-/* @global-exclude-end */
-
 .swc-Button {
   --_swc-button-border-width: token("border-width-200");
   --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
@@ -86,8 +62,7 @@
 }
 
 /* TODO: if swc-icon becomes public, pass size overrides to appropriate custom properties */
-slot[name="icon"]::slotted(*),
-.swc-Button-pendingSpinner {
+slot[name="icon"]::slotted(*) {
   --_swc-button-icon-size: var(--swc-button-icon-size, token("workflow-icon-size-100"));
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
 
@@ -97,9 +72,6 @@ slot[name="icon"]::slotted(*),
   block-size: var(--_swc-button-icon-block-size);
   margin-block: calc((var(--_swc-button-icon-block-size) - 1lh) / 2 * -1); /* Ensures vertical alignment with text */
   margin-inline-start: calc(var(--swc-button-edge-to-visual, token("component-pill-edge-to-visual-100")) - var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")));
-}
-
-slot[name="icon"]::slotted(*) {
   color: inherit;
   fill: currentcolor;
 }
@@ -337,11 +309,15 @@ slot[name="icon"]::slotted(*) {
 
 /* ── Pending ──────────────────────────────────────── */
 
-/* @global-exclude: pending state requires JS runtime (ButtonBase.pendingActive) */
+/* The animated spinner's structure, geometry, and animation are provided by
+   `pendingControllerStyles` from the PendingController; the rules below theme
+   that spinner with button tokens and apply the button-specific busy treatment. */
+
+/* @global-exclude: pending state requires JS runtime (PendingController.pendingActive) */
 
 /* Cursor changes immediately on [pending]. Disabled colors, label/icon fade,
-   and spinner appearance are deferred to .swc-Button--pendingActive, which is
-   added by ButtonBase after a 1-second delay so the button does not flash to
+   and spinner appearance are deferred to .swc-Button--pendingActive, which the
+   PendingController adds after a 1-second delay so the button does not flash to
    its unavailable appearance for operations that complete quickly. */
 :host([pending]) .swc-Button {
   cursor: default;
@@ -351,7 +327,7 @@ slot[name="icon"]::slotted(*) {
   --swc-button-down-state-transform: none;
 
   justify-content: center;
-  inline-size: var(--_swc-button-pending-inline-size); /* Preserve measured inline size to avoid impacting layout, set via JS when state changes */
+  inline-size: var(--swc-pending-inline-size); /* Preserve measured inline size to avoid impacting layout, set via JS when state changes */
 
   /* Disabled colors reference the already-resolved disabled vars so outline and
    static-color variants automatically get their correct unavailable appearance. */
@@ -374,52 +350,26 @@ slot[name="icon"]::slotted(*) {
   display: none;
 }
 
-/* Positioning and sizing shared with icon */
-.swc-Button-pendingSpinner {
-  --_swc-pending-spinner-track-border-color: token("track-color");
-  --_swc-pending-spinner-fill-border-color: token("accent-content-color-default");
-  --_swc-pending-spinner-thickness: 2px;
+/* Theme and align the controller-rendered spinner like a slotted icon. */
+.swc-PendingSpinner {
+  --swc-pending-spinner-size: var(--swc-button-icon-size, token("workflow-icon-size-100"));
+  --swc-pending-spinner-track-color: token("track-color");
+  --swc-pending-spinner-fill-color: token("accent-content-color-default");
+  --swc-pending-spinner-thickness: 2px;
 
-  display: none;
+  align-self: flex-start;
+  margin-block: calc((var(--swc-pending-spinner-size) - 1lh) / 2 * -1); /* Vertical alignment with the text line */
+  margin-inline-start: calc(var(--swc-button-edge-to-visual, token("component-pill-edge-to-visual-100")) - var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")));
 }
 
-.swc-Button--pendingActive .swc-Button-pendingSpinner {
-  display: inline-block;
+:host([static-color="white"]) .swc-PendingSpinner {
+  --swc-pending-spinner-track-color: token("static-white-track-color");
+  --swc-pending-spinner-fill-color: token("static-white-track-indicator-color");
 }
 
-:host([static-color="white"]) .swc-Button-pendingSpinner {
-  --_swc-pending-spinner-track-border-color: token("static-white-track-color");
-  --_swc-pending-spinner-fill-border-color: token("static-white-track-indicator-color");
-}
-
-:host([static-color="black"]) .swc-Button-pendingSpinner {
-  --_swc-pending-spinner-track-border-color: token("static-black-track-color");
-  --_swc-pending-spinner-fill-border-color: token("static-black-track-indicator-color");
-}
-
-.swc-Button-pendingSpinner-track,
-.swc-Button-pendingSpinner-fill {
-  inline-size: var(--_swc-button-icon-size);
-  block-size: var(--_swc-button-icon-size);
-}
-
-.swc-Button-pendingSpinner-track {
-  stroke: var(--_swc-pending-spinner-track-border-color);
-  stroke-width: var(--_swc-pending-spinner-thickness);
-}
-
-.swc-Button-pendingSpinner-fill {
-  stroke: var(--_swc-pending-spinner-fill-border-color);
-  stroke-width: var(--_swc-pending-spinner-thickness);
-  transform: rotate(-90deg);
-  transform-origin: center;
-}
-
-.swc-Button--pendingActive .swc-Button-pendingSpinner-fill {
-  animation:
-    swc-pending-spinner-rotate 1s cubic-bezier(0.6, 0.1, 0.3, 0.9) infinite,
-    swc-pending-spinner-dashoffset 1s cubic-bezier(0.25, 0.1, 0.25, 1.3) infinite;
-  will-change: transform;
+:host([static-color="black"]) .swc-PendingSpinner {
+  --swc-pending-spinner-track-color: token("static-black-track-color");
+  --swc-pending-spinner-fill-color: token("static-black-track-indicator-color");
 }
 
 /* @global-exclude-end */
@@ -448,21 +398,9 @@ slot[name="icon"]::slotted(*) {
   .swc-Button {
     transition-duration: 0ms;
   }
-
-  /* @global-exclude: pending spinner reduced-motion override requires JS runtime */
-  .swc-Button--pendingActive .swc-Button-pendingSpinner-fill {
-    --swc-pending-spinner-dashoffset-30: 0;
-    --swc-pending-spinner-rotate-start: 0deg;
-    --swc-pending-spinner-rotate-end: 360deg;
-
-    animation-duration: 15s;
-    animation-timing-function: linear, linear;
-  }
-
-  /* @global-exclude-end */
 }
 
-/* @global-exclude: pending state requires JS runtime (ButtonBase.pendingActive) */
+/* @global-exclude: pending state requires JS runtime (PendingController.pendingActive) */
 @media (forced-colors: active) {
   /* Pending-active button maps all interactive color states to system disabled
      colors so it visually matches native disabled controls in high-contrast
@@ -485,18 +423,18 @@ slot[name="icon"]::slotted(*) {
   /* SVG stroke values are not auto-remapped by forced-colors.
      Selections match swc-progress-circle. */
 
-  .swc-Button-pendingSpinner-track {
+  .swc-PendingSpinner-track {
     @media (prefers-color-scheme: dark) {
-      --_swc-pending-spinner-track-border-color: token("static-white-track-color");
+      --swc-pending-spinner-track-color: token("static-white-track-color");
     }
 
     @media (prefers-color-scheme: light) {
-      --_swc-pending-spinner-track-border-color: token("static-black-track-color");
+      --swc-pending-spinner-track-color: token("static-black-track-color");
     }
   }
 
-  .swc-Button-pendingSpinner-fill {
-    --_swc-pending-spinner-fill-border-color: Highlight;
+  .swc-PendingSpinner-fill {
+    --swc-pending-spinner-fill-color: Highlight;
   }
 }
 

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -60,6 +60,17 @@
   outline-offset: token("focus-indicator-gap");
 }
 
+.swc-Button:disabled:is(*, :hover) {
+  color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
+  background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
+  border-color: var(--swc-button-border-color-disabled, transparent);
+  transform: none;
+}
+
+.swc-Button--disabled .swc-Button-icon {
+  pointer-events: none;
+}
+
 .swc-Button:hover {
   color: var(--swc-button-content-color-hover, token("gray-25"));
   background-color: var(--swc-button-background-color-hover, token("neutral-background-color-hover"));
@@ -74,13 +85,6 @@
   will-change: transform;
 }
 
-.swc-Button:disabled:is(*, :hover) {
-  color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
-  background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
-  border-color: var(--swc-button-border-color-disabled, transparent);
-  transform: none;
-}
-
 .swc-Button-label {
   text-align: center;
 }
@@ -89,8 +93,7 @@
   text-align: start;
 }
 
-.swc-Button-icon,
-.swc-Button-pendingSpinner {
+.swc-Button-icon {
   --_swc-button-icon-size: var(--swc-button-icon-size, token("workflow-icon-size-100"));
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
 
@@ -100,9 +103,6 @@
   block-size: var(--_swc-button-icon-block-size);
   margin-block: calc((var(--_swc-button-icon-block-size) - 1lh) / 2 * -1);
   margin-inline-start: calc(var(--swc-button-edge-to-visual, token("component-pill-edge-to-visual-100")) - var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")));
-}
-
-.swc-Button-icon {
   color: inherit;
   fill: currentcolor;
 }

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
@@ -44,6 +44,7 @@
 - Button
     - [Button accessibility migration analysis](button/accessibility-migration-analysis.md)
     - [Button Migration Plan](button/migration-plan.md)
+    - [Pending controller extraction](button/pending-controller-extraction.md)
     - [Button migration roadmap](button/rendering-and-styling-migration-analysis.md)
 - Button Group
     - [Button group accessibility migration analysis](button-group/accessibility-migration-analysis.md)

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/button/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/button/migration-plan.md
@@ -61,7 +61,7 @@
 - 2nd-gen `sp-button` should render an internal semantic `<button>` and move semantics off the host
 - Pending must remain focusable while unavailable, use `aria-disabled="true"`, and announce a descriptive busy state
 - The visual API should use React-aligned `fillStyle` terminology: `primary` / `secondary` support `fill` + `outline`; `accent` / `negative` are fill-only
-- Pending will use a 1-second delayed inline animated SVG spinner in the initial migration; reuse can be evaluated later
+- Pending will use a 1-second delayed inline animated SVG spinner in the initial migration; reuse can be evaluated later (realized post-migration — see the Post-migration update below)
 - Component Button styles and [`global-button.css`](../../../../2nd-gen/packages/swc/stylesheets/global/global-button.css) should share source/imports if possible
 - `core` should own reusable semantic rules and serve as the intended reuse base for later button-like migrations; `swc` should own `sp-button` rendering and S2 styling
 
@@ -330,9 +330,11 @@ Using an internal semantic `<button>` also means:
 
 Follow the [Badge migration reference](../../02_workstreams/02_2nd-gen-component-migration/02_step-by-step/01_washing-machine-workflow.md#reference-badge-migration) as the concrete pattern for the core/SWC split.
 
+> **Post-migration update (2026-06-10): pending logic extracted into `PendingController`.** The reuse deferred during the initial migration has since been implemented. The pending behavior (1-second delayed `pendingActive`, inline-size freeze, derived busy accessible name, and the animated spinner with its own themeable styles) now lives in a reusable Lit reactive controller at `2nd-gen/packages/core/controllers/pending-controller/`, exported as `PendingController` / `pendingControllerStyles`. The `pending` and `pending-label` properties moved off `ButtonBase` onto `swc-button` (`Button.ts`), and `ButtonBase` is now pending-agnostic (click suppression generalized via `isActivationSuppressed()`). The sections below describe the original migration state; where they place pending logic in `ButtonBase`, read it as relocated to the controller + `swc-button`.
+
 | Layer | Path | Contains |
 |---|---|---|
-| **Core** | `2nd-gen/packages/core/components/button/` | `Button.base.ts`, `Button.types.ts`, validation, state, accessible-name logic, attribute forwarding, pending-label behavior, and other reusable semantic rules. No rendering. |
+| **Core** | `2nd-gen/packages/core/components/button/` | `Button.base.ts`, `Button.types.ts`, validation, state, accessible-name logic, attribute forwarding, and other reusable semantic rules. No rendering. (Pending behavior was later extracted to `core/controllers/pending-controller/`; see the post-migration update above.) |
 | **SWC** | `2nd-gen/packages/swc/components/button/` | `Button.ts`, `button.css`, element registration, stories, tests, and the specific S2 rendering/styling for `sp-button`. |
 
 Planned rendering shape:

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/button/pending-controller-extraction.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/button/pending-controller-extraction.md
@@ -1,0 +1,90 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../../../README.md) / [Project planning](../../README.md) / [Components](../README.md) / Button / Pending controller extraction
+
+<!-- Document title (editable) -->
+
+# Pending controller extraction
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [Status](#status)
+- [Goal](#goal)
+- [Background](#background)
+- [Design decisions](#design-decisions)
+- [Implementation map](#implementation-map)
+- [Public API surface (controller)](#public-api-surface-controller)
+- [Checklist](#checklist)
+- [Follow-ups / not in scope](#follow-ups--not-in-scope)
+
+</details>
+
+<!-- Document content (editable) -->
+
+Tracking doc for extracting Button's pending (busy) state logic into a reusable Lit reactive controller in `core`. This realizes the reuse deferred during the initial Button migration (see [migration-plan.md](./migration-plan.md), TL;DR and the post-migration update on the architecture section).
+
+## Status
+
+**Implemented.** core + swc build, 22/22 Button tests, 6/6 controller stories (render + axe), lint and `lint:docs-pages` clean.
+
+## Goal
+
+1. Migrate the 1st-gen pending-state reactive controller into `2nd-gen/packages/core/controllers/`.
+2. Remove the pending logic from the core Button base class (`ButtonBase`).
+3. Drive the pending state in `swc-button` (`Button.ts`) through the new controller.
+
+## Background
+
+| Source | Approach |
+| --- | --- |
+| 1st-gen `PendingStateController` (`1st-gen/tools/reactive-controllers/src/PendingState.ts`) | Renders `<sp-progress-circle>`, caches/restores the host `aria-label`, requires the host to be the interactive element. |
+| 2nd-gen Button (pre-extraction) | Pending logic split across `ButtonBase` (delay timer, `pendingActive`, accessible-name derivation, click suppression, inline-size freeze) and `Button.ts` (inline SVG spinner, aria bindings). Richer and more accessible (`SWC-459`). |
+
+A verbatim 1st-gen port would have regressed the 2nd-gen button (loss of the 1s delay, inline-size freeze, `aria-disabled`, the busy-name work) and reintroduced the shadow-DOM limitation. Decision: build a new 2nd-gen controller that takes the 1st-gen pattern/intent but encapsulates the current 2nd-gen behavior.
+
+## Design decisions
+
+- **Controller renders its own spinner and ships its own styles**, fully decoupled from button. Reusable by any component with a pending state. Themeable via `--swc-pending-spinner-*` custom properties; no design-token dependency.
+  - Build constraint: the `core` package's vite config has no `vite-plugin-lit-css` / `postcss-token`, so the controller styles use an inline Lit `css` literal (no `token()` macro), with custom-property theming hooks.
+- **`pending` / `pending-label` moved to `swc-button`**; `ButtonBase` is pending-agnostic. Click suppression generalized via a `protected isActivationSuppressed()` hook that `swc-button` overrides to add `pending`.
+- **Behavior parity:** `aria-disabled`, the derived busy `aria-label`, and click suppression remain synchronous on `pending`; the visual treatment (disabled palette, spinner, frozen size) keys off the 1s-delayed `pendingActive`. The spinner now renders only while `pendingActive` (previously rendered hidden during the delay) — visually identical.
+
+## Implementation map
+
+| Area | Path |
+| --- | --- |
+| Controller (logic + styles) | `2nd-gen/packages/core/controllers/pending-controller/src/pending-controller.ts` |
+| Controller barrel | `2nd-gen/packages/core/controllers/pending-controller/index.ts` |
+| Controllers index + package exports | `2nd-gen/packages/core/controllers/index.ts`, `2nd-gen/packages/core/package.json` |
+| Base class (pending removed) | `2nd-gen/packages/core/components/button/Button.base.ts` |
+| Concrete button (controller wired) | `2nd-gen/packages/swc/components/button/Button.ts` |
+| Button CSS (busy treatment + spinner theming) | `2nd-gen/packages/swc/components/button/button.css` |
+| Controller docs + stories | `2nd-gen/packages/core/controllers/pending-controller/pending-controller.mdx`, `.../stories/` |
+
+## Public API surface (controller)
+
+- `PendingController` — `pendingActive` (getter), `getPendingAccessibleName()`, `renderPendingState()`.
+- `pendingControllerStyles` — `CSSResult` for the host's `static styles`.
+- `PendingControllerHost` — `{ pending, pendingLabel? }`.
+- `PendingControllerOptions` — `{ delay?, targetSelector?, resolveAccessibleName? }`.
+- Theming: `--swc-pending-spinner-{size,track-color,fill-color,thickness}`, `--swc-pending-inline-size`.
+
+## Checklist
+
+- [x] Controller created in `core/controllers` following the hover/placement conventions (folder, barrel, index, stories, mdx)
+- [x] Controller exported from the controllers barrel and `core/package.json` (`exports` + `typesVersions`)
+- [x] Pending logic removed from `ButtonBase`; click suppression generalized
+- [x] `pending` / `pending-label` declared on `swc-button`; controller wired into render
+- [x] `button.css` keeps only button-specific busy treatment + spinner theming; spinner internals moved to the controller
+- [x] Stories + per-unit MDX authored (`controller` tag so `ApiTable` is omitted; hand-authored `## API`)
+- [x] Builds pass (core, swc); generated `global-button.css` regenerated and in sync
+- [x] Tests pass (22 Button, 6 controller stories); lint + `lint:docs-pages` clean
+- [x] `migration-plan.md` updated with the post-migration note
+
+## Follow-ups / not in scope
+
+- Migrating other pending-capable 1st-gen components (Combobox, Picker) to this controller; the shadow-DOM interactive-element limitation that blocked the 1st-gen controller does not apply here because the host applies aria in its own template.
+- Localizing the `", busy"` suffix (currently hard-coded, matching the initial Button migration).


### PR DESCRIPTION
THIS IS JUST A POC, THIS IS ONE SHOT AND STILL NEEDS A STYLESHEET CREATED TO SUPPORT THIS BUT CAPTURES THE ESSENCE OF THE CONTROLLER FUNCTIONALITY AND IMPLEMENTATION

## Description

Extracts Button's pending (busy) state logic out of the core `ButtonBase` and into a new reusable Lit reactive controller in `core`, then drives `swc-button` through it. This realizes the pending-state reuse that was deferred during the initial Button migration.

- **New controller** — `2nd-gen/packages/core/controllers/pending-controller/`. `PendingController` owns the 1-second-delayed `pendingActive` flag, the inline-size freeze (`--swc-pending-inline-size`), the derived busy accessible name, and rendering its own animated SVG spinner. It ships its own styles (`pendingControllerStyles`, an inline Lit `css` literal, since `core` has no `token()`/`lit-css` build step) themeable via `--swc-pending-spinner-*` custom properties, so it carries no design-token or button coupling and is reusable by any component with a pending state.
- **Exports** — added to the controllers barrel and `core/package.json` (`exports` + `typesVersions`) as `./controllers/pending-controller`.
- **`ButtonBase` (core)** — removed `pending`, `pending-label`, `pendingActive`, the timer, and the busy accessible-name/`aria-disabled` logic. Click suppression is generalized via a `protected isActivationSuppressed()` hook.
- **`swc-button` (`Button.ts`)** — declares `pending` / `pending-label`, instantiates the controller, and renders through it; overrides `isActivationSuppressed()` to add `pending`. `button.css` keeps only button-specific busy treatment (disabled palette, label/icon hiding, frozen size) plus spinner theming.
- **Docs/stories** — controller stories + per-unit MDX (tagged `controller`, hand-authored `## API`). Tracked in `CONTRIBUTOR-DOCS/03_project-planning/03_components/button/pending-controller-extraction.md`; the Button migration plan notes the extraction.

### Behavior parity

`aria-disabled`, the derived busy `aria-label`, and click suppression remain synchronous on `pending`; the visual treatment (disabled palette, spinner, frozen inline size) keys off the 1-second-delayed `pendingActive`. The spinner now renders only while `pendingActive` (previously rendered hidden during the delay) — visually identical. No public API change to `swc-button` (`pending` / `pending-label` keep identical reflected attributes).

## Motivation and context

The initial Button migration intentionally inlined the pending behavior across `ButtonBase` and `Button.ts` and deferred reuse. Pending is a cross-component concern (other button-likes and, longer term, other busy controls can use it), so it belongs in a dedicated, decoupled controller alongside the other `core` reactive controllers (hover, placement, focusgroup).

## Related issue(s)

- N/A

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Pending spinner appears after the delay and freezes button width_
  1. Open Storybook → Components → Button → Docs (or the Playground).
  2. Toggle `pending` on a labeled button.
  3. Expect: after ~1s the label/icon hide, the button keeps its prior width, disabled colors apply, and the animated spinner appears centered.

- [ ] _Pending is announced and non-activatable while focusable_
  1. On a pending button, confirm the internal `<button>` has `aria-disabled="true"` and no native `disabled`.
  2. Confirm `aria-label` is the derived `"<name>, busy"` (or the explicit `pending-label`).
  3. Click/Enter/Space do not fire activation; the button still receives focus via Tab.

- [ ] _Controller docs page renders_
  1. Open Storybook → Controllers → Pending controller.
  2. Expect the Docs page, the demo host stories, and the hand-authored API table to render with no console errors.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  1. Open Storybook → Components → Button and Tab to a `pending` button.
  2. Confirm the button is reachable and shows a visible focus indicator while pending (it stays focusable, not removed from the tab order).
  3. Press <kbd>Enter</kbd> and <kbd>Space</kbd>; expect no activation while pending. Clear `pending` and confirm activation works again. Confirm a `disabled` button is skipped in the Tab order (distinct from pending).

- [ ] **Screen reader** (required — document steps below)
  1. With VoiceOver/NVDA, focus a non-pending button; confirm its name and `button` role are announced.
  2. Set `pending`; confirm the control is announced as unavailable (`aria-disabled`) and the name reflects the busy state (`"<name>, busy"`, or the explicit `pending-label`).
  3. Confirm the spinner is not separately announced (rendered `aria-hidden`). Clear `pending` and confirm the name returns to normal.
