### PR TITLE
test(close-button): add Playwright a11y snapshots and keyboard coverage

### DIFF
--- a/2nd-gen/packages/swc/components/close-button/test/close-button.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.a11y.spec.ts
@@ -17,7 +17,10 @@ import { gotoStory } from '../../../utils/a11y-helpers.js';
 /**
  * Accessibility tests for Close Button component (2nd Generation).
  *
- * Placeholder: ARIA snapshot coverage is added in Phase 6.
+ * ARIA snapshot tests validate the accessibility tree structure.
+ * aXe WCAG compliance and color contrast validation are run via
+ * test-storybook (see .storybook/test-runner.ts). Both are included
+ * in the `test:a11y` command.
  */
 
 test.describe('Close Button - ARIA Snapshots', () => {
@@ -32,5 +35,138 @@ test.describe('Close Button - ARIA Snapshots', () => {
     await expect(root).toMatchAriaSnapshot(`
       - button "Close"
     `);
+  });
+
+  test('should handle anatomy story', async ({ page }) => {
+    const root = await gotoStory(
+      page,
+      'components-close-button--anatomy',
+      'swc-close-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Close"
+    `);
+  });
+
+  test('should handle different sizes', async ({ page }) => {
+    const root = await gotoStory(
+      page,
+      'components-close-button--sizes',
+      'swc-close-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Close (s)"
+      - button "Close (m)"
+      - button "Close (l)"
+      - button "Close (xl)"
+    `);
+  });
+
+  test('should handle static colors', async ({ page }) => {
+    const root = await gotoStory(
+      page,
+      'components-close-button--static-colors',
+      'swc-close-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Close (white)"
+      - button "Close (black)"
+    `);
+  });
+
+  test('should handle default and disabled states', async ({ page }) => {
+    const root = await gotoStory(
+      page,
+      'components-close-button--states',
+      'swc-close-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Close"
+      - button "Close" [disabled]
+    `);
+  });
+
+  test('should handle accessibility story naming patterns', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-close-button--accessibility',
+      'swc-close-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Close"
+      - button "Dismiss"
+      - button "Close dialog"
+      - button "Close" [disabled]
+    `);
+  });
+});
+
+test.describe('Close Button - Keyboard', () => {
+  test('should route tab focus to the internal button via delegatesFocus', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-close-button--overview',
+      'swc-close-button'
+    );
+
+    await page.keyboard.press('Tab');
+
+    const focusedTag = await root
+      .locator('swc-close-button')
+      .first()
+      .evaluate((element) => {
+        const shadowRoot = element.shadowRoot;
+        return shadowRoot?.activeElement?.tagName.toLowerCase();
+      });
+
+    expect(focusedTag, 'delegated focus lands on the inner native button').toBe(
+      'button'
+    );
+  });
+
+  test('should skip disabled close button when tabbing through states', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-close-button--states',
+      'swc-close-button'
+    );
+
+    await page.keyboard.press('Tab');
+
+    const firstButtonFocused = await root
+      .locator('swc-close-button')
+      .nth(0)
+      .evaluate((element) => {
+        const shadowRoot = element.shadowRoot;
+        const button = shadowRoot?.querySelector('button');
+        return shadowRoot?.activeElement === button && !button?.disabled;
+      });
+
+    expect(
+      firstButtonFocused,
+      'first enabled close button receives focus'
+    ).toBe(true);
+
+    await page.keyboard.press('Tab');
+
+    const disabledButtonFocused = await root
+      .locator('swc-close-button')
+      .nth(1)
+      .evaluate((element) => {
+        const shadowRoot = element.shadowRoot;
+        const button = shadowRoot?.querySelector('button');
+        return shadowRoot?.activeElement === button;
+      });
+
+    expect(
+      disabledButtonFocused,
+      'disabled close button is not focused after tab'
+    ).toBe(false);
   });
 });

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/close-button/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/close-button/migration-plan.md
@@ -235,7 +235,7 @@ Prerequisite dependency:
 
 ### Testing
 - [x] Unit tests for API and DOM contract (Storybook interaction tests on integration branch).
-- [ ] Playwright a11y snapshots and keyboard tests.
+- [x] Playwright a11y snapshots and keyboard tests.
 - [x] Storybook interaction coverage for API and accessibility contract.
 
 ### Documentation


### PR DESCRIPTION
## Description

Completes **Phase 6 (Testing)** for the `swc-close-button` 2nd-gen migration.

- Expands `close-button.a11y.spec.ts` from a single placeholder snapshot to full Playwright coverage.
- Adds **ARIA snapshot** tests for Overview, Anatomy, Sizes, Static colors, States, and Accessibility stories.
- Adds **keyboard** tests for `delegatesFocus` (Tab lands on the inner native `<button>`) and disabled skip behavior in the States story.
- Ticks **Playwright a11y snapshots and keyboard tests** in `migration-plan.md`.

No API, styling, or docs changes in this PR. Stacked on **#6385** (`ttomar/close-button-styling-v2`).

## Motivation and context

API (#6360) and styling/docs (#6385) PRs deferred Playwright a11y work to Phase 6. Storybook interaction tests already cover the DOM contract and keyboard activation; this PR adds the automated accessibility-tree and tab-focus coverage expected by the washing-machine workflow before the integration branch merges to `main`.

## Related issue(s)

- SWC-2087 (epic — close-button 2nd-gen migration)
- SWC-2089 (planning)

## Screenshots (if appropriate)

N/A — test-only change.

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published. _(Deferred — integration branch; changeset with final merge to `main`.)_
- [x] I have included updated documentation if my change required it. _(Migration plan Testing checklist only.)_

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features _(N/A — integration-branch PR)_
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash _(N/A — no visual changes)_

### Manual review test cases

- [ ] **Playwright a11y suite**
  1. From `2nd-gen/packages/swc`: `yarn playwright test components/close-button/test/close-button.a11y.spec.ts --project=chromium`
  2. Expect **8/8** tests pass (6 ARIA snapshots + 2 keyboard).

- [ ] **Storybook interaction tests (regression)**
  1. From `2nd-gen/packages/swc`: `yarn test -- --run --project storybook components/close-button`
  2. Expect all Close Button/Tests stories pass (no regressions from prior API PR).

- [ ] **Spot-check ARIA tree in Storybook**
  1. Open 2nd-gen Storybook → Close Button → **Accessibility**.
  2. Confirm four dismiss controls: `accessible-label`, slot text (“Dismiss”), dialog chrome (“Close dialog”), and disabled.
  3. Inspect accessibility tree — each should be a single named `button`; icon must not duplicate the name.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

_(Automated tests only; device review is optional for this PR.)_

## Accessibility testing checklist

Automated Playwright coverage is the primary deliverable; manual steps below mirror what the new tests assert.

- [x] **Keyboard** (required — document steps below)
  1. Open 2nd-gen Storybook → Close Button → **Overview**.
  2. Press **Tab** — focus should land on the inner `<button>` (delegated focus), with a visible focus indicator (from #6385 styling).
  3. Open Close Button → **States** — Tab to the first control, then Tab again — the **disabled** instance should not receive focus.
  4. On an enabled control, **Enter** and **Space** activate the button (covered by existing Storybook tests).

- [x] **Screen reader** (required — document steps below)
  1. Overview with `accessible-label="Close"` — announced as **button**, name **“Close”**.
  2. Accessibility story → slot-only instance — announced as **button**, name **“Dismiss”**.
  3. Accessibility story → dialog chrome — announced as **button**, name **“Close dialog”**.
  4. Disabled instance — announced as **button**, name **“Close”**, disabled state exposed; icon must not add a second name (`aria-hidden="true"` on icon wrapper).
