### PR TITLE
fix(ci): use existing unit group in Coveralls workflow

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -51,7 +51,7 @@ jobs:
         run: cd 1st-gen && yarn playwright install --with-deps
 
       - name: Run unit tests with coverage
-        run: cd 1st-gen && yarn test:ci --config web-test-runner.config.ci-chromium.js --group coveralls-ci --coverage
+        run: cd 1st-gen && yarn test:ci --config web-test-runner.config.ci-chromium.js --group unit --coverage
         continue-on-error: true
 
       - name: Upload coverage to Coveralls


### PR DESCRIPTION
## Summary
- Fixes the Coveralls CI job failing with `Could not find any group named coveralls-ci`
- The `coveralls-ci` group was removed during the monorepo migration (#5785) but the workflow still referenced it
- Switches to the existing `unit` group, matching the CircleCI coverage job

## Test plan
- [x] Locally verified `--group unit` resolves 144 test files (old `--group coveralls-ci` fails immediately)
- [ ] Coveralls workflow passes on this PR