### PR TITLE
docs(status-light): remove a11y.exclude for neutral variant color contrast

### DIFF
--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -260,6 +260,7 @@ const preview = {
                 'Spectrum SWC migration',
                 'Anti patterns',
                 'Property order quick reference',
+                'Stylesheets',
               ],
               'TypeScript',
               [
@@ -336,7 +337,10 @@ const preview = {
                   'Rendering and styling migration analysis',
                 ],
                 'Action group',
-                ['Rendering and styling migration analysis'],
+                [
+                  'Accessibility migration analysis',
+                  'Rendering and styling migration analysis',
+                ],
                 'Action menu',
                 [
                   'Accessibility migration analysis',
@@ -379,6 +383,11 @@ const preview = {
                 ],
                 'Color field',
                 ['Rendering and styling migration analysis'],
+                'Color handle',
+                [
+                  'Accessibility migration analysis',
+                  'Rendering and styling migration analysis',
+                ],
                 'Color loupe',
                 [
                   'Accessibility migration analysis',

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -188,19 +188,6 @@ export const SemanticVariants: Story = {
         })
     )}
   `,
-  parameters: {
-    a11y: {
-      // @todo Known issue: neutral variant has color contrast of 4.39:1 vs required 4.5:1
-      // Exclude only the neutral variant from color-contrast checks
-      // Tracking this in SWC-1606
-      exclude: {
-        'color-contrast': [
-          'swc-status-light[variant="neutral"]',
-          '.swc-StatusLight--neutral',
-        ],
-      },
-    },
-  },
   tags: ['options'],
 };
 
@@ -282,19 +269,6 @@ export const Accessibility: Story = {
       'default-slot': nonSemanticLabels['silver'],
     })}
   `,
-  parameters: {
-    a11y: {
-      // @todo Known issue: neutral variant has color contrast of 4.39:1 vs required 4.5:1
-      // Exclude only the neutral variant from color-contrast checks
-      // Tracking this in SWC-1606
-      exclude: {
-        'color-contrast': [
-          'swc-status-light[variant="neutral"]',
-          '.swc-StatusLight--neutral',
-        ],
-      },
-    },
-  },
   tags: ['a11y'],
 };
 


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

Removes the temporary `a11y.exclude` overrides for the `color-contrast` axe rule on the neutral variant in `status-light.stories.ts`. The exclusions were on the `SemanticVariants` and `Accessibility` stories.

## Motivation and context

The exclusions were added as a temporary unblock when `neutral-content-color-default` resolved to gray-600, giving the neutral status light text a contrast ratio of ~4.39:1 against white (below the WCAG AA threshold of 4.5:1). A subsequent cleanup updated that token to gray-800, which has a contrast ratio of 14.55:1 and passes without any exclusion. The root cause has already been fixed; the workaround can be removed.

## Related issue(s)

- fixes SWC-1606

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

- [ ] Neutral variant passes color contrast
  1. Open 2nd-gen Storybook and navigate to Status light → Semantic variants
  2. Open the Accessibility panel
  3. Expect 0 violations and color contrast listed under Passes

- [ ] No regressions on other variants
  1. Open Status light → Accessibility
  2. Open the Accessibility panel
  3. Expect 0 violations across all variants

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

<!---
    Manual accessibility testing is required because automated tools cannot catch all issues (e.g. focus order, screen reader announcements, keyboard flow).
    You must document your keyboard and screen reader testing steps below. Reviewers will use this checklist during review.
    See: [Accessibility testing guide](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTOR-DOCS/01_contributor-guides/09_accessibility-testing.md)
-->

**Required:** Complete each applicable item and document your testing steps (replace the placeholders with your component-specific instructions).

**Required:** Complete each applicable item and document your testing steps (replace the placeholders with your component-specific instructions).

- [x] **Keyboard** (required — document steps below) — Status light is non-interactive; no keyboard behavior to verify.
  1. Tab through a Status light story page
  2. Confirm focus passes through without trapping on any status light element
  3. Expect no regressions in surrounding interactive elements

- [x] **Screen reader** (required — document steps below) — Role and label announcements are unchanged by this fix.
  1. Navigate to Status light → Accessibility in Storybook with a screen reader active
  2. Move through each status light element
  3. Expect each is announced with its label text and no contrast-related errors
