### PR TITLE
feat(icon): make swc-icon public with BYO SVG docs and private elements catalog

### DIFF
--- a/.changeset/icon-public-rollout.md
+++ b/.changeset/icon-public-rollout.md
@@ -1,0 +1,9 @@
+---
+'@adobe/spectrum-wc': minor
+---
+
+Make `<swc-icon>` public with BYO SVG documentation.
+
+- **API**: slot inline SVG via the default slot; `label` and `size` attributes; `--swc-icon-*` custom properties. No iconsets, `name`, or `src`.
+- **Packaging**: `@adobe/spectrum-wc/icon` exports `<swc-icon>` only. Internal SVG factories under `elements/` remain monorepo-only.
+- **Docs**: public Storybook page, consumer migration guide, and maintainer catalog in `*.internal.*` stories excluded from production builds.

--- a/2nd-gen/packages/core/components/icon/Icon.base.ts
+++ b/2nd-gen/packages/core/components/icon/Icon.base.ts
@@ -82,9 +82,11 @@ export abstract class IconBase extends SizedMixin(SpectrumElement, {
     if (this.label) {
       svgElement.setAttribute('aria-label', this.label);
       svgElement.removeAttribute('aria-hidden');
+      svgElement.removeAttribute('focusable');
     } else {
       svgElement.setAttribute('aria-hidden', 'true');
       svgElement.removeAttribute('aria-label');
+      svgElement.setAttribute('focusable', 'false');
     }
   }
 

--- a/2nd-gen/packages/swc/.storybook/blocks/GettingStarted.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/GettingStarted.tsx
@@ -59,13 +59,6 @@ Import the side effectful registration of \`<${tagName}>\` via:
 import '@adobe/spectrum-wc/components/${packageName}/${tagName}.js';
 \`\`\`
 
-To reference the \`${baseClassName}\` type, import it as a type-only import:
-
-\`\`\`typescript
-import type { ${baseClassName} } from '@adobe/spectrum-wc/components/${packageName}';
-\`\`\`
-
-> The class is exposed primarily for type purposes. Extending it is possible, but the internal shape is not part of the public API — if you choose to subclass, you do so at your own risk and may need to adjust your code between releases.
 `;
 
     return <Markdown>{markdownContent}</Markdown>;

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -422,6 +422,8 @@ const preview = {
                 ],
                 'Help text',
                 ['Rendering and styling migration analysis'],
+                'Icon',
+                ['Migration plan'],
                 'Illustrated message',
                 [
                   'Accessibility migration analysis',

--- a/2nd-gen/packages/swc/components/badge/Badge.ts
+++ b/2nd-gen/packages/swc/components/badge/Badge.ts
@@ -37,7 +37,9 @@ import styles from './badge.css';
  *
  * @example
  * <swc-badge variant="neutral" fixed="fill">
- *   <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
+ *   <swc-icon slot="icon" aria-hidden="true">
+ *     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">...</svg>
+ *   </swc-icon>
  *   Verified
  * </swc-badge>
  *

--- a/2nd-gen/packages/swc/components/badge/Badge.ts
+++ b/2nd-gen/packages/swc/components/badge/Badge.ts
@@ -37,7 +37,7 @@ import styles from './badge.css';
  *
  * @example
  * <swc-badge variant="neutral" fixed="fill">
- *   <swc-icon slot="icon" aria-hidden="true">
+ *   <swc-icon slot="icon">
  *     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">...</svg>
  *   </swc-icon>
  *   Verified

--- a/2nd-gen/packages/swc/components/badge/badge.mdx
+++ b/2nd-gen/packages/swc/components/badge/badge.mdx
@@ -152,7 +152,7 @@ Badges with visible text are announced directly by screen readers. The text in t
 ### Icon + text
 
 When an icon accompanies a text label, the icon is decorative and should be hidden from assistive technology.
-Apply `aria-hidden="true"` to the `<swc-icon>` so screen readers only announce the label text.
+Omit `label` on `<swc-icon>` so screen readers only announce the label text.
 
 ### Icon only
 

--- a/2nd-gen/packages/swc/components/badge/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/badge/migration-guide.mdx
@@ -94,13 +94,13 @@ Add `aria-label` to icon-only badges so assistive tech announces a name:
 </sp-badge>
 <!-- After (default size is `s`; use `size="m"` if you need medium) -->
 <swc-badge aria-label="Approved">
-  <swc-icon slot="icon" aria-hidden="true">
+  <swc-icon slot="icon">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">...</svg>
   </swc-icon>
 </swc-badge>
 ```
 
-Add `aria-hidden="true"` to decorative icons paired with text so screen readers don't announce the icon and label as duplicate content:
+Omit `label` on decorative icons paired with text so `<swc-icon>` can hide the icon from assistive technology:
 
 ```html
 <!-- Before -->
@@ -110,7 +110,7 @@ Add `aria-hidden="true"` to decorative icons paired with text so screen readers 
 </sp-badge>
 <!-- After -->
 <swc-badge variant="positive">
-  <swc-icon slot="icon" aria-hidden="true">
+  <swc-icon slot="icon">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">...</svg>
   </swc-icon>
   Approved
@@ -133,7 +133,7 @@ The `outline` attribute can only be used with semantic variants (`accent`, `info
 ## Accessibility
 
 - **Icon-only badges** must have `aria-label` on the host. See [step 3](#3-fix-consumer-facing-accessibility-gaps).
-- **Decorative icons** paired with text should use `aria-hidden="true"` so screen readers don't announce duplicate content. See [step 3](#3-fix-consumer-facing-accessibility-gaps).
+- **Decorative icons** paired with text should omit `label` on `<swc-icon>` so the icon remains hidden from assistive technology and the text is announced once. See [step 3](#3-fix-consumer-facing-accessibility-gaps).
 - Badges are non-interactive. Refactor any focusable or clickable badges to `<swc-action-button>`, `<swc-tag>`, or a native button.
 
 ## Styling
@@ -225,5 +225,5 @@ Replace every `--mod-badge-*` property with its `--swc-badge-*` equivalent:
 - [ ] Add an explicit `variant` to every `<swc-badge>` — use `variant="informative"` if that was the Spectrum 1 default intent
 - [ ] Replace `--mod-badge-*` overrides on semantic variants with `--swc-badge-*`; retoken globally for non-semantic color variants
 - [ ] Add `aria-label` to icon-only badges
-- [ ] Add `aria-hidden="true"` to decorative icons
+- [ ] Omit `label` on decorative `<swc-icon>` usage
 - [ ] Refactor any interactive badges

--- a/2nd-gen/packages/swc/components/badge/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/badge/migration-guide.mdx
@@ -94,7 +94,9 @@ Add `aria-label` to icon-only badges so assistive tech announces a name:
 </sp-badge>
 <!-- After (default size is `s`; use `size="m"` if you need medium) -->
 <swc-badge aria-label="Approved">
-  <sp-icon-checkmark-circle slot="icon"></sp-icon-checkmark-circle>
+  <swc-icon slot="icon" aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">...</svg>
+  </swc-icon>
 </swc-badge>
 ```
 
@@ -108,10 +110,9 @@ Add `aria-hidden="true"` to decorative icons paired with text so screen readers 
 </sp-badge>
 <!-- After -->
 <swc-badge variant="positive">
-  <sp-icon-checkmark-circle
-    aria-hidden="true"
-    slot="icon"
-  ></sp-icon-checkmark-circle>
+  <swc-icon slot="icon" aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">...</svg>
+  </swc-icon>
   Approved
 </swc-badge>
 ```

--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -199,7 +199,7 @@ export const Playground: Story = {
       >
         ${iconKey
           ? html`
-              <swc-icon size=${size} slot="icon" aria-hidden="true">
+              <swc-icon size=${size} slot="icon">
                 ${iconForSize(Icons, iconKey, size)}
               </swc-icon>
             `
@@ -488,9 +488,9 @@ export const Accessibility: Story = {
       'default-slot': 'Version 1.2.10',
     })}
 
-    <!-- Icon + text: icon is decorative, aria-hidden="true" hides it from assistive technology -->
+    <!-- Icon + text: omit label on swc-icon so it remains decorative. -->
     <swc-badge variant="positive" size=${args.size}>
-      <swc-icon size=${args.size} slot="icon" aria-hidden="true">
+      <swc-icon size=${args.size} slot="icon">
         ${iconForSize(Icons, 'Checkmark', args.size)}
       </swc-icon>
       Approved

--- a/2nd-gen/packages/swc/components/button/button.mdx
+++ b/2nd-gen/packages/swc/components/button/button.mdx
@@ -14,6 +14,8 @@ A button consists of:
 - **Default slot**: visible text label
 - **icon slot**: optional leading icon
 
+For the `icon` slot, use `<swc-icon>` with slotted SVG content.
+
 When only an icon is provided (no label), the button renders as a circular icon-only button. Icon-only buttons must include an `accessible-label` attribute so the action is announced to screen reader users.
 
 <Canvas of={ButtonStories.Anatomy} />

--- a/2nd-gen/packages/swc/components/button/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/button/migration-guide.mdx
@@ -90,7 +90,7 @@ The deprecated aliases `cta`, `overBackground`, `white`, and `black` are removed
 </sp-button>
 <!-- After -->
 <swc-button accessible-label="Add item">
-  <swc-icon slot="icon" aria-hidden="true">
+  <swc-icon slot="icon">
     <svg viewBox="0 0 36 36">...</svg>
   </swc-icon>
 </swc-button>

--- a/2nd-gen/packages/swc/components/button/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/button/migration-guide.mdx
@@ -86,11 +86,13 @@ The deprecated aliases `cta`, `overBackground`, `white`, and `black` are removed
 ```html
 <!-- Before -->
 <sp-button label="Add item">
-  <svg slot="icon">...</svg>
+  <sp-icon-help slot="icon"></sp-icon-help>
 </sp-button>
 <!-- After -->
 <swc-button accessible-label="Add item">
-  <svg slot="icon">...</svg>
+  <swc-icon slot="icon" aria-hidden="true">
+    <svg viewBox="0 0 36 36">...</svg>
+  </swc-icon>
 </swc-button>
 ```
 

--- a/2nd-gen/packages/swc/components/button/stories/button.stories.ts
+++ b/2nd-gen/packages/swc/components/button/stories/button.stories.ts
@@ -116,7 +116,7 @@ const staticColorLabels = {
   black: 'Static black',
 } as const satisfies Record<ButtonStaticColor, string>;
 
-const addIconSvg = `<swc-icon slot="icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" focusable="false"><path d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"/></svg></swc-icon>`;
+const addIconSvg = `<swc-icon slot="icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36"><path d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"/></svg></swc-icon>`;
 
 // ────────────────────
 //    PLAYGROUND STORY
@@ -165,11 +165,7 @@ export const Anatomy: Story = {
       accessible-label="Add"
     >
       <swc-icon slot="icon">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 36 36"
-          focusable="false"
-        >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
           <path
             d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
           />
@@ -371,17 +367,13 @@ export const Accessibility: Story = {
       size=${args.size ?? 'm'}
       accessible-label="Add item"
     >
-      <svg
-        slot="icon"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 36 36"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path
-          d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
-        />
-      </svg>
+      <swc-icon slot="icon">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36">
+          <path
+            d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
+          />
+        </svg>
+      </swc-icon>
     </swc-button>
     ${template({
       ...args,

--- a/2nd-gen/packages/swc/components/button/stories/button.stories.ts
+++ b/2nd-gen/packages/swc/components/button/stories/button.stories.ts
@@ -26,6 +26,7 @@ import {
 } from '@spectrum-web-components/core/components/button';
 
 import '@adobe/spectrum-wc/components/button/swc-button.js';
+import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 
 // ────────────────
 //    METADATA
@@ -115,7 +116,7 @@ const staticColorLabels = {
   black: 'Static black',
 } as const satisfies Record<ButtonStaticColor, string>;
 
-const addIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" aria-hidden="true" focusable="false"><path d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"/></svg>`;
+const addIconSvg = `<swc-icon slot="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" aria-hidden="true" focusable="false"><path d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"/></svg></swc-icon>`;
 
 // ────────────────────
 //    PLAYGROUND STORY
@@ -163,19 +164,18 @@ export const Anatomy: Story = {
       size=${args.size}
       accessible-label="Add"
     >
-      <svg
-        slot="icon"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 36 36"
-        height="18"
-        width="18"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path
-          d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
-        />
-      </svg>
+      <swc-icon slot="icon" aria-hidden="true">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 36 36"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"
+          />
+        </svg>
+      </swc-icon>
     </swc-button>
   `,
   tags: ['anatomy'],

--- a/2nd-gen/packages/swc/components/button/stories/button.stories.ts
+++ b/2nd-gen/packages/swc/components/button/stories/button.stories.ts
@@ -116,7 +116,7 @@ const staticColorLabels = {
   black: 'Static black',
 } as const satisfies Record<ButtonStaticColor, string>;
 
-const addIconSvg = `<swc-icon slot="icon" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" aria-hidden="true" focusable="false"><path d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"/></svg></swc-icon>`;
+const addIconSvg = `<swc-icon slot="icon"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" focusable="false"><path d="M31.5 17H19V4.5a1 1 0 0 0-2 0V17H4.5a1 1 0 0 0 0 2H17v12.5a1 1 0 0 0 2 0V19h12.5a1 1 0 0 0 0-2z"/></svg></swc-icon>`;
 
 // ────────────────────
 //    PLAYGROUND STORY
@@ -164,11 +164,10 @@ export const Anatomy: Story = {
       size=${args.size}
       accessible-label="Add"
     >
-      <swc-icon slot="icon" aria-hidden="true">
+      <swc-icon slot="icon">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 36 36"
-          aria-hidden="true"
           focusable="false"
         >
           <path

--- a/2nd-gen/packages/swc/components/icon/Icon.ts
+++ b/2nd-gen/packages/swc/components/icon/Icon.ts
@@ -22,16 +22,11 @@ import styles from './icon.css';
  * @since 2.0.0
  *
  * @example
- * <swc-icon label="Search">
- *   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
- *     <path d="M14.5 13.09 11.41 10a6 6 0 1 0-1.41 1.41l3.09 3.09a1 1 0 0 0 1.41-1.41zM3 7a4 4 0 1 1 8 0 4 4 0 0 1-8 0z"/>
+ * <swc-icon label="Expand">
+ *   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+ *     <path d="M2.83789 9.8252c-.19238 0-.38379-.07324-.53027-.21973-.29297-.29297-.29297-.76758 0-1.06055l3.54395-3.54492L2.30762 1.45508c-.29297-.29297-.29297-.76758 0-1.06055s.76758-.29297 1.06055 0l4.07422 4.0752c.29297.29297.29297.76758 0 1.06055l-4.07422 4.0752c-.14648.14648-.33789.21973-.53027.21973Z"/>
  *   </svg>
  * </swc-icon>
- *
- * @example
- * import { Chevron100Icon } from './elements/Chevron100Icon.js';
- *
- * html`<swc-icon label="Expand">${Chevron100Icon()}</swc-icon>`;
  *
  * @cssprop --swc-icon-color - Color of the icon.
  * @cssprop --swc-icon-inline-size - Inline size of the icon.

--- a/2nd-gen/packages/swc/components/icon/Icon.ts
+++ b/2nd-gen/packages/swc/components/icon/Icon.ts
@@ -19,7 +19,6 @@ import styles from './icon.css';
  * Minimal icon renderer that accepts slotted SVG markup.
  *
  * @element swc-icon
- * @status internal
  * @since 2.0.0
  *
  * @example

--- a/2nd-gen/packages/swc/components/icon/icon.internal.mdx
+++ b/2nd-gen/packages/swc/components/icon/icon.internal.mdx
@@ -3,49 +3,15 @@ import { DocsFooter, DocsHeader } from '../../.storybook/blocks';
 
 import * as IconStories from './stories/icon.internal.stories';
 
-<Meta of={IconStories} />
+<Meta of={IconStories} name="Internal catalog" />
 
 <DocsHeader />
 
-## Anatomy
+## Usage
 
-An icon consists of:
+> Maintainer catalog only. Not published in production Storybook.
 
-1. **Rendered graphic**: a shared slotted SVG template
-
-### Content
-
-- Default slot: provide SVG markup to render.
-
-<Canvas of={IconStories.Anatomy} />
-
-## Options
-
-### Sizes
-
-Icons come in five sizes to fit different layout contexts:
-
-- **Extra-small (`xs`)**: dense UIs and compact metadata rows
-- **Small (`s`)**: supporting iconography in constrained spaces
-- **Medium (`m`)**: default size for general component usage
-- **Large (`l`)**: prominent icon usage in larger controls
-- **Extra-large (`xl`)**: high-emphasis icon presentation
-
-<Canvas of={IconStories.Sizes} />
-
-### Sources
-
-#### Shared templates
-
-Import reusable templates from `../elements/index.js` and slot them into `<swc-icon>`. This keeps icon usage centralized and avoids per-component SVG duplication.
-
-<Canvas of={IconStories.Sources} />
-
-### Shared Templates
-
-Use the shared icon catalog to keep icon usage consistent across components.
-
-Example import:
+Import reusable SVG factories from `../elements/index.js` for monorepo components. Slot the returned Lit template into `<swc-icon>`.
 
 ```ts
 import { Chevron100Icon } from '../elements/index.js';
@@ -53,29 +19,12 @@ import { Chevron100Icon } from '../elements/index.js';
 
 <Canvas of={IconStories.SharedTemplates} />
 
-### Available Icons
+## Options
 
-Available shared icons in the current internal catalog. Use this story as a quick reference for what can be imported from `../elements/index.js`.
+### Available icons
+
+Shared icons in the current internal catalog. Use this story as a quick reference for what can be imported from `../elements/index.js`.
 
 <Canvas of={IconStories.AvailableIcons} />
-
-## Accessibility
-
-### Features
-
-The `<swc-icon>` element implements several accessibility features:
-
-#### SVG labeling
-
-- Slotted SVGs receive `role="img"` and use `aria-label` when `label` is provided
-- When no label is provided, slotted SVGs are marked `aria-hidden="true"`
-
-### Best practices
-
-- Always provide a descriptive `label` for informative icons
-- Use empty labels only for purely decorative icons
-- Keep labels short and specific (e.g., "Search" instead of "Icon")
-
-<Canvas of={IconStories.Accessibility} />
 
 <DocsFooter />

--- a/2nd-gen/packages/swc/components/icon/icon.mdx
+++ b/2nd-gen/packages/swc/components/icon/icon.mdx
@@ -1,0 +1,70 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { DocsFooter, DocsHeader } from '../../.storybook/blocks';
+
+import * as IconStories from './stories/icon.stories';
+
+<Meta of={IconStories} />
+
+<DocsHeader />
+
+## Anatomy
+
+An icon consists of:
+
+1. **Rendered graphic**: SVG markup slotted into the default slot
+
+### Content
+
+- Default slot: provide inline `<svg>` markup (or a Lit template that renders SVG).
+
+<Canvas of={IconStories.Anatomy} />
+
+## Options
+
+### Sizes
+
+Icons come in five sizes to fit different layout contexts:
+
+- **Extra-small (`xs`)**: dense UIs and compact metadata rows
+- **Small (`s`)**: supporting iconography in constrained spaces
+- **Medium (`m`)**: default size for general component usage
+- **Large (`l`)**: prominent icon usage in larger controls
+- **Extra-large (`xl`)**: high-emphasis icon presentation
+
+<Canvas of={IconStories.Sizes} />
+
+### Inline SVG source
+
+Provide icon artwork as slotted SVG. Spectrum 2 does not include iconsets or a `name` attribute. Copy or import SVG from your design source and slot it directly:
+
+```html
+<swc-icon label="Expand">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+    <path
+      d="M2.83789 9.8252c-.19238 0-.38379-.07324-.53027-.21973-.29297-.29297-.29297-.76758 0-1.06055l3.54395-3.54492L2.30762 1.45508c-.29297-.29297-.29297-.76758 0-1.06055s.76758-.29297 1.06055 0l4.07422 4.0752c.29297.29297.29297.76758 0 1.06055l-4.07422 4.0752c-.14648.14648-.33789.21973-.53027.21973Z"
+    />
+  </svg>
+</swc-icon>
+```
+
+## Accessibility
+
+### Features
+
+The `<swc-icon>` element implements several accessibility features:
+
+#### SVG labeling
+
+- Slotted SVGs receive `role="img"` and use `aria-label` when `label` is provided
+- When no label is provided, slotted SVGs are marked `aria-hidden="true"`
+
+### Best practices
+
+- Always provide a descriptive `label` for informative icons
+- Use empty labels only for purely decorative icons
+- Keep labels short and specific (e.g., "Expand" instead of "Icon")
+- When an icon accompanies visible text, omit `label` and set `aria-hidden="true"` on the icon so screen readers do not announce duplicate content
+
+<Canvas of={IconStories.Accessibility} />
+
+<DocsFooter />

--- a/2nd-gen/packages/swc/components/icon/icon.mdx
+++ b/2nd-gen/packages/swc/components/icon/icon.mdx
@@ -23,19 +23,19 @@ An icon consists of:
 
 ### Sizes
 
-Icons come in five sizes to fit different layout contexts:
+Icons come in five sizes to fit with component sizes. Refer to specific components for recommended size pairings.
 
-- **Extra-small (`xs`)**: dense UIs and compact metadata rows
-- **Small (`s`)**: supporting iconography in constrained spaces
-- **Medium (`m`)**: default size for general component usage
-- **Large (`l`)**: prominent icon usage in larger controls
-- **Extra-large (`xl`)**: high-emphasis icon presentation
+- Extra-small (`xs`)
+- Small (`s`)
+- Medium (`m`)
+- Large (`l`)
+- Extra-large (`xl`)
 
 <Canvas of={IconStories.Sizes} />
 
 ### Inline SVG source
 
-Provide icon artwork as slotted SVG. Spectrum 2 does not include iconsets or a `name` attribute. Copy or import SVG from your design source and slot it directly:
+Provide icon artwork as slotted SVG. Spectrum 2 does not include iconsets or a `name` attribute. Copy or import SVG from your design source and slot it directly. Keep the `xmlns` and `viewBox` attributes, and remove `width` or `height` attributes so the icon can receive dimensions from the component `size` attribute.
 
 ```html
 <swc-icon label="Expand">
@@ -61,7 +61,7 @@ The `<swc-icon>` element implements several accessibility features:
 ### Best practices
 
 - Always provide a descriptive `label` for informative icons
-- Use empty labels only for purely decorative icons
+- Omit labels only for purely decorative icons
 - Keep labels short and specific (e.g., "Expand" instead of "Icon")
 - When an icon accompanies visible text, omit `label` so `<swc-icon>` treats it as decorative and hides it from assistive technology
 

--- a/2nd-gen/packages/swc/components/icon/icon.mdx
+++ b/2nd-gen/packages/swc/components/icon/icon.mdx
@@ -63,7 +63,7 @@ The `<swc-icon>` element implements several accessibility features:
 - Always provide a descriptive `label` for informative icons
 - Use empty labels only for purely decorative icons
 - Keep labels short and specific (e.g., "Expand" instead of "Icon")
-- When an icon accompanies visible text, omit `label` and set `aria-hidden="true"` on the icon so screen readers do not announce duplicate content
+- When an icon accompanies visible text, omit `label` so `<swc-icon>` treats it as decorative and hides it from assistive technology
 
 <Canvas of={IconStories.Accessibility} />
 

--- a/2nd-gen/packages/swc/components/icon/index.ts
+++ b/2nd-gen/packages/swc/components/icon/index.ts
@@ -10,4 +10,3 @@
  * governing permissions and limitations under the License.
  */
 export * from './Icon.js';
-export * from './elements/index.js';

--- a/2nd-gen/packages/swc/components/icon/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/icon/migration-guide.mdx
@@ -40,13 +40,13 @@ import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 
 ### Removed in Spectrum 2
 
-| Removed                          | Replacement                                                                                                   |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `name` attribute                 | Slot an SVG directly, or use an icon factory function — see [step 2](#2-replace-name-or-src-with-slotted-svg) |
-| `src` attribute                  | Slot an `<svg>` or `<img>` element directly — see [step 2](#2-replace-name-or-src-with-slotted-svg)           |
-| `error` event                    | Removed along with `src` support — remove any `error` listeners on `sp-icon`                                  |
-| `xxs` and `xxl` size values      | Use `xs` for `xxs` and `xl` for `xxl`                                                                         |
-| `--mod-icon-*` custom properties | `--swc-icon-*` equivalents (see [Styling](#styling))                                                          |
+| Removed                          | Replacement                                                                                        |
+| -------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `name` attribute                 | Slot an inline `<svg>`. See [step 2](#2-replace-name-or-src-with-slotted-svg)                      |
+| `src` attribute                  | Slot an `<svg>` or use a standalone `<img>`. See [step 2](#2-replace-name-or-src-with-slotted-svg) |
+| `error` event                    | Removed along with `src` support. Remove any `error` listeners on `sp-icon`                        |
+| `xxs` and `xxl` size values      | Use `xs` for `xxs` and `xl` for `xxl`                                                              |
+| `--mod-icon-*` custom properties | `--swc-icon-*` equivalents (see [Styling](#styling))                                               |
 
 ## Update your code
 
@@ -65,29 +65,17 @@ import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 
 ### 2. Replace `name` or `src` with slotted SVG
 
-The `name` attribute (iconset registry lookup) and `src` attribute (image URL) have both been removed. All icon content must now be provided as slotted content.
+The `name` attribute (iconset registry lookup) and `src` attribute (image URL) have both been removed. All icon content must now be provided as slotted SVG markup.
 
-**Migrating `name`-based icons with Lit:**
+**Migrating `name`-based icons:**
 
-Icon factory functions are available from `@adobe/spectrum-wc/components/icon/elements/index.js`. Each factory returns a Lit `TemplateResult` and must be used inside a `html` tagged template literal.
-
-```ts
-import { Arrow100Icon } from '@adobe/spectrum-wc/components/icon/elements/index.js';
-import { html } from 'lit';
-
-// Inside a Lit template:
-html`
-  <swc-icon label="Arrow">${Arrow100Icon()}</swc-icon>
-`;
-```
-
-**Migrating `name`-based icons without Lit (or using inline SVG):**
+Copy the SVG from your design source or icon library and slot it directly:
 
 ```html
 <!-- Before -->
 <sp-icon name="ui:Arrow100"></sp-icon>
 
-<!-- After: inline SVG in the default slot -->
+<!-- After -->
 <swc-icon label="Arrow">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
     <path
@@ -97,18 +85,32 @@ html`
 </swc-icon>
 ```
 
+**With Lit:**
+
+```ts
+import { html } from 'lit';
+
+html`
+  <swc-icon label="Arrow">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+      <path d="…" />
+    </svg>
+  </swc-icon>
+`;
+```
+
 **Migrating `src`-based icons:**
 
 ```html
 <!-- Before -->
 <sp-icon src="/icons/my-icon.svg" label="My icon"></sp-icon>
 
-<!-- After: option 1 — inline SVG in the default slot -->
+<!-- After: option 1, inline SVG in the default slot -->
 <swc-icon label="My icon">
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">…</svg>
 </swc-icon>
 
-<!-- After: option 2 — standalone <img> when no icon wrapper is needed -->
+<!-- After: option 2, standalone <img> when no icon wrapper is needed -->
 <img src="/icons/my-icon.svg" alt="My icon" />
 ```
 
@@ -136,14 +138,14 @@ The `xxs` and `xxl` size values have been removed. Update to the nearest availab
 When an icon communicates information not available from surrounding text, add a `label` attribute so assistive technology can announce it.
 
 ```html
-<!-- Decorative icon alongside visible text — omit label -->
+<!-- Decorative icon alongside visible text: omit label -->
 <swc-icon><svg>…</svg></swc-icon>
 Save
 
-<!-- Meaningful standalone icon — set label directly on the icon -->
+<!-- Meaningful standalone icon: set label directly on the icon -->
 <swc-icon label="Search"><svg>…</svg></swc-icon>
 
-<!-- Icon inside an interactive element — label the wrapper instead -->
+<!-- Icon inside an interactive element: label the wrapper instead -->
 <button aria-label="Search">
   <swc-icon><svg>…</svg></swc-icon>
 </button>
@@ -217,7 +219,7 @@ Replace every `--mod-icon-*` property with its `--swc-icon-*` equivalent:
 
 - [ ] Update imports
 - [ ] Rename all `<sp-icon>` to `<swc-icon>`
-- [ ] Replace `name`-based icons with slotted SVG or icon factory functions
+- [ ] Replace `name`-based icons with slotted inline SVG
 - [ ] Replace `src`-based icons with slotted SVG or standalone `<img>`
 - [ ] Remove any `error` event listeners on icon elements
 - [ ] Update `xxs` size to `xs` and `xxl` size to `xl`

--- a/2nd-gen/packages/swc/components/icon/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/icon/migration-guide.mdx
@@ -69,7 +69,7 @@ The `name` attribute (iconset registry lookup) and `src` attribute (image URL) h
 
 **Migrating `name`-based icons:**
 
-Copy the SVG from your design source or icon library and slot it directly:
+Copy the SVG from your design source or icon library and slot it directly. Keep `xmlns` and `viewBox`, and remove any `width` or `height` attributes so `<swc-icon size="...">` controls dimensions consistently:
 
 ```html
 <!-- Before -->
@@ -85,7 +85,7 @@ Copy the SVG from your design source or icon library and slot it directly:
 </swc-icon>
 ```
 
-**With Lit:**
+**In templates (including Lit):**
 
 ```ts
 import { html } from 'lit';
@@ -154,7 +154,7 @@ Save
 ## Accessibility
 
 - The component always sets `role="img"` on the slotted SVG.
-- Without `label`, `aria-hidden="true"` is set on both the host and the slotted SVG, hiding the icon entirely from assistive technology. Use this for decorative icons that appear alongside visible text.
+- Without `label`, `aria-hidden="true"` is set on both the host and the slotted SVG, and `focusable="false"` is applied to the slotted SVG. This hides decorative icons from assistive technology and avoids SVG focus behavior in legacy screen reader/browser combinations.
 - When `label` is set, `aria-hidden` is removed from both the host and the SVG, and `aria-label` is applied to the SVG so screen readers announce the icon with a meaningful name.
 - `<swc-icon>` is not focusable. For interactive icons, wrap them in a `<button>` or `<a>` element and set the accessible name on the interactive wrapper rather than on the icon.
 

--- a/2nd-gen/packages/swc/components/icon/stories/icon.internal.stories.ts
+++ b/2nd-gen/packages/swc/components/icon/stories/icon.internal.stories.ts
@@ -64,6 +64,30 @@ export default meta;
 
 const iconSvg = Chevron100Icon();
 
+const iconCatalog = Object.entries(iconElements)
+  .filter(
+    ([name, iconFactory]) =>
+      name.endsWith('Icon') && typeof iconFactory === 'function'
+  )
+  .sort(([a], [b]) => a.localeCompare(b))
+  .map(([name, iconFactory]) => ({
+    name,
+    icon: iconFactory as () => TemplateResult,
+  }));
+
+const defaultIconName = 'Chevron100Icon';
+
+argTypes['icon-name'] = {
+  name: 'icon-name',
+  control: { type: 'select' },
+  options: iconCatalog.map(({ name }) => name),
+  description: 'Internal icon factory to render in the default slot.',
+  table: {
+    category: 'Story controls',
+    type: { summary: 'string' },
+  },
+};
+
 const sizeLabels = {
   xs: 'Extra-small',
   s: 'Small',
@@ -81,16 +105,32 @@ const iconCardStyles = {
   padding: '8px',
 } as const;
 
+type InternalIconStoryArgs = Record<string, unknown> & {
+  'icon-name'?: string;
+};
+
+const renderInternalIcon = ({
+  'icon-name': iconName = defaultIconName,
+  ...iconArgs
+}: InternalIconStoryArgs) =>
+  template(
+    iconArgs,
+    (
+      iconCatalog.find(({ name }) => name === iconName)?.icon ?? Chevron100Icon
+    )()
+  );
+
 // ────────────────────
 //    PLAYGROUND STORY
 // ────────────────────
 
 export const Playground: Story = {
   tags: ['dev'],
-  render: (args) => template(args, iconSvg),
+  render: (args) => renderInternalIcon(args),
   args: {
     label: 'Search',
     size: 'm',
+    'icon-name': defaultIconName,
   },
 };
 
@@ -150,23 +190,13 @@ export const SharedTemplates: Story = {
 
 export const AvailableIcons: Story = {
   render: (args) => {
-    const catalog = Object.entries(iconElements)
-      .filter(
-        ([name, iconFactory]) =>
-          name.endsWith('Icon') && typeof iconFactory === 'function'
-      )
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([name, iconFactory]) => ({
-        name,
-        icon: (iconFactory as () => TemplateResult)(),
-      }));
     return html`
-      ${catalog.map(
+      ${iconCatalog.map(
         (entry) => html`
           <div style=${styleMap(iconCardStyles)}>
             ${template(
               { ...args, label: args.label || entry.name },
-              entry.icon
+              entry.icon()
             )}
             <code>${entry.name}</code>
           </div>

--- a/2nd-gen/packages/swc/components/icon/stories/icon.stories.ts
+++ b/2nd-gen/packages/swc/components/icon/stories/icon.stories.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
@@ -30,6 +31,16 @@ argTypes.size = {
   ...argTypes.size,
   control: { type: 'select' },
   options: ICON_VALID_SIZES,
+};
+
+argTypes.svg = {
+  name: 'svg',
+  control: { type: 'text' },
+  description: 'Inline SVG markup to render in the default slot.',
+  table: {
+    category: 'Story controls',
+    type: { summary: 'string' },
+  },
 };
 
 /**
@@ -58,13 +69,11 @@ export default meta;
 // ────────────────────
 
 // SVG copied from `elements/Chevron100Icon.ts` for docs examples (BYO slot content).
-const chevronIconSvg = html`
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
-    <path
-      d="M2.83789 9.8252c-.19238 0-.38379-.07324-.53027-.21973-.29297-.29297-.29297-.76758 0-1.06055l3.54395-3.54492L2.30762 1.45508c-.29297-.29297-.29297-.76758 0-1.06055s.76758-.29297 1.06055 0l4.07422 4.0752c.29297.29297.29297.76758 0 1.06055l-4.07422 4.0752c-.14648.14648-.33789.21973-.53027.21973Z"
-    />
-  </svg>
-`;
+const chevronIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  <path
+    d="M2.83789 9.8252c-.19238 0-.38379-.07324-.53027-.21973-.29297-.29297-.29297-.76758 0-1.06055l3.54395-3.54492L2.30762 1.45508c-.29297-.29297-.29297-.76758 0-1.06055s.76758-.29297 1.06055 0l4.07422 4.0752c.29297.29297.29297.76758 0 1.06055l-4.07422 4.0752c-.14648.14648-.33789.21973-.53027.21973Z"
+  />
+</svg>`;
 
 const sizeLabels = {
   xs: 'Extra-small',
@@ -74,16 +83,26 @@ const sizeLabels = {
   xl: 'Extra-large',
 } as const satisfies Record<IconSize, string>;
 
+type IconStoryArgs = Record<string, unknown> & {
+  svg?: string;
+};
+
+const renderStoryIcon = ({
+  svg = chevronIconSvg,
+  ...iconArgs
+}: IconStoryArgs) => template(iconArgs, unsafeHTML(svg));
+
 // ────────────────────
 //    PLAYGROUND STORY
 // ────────────────────
 
 export const Playground: Story = {
   tags: ['dev'],
-  render: (args) => template(args, chevronIconSvg),
+  render: (args) => renderStoryIcon(args),
   args: {
     label: 'Expand',
     size: 'm',
+    svg: chevronIconSvg,
   },
 };
 
@@ -93,7 +112,7 @@ export const Playground: Story = {
 
 export const Overview: Story = {
   tags: ['overview'],
-  render: (args) => template(args, chevronIconSvg),
+  render: (args) => renderStoryIcon(args),
   args: {
     label: 'Expand',
     size: 'm',
@@ -106,7 +125,7 @@ export const Overview: Story = {
 
 export const Anatomy: Story = {
   render: (args) =>
-    template({ ...args, label: args.label || 'Chevron icon' }, chevronIconSvg),
+    renderStoryIcon({ ...args, label: args.label || 'Chevron icon' }),
   tags: ['anatomy'],
 };
 
@@ -117,10 +136,7 @@ export const Anatomy: Story = {
 export const Sizes: Story = {
   render: (args) => html`
     ${ICON_VALID_SIZES.map((size) =>
-      template(
-        { ...args, label: args.label || sizeLabels[size], size },
-        chevronIconSvg
-      )
+      renderStoryIcon({ ...args, label: args.label || sizeLabels[size], size })
     )}
   `,
   tags: ['options'],
@@ -134,6 +150,6 @@ export const Sizes: Story = {
 // ────────────────────────────────
 
 export const Accessibility: Story = {
-  render: (args) => template(args, chevronIconSvg),
+  render: (args) => renderStoryIcon(args),
   tags: ['a11y'],
 };

--- a/2nd-gen/packages/swc/components/icon/stories/icon.stories.ts
+++ b/2nd-gen/packages/swc/components/icon/stories/icon.stories.ts
@@ -9,8 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { html, type TemplateResult } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
+import { html } from 'lit';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
@@ -20,9 +19,6 @@ import {
 } from '@spectrum-web-components/core/components/icon';
 
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
-
-import { Chevron100Icon } from '../elements/index.js';
-import * as iconElements from '../elements/index.js';
 
 // ────────────────
 //    METADATA
@@ -37,20 +33,19 @@ argTypes.size = {
 };
 
 /**
- * **Internal maintainer catalog.**
- *
- * Shared SVG templates under `../elements/` for monorepo usage only.
- * Public `<swc-icon>` docs use BYO inline SVG. See `icon.stories.ts`.
+ * Icons represent symbols, objects, or actions. `<swc-icon>` renders SVG markup
+ * from the default slot. Bring your own SVG. Spectrum 2 does not ship iconsets
+ * or a `name` registry.
  */
 const meta: Meta = {
-  title: 'Icon/Internal catalog',
+  title: 'Icon',
   component: 'swc-icon',
   args,
   argTypes,
   render: (args) => template(args),
   parameters: {
     docs: {
-      subtitle: `Internal SVG template catalog for monorepo maintainers.`,
+      subtitle: `Slot your own SVG to render an icon at a Spectrum size.`,
     },
   },
   tags: ['migrated'],
@@ -62,7 +57,14 @@ export default meta;
 //    HELPERS
 // ────────────────────
 
-const iconSvg = Chevron100Icon();
+// SVG copied from `elements/Chevron100Icon.ts` for docs examples (BYO slot content).
+const chevronIconSvg = html`
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+    <path
+      d="M2.83789 9.8252c-.19238 0-.38379-.07324-.53027-.21973-.29297-.29297-.29297-.76758 0-1.06055l3.54395-3.54492L2.30762 1.45508c-.29297-.29297-.29297-.76758 0-1.06055s.76758-.29297 1.06055 0l4.07422 4.0752c.29297.29297.29297.76758 0 1.06055l-4.07422 4.0752c-.14648.14648-.33789.21973-.53027.21973Z"
+    />
+  </svg>
+`;
 
 const sizeLabels = {
   xs: 'Extra-small',
@@ -72,24 +74,15 @@ const sizeLabels = {
   xl: 'Extra-large',
 } as const satisfies Record<IconSize, string>;
 
-const iconCardStyles = {
-  display: 'inline-flex',
-  'flex-direction': 'column',
-  'align-items': 'center',
-  gap: '8px',
-  'min-inline-size': '120px',
-  padding: '8px',
-} as const;
-
 // ────────────────────
 //    PLAYGROUND STORY
 // ────────────────────
 
 export const Playground: Story = {
   tags: ['dev'],
-  render: (args) => template(args, iconSvg),
+  render: (args) => template(args, chevronIconSvg),
   args: {
-    label: 'Search',
+    label: 'Expand',
     size: 'm',
   },
 };
@@ -100,9 +93,9 @@ export const Playground: Story = {
 
 export const Overview: Story = {
   tags: ['overview'],
-  render: (args) => template(args, iconSvg),
+  render: (args) => template(args, chevronIconSvg),
   args: {
-    label: 'Search',
+    label: 'Expand',
     size: 'm',
   },
 };
@@ -113,7 +106,7 @@ export const Overview: Story = {
 
 export const Anatomy: Story = {
   render: (args) =>
-    template({ ...args, label: args.label || 'Chevron icon' }, iconSvg),
+    template({ ...args, label: args.label || 'Chevron icon' }, chevronIconSvg),
   tags: ['anatomy'],
 };
 
@@ -126,7 +119,7 @@ export const Sizes: Story = {
     ${ICON_VALID_SIZES.map((size) =>
       template(
         { ...args, label: args.label || sizeLabels[size], size },
-        iconSvg
+        chevronIconSvg
       )
     )}
   `,
@@ -136,60 +129,11 @@ export const Sizes: Story = {
   },
 };
 
-export const Sources: Story = {
-  render: (args) =>
-    template({ ...args, label: args.label || 'Chevron icon' }, iconSvg),
-  tags: ['options'],
-};
-
-export const SharedTemplates: Story = {
-  render: (args) =>
-    template({ ...args, label: args.label || 'Chevron' }, Chevron100Icon()),
-  tags: ['options'],
-};
-
-export const AvailableIcons: Story = {
-  render: (args) => {
-    const catalog = Object.entries(iconElements)
-      .filter(
-        ([name, iconFactory]) =>
-          name.endsWith('Icon') && typeof iconFactory === 'function'
-      )
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([name, iconFactory]) => ({
-        name,
-        icon: (iconFactory as () => TemplateResult)(),
-      }));
-    return html`
-      ${catalog.map(
-        (entry) => html`
-          <div style=${styleMap(iconCardStyles)}>
-            ${template(
-              { ...args, label: args.label || entry.name },
-              entry.icon
-            )}
-            <code>${entry.name}</code>
-          </div>
-        `
-      )}
-    `;
-  },
-  tags: ['options'],
-  parameters: {
-    docs: {
-      canvas: {
-        sourceState: 'none',
-      },
-    },
-    flexLayout: 'row-wrap',
-  },
-};
-
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────
 
 export const Accessibility: Story = {
-  render: (args) => template(args, iconSvg),
+  render: (args) => template(args, chevronIconSvg),
   tags: ['a11y'],
 };

--- a/2nd-gen/packages/swc/components/icon/test/icon.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/icon/test/icon.a11y.spec.ts
@@ -29,7 +29,7 @@ test.describe('Icon - ARIA Snapshots', () => {
   }) => {
     const root = await gotoStory(page, 'components-icon--overview', 'swc-icon');
     await expect(root).toMatchAriaSnapshot(`
-      - img "Search"
+      - img "Expand"
     `);
   });
 

--- a/2nd-gen/packages/swc/components/icon/test/icon.test.ts
+++ b/2nd-gen/packages/swc/components/icon/test/icon.test.ts
@@ -18,8 +18,12 @@ import { Icon } from '@adobe/spectrum-wc/icon';
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 
 import { getComponent } from '../../../utils/test-utils.js';
-import meta from '../stories/icon.internal.stories.js';
-import { Overview } from '../stories/icon.internal.stories.js';
+import meta from '../stories/icon.stories.js';
+import { Overview } from '../stories/icon.stories.js';
+
+// Copied from `elements/Chevron100Icon.ts`.
+const chevronPath =
+  'M2.83789 9.8252c-.19238 0-.38379-.07324-.53027-.21973-.29297-.29297-.29297-.76758 0-1.06055l3.54395-3.54492L2.30762 1.45508c-.29297-.29297-.29297-.76758 0-1.06055s.76758-.29297 1.06055 0l4.07422 4.0752c.29297.29297.29297.76758 0 1.06055l-4.07422 4.0752c-.14648.14648-.33789.21973-.53027.21973Z';
 
 // This file defines dev-only test stories that reuse the main story metadata.
 export default {
@@ -42,7 +46,7 @@ export const OverviewTest: Story = {
     const icon = await getComponent<Icon>(canvasElement, 'swc-icon');
 
     await step('renders with expected default properties', async () => {
-      expect(icon.label, 'label property is "Search"').toBe('Search');
+      expect(icon.label, 'label property is "Expand"').toBe('Expand');
       expect(icon.shadowRoot, 'shadow root is attached').toBeTruthy();
     });
   },
@@ -54,11 +58,9 @@ export const OverviewTest: Story = {
 
 export const SizeAttributeTest: Story = {
   render: () => html`
-    <swc-icon size="xl" label="Search">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-        <path
-          d="M14.5 13.09 11.41 10a6 6 0 1 0-1.41 1.41l3.09 3.09a1 1 0 0 0 1.41-1.41zM3 7a4 4 0 1 1 8 0 4 4 0 0 1-8 0z"
-        />
+    <swc-icon size="xl" label="Expand">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+        <path d=${chevronPath} />
       </svg>
     </swc-icon>
   `,
@@ -77,11 +79,9 @@ export const SizeAttributeTest: Story = {
 
 export const SlottedSvgAccessibilityTest: Story = {
   render: () => html`
-    <swc-icon label="Search">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-        <path
-          d="M14.5 13.09 11.41 10a6 6 0 1 0-1.41 1.41l3.09 3.09a1 1 0 0 0 1.41-1.41zM3 7a4 4 0 1 1 8 0 4 4 0 0 1-8 0z"
-        />
+    <swc-icon label="Expand">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+        <path d=${chevronPath} />
       </svg>
     </swc-icon>
   `,
@@ -96,7 +96,7 @@ export const SlottedSvgAccessibilityTest: Story = {
       expect(
         svg.getAttribute('aria-label'),
         'slotted SVG aria-label matches icon label'
-      ).toBe('Search');
+      ).toBe('Expand');
     });
   },
 };
@@ -104,10 +104,8 @@ export const SlottedSvgAccessibilityTest: Story = {
 export const NoLabelAriaHiddenTest: Story = {
   render: () => html`
     <swc-icon>
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-        <path
-          d="M14.5 13.09 11.41 10a6 6 0 1 0-1.41 1.41l3.09 3.09a1 1 0 0 0 1.41-1.41zM3 7a4 4 0 1 1 8 0 4 4 0 0 1-8 0z"
-        />
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+        <path d=${chevronPath} />
       </svg>
     </swc-icon>
   `,
@@ -135,10 +133,8 @@ export const NoLabelAriaHiddenTest: Story = {
 export const LabelTogglingTest: Story = {
   render: () => html`
     <swc-icon label="x">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-        <path
-          d="M14.5 13.09 11.41 10a6 6 0 1 0-1.41 1.41l3.09 3.09a1 1 0 0 0 1.41-1.41zM3 7a4 4 0 1 1 8 0 4 4 0 0 1-8 0z"
-        />
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+        <path d=${chevronPath} />
       </svg>
     </swc-icon>
   `,

--- a/2nd-gen/packages/swc/components/icon/test/icon.test.ts
+++ b/2nd-gen/packages/swc/components/icon/test/icon.test.ts
@@ -123,6 +123,10 @@ export const NoLabelAriaHiddenTest: Story = {
         'slotted SVG has no aria-label when icon has no label'
       ).toBe(false);
       expect(
+        svg.getAttribute('focusable'),
+        'slotted SVG sets focusable="false" when icon has no label'
+      ).toBe('false');
+      expect(
         icon.getAttribute('aria-hidden'),
         'host element has aria-hidden="true" when no label'
       ).toBe('true');
@@ -151,6 +155,10 @@ export const LabelTogglingTest: Story = {
         svg().getAttribute('aria-hidden'),
         'SVG has no aria-hidden when label is set'
       ).toBeNull();
+      expect(
+        svg().getAttribute('focusable'),
+        'SVG has no focusable attribute when label is set'
+      ).toBeNull();
     });
 
     await step('clearing label sets aria-hidden on svg', async () => {
@@ -164,6 +172,10 @@ export const LabelTogglingTest: Story = {
         svg().hasAttribute('aria-label'),
         'SVG has no aria-label after label is cleared'
       ).toBe(false);
+      expect(
+        svg().getAttribute('focusable'),
+        'SVG sets focusable="false" after label is cleared'
+      ).toBe('false');
     });
 
     await step('setting label "y" restores aria-label on svg', async () => {
@@ -176,6 +188,10 @@ export const LabelTogglingTest: Story = {
       expect(
         svg().getAttribute('aria-hidden'),
         'SVG has no aria-hidden after label is restored'
+      ).toBeNull();
+      expect(
+        svg().getAttribute('focusable'),
+        'SVG has no focusable attribute after label is restored'
       ).toBeNull();
     });
   },

--- a/2nd-gen/packages/swc/components/tabs/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/tabs/migration-guide.mdx
@@ -128,7 +128,9 @@ The `label` attribute on `<sp-tab>` is removed. Use `aria-label` directly.
 
 <!-- After -->
 <swc-tab tab-id="dashboard" aria-label="Dashboard">
-  <sp-icon-dashboard slot="icon"></sp-icon-dashboard>
+  <swc-icon slot="icon" aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">...</svg>
+  </swc-icon>
 </swc-tab>
 ```
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/message-sources/MessageSources.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/message-sources/MessageSources.ts
@@ -14,11 +14,11 @@ import { CSSResultArray, html, TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 
-import { Chevron75Icon } from '@adobe/spectrum-wc/icon/elements/index.js';
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
 
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 
+import { Chevron75Icon } from '../../../components/icon/elements/index.js';
 import { uniqueId } from '../../../utils/id.js';
 
 import styles from './message-sources.css';

--- a/2nd-gen/packages/swc/patterns/conversational-ai/response-status/ResponseStatus.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/response-status/ResponseStatus.ts
@@ -14,12 +14,12 @@ import { CSSResultArray, html, TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-import { Chevron75Icon } from '@adobe/spectrum-wc/icon/elements/index.js';
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
 
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 import '@adobe/spectrum-wc/components/progress-circle/swc-progress-circle.js';
 
+import { Chevron75Icon } from '../../../components/icon/elements/index.js';
 import { uniqueId } from '../../../utils/id.js';
 import { CheckCircleIcon } from '../utils/icons/index.js';
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/README.md
@@ -82,6 +82,8 @@
     - [Grid migration roadmap](grid/rendering-and-styling-migration-analysis.md)
 - Help Text
     - [Help text migration roadmap](help-text/rendering-and-styling-migration-analysis.md)
+- Icon
+    - [Icon migration plan](icon/migration-plan.md)
 - Illustrated Message
     - [Illustrated message accessibility migration analysis](illustrated-message/accessibility-migration-analysis.md)
     - [`sp-illustrated-message` Migration Plan](illustrated-message/migration-plan.md)

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/icon/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/icon/migration-plan.md
@@ -36,8 +36,8 @@
 
 ## TL;DR
 
-- **Public:** `<swc-icon>` — slot your own SVG (`label`, `size`, `--swc-icon-*`). Same shape as badge/button docs.
-- **Private:** `components/icon/elements/*` — monorepo + dev Storybook (`*.internal.*`) only. No iconsets, no `name`/`src`.
+- **Public:** `<swc-icon>` slots your own SVG (`label`, `size`, `--swc-icon-*`). Same shape as badge/button docs.
+- **Private:** `components/icon/elements/*` is monorepo + dev Storybook (`*.internal.*`) only. No iconsets, no `name`/`src`.
 - **Packaging fix:** `index.ts` must export `Icon` only. `package.json` `exports` already has no `elements/` path; the barrel re-export is the leak. Vite glob stays as-is.
 
 ---
@@ -57,11 +57,11 @@
 | --- | --- |
 | `name` + iconsets | Default slot: inline `<svg>` |
 | `src` | Slot `<svg>` or standalone `<img>` |
-| `error` event | — |
+| `error` event | (none) |
 | `xxs` / `xxl` | `xs` / `xl` |
 | `--mod-icon-*` | `--swc-icon-*` |
 
-Detail lives in the consumer [`migration-guide.mdx`](../../../../2nd-gen/packages/swc/components/icon/migration-guide.internal.mdx) once promoted (follow [`badge/migration-guide.mdx`](../../../../2nd-gen/packages/swc/components/badge/migration-guide.mdx)).
+Detail lives in the consumer [`migration-guide.mdx`](../../../../2nd-gen/packages/swc/components/icon/migration-guide.mdx) (follow [`badge/migration-guide.mdx`](../../../../2nd-gen/packages/swc/components/badge/migration-guide.mdx)).
 
 ---
 
@@ -71,9 +71,9 @@ Detail lives in the consumer [`migration-guide.mdx`](../../../../2nd-gen/package
 
 **This PR:**
 
-- [ ] `index.ts` — export `Icon` only
-- [ ] Pattern imports — relative paths to `elements/`, not `@adobe/spectrum-wc/icon/elements`
-- [ ] JSDoc `@example` — inline SVG only (drop `Chevron100Icon` example)
+- [ ] `index.ts`: export `Icon` only
+- [ ] Pattern imports: relative paths to `elements/`, not `@adobe/spectrum-wc/icon/elements`
+- [ ] JSDoc `@example`: inline SVG only (drop `Chevron100Icon` example)
 - [ ] Public `icon.stories.ts` + `icon.mdx` (BYO SVG)
 - [ ] `migration-guide.internal.mdx` → `migration-guide.mdx` (no public elements path)
 - [ ] Trim `icon.internal.mdx` to catalog-only
@@ -170,4 +170,4 @@ rg 'icon/elements|@adobe/spectrum-wc/icon/elements' 2nd-gen/packages/swc/compone
 
 - [`2nd-gen/packages/swc/components/icon/`](../../../../2nd-gen/packages/swc/components/icon/)
 - [`1st-gen/packages/icon/src/Icon.ts`](../../../../1st-gen/packages/icon/src/Icon.ts)
-- [`.storybook/main.ts`](../../../../2nd-gen/packages/swc/.storybook/main.ts) — `*.internal.*` exclusion
+- [`.storybook/main.ts`](../../../../2nd-gen/packages/swc/.storybook/main.ts): `*.internal.*` exclusion

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/icon/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/icon/migration-plan.md
@@ -1,0 +1,81 @@
+<!-- Generated breadcrumbs - DO NOT EDIT -->
+
+[CONTRIBUTOR-DOCS](../../../README.md) / [Project planning](../../README.md) / [Components](../README.md) / Icon / Icon migration plan
+
+<!-- Document title (editable) -->
+
+# Icon migration plan
+
+<!-- Generated TOC - DO NOT EDIT -->
+
+<details open>
+<summary><strong>In this doc</strong></summary>
+
+- [TL;DR](#tldr)
+- [Decisions](#decisions)
+- [Breaking changes (consumer)](#breaking-changes-consumer)
+- [Checklist](#checklist)
+- [References](#references)
+
+</details>
+
+<!-- Document content (editable) -->
+
+> One PR. Component already exists; this is go-public + docs + export boundary.
+
+---
+
+## TL;DR
+
+- **Public:** `<swc-icon>` — slot your own SVG (`label`, `size`, `--swc-icon-*`). Same shape as badge/button docs.
+- **Private:** `components/icon/elements/*` — monorepo + dev Storybook (`*.internal.*`) only. No iconsets, no `name`/`src`.
+- **Packaging fix:** `index.ts` must export `Icon` only. `package.json` `exports` already has no `elements/` path; the barrel re-export is the leak. Vite glob stays as-is.
+
+---
+
+## Decisions
+
+- Ship `<swc-icon>`; do not ship or document `elements/*` as npm API.
+- Public docs: `icon.stories.ts`, `icon.mdx`, `migration-guide.mdx` (BYO SVG; promote from `.internal`, strip elements import guidance).
+- Keep `icon.internal.*` for maintainer catalog in local Storybook (prod build already excludes `*.internal.*`).
+- Monorepo: relative imports to `elements/` (badge pattern). Fix `@adobe/spectrum-wc/icon/elements` in conversational-ai patterns.
+
+---
+
+## Breaking changes (consumer)
+
+| Removed (`sp-icon`) | Use instead |
+| --- | --- |
+| `name` + iconsets | Default slot: inline `<svg>` |
+| `src` | Slot `<svg>` or standalone `<img>` |
+| `error` event | — |
+| `xxs` / `xxl` | `xs` / `xl` |
+| `--mod-icon-*` | `--swc-icon-*` |
+
+Detail lives in the consumer [`migration-guide.mdx`](../../../../2nd-gen/packages/swc/components/icon/migration-guide.internal.mdx) once promoted (follow [`badge/migration-guide.mdx`](../../../../2nd-gen/packages/swc/components/badge/migration-guide.mdx)).
+
+---
+
+## Checklist
+
+**Done:** core + SWC implementation, a11y behavior, unit + playwright tests, `@status internal` removed from JSDoc.
+
+**This PR:**
+
+- [ ] `index.ts` — export `Icon` only
+- [ ] Pattern imports — relative paths to `elements/`, not `@adobe/spectrum-wc/icon/elements`
+- [ ] JSDoc `@example` — inline SVG only (drop `Chevron100Icon` example)
+- [ ] Public `icon.stories.ts` + `icon.mdx` (BYO SVG)
+- [ ] `migration-guide.internal.mdx` → `migration-guide.mdx` (no public elements path)
+- [ ] Trim `icon.internal.mdx` to catalog-only
+- [ ] Spot-check badge (and other) MDX for correct `<swc-icon>` guidance
+- [ ] `yarn lint:docs-pages`, tests, Storybook build
+- [ ] Changeset
+
+---
+
+## References
+
+- [`2nd-gen/packages/swc/components/icon/`](../../../../2nd-gen/packages/swc/components/icon/)
+- [`1st-gen/packages/icon/src/Icon.ts`](../../../../1st-gen/packages/icon/src/Icon.ts)
+- [`.storybook/main.ts`](../../../../2nd-gen/packages/swc/.storybook/main.ts) — `*.internal.*` exclusion

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/icon/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/icon/migration-plan.md
@@ -15,6 +15,15 @@
 - [Decisions](#decisions)
 - [Breaking changes (consumer)](#breaking-changes-consumer)
 - [Checklist](#checklist)
+- [How we'll achieve it](#how-well-achieve-it)
+    - [1. Package export (`index.ts`)](#1-package-export-indexts)
+    - [2. Monorepo imports (patterns)](#2-monorepo-imports-patterns)
+    - [3. JSDoc (`Icon.ts`)](#3-jsdoc-iconts)
+    - [4. Public Storybook (`icon.stories.ts` + `icon.mdx`)](#4-public-storybook-iconstoriests--iconmdx)
+    - [5. Consumer migration guide](#5-consumer-migration-guide)
+    - [6. Tests and story IDs](#6-tests-and-story-ids)
+    - [7. Downstream doc audit](#7-downstream-doc-audit)
+    - [8. Ship](#8-ship)
 - [References](#references)
 
 </details>
@@ -71,6 +80,89 @@ Detail lives in the consumer [`migration-guide.mdx`](../../../../2nd-gen/package
 - [ ] Spot-check badge (and other) MDX for correct `<swc-icon>` guidance
 - [ ] `yarn lint:docs-pages`, tests, Storybook build
 - [ ] Changeset
+
+---
+
+## How we'll achieve it
+
+Follow [`badge/`](../../../../2nd-gen/packages/swc/components/badge/) and [`divider/`](../../../../2nd-gen/packages/swc/components/divider/) for public docs shape. Keep [`icon.internal.*`](../../../../2nd-gen/packages/swc/components/icon/) for the maintainer catalog.
+
+### 1. Package export (`index.ts`)
+
+In [`components/icon/index.ts`](../../../../2nd-gen/packages/swc/components/icon/index.ts), drop the elements re-export:
+
+```ts
+export * from './Icon.js';
+// remove: export * from './elements/index.js';
+```
+
+No `package.json` or `vite.config.ts` change. `@adobe/spectrum-wc/icon` stops exposing factories; `elements/` files may still land in `dist/` for monorepo imports but stay unsupported.
+
+### 2. Monorepo imports (patterns)
+
+Replace package-path element imports with relative paths (same as [`badge/stories/badge.stories.ts`](../../../../2nd-gen/packages/swc/components/badge/stories/badge.stories.ts)):
+
+```ts
+// Before
+import { Chevron75Icon } from '@adobe/spectrum-wc/icon/elements/index.js';
+
+// After (from patterns/conversational-ai/response-status/)
+import { Chevron75Icon } from '../../../components/icon/elements/index.js';
+```
+
+Files today: `ResponseStatus.ts`, `MessageSources.ts`. Grep for `@adobe/spectrum-wc/icon/elements` before merge.
+
+### 3. JSDoc (`Icon.ts`)
+
+In [`Icon.ts`](../../../../2nd-gen/packages/swc/components/icon/Icon.ts), keep one `@example` with inline `<svg>`. Remove the `Chevron100Icon` factory example.
+
+### 4. Public Storybook (`icon.stories.ts` + `icon.mdx`)
+
+**Stories:** Copy [`icon.internal.stories.ts`](../../../../2nd-gen/packages/swc/components/icon/stories/icon.internal.stories.ts) → `icon.stories.ts`, then:
+
+- Update meta JSDoc: public component, BYO SVG (not “internal-only”).
+- Use a shared inline SVG helper in stories (search icon path already in tests) for Overview, Anatomy, Sizes, Accessibility.
+- **Do not** copy `Sources`, `SharedTemplates`, or `AvailableIcons` to the public file; those stay in `.internal.stories.ts`.
+- Tags: `overview`, `anatomy`, `options`, `a11y`; Playground `['dev']`; meta `tags: ['migrated']`.
+
+**MDX:** Add `icon.mdx` beside [`Icon.ts`](../../../../2nd-gen/packages/swc/components/icon/Icon.ts), wired to `icon.stories.ts` (`<Meta of={Stories} />`, `<DocsHeader />`, `<DocsFooter />`). Sections: Anatomy, Options (Sizes + inline SVG source), Accessibility. Pattern: [`divider.mdx`](../../../../2nd-gen/packages/swc/components/divider/divider.mdx).
+
+**Internal docs:** Strip catalog prose from [`icon.internal.mdx`](../../../../2nd-gen/packages/swc/components/icon/icon.internal.mdx); keep Shared templates / Available icons canvases pointing at `.internal.stories.ts`.
+
+Prod Storybook already skips `*.internal.*` via [`.storybook/main.ts`](../../../../2nd-gen/packages/swc/.storybook/main.ts).
+
+### 5. Consumer migration guide
+
+Copy [`migration-guide.internal.mdx`](../../../../2nd-gen/packages/swc/components/icon/migration-guide.internal.mdx) → `migration-guide.mdx`:
+
+- Keep: tag/import rename, removed `name`/`src`, size table, `--mod-icon-*` → `--swc-icon-*`, a11y, checklist.
+- **Remove:** any `@adobe/spectrum-wc/.../elements` import guidance and “icon factory” migration path.
+- **Add:** BYO SVG as the primary migration path (inline slot + optional Lit `` html`<svg>…` `` template).
+- Shape: [`badge/migration-guide.mdx`](../../../../2nd-gen/packages/swc/components/badge/migration-guide.mdx).
+
+Delete or keep `migration-guide.internal.mdx` only if nothing references it; prefer single public file.
+
+### 6. Tests and story IDs
+
+- [`icon.test.ts`](../../../../2nd-gen/packages/swc/components/icon/test/icon.test.ts): point at `icon.stories.js` after rename; keep inline SVG renders.
+- [`icon.a11y.spec.ts`](../../../../2nd-gen/packages/swc/components/icon/test/icon.a11y.spec.ts): update story IDs if public story slug changes (e.g. still `components-icon--overview` if title stays `Icon`).
+- Run `yarn test` and `yarn test:a11y` in `2nd-gen/packages/swc`.
+
+### 7. Downstream doc audit
+
+Grep public MDX for `elements/` and wrong icon guidance:
+
+```bash
+rg 'icon/elements|@adobe/spectrum-wc/icon/elements' 2nd-gen/packages/swc/components --glob '*.mdx'
+```
+
+[`badge.mdx`](../../../../2nd-gen/packages/swc/components/badge/badge.mdx) is the reference: icon slot + `aria-hidden` when paired with text; `role="img"` + `aria-label` on badge for icon-only. Fix only if something contradicts that.
+
+### 8. Ship
+
+- `yarn lint:docs-pages` in repo root (validates `icon.mdx` section order and canvases).
+- `yarn storybook:build` in `2nd-gen/packages/swc` (confirms public Icon page, no internal catalog in prod).
+- Add a `@adobe/spectrum-wc` changeset (`minor`: public `swc-icon` documentation and export surface).
 
 ---
 

--- a/CONTRIBUTOR-DOCS/03_project-planning/README.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/README.md
@@ -47,6 +47,7 @@
     - Field Label
     - Grid
     - Help Text
+    - Icon
     - Illustrated Message
     - Infield Button
     - Infield Progress Circle


### PR DESCRIPTION
 ## Description

  Make `<swc-icon>` a public 2nd-gen component: public Storybook docs, consumer migration guide, and npm export
  boundary, while keeping the internal `elements/` SVG catalog monorepo-only.

  ### Included in this PR

  - Contributor [icon migration plan](CONTRIBUTOR-DOCS/03_project-planning/03_components/icon/migration-plan.md)
  - Remove `@status internal` from `swc-icon` JSDoc and keep it aligned with other public 2nd-gen components
  (`@since` only)
  - Export `Icon` only from `components/icon/index.ts` so `@adobe/spectrum-wc/icon` stops leaking internal SVG
  factories
  - Public `icon.stories.ts`, `icon.mdx`, and `migration-guide.mdx` for a BYO SVG contract with no public
  `elements/` import path
  - Trim `icon.internal.*` down to a maintainer-only catalog for dev Storybook
  - Fix conversational-ai pattern imports to use local relative `elements/` paths instead of a public package
  path
  - Update `swc-icon` JSDoc examples to inline SVG only
  - Add a changeset for `@adobe/spectrum-wc`
  - Update 2nd-gen button docs and stories to prefer `<swc-icon slot="icon">...</swc-icon>` in icon-slot
  examples, matching the intended public icon path

  ## Motivation and context

  `<swc-icon>` already exists in 2nd-gen and is used internally by components and patterns, but it is still
  treated like an internal implementation detail. Consumers migrating from `<sp-icon>` need a documented public
  wrapper whose contract is simple: slot your own SVG.

  This PR makes that public contract explicit.

  It does **not** turn the internal `elements/` SVG catalog into a public icon registry. Those factories remain a
  maintainer convenience for SWC development only.

  It also aligns button docs with that direction so 2nd-gen documentation points consumers toward `swc-icon`
  instead of encouraging raw slotted SVG as the primary path.

  ## Related issue(s)

  - N/A

  ## Screenshots

  N/A. This is primarily a docs, Storybook, and package export-boundary change.

  ## Author's checklist

  - [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/
  CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/
  PULL_REQUESTS.md)** documents.
  - [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/
  TR/wai-aria-practices/)
  - [x] I have added automated tests to cover my changes. _(Existing icon unit + Playwright a11y tests; re-run
  after public story rename.)_
  - [x] I have included a well-written changeset if my change needs to be published.
  - [x] I have included updated documentation if my change required it.

  ## Reviewer's checklist

  - [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
  - [x] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major`
  features
  - [x] Automated tests cover all use cases and follow best practices for writing
  - [ ] Validated on all supported browsers
  - [ ] All VRTs are approved before the author can update Golden Hash

  ## Manual review test cases

  - [ ] **Public icon docs (production Storybook build)**
    1. Run `yarn storybook:build` in `2nd-gen/packages/swc`
    2. Open the **Icon** docs page under Components
    3. Expect: Overview, Sizes, Anatomy, Accessibility all render from the public docs/stories
    4. Expect: examples show `<swc-icon>` with slotted inline SVG
    5. Expect: no "Shared templates", "Available icons", or `elements/` import guidance on the public page

  - [ ] **Internal catalog (dev Storybook only)**
    1. Run `yarn storybook` in `2nd-gen/packages/swc`
    2. Open **Icon / Internal catalog**
    3. Expect: maintainer catalog and `elements/` reference still exist locally in dev Storybook

  - [ ] **Consumer migration guide**
    1. Open **Icon → Migration guide** in Storybook
    2. Expect: `sp-icon` → `swc-icon`, slot your own SVG, and no public `@adobe/spectrum-wc/.../elements` import
    path
    3. Expect: breaking changes documented (`name`, `src`, `xxs` / `xxl`, `--mod-icon-*`)

  - [ ] **Package export boundary**
    1. Confirm `components/icon/index.ts` exports `Icon` only
    2. Confirm `@adobe/spectrum-wc/icon` does not re-export `Chevron100Icon` or other internal factories
    3. Confirm internal component/pattern usage still resolves via local relative `elements/` imports

  - [ ] **Button docs alignment**
    1. Open **Button** docs in Storybook
    2. Expect: icon-slot guidance prefers `<swc-icon>` as the documented path
    3. Expect: anatomy and migration examples use `<swc-icon slot="icon">...</swc-icon>`

  - [ ] **Downstream patterns**
    1. Open conversational-ai pattern stories that use chevrons
    2. Expect: no `@adobe/spectrum-wc/icon/elements` imports in source
    3. Expect: icons still render correctly

  ## Device review

  - [ ] Did it pass in Desktop?
  - [ ] Did it pass in (emulated) Mobile?
  - [ ] Did it pass in (emulated) iPad?

  ## Accessibility testing checklist

  Icon a11y behavior is unchanged: slotted SVG receives image semantics when `label` is provided, and decorative
  usage remains hidden from the accessibility tree when no label is present. Re-verify on the public docs
  stories.

  - [ ] **Keyboard**
    1. Open **Icon → Accessibility** in Storybook
    2. Tab through the page
    3. Expect: `<swc-icon>` is not focusable and does not create stray focus stops

  - [ ] **Screen reader**
    1. Open a labelled icon example and a decorative icon example
    2. With VoiceOver or NVDA, inspect the labelled icon
    3. Expect: labelled icon is announced as an image with its provided name
    4. Expect: decorative icon with no label is hidden from the accessibility tree