### PR TITLE
perf(ci): remove wireit build cache from downstream jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,18 +164,11 @@ commands:
   downstream:
     steps:
       - setup-node-dependencies
-      - restore_cache:
-          keys:
-            - cache-wireit-1st-gen-{{ arch }}-{{ checksum "1st-gen/package.json" }}-
       - run:
           name: Build the project
           command: |
             yarn build
       - save-node-dependencies-cache
-      - save_cache:
-          paths:
-            - 1st-gen/.wireit
-          key: cache-wireit-1st-gen-{{ arch }}-{{ checksum "1st-gen/package.json" }}-{{ .Revision }}
       - attach_workspace:
           at: /
   downstream-2ndgen:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,10 @@ jobs:
           paths:
             - 1st-gen/packages
             - 1st-gen/tools
+            - 1st-gen/test
+            - 1st-gen/scripts
+            - 1st-gen/storybook
+            - 1st-gen/projects
 
   test-chromium:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,12 +432,11 @@ jobs:
             - store_artifacts:
                 path: 2nd-gen/packages/swc/coverage
 
-  # 2nd-gen Storybook-based tests: ARIA snapshots (Playwright) + axe-core WCAG (test-runner)
-  # Both suites run against the same static Storybook build, so we build once and run both.
+  # 2nd-gen ARIA snapshot tests (Playwright)
   # NOTE: Uses full `downstream` because Storybook build has 1st-gen references
   # (contributor-docs generation, CEM analysis). The tests run against the
   # built static Storybook to avoid Vite dev-server cold-start flakiness.
-  test-2ndgen-storybook:
+  test-2ndgen-a11y:
     executor: node
 
     steps:
@@ -456,6 +455,20 @@ jobs:
           path: /root/project/2nd-gen/test/playwright-a11y/results
       - store_artifacts:
           path: 2nd-gen/test/playwright-a11y/report
+
+  # 2nd-gen axe-core WCAG tests (Storybook test-runner)
+  # NOTE: Uses full `downstream` because Storybook build has 1st-gen references
+  test-2ndgen-axe:
+    executor: node
+
+    steps:
+      - halt-if-not-affected:
+          gen: 2nd-gen
+      - downstream
+      - run:
+          name: Build 2nd-gen Storybook (production)
+          command: |
+            NODE_ENV=production SWC_STORYBOOK_MODE=ci-a11y yarn workspace @adobe/spectrum-wc storybook:build
       - run:
           name: Run axe-core WCAG tests
           command: |
@@ -673,7 +686,8 @@ workflows:
           matrix:
             parameters:
               browser: [chromium, firefox, webkit]
-      - test-2ndgen-storybook
+      - test-2ndgen-a11y
+      - test-2ndgen-axe
       # 1st-gen tests
       - test-chromium
       - test-chromium-memory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,11 +168,8 @@ commands:
   downstream:
     steps:
       - setup-node-dependencies
-      - run:
-          name: Build the project
-          command: |
-            yarn build
-      - save-node-dependencies-cache
+      - attach_workspace:
+          at: .
   downstream-2ndgen:
     description: 'Setup and build for 2nd-gen tests'
     steps:
@@ -321,6 +318,20 @@ commands:
           key: v2-golden-images-{{ .Branch }}-<< parameters.regression_system >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-{{ .Revision }}
 
 jobs:
+  build:
+    executor: node
+    steps:
+      - setup-node-dependencies
+      - run:
+          name: Build the project
+          command: yarn build
+      - save-node-dependencies-cache
+      - persist_to_workspace:
+          root: .
+          paths:
+            - 1st-gen/packages
+            - 1st-gen/tools
+
   test-chromium:
     executor: node
     parallelism: 5
@@ -680,32 +691,44 @@ workflows:
   # fast no-op, instead of being absent from the status check list.
   build:
     jobs:
-      # 2nd-gen tests
+      - build
+      # 2nd-gen tests (downstream-2ndgen — no dependency on build job)
       - test-2ndgen-browser:
           name: test-2ndgen-browser-<< matrix.browser >>
           matrix:
             parameters:
               browser: [chromium, firefox, webkit]
-      - test-2ndgen-a11y
-      - test-2ndgen-axe
+      # 2nd-gen Storybook tests use downstream (needs 1st-gen build)
+      - test-2ndgen-a11y:
+          requires: [build]
+      - test-2ndgen-axe:
+          requires: [build]
       # 1st-gen tests
-      - test-chromium
-      - test-chromium-memory
-      - test-firefox
-      - test-webkit
-      - test-chromium-coverage
+      - test-chromium:
+          requires: [build]
+      - test-chromium-memory:
+          requires: [build]
+      - test-firefox:
+          requires: [build]
+      - test-webkit:
+          requires: [build]
+      - test-chromium-coverage:
+          requires: [build]
       - hcm-visual:
+          requires: [build]
           filters:
             branches:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
       - beta-docs:
+          requires: [build]
           filters:
             branches:
               # Beta docs are only published from main
               only: main
       - visual:
           name: << matrix.system >>-<< matrix.color >>-<< matrix.scale >>-<< matrix.dir >>
+          requires: [build]
           matrix:
             parameters:
               system: [spectrum, express, spectrum-two]
@@ -718,6 +741,7 @@ workflows:
               ignore: /pull\/[0-9]+/
       - visual:
           name: << matrix.system >>-<< matrix.color >>-<< matrix.scale >>-<< matrix.dir >>
+          requires: [build]
           matrix:
             parameters:
               system: [spectrum, express, spectrum-two]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ parameters:
     type: string
     default: 75b8c3cdc71a773889e3bdd1032f89ff73c12475
 
-  wireit_cache_name:
-    type: string
-    default: wireit
 commands:
   halt-if-not-affected:
     description: >
@@ -124,17 +121,20 @@ commands:
   install-azcopy:
     description: 'Install AzCopy and set up authentication'
     steps:
+      - restore_cache:
+          keys:
+            - azcopy-v10.29.1-{{ arch }}
       - run:
           when: always
           name: Install AzCopy
           command: |
-            # Create a bin directory in the home folder
             mkdir -p ~/bin
-            cd ~/bin
-            wget -O azcopy.tar.gz https://github.com/Azure/azure-storage-azcopy/releases/download/v10.29.1/azcopy_linux_amd64_10.29.1.tar.gz
-            tar -xf azcopy.tar.gz --strip-components=1
-            chmod +x azcopy
-            # Add to PATH and set environment variables
+            if [ ! -f ~/bin/azcopy ]; then
+              cd ~/bin
+              wget -O azcopy.tar.gz https://github.com/Azure/azure-storage-azcopy/releases/download/v10.29.1/azcopy_linux_amd64_10.29.1.tar.gz
+              tar -xf azcopy.tar.gz --strip-components=1
+              chmod +x azcopy
+            fi
             echo 'export PATH=~/bin:$PATH' >> $BASH_ENV
             echo 'export AZCOPY_AUTO_LOGIN_TYPE="SPN"' >> $BASH_ENV
             echo 'export AZCOPY_SPA_APPLICATION_ID="$AZURE_CLIENT_ID"' >> $BASH_ENV
@@ -142,6 +142,10 @@ commands:
             echo 'export AZCOPY_TENANT_ID="$AZURE_TENANT_ID"' >> $BASH_ENV
             source $BASH_ENV
             azcopy --version
+      - save_cache:
+          paths:
+            - ~/bin/azcopy
+          key: azcopy-v10.29.1-{{ arch }}
   setup-node-dependencies:
     description: 'Checkout code and install node dependencies'
     steps:
@@ -169,8 +173,6 @@ commands:
           command: |
             yarn build
       - save-node-dependencies-cache
-      - attach_workspace:
-          at: /
   downstream-2ndgen:
     description: 'Setup and build for 2nd-gen tests'
     steps:
@@ -430,11 +432,12 @@ jobs:
             - store_artifacts:
                 path: 2nd-gen/packages/swc/coverage
 
-  # 2nd-gen ARIA snapshot tests (Playwright)
+  # 2nd-gen Storybook-based tests: ARIA snapshots (Playwright) + axe-core WCAG (test-runner)
+  # Both suites run against the same static Storybook build, so we build once and run both.
   # NOTE: Uses full `downstream` because Storybook build has 1st-gen references
   # (contributor-docs generation, CEM analysis). The tests run against the
   # built static Storybook to avoid Vite dev-server cold-start flakiness.
-  test-2ndgen-a11y:
+  test-2ndgen-storybook:
     executor: node
 
     steps:
@@ -453,20 +456,6 @@ jobs:
           path: /root/project/2nd-gen/test/playwright-a11y/results
       - store_artifacts:
           path: 2nd-gen/test/playwright-a11y/report
-
-  # 2nd-gen axe-core WCAG tests (Storybook test-runner)
-  # NOTE: Uses full `downstream` because Storybook build has 1st-gen references
-  test-2ndgen-axe:
-    executor: node
-
-    steps:
-      - halt-if-not-affected:
-          gen: 2nd-gen
-      - downstream
-      - run:
-          name: Build 2nd-gen Storybook (production)
-          command: |
-            NODE_ENV=production SWC_STORYBOOK_MODE=ci-a11y yarn workspace @adobe/spectrum-wc storybook:build
       - run:
           name: Run axe-core WCAG tests
           command: |
@@ -684,8 +673,7 @@ workflows:
           matrix:
             parameters:
               browser: [chromium, firefox, webkit]
-      - test-2ndgen-a11y
-      - test-2ndgen-axe
+      - test-2ndgen-storybook
       # 1st-gen tests
       - test-chromium
       - test-chromium-memory


### PR DESCRIPTION
## Description

Optimizes the CircleCI pipeline by removing a slow wireit build cache and cleaning up dead configuration. Three changes in total:

1. **Remove wireit build cache** — the restore step was taking 3m 31s while the cold build only takes 1m 28s; net saving of ~2m per job
2. **Remove dead \`attach_workspace\`** — the \`downstream\` command called \`attach_workspace\` after every build, but nothing in the workflow ever called \`persist_to_workspace\`, making it a permanent no-op
3. **Cache AzCopy binary** — VRT jobs were downloading and unpacking a ~30 MB binary on every run; now cached by version and arch

An additional commit on this branch also experiments with a **shared build workspace** (see below).

## Motivation and context

Observed that the wireit cache restore in \`test-chromium (946088)\` was taking 3m 31s while the cold build only takes 1m 28s. The same overhead applied to every job using the \`downstream\` reusable steps.

## Results

Three pipeline runs on the same branch, measured job-by-job:

| Job | Before (wireit cache) | No cache | + Workspace |
|-----|-----------------------|----------|-------------|
| test-webkit | 7m 22s | 4m 1s | 2m 4s |
| test-firefox | 12m 55s | 4m 22s | 2m 58s |
| test-chromium-memory | 7m 21s | 3m 33s | 1m 57s |
| test-chromium-coverage | 11m 33s | 7m 3s | 7m 17s |
| test-chromium | 8m 21s | 4m 4s | 2m 37s |
| test-2ndgen-browser-webkit | 3m 1s | 2m 39s | 2m 26s |
| test-2ndgen-browser-firefox | 3m 10s | 3m 5s | 2m 56s |
| test-2ndgen-browser-chromium | 2m 32s | 2m 23s | 2m 45s |
| test-2ndgen-axe | 7m 52s | 4m 24s | 3m 29s |
| test-2ndgen-a11y | 5m 46s | 3m 38s | 1m 42s |
| spectrum-two-light-medium-ltr | 10m 4s | 6m 27s | 5m 32s |
| spectrum-two-dark-large-rtl | 11m 58s | 6m 53s | 4m 50s |
| spectrum-light-medium-ltr | 10m 46s | 6m 33s | 5m 48s |
| spectrum-dark-large-rtl | 10m 53s | 7m 0s | 5m 36s |
| hcm-visual | 11m 42s | 6m 24s | 5m 12s |
| express-light-medium-ltr | 10m 59s | 5m 10s | 5m 10s |
| express-dark-large-rtl | 12m 3s | 6m 53s | 5m 29s |
| build (new) | — | — | 2m 36s |
| **Total pipeline (wall clock)** | **12m 58s** | **7m 6s** | **9m 56s** |

### Before — pipeline 40211 (12m 58s)


### After removing wireit cache — pipeline 40214 (7m 6s)


### After adding shared workspace — pipeline 40218 (9m 56s)


### Tradeoff: workspace vs no workspace

The workspace approach (+ Workspace column) makes every individual job faster by sharing the compiled 1st-gen build output rather than rebuilding in each job. However, all downstream jobs must wait for the \`build\` job to finish before they can start — this serializes the pipeline and increases total wall-clock time from 7m 6s to 9m 56s.

The net effect depends on what you optimize for:
- **Wall-clock time** (how long until the last check goes green): the no-cache approach wins at 7m 6s
- **Compute credits** (total CPU-minutes consumed across all jobs): the workspace approach wins by a significant margin, since ~17 jobs each save ~1m 28s of build time

This PR ships only the no-cache changes (commits 1–3). The workspace experiment is the last commit and can be reverted or landed separately once the tradeoff is decided.

## Related issue(s)

N/A — observed in CircleCI pipelines 40211 / 40214 / 40218.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Accessibility testing checklist

No UI changes — CI configuration only.

- [ ] **Keyboard** — not applicable
- [ ] **Screen reader** — not applicable