### PR TITLE
fix(ci): allow run_vrt label to trigger Chromatic

### DIFF
--- a/.github/workflows/chromatic-vrt.yml
+++ b/.github/workflows/chromatic-vrt.yml
@@ -9,9 +9,6 @@ on:
       - '.github/workflows/chromatic-vrt.yml'
   pull_request:
     types: [opened, synchronize, reopened, labeled, ready_for_review]
-    paths:
-      - '2nd-gen/**'
-      - '.github/workflows/chromatic-vrt.yml'
   workflow_dispatch:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary
- Remove the `pull_request.paths` filter from the Chromatic VRT workflow so `run_vrt` label events can create a workflow run.
- Keep the existing job-level `run_vrt` condition and the scoped `push` path filter for `main` baseline runs.

## Problem
The Chromatic check is required, but the workflow also had a `pull_request.paths` filter limited to `2nd-gen/**` and the workflow file itself. For PRs outside those paths, adding the `run_vrt` label did not create a Chromatic workflow run at all, so the required check could not run.

This moves the decision back to the job-level condition, where the existing `run_vrt` label check can actually be evaluated for every pull request event.

## Test plan
- Checked the workflow diff to confirm only the PR path filter was removed.
- Confirmed no IDE lints for `.github/workflows/chromatic-vrt.yml`.
- Relied on pre-commit formatting for the workflow file.