### PR TITLE
fix(storybook): run play functions in Chromatic VRT snapshots

### DIFF
--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -15,6 +15,7 @@ import {
   type Options,
   setStorybookHelpersConfig,
 } from '@wc-toolkit/storybook-helpers';
+import isChromatic from 'chromatic/isChromatic';
 
 import customElements from './custom-elements.json';
 import { withContext } from './decorators/contexts.js';
@@ -135,6 +136,12 @@ const preview = {
   ],
   parameters: {
     layout: 'centered',
+    // The Storybook patch (.yarn/patches/storybook-npm-10.4.1.patch) gates play
+    // functions on initial render behind `parameters.autoplay` so they do not run
+    // automatically while browsing the dev UI. Chromatic renders each story via that
+    // same initial path, so without this it would snapshot the pre-play state. Enable
+    // autoplay only under Chromatic to restore correct visual regression snapshots.
+    autoplay: isChromatic(),
     backgrounds: { disable: true }, // Use custom context switches
     controls: {
       expanded: true,

--- a/2nd-gen/packages/swc/package.json
+++ b/2nd-gen/packages/swc/package.json
@@ -105,6 +105,7 @@
     "@wc-toolkit/storybook-helpers": "patch:@wc-toolkit/storybook-helpers@npm%3A10.3.0#~/.yarn/patches/@wc-toolkit-storybook-helpers-npm-10.3.0-03023714ff.patch",
     "aria-query": "5.3.2",
     "autoprefixer": "10.4.21",
+    "chromatic": "13.3.5",
     "dom-accessibility-api": "0.7.0",
     "glob": "11.0.3",
     "playwright": "1.53.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,6 +216,7 @@ __metadata:
     "@wc-toolkit/storybook-helpers": "patch:@wc-toolkit/storybook-helpers@npm%3A10.3.0#~/.yarn/patches/@wc-toolkit-storybook-helpers-npm-10.3.0-03023714ff.patch"
     aria-query: "npm:5.3.2"
     autoprefixer: "npm:10.4.21"
+    chromatic: "npm:13.3.5"
     dom-accessibility-api: "npm:0.7.0"
     glob: "npm:11.0.3"
     lit: "npm:^2.5.0 || ^3.1.3"
@@ -13385,6 +13386,25 @@ __metadata:
     chromatic: dist/bin.js
     chromatic-cli: dist/bin.js
   checksum: 10c0/0f3419b45c648746ce4bb332a8c00548a41d0981a83c44f259fccced83245109448f1f713dd0379af4f386f0e614b11a52be5c0693ec71a99edc8aaed477c5bc
+  languageName: node
+  linkType: hard
+
+"chromatic@npm:13.3.5":
+  version: 13.3.5
+  resolution: "chromatic@npm:13.3.5"
+  peerDependencies:
+    "@chromatic-com/cypress": ^0.*.* || ^1.0.0
+    "@chromatic-com/playwright": ^0.*.* || ^1.0.0
+  peerDependenciesMeta:
+    "@chromatic-com/cypress":
+      optional: true
+    "@chromatic-com/playwright":
+      optional: true
+  bin:
+    chroma: dist/bin.js
+    chromatic: dist/bin.js
+    chromatic-cli: dist/bin.js
+  checksum: 10c0/58b3d7984db000f8c7b605788569a24c3f3cd41bb6b2d3a94f18acc9ff11ce6c6881f795c8390a94ff721ccfcf8a2d7942e78a54a1f70294a7b3d35ccc382154
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

The Storybook 10.4.1 patch (`.yarn/patches/storybook-npm-10.4.1.patch`) gates play functions on a story's **initial** render behind `parameters.autoplay`, so they no longer auto-run while browsing the dev UI. Chromatic renders each story through that same initial path (`renderToElement` → `render({ initial: true, forceRemount: true })`) and never remounts, so play functions were skipped during VRT capture. Snapshots reflected the pre-play state (e.g. tooltips captured **closed** instead of open).

This enables `autoplay` globally **only** under `isChromatic()`:

```ts
import isChromatic from 'chromatic/isChromatic';
// parameters:
autoplay: isChromatic(),
```

Global parameters merge into every story, so the patched condition `this.story?.parameters?.autoplay ?? false` resolves to `true` in Chromatic for all stories and `false` in the interactive dev UI. The `playFunction &&` guard leaves play-less stories (Playground, Overview) untouched. This restores the pre-patch Chromatic behavior while preserving the dev-UI quietness the patch was added for.

`chromatic` is declared as a direct devDependency of `@adobe/spectrum-wc` so the `chromatic/isChromatic` import does not rely on dependency hoisting.

## Motivation and context

Tooltip 2nd-gen stories use play functions to open the tooltip (`tooltip.open = true` + `waitFor(:popover-open)`) so Chromatic can snapshot the open state. Under the patch those snapshots were wrong. The same latent bug affects any component whose VRT depends on a play function, not just tooltip.

> **Note:** this PR is based on `swc-2017/tooltip` so Chromatic exercises the tooltip stories. It should be retargeted to `main` (or folded into the tooltip PR) before merge, since the fix is repo-wide.

## Related issue(s)

- SWC-2017

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have reviewed the Accessibility Practices for this feature.
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

### Manual review test cases

- [ ] _Play functions run in Chromatic_
  1. Open the Chromatic build for this PR
  2. Inspect the Tooltip stories (Open, Placements, Variants, etc.)
  3. Expect tooltips to render in their opened state in the snapshots

- [ ] _Dev UI stays quiet_
  1. Run `yarn storybook` locally
  2. Navigate to Tooltip stories
  3. Expect play functions to NOT auto-run (tooltips stay closed until interacted with)

## Accessibility testing checklist

This change affects only Storybook's VRT snapshot capture (when play functions run); it introduces no DOM, role, or focus changes to any component.

- [ ] **Keyboard** (required — document steps below)
  - No focusable parts are added or changed by this PR. Confirm no regression in Tooltip keyboard behavior (Tab to trigger, tooltip shows on focus, Escape dismisses) in the dev UI.

- [ ] **Screen reader** (required — document steps below)
  - No ARIA/role changes. Confirm Tooltip announcements are unchanged from the base branch.