### PR TITLE
test(accordion): cover focus() and click() host delegation methods

### DIFF
--- a/2nd-gen/packages/swc/components/accordion/test/accordion.test.ts
+++ b/2nd-gen/packages/swc/components/accordion/test/accordion.test.ts
@@ -1442,6 +1442,68 @@ export const SizePropagationDynamicTest: Story = {
 // TEST: Enforced exclusive open on host re-enable
 // ──────────────────────────────────────────────────────────────
 
+// ──────────────────────────────────────────────────────────────
+// TEST: Host-element focus/click delegation
+// ──────────────────────────────────────────────────────────────
+
+export const FocusDelegationTest: Story = {
+  render: () => html`
+    <swc-accordion density="regular">
+      <swc-accordion-item>
+        <span slot="label">Item 1</span>
+        <p>Panel 1</p>
+      </swc-accordion-item>
+    </swc-accordion>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const item = await getComponent<AccordionItem>(
+      canvasElement,
+      'swc-accordion-item'
+    );
+
+    await step(
+      'item.focus() moves focus to the inner header button',
+      async () => {
+        item.focus();
+        expect(
+          item.shadowRoot?.activeElement,
+          'inner header button holds focus after item.focus()'
+        ).toBe(item.shadowRoot?.getElementById('header'));
+      }
+    );
+  },
+};
+
+export const ClickDelegationTest: Story = {
+  render: () => html`
+    <swc-accordion density="regular">
+      <swc-accordion-item>
+        <span slot="label">Item 1</span>
+        <p>Panel 1</p>
+      </swc-accordion-item>
+    </swc-accordion>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const item = await getComponent<AccordionItem>(
+      canvasElement,
+      'swc-accordion-item'
+    );
+
+    await step('item.click() toggles the item open', async () => {
+      expect(item.open, 'item starts closed').toBe(false);
+      item.click();
+      await item.updateComplete;
+      expect(item.open, 'item is open after item.click()').toBe(true);
+    });
+
+    await step('item.click() toggles the item closed again', async () => {
+      item.click();
+      await item.updateComplete;
+      expect(item.open, 'item is closed after second item.click()').toBe(false);
+    });
+  },
+};
+
 export const EnforceExclusiveOpenOnReenableTest: Story = {
   render: () => html`
     <swc-accordion density="regular" disabled>


### PR DESCRIPTION
## Description

Adds two Storybook play-function test stories to `accordion.test.ts` that call `focus()` and `click()` directly on the `<swc-accordion-item>` host element. These delegation methods forward to the inner shadow-DOM header button but were never exercised — every existing test called `.focus()` and `.click()` on the shadow button directly.

## Motivation and context

The `components/**/*.{ts,js}` function coverage threshold is set to 98%. The accordion migration (#6268) introduced `AccordionItem.focus()` and `AccordionItem.click()` as public delegation methods, but no test called them on the host element. This left two functions uncovered (84/86 = 97.67%), causing CI to fail on main with:

> ERROR: Coverage for functions (97.67%) does not meet "components/**/*.{ts,js}" threshold (98%)

## Related issue(s)

- fixes pipeline failure on main (coverage regression from #6268)

## Screenshots (if appropriate)

N/A — test-only change.

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

> No changeset needed — test-only change with no published API surface. No documentation update needed.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] CI coverage passes at ≥98% for `components/**/*.{ts,js}` functions
  1. Merge this PR
  2. Check the `test / coverage` CI step
  3. Expect no threshold failure for the accordion component

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

No interactive behavior was changed — this PR adds tests only. The `focus()` and `click()` delegation methods already existed and are covered by the existing a11y spec (`accordion.a11y.spec.ts`).

- [ ] **Keyboard** — no changes to keyboard behavior; no new steps required.
- [ ] **Screen reader** — no changes to announcements or ARIA; no new steps required.
