### PR TITLE
ci: add 2nd-gen-only beta publish scope to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,14 @@ on:
         description: 'NPM dist-tag (e.g., latest, beta, snapshot)'
         required: false
         default: 'next'
+      scope:
+        description: 'Packages to publish: all (1st-gen + 2nd-gen) or 2nd-gen (core + @adobe/spectrum-wc only)'
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - 2nd-gen
   pull_request:
     types: [labeled, synchronize]
   push:
@@ -95,6 +103,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ github.event.inputs.tag }}
+          INPUT_SCOPE: ${{ github.event.inputs.scope }}
         run: |
           if [ "$EVENT_NAME" == "pull_request" ]; then
             # PRs with the snapshot-release label always use snapshot-test
@@ -107,16 +116,30 @@ jobs:
             WORKFLOW_TAG="next"
           fi
 
+          # Publish scope only applies to manual runs; everything else publishes all packages
+          if [ "$EVENT_NAME" == "workflow_dispatch" ] && [ "$INPUT_SCOPE" == "2nd-gen" ]; then
+            WORKFLOW_SCOPE="2nd-gen"
+          else
+            WORKFLOW_SCOPE="all"
+          fi
+
           echo "tag=$WORKFLOW_TAG" >> $GITHUB_OUTPUT
+          echo "scope=$WORKFLOW_SCOPE" >> $GITHUB_OUTPUT
           echo "Using npm tag: $WORKFLOW_TAG"
+          echo "Publish scope: $WORKFLOW_SCOPE"
 
       - name: Validate release tag
         env:
           TAG: ${{ steps.extract-tag.outputs.tag }}
+          SCOPE: ${{ steps.extract-tag.outputs.scope }}
           GIT_REF: ${{ github.ref }}
         run: |
           if [ "$TAG" == "latest" ] && [ "$GIT_REF" != "refs/heads/main" ]; then
             echo "ERROR: Cannot publish 'latest' from non-main branch"
+            exit 1
+          fi
+          if [ "$SCOPE" == "2nd-gen" ] && [ "$TAG" == "latest" ]; then
+            echo "ERROR: 2nd-gen-only scope does not support the 'latest' tag; use a pre-release tag such as 'beta'"
             exit 1
           fi
 
@@ -139,9 +162,11 @@ jobs:
         run: yarn build
 
       - name: Generate custom elements manifests
+        if: steps.extract-tag.outputs.scope != '2nd-gen'
         run: yarn workspace @spectrum-web-components/1st-gen custom-element-json
 
       - name: Confirm build artifacts
+        if: steps.extract-tag.outputs.scope != '2nd-gen'
         run: yarn workspace @spectrum-web-components/1st-gen build:confirm
 
       - name: Version packages
@@ -172,7 +197,7 @@ jobs:
           yarn build
 
       - name: Publish all packages
-        if: steps.npm-auth.outcome == 'success'
+        if: steps.npm-auth.outcome == 'success' && steps.extract-tag.outputs.scope != '2nd-gen'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
           TAG: ${{ steps.extract-tag.outputs.tag }}
@@ -187,12 +212,33 @@ jobs:
             yarn changeset publish --no-git-tag --tag $TAG
           fi
 
+      - name: Publish 2nd-gen packages only
+        if: steps.npm-auth.outcome == 'success' && steps.extract-tag.outputs.scope == '2nd-gen'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
+          TAG: ${{ steps.extract-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Publish ONLY the 2nd-gen packages, leaving 1st-gen untouched even if
+          # 1st-gen changesets are present in this run (they stay unpublished and
+          # continue to release as `next` from the normal main pipeline).
+          #
+          # `yarn pack` resolves the workspace: protocol and honors each package's
+          # files field, producing a publishable tarball. `npm publish` then selects
+          # the correct auth automatically, matching how `changeset publish` behaves:
+          # - @spectrum-web-components/core -> OIDC trusted publishing
+          # - @adobe/spectrum-wc           -> npm token (from ~/.npmrc)
+          yarn workspace @spectrum-web-components/core pack --out /tmp/swc-core.tgz
+          yarn workspace @adobe/spectrum-wc pack --out /tmp/swc-wc.tgz
+          npm publish /tmp/swc-core.tgz --tag "$TAG" --access public
+          npm publish /tmp/swc-wc.tgz --tag "$TAG" --access public
+
       - name: Build React wrappers
-        if: needs.check-changesets.outputs.has_1st_gen_changesets == 'true'
+        if: needs.check-changesets.outputs.has_1st_gen_changesets == 'true' && steps.extract-tag.outputs.scope != '2nd-gen'
         run: yarn workspace @spectrum-web-components/1st-gen build:react
 
       - name: Publish React wrappers
-        if: needs.check-changesets.outputs.has_1st_gen_changesets == 'true'
+        if: needs.check-changesets.outputs.has_1st_gen_changesets == 'true' && steps.extract-tag.outputs.scope != '2nd-gen'
         env:
           TAG: ${{ steps.extract-tag.outputs.tag }}
         run: |
@@ -236,6 +282,7 @@ jobs:
         if: always()
         env:
           TAG: ${{ steps.extract-tag.outputs.tag }}
+          SCOPE: ${{ steps.extract-tag.outputs.scope }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -267,6 +314,7 @@ jobs:
             echo "| **Trigger** | Manual dispatch |" >> $GITHUB_STEP_SUMMARY
             echo "| **Branch** | \`${REF_NAME}\` |" >> $GITHUB_STEP_SUMMARY
             echo "| **NPM tag** | \`${TAG}\` |" >> $GITHUB_STEP_SUMMARY
+            echo "| **Scope** | \`${SCOPE}\` |" >> $GITHUB_STEP_SUMMARY
             echo "| **Actor** | @${ACTOR} |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,8 +62,11 @@ jobs:
             HAS_1ST_GEN=false
             for file in .changeset/*.md; do
               if [ "$(basename "$file")" != "README.md" ]; then
-                PACKAGES=$(grep -oP "@spectrum-web-components/[a-z-]+" "$file")
-                NON_CORE=$(echo "$PACKAGES" | grep -v "^@spectrum-web-components/core$")
+                # `|| true` keeps `set -e` from aborting when grep finds no match
+                # (e.g. a changeset that references only @spectrum-web-components/core,
+                # or only @adobe/spectrum-wc with no @spectrum-web-components/* package).
+                PACKAGES=$(grep -oP "@spectrum-web-components/[a-z-]+" "$file" || true)
+                NON_CORE=$(echo "$PACKAGES" | grep -v "^@spectrum-web-components/core$" || true)
                 if [ -n "$NON_CORE" ]; then
                   HAS_1ST_GEN=true
                   break

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,11 @@ on:
         options:
           - all
           - 2nd-gen
+      dry_run:
+        description: 'Dry run: build, version, and pack but use npm publish --dry-run (no registry writes). Only applies to the 2nd-gen scope.'
+        required: false
+        type: boolean
+        default: false
   pull_request:
     types: [labeled, synchronize]
   push:
@@ -217,6 +222,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
           TAG: ${{ steps.extract-tag.outputs.tag }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           set -euo pipefail
           # Publish ONLY the 2nd-gen packages, leaving 1st-gen untouched even if
@@ -228,10 +234,15 @@ jobs:
           # the correct auth automatically, matching how `changeset publish` behaves:
           # - @spectrum-web-components/core -> OIDC trusted publishing
           # - @adobe/spectrum-wc           -> npm token (from ~/.npmrc)
+          PUBLISH_FLAGS="--tag $TAG --access public"
+          if [ "$DRY_RUN" == "true" ]; then
+            PUBLISH_FLAGS="$PUBLISH_FLAGS --dry-run"
+            echo "::notice::DRY RUN - packing only, no packages will be published to npm"
+          fi
           yarn workspace @spectrum-web-components/core pack --out /tmp/swc-core.tgz
           yarn workspace @adobe/spectrum-wc pack --out /tmp/swc-wc.tgz
-          npm publish /tmp/swc-core.tgz --tag "$TAG" --access public
-          npm publish /tmp/swc-wc.tgz --tag "$TAG" --access public
+          npm publish /tmp/swc-core.tgz $PUBLISH_FLAGS
+          npm publish /tmp/swc-wc.tgz $PUBLISH_FLAGS
 
       - name: Build React wrappers
         if: needs.check-changesets.outputs.has_1st_gen_changesets == 'true' && steps.extract-tag.outputs.scope != '2nd-gen'


### PR DESCRIPTION
## Description

Adds a manual, scoped pre-release path to the **Publish Packages** workflow so a private beta of the 2nd-gen packages can be cut on demand **without** releasing 1st-gen.

- New `workflow_dispatch` input `scope` (`all` | `2nd-gen`). Defaults to `all`.
- New `workflow_dispatch` input `dry_run` (boolean, default `false`) for the 2nd-gen scope; uses `npm publish --dry-run` so the build/version/pack can be validated without writing to npm.
- When `scope == 2nd-gen`:
  - Only `@spectrum-web-components/core` and `@adobe/spectrum-wc` are packed (`yarn pack`, which resolves the `workspace:` protocol) and published with the chosen dist-tag.
  - `core` continues to use OIDC trusted publishing and `@adobe/spectrum-wc` the npm token, matching `changeset publish` behavior — so this must remain in `publish.yml` (same workflow file + `npm-publish` environment) for OIDC to keep matching.
  - 1st-gen steps (custom-elements manifest, `build:confirm`, React wrappers) are skipped, and 1st-gen is **never published** even when 1st-gen changesets are present.
  - The `latest` tag is rejected for this scope.
- Fixes a pre-existing `bash -e` bug in `check-changesets`: the package-detection `grep` aborted the job whenever a changeset referenced only `@spectrum-web-components/core` (`grep -v` matches nothing and exits 1). Added `|| true`.

This is **backward compatible**: the default `all` scope and the automatic push-to-`main` `next` release are unchanged; `scope` is only evaluated for manual runs.

> The new `scope`/`dry_run` inputs only appear in the **Run workflow** UI once this is on `main` (the form is rendered from the default branch). Until then they can only be passed via `gh workflow run --ref <branch> -f scope=2nd-gen`.

## Motivation and context

We are running a private (unannounced) beta of the 2nd-gen components through mid-July. Releases need to go out under the `beta` dist-tag for the 2nd-gen packages only, while 1st-gen continues its normal `next`/`latest` cadence from `main`. The existing workflow publishes every changeset-bumped package under a single tag, so it cannot scope a beta to 2nd-gen.

## Related issue(s)

- fixes [add Jira/issue number]

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [ ] I have reviewed the Accessibility Practices for this feature.
- [x] I have added automated tests to cover my changes.<!-- N/A: CI workflow change only -->
- [x] I have included a well-written changeset if my change needs to be published.<!-- N/A: no published package code changes -->
- [ ] I have included updated documentation if my change required it.<!-- follow-up: note the option in the Releasing SWC guide -->

### Manual review test cases

- [ ] _Dry run from the branch publishes nothing but validates packing_
  1. `gh workflow run publish.yml --ref rajdeepchandra/ci-2nd-gen-beta-publish -f tag=beta -f scope=2nd-gen -f dry_run=true`
  2. Confirm `check-changesets` passes and the "Publish 2nd-gen packages only" step runs `npm publish --dry-run` for `core` + `@adobe/spectrum-wc`.
  3. Expect no 1st-gen steps to run and nothing written to npm.

- [ ] _Real 2nd-gen beta publishes only core + swc_
  1. After merge, in **Actions → Publish Packages → Run workflow**, set dist-tag `beta`, scope `2nd-gen`.
  2. Expect only `@spectrum-web-components/core@…-beta-…` and `@adobe/spectrum-wc@…-beta-…` on npm under the `beta` tag.
  3. Expect no 1st-gen packages or React wrappers published, even if 1st-gen changesets exist.

## Accessibility testing checklist

> Not applicable — this PR only changes CI/release automation (`.github/workflows/publish.yml`); there are no component, markup, or styling changes.

- [ ] **Keyboard** — N/A (no UI changes)
- [ ] **Screen reader** — N/A (no UI changes)

Made with [Cursor](https://cursor.com)