### PR TITLE
chore(color-loupe): consume shared opacity-checkerboard styles

### DIFF
--- a/2nd-gen/packages/swc/components/color-loupe/ColorLoupe.ts
+++ b/2nd-gen/packages/swc/components/color-loupe/ColorLoupe.ts
@@ -15,6 +15,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 import { ColorLoupeBase } from '@spectrum-web-components/core/components/color-loupe';
 
+import opacityCheckerboardStyles from '../../stylesheets/shared/opacity-checkerboard.css';
 import styles from './color-loupe.css';
 
 /**
@@ -34,20 +35,18 @@ export class ColorLoupe extends ColorLoupeBase {
   //     RENDERING & STYLING
   // ──────────────────────────────
 
-  /**
-   * @todo SWC-2029 - Migrate opacity-checkerboard to 2nd gen and consume it
-   * here; checkerboard styling is currently hardcoded in color-loupe.css.
-   */
   public static override get styles(): CSSResultArray {
-    return [styles];
+    return [opacityCheckerboardStyles, styles];
   }
 
   protected override render(): TemplateResult {
     return html`
       <div class="swc-ColorLoupe">
-        <div class="swc-ColorLoupe-checkerboard swc-ColorLoupe--clipped"></div>
         <div
-          class="swc-ColorLoupe-colorFill swc-ColorLoupe--clipped"
+          class="swc-ColorLoupe-layer swc-OpacityCheckerboard swc-ColorLoupe--clipped"
+        ></div>
+        <div
+          class="swc-ColorLoupe-layer swc-ColorLoupe-colorFill swc-ColorLoupe--clipped"
           style=${styleMap({
             '--swc-color-loupe-picked-color': this.color,
           })}

--- a/2nd-gen/packages/swc/components/color-loupe/color-loupe.css
+++ b/2nd-gen/packages/swc/components/color-loupe/color-loupe.css
@@ -39,26 +39,21 @@
     opacity 125ms ease-in-out;
 }
 
-/* Opacity checkerboard shown behind transparent picked colors.
-   The dark-square token has separate light/dark theme values, so
-   we use light-dark() with the explicit theme variants. */
-.swc-ColorLoupe-checkerboard {
+/* Shared positioning for the stacked loupe layers (the transparency
+   checkerboard and the color fill). Both sit inset by the loupe border. The
+   checkerboard pattern itself comes from the shared `.swc-OpacityCheckerboard`
+   fragment added to the styles array. */
+.swc-ColorLoupe-layer {
   position: absolute;
   inset-block-start: 2px;
   inset-inline-start: 2px;
   inline-size: 100%;
   block-size: 100%;
-  background: repeating-conic-gradient(light-dark(var(--swc-opacity-checkerboard-square-dark-light), var(--swc-opacity-checkerboard-square-dark-dark)) 0% 25%, token("opacity-checkerboard-square-light") 0% 50%) 0 0 / token("opacity-checkerboard-square-size-medium") token("opacity-checkerboard-square-size-medium");
 }
 
 /* Color fill layer — displays the picked color set by the component via
    the --swc-color-loupe-picked-color custom property. */
 .swc-ColorLoupe-colorFill {
-  position: absolute;
-  inset-block-start: 2px;
-  inset-inline-start: 2px;
-  inline-size: 100%;
-  block-size: 100%;
   background: var(--swc-color-loupe-picked-color);
 }
 
@@ -103,8 +98,9 @@
 }
 
 @media (forced-colors: active) {
-  .swc-ColorLoupe-colorFill,
-  .swc-ColorLoupe-checkerboard {
+  /* The checkerboard layer keeps `forced-color-adjust: none` via the shared
+     `.swc-OpacityCheckerboard` fragment; only the color fill needs it here. */
+  .swc-ColorLoupe-colorFill {
     forced-color-adjust: none;
   }
 


### PR DESCRIPTION
## Description

Refactors 2nd-gen `color-loupe` to consume the shared opacity-checkerboard `css` fragment (`swc/stylesheets/shared/opacity-checkerboard.css`) instead of inlining its own `repeating-conic-gradient` background. Mirrors the `meter` shared-stylesheet pattern (`[sharedStyles, styles]`).

- `ColorLoupe.ts`: import `opacityCheckerboardStyles`, add it to the `styles` array, remove the `@todo SWC-2029`, and add `swc-OpacityCheckerboard` to the checkerboard layer.
- `color-loupe.css`: drop the inlined checkerboard `background` (now owned by the shared fragment) and trim the forced-colors block (the fragment already sets `forced-color-adjust: none` on the checkerboard layer).
- Replaced the now-redundant `.swc-ColorLoupe-checkerboard` class (its name collided with the shared `.swc-OpacityCheckerboard`) with a shared `.swc-ColorLoupe-layer` positioning class used by both the checkerboard and color-fill layers, de-duplicating identical positioning.

## Motivation and context

Completes follow-up **A1** from the opacity-checkerboard migration (the `@todo SWC-2029` left in `ColorLoupe.ts`). The shared fragment now exists, so the loupe should consume it rather than keep a private copy of the rule.

This also fixes a size regression: the shared fragment sizes tiles at `square-size * 2` (the 1st-gen behavior, inherited from `@spectrum-web-components/opacity-checkerboard`). The original gen-2 loupe migration dropped the `* 2` when it inlined the pattern, so squares rendered at half size (8px instead of 16px). Consuming the fragment restores the correct 16px tiles.

## Related issue(s)

- SWC-2029

## Screenshots (if appropriate)

Checkerboard square size in the loupe changes from 8px to 16px (restores 1st-gen size).

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have reviewed the Accessibility Practices for this feature.
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Checkerboard renders behind a transparent color_
  1. Open Storybook → Color Loupe → Anatomy (or a story with a semi-transparent `color`)
  2. Observe the loupe with a transparent picked color
  3. Expect the opacity checkerboard pattern visible behind the color, clipped to the loupe shape, with 16px squares

- [ ] _Solid color covers the checkerboard_
  1. Set an opaque `color` on the loupe
  2. Expect the checkerboard fully covered

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

The color loupe is a non-interactive, visual-only element; the checkerboard layer is decorative (`aria-hidden` SVG sibling, no role/name on the loupe). This change is styling-only and does not alter semantics.

- [ ] **Keyboard**
  1. The loupe has no focusable parts; confirm it is not in the tab order and that surrounding color-selection examples are unaffected.

- [ ] **Screen reader**
  1. Open a story using the loupe with a screen reader.
  2. Confirm the loupe and its checkerboard are not announced (decorative), and the owning control still conveys color/value.

> Note: VRT golden snapshots for color-loupe stories change due to the corrected 16px square size and require re-approval.
