### PR TITLE
feat(core): adding focus retained story and tests to pending state co…

### DIFF
--- a/2nd-gen/packages/core/controllers/pending-controller/pending-controller.mdx
+++ b/2nd-gen/packages/core/controllers/pending-controller/pending-controller.mdx
@@ -93,6 +93,14 @@ A `pendingLabel` on the host overrides the derived name and is used verbatim as 
 
 <Canvas of={Stories.ExplicitPendingLabel} />
 
+### Focus retained on re-render
+
+When `pendingActive` transitions from `false` to `true`, the controller calls `host.requestUpdate()`, which triggers a Lit re-render. Because lit-html patches the DOM in place rather than replacing elements, the focused `<button>` element is not destroyed; its class and content are updated around it. Focus remains on the button throughout the re-render.
+
+Click the button below to start a pending operation. The button receives focus via the click and re-renders after the controller's delay. Focus is preserved.
+
+<Canvas of={Stories.FocusRetained} />
+
 ## Accessibility
 
 ### Features

--- a/2nd-gen/packages/core/controllers/pending-controller/stories/demo-hosts.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/stories/demo-hosts.ts
@@ -90,11 +90,13 @@ export class DemoPendingHost extends LitElement {
     pending: { type: Boolean, reflect: true },
     pendingLabel: { type: String, attribute: 'pending-label' },
     label: { type: String },
+    clickPending: { type: Boolean, attribute: 'click-pending' },
   };
 
   declare pending: boolean;
   declare pendingLabel?: string;
   declare label: string;
+  declare clickPending: boolean;
 
   private readonly pendingController = new PendingController(this, {
     delay: 250,
@@ -103,10 +105,32 @@ export class DemoPendingHost extends LitElement {
       this.label || (this.textContent?.trim() ?? null),
   });
 
+  private resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private readonly onButtonClick = (): void => {
+    if (this.pending) {
+      return;
+    }
+    this.pending = true;
+    this.resetTimer = setTimeout(() => {
+      this.resetTimer = null;
+      this.pending = false;
+    }, 2000);
+  };
+
   constructor() {
     super();
     this.pending = false;
     this.label = 'Save';
+    this.clickPending = false;
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback?.();
+    if (this.resetTimer !== null) {
+      clearTimeout(this.resetTimer);
+      this.resetTimer = null;
+    }
   }
 
   protected override render(): TemplateResult {
@@ -123,6 +147,7 @@ export class DemoPendingHost extends LitElement {
             ? this.pendingController.getPendingAccessibleName()
             : undefined
         )}
+        @click=${this.clickPending ? this.onButtonClick : null}
       >
         <span class="demo-button-label">${this.label}</span>
         ${this.pendingController.renderPendingState()}

--- a/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.stories.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.stories.ts
@@ -131,6 +131,14 @@ export const ExplicitPendingLabel: Story = {
 };
 ExplicitPendingLabel.storyName = 'Explicit pending label';
 
+export const FocusRetained: Story = {
+  render: () => html`
+    <demo-pending-host click-pending .label=${'Save'}></demo-pending-host>
+  `,
+  tags: ['behaviors'],
+};
+FocusRetained.storyName = 'Focus retained on re-render';
+
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────

--- a/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.test.ts
+++ b/2nd-gen/packages/core/controllers/pending-controller/stories/pending-controller.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * These Storybook play tests verify observable `PendingController` behavior using
+ * real browser timers and programmatic property changes.
+ *
+ * ### Timing
+ *
+ * The `demo-pending-host` element uses a 250 ms controller delay (shortened from
+ * the 1000 ms production default) so tests are responsive without multi-second
+ * waits. All `wait()` calls include a buffer beyond the configured delay.
+ *
+ * ### Focus-retention contract
+ *
+ * When `pendingActive` transitions from `false` to `true`, the controller calls
+ * `host.requestUpdate()`, which triggers a Lit re-render. Because lit-html patches
+ * the DOM in place rather than replacing elements, the focused `<button>` is not
+ * destroyed. The test verifies that `shadowRoot.activeElement` still points to the
+ * same internal button after the re-render.
+ */
+
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import './demo-hosts.js';
+
+import type { DemoPendingHost } from './demo-hosts.js';
+import pendingMeta, { FocusRetained } from './pending-controller.stories.js';
+
+// ─────────────────────────
+//     HELPERS
+// ─────────────────────────
+
+/** Waits `ms` milliseconds for async timers to settle. */
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─────────────────────────
+//     META
+// ─────────────────────────
+
+export default {
+  ...pendingMeta,
+  title: 'Controllers/Pending controller/Tests',
+  parameters: {
+    ...pendingMeta.parameters,
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+// ──────────────────────────────────────────────────────────────────────────
+//     Focus retained through controller-triggered re-render
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Verifies that when `pendingActive` becomes `true` (after the controller's 250 ms
+ * delay following a mouse-focus-style interaction), Lit's in-place DOM patch does
+ * not move focus away from the internal `<button>`.
+ *
+ * Sequence:
+ * 1. Focus the internal button (simulating mouse-click focus).
+ * 2. Verify focus is on the button before any pending state.
+ * 3. Set `pending = true` — immediately applies `aria-disabled` and `aria-label`.
+ * 4. Wait for the controller's 250 ms delay (plus a buffer).
+ * 5. Verify `pendingActive` visual is active (spinner present, CSS class applied).
+ * 6. Verify focus is still on the same button element after the re-render.
+ */
+export const FocusRetainedTest: Story = {
+  ...FocusRetained,
+  play: async ({ canvasElement, step }) => {
+    const host =
+      canvasElement.querySelector<DemoPendingHost>('demo-pending-host');
+    if (!host) {
+      throw new Error('demo-pending-host not found');
+    }
+
+    const shadowRoot = host.shadowRoot as ShadowRoot;
+    const internalButton =
+      shadowRoot.querySelector<HTMLButtonElement>('button');
+    if (!internalButton) {
+      throw new Error('Internal <button> not found');
+    }
+
+    await step('button is not pending in initial state', async () => {
+      expect(host.pending, 'pending defaults to false').toBe(false);
+      expect(
+        internalButton.getAttribute('aria-disabled'),
+        'aria-disabled is absent in default state'
+      ).toBeNull();
+    });
+
+    await step(
+      'mouse-focus-style interaction: button receives focus',
+      async () => {
+        // Dispatch pointerdown before focus to mirror the sequence a real
+        // mouse click produces (pointer-click focus, not keyboard focus).
+        internalButton.dispatchEvent(
+          new PointerEvent('pointerdown', { bubbles: true, composed: true })
+        );
+        internalButton.focus();
+        expect(
+          shadowRoot.activeElement,
+          'internal button is the active element in the shadow root'
+        ).toBe(internalButton);
+      }
+    );
+
+    await step(
+      'setting pending=true immediately applies aria attributes; focus is preserved',
+      async () => {
+        host.pending = true;
+        await host.updateComplete;
+
+        expect(
+          internalButton.getAttribute('aria-disabled'),
+          'aria-disabled is set to true immediately when pending'
+        ).toBe('true');
+        expect(
+          internalButton.getAttribute('aria-label'),
+          'aria-label is set to the derived busy name immediately'
+        ).toBe('Save, busy');
+        expect(
+          shadowRoot.activeElement,
+          'focus is still on the internal button after the immediate aria update'
+        ).toBe(internalButton);
+      }
+    );
+
+    await step(
+      'after the controller delay, pendingActive re-renders the button; focus is preserved',
+      async () => {
+        // The demo host uses delay=250 ms. Wait 350 ms to include a buffer.
+        await wait(350);
+        await host.updateComplete;
+
+        const spinner = shadowRoot.querySelector('.swc-PendingSpinner');
+        expect(
+          spinner,
+          'spinner is rendered once pendingActive is true'
+        ).toBeTruthy();
+        expect(
+          internalButton.classList.contains('demo-button--pendingActive'),
+          'pendingActive CSS class is applied after the controller delay'
+        ).toBe(true);
+        expect(
+          shadowRoot.activeElement,
+          'focus is still on the same button element after the controller-triggered re-render'
+        ).toBe(internalButton);
+      }
+    );
+
+    await step(
+      'clearing pending removes the busy visual; focus is preserved',
+      async () => {
+        host.pending = false;
+        await host.updateComplete;
+        // Allow the deactivation re-render to settle.
+        await wait(50);
+        await host.updateComplete;
+
+        expect(
+          shadowRoot.querySelector('.swc-PendingSpinner'),
+          'spinner is removed after pending clears'
+        ).toBeNull();
+        expect(
+          internalButton.classList.contains('demo-button--pendingActive'),
+          'pendingActive class is removed after pending clears'
+        ).toBe(false);
+        expect(
+          shadowRoot.activeElement,
+          'focus is still on the button after pending clears'
+        ).toBe(internalButton);
+      }
+    );
+  },
+};
+FocusRetainedTest.storyName = 'Focus retained on re-render (test)';

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -361,6 +361,7 @@ const preview = {
                 [
                   'Accessibility migration analysis',
                   'Migration plan',
+                  'Pending controller extraction',
                   'Rendering and styling migration analysis',
                 ],
                 'Button group',


### PR DESCRIPTION
…ntroller

<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

- Added tests and stories to determine if focus is retained on button even if pending state changes.

<!--- Describe your changes in detail -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
As I was reviewing this PR, I wanted to test if focus is retained when pending state changes, but I couldn't fake it just from the browser alone, so I made this branch. It may be worth keeping this test.

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- fixes [Issue Number]

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

- [ ] _Pending state focus_
  1. Checkout this branch
  2. Run storybook locally
  3. Open the Pending state Controller Docs
  4. Go to http://localhost:6006/?path=/docs/core-controllers-pending-controller--docs#focus-retained-on-re-render
  5. Using a keyboard navigate to the button in the demo.
  6. Press <kbd>Enter</kbd> to toggle pending state and wait for pending state to change
  7. Ensure focus remains on button even after pending state changes.
  8. Ensure all tests pass.