### PR TITLE
fix(global-css): global element styling inheritance of child text elements

### DIFF
--- a/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
@@ -217,6 +217,7 @@
 }
 }
 
-.swc-ActionButton {
+.swc-ActionButton,
+.swc-ActionButton-label {
 all: revert-layer !important;
 }

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -16,84 +16,66 @@
 
 @layer swc-global-elements {.swc-Button, .swc-Button * {
   box-sizing: border-box;
-}
-
-.swc-Button {
+}.swc-Button {
   -webkit-tap-highlight-color: transparent;
   display: inline-flex;
   position: relative;
-  gap: var(--swc-button-gap, token("text-to-visual-100"));
   align-items: center;
   justify-content: center;
+  margin: 0;
+  text-transform: none;
+  text-decoration: none;
+  border-style: solid;
+  overflow: visible;
+  user-select: none;
+  --_swc-button-border-width: token("border-width-200");
+  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
+
+  gap: var(--swc-button-gap, token("text-to-visual-100"));
   max-inline-size: var(--swc-button-max-inline-size, inherit);
   min-block-size: var(--_swc-button-min-block-size);
   padding-block: calc(var(--swc-button-padding-vertical, token("component-padding-vertical-100")) - var(--_swc-button-border-width));
   padding-inline: calc(var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")) - var(--_swc-button-border-width));
-  margin: 0;
   font-family: token("sans-serif-font");
   font-size: var(--swc-button-font-size, token("font-size-100"));
   font-weight: token("bold-font-weight");
   line-height: round(down, calc(token("line-height-100") * 1em), 1px);
   color: var(--swc-button-content-color-default, token("gray-25"));
-  text-transform: none;
-  text-decoration: none;
   background-color: var(--swc-button-background-color-default, token("neutral-background-color-default"));
   border-color: var(--swc-button-border-color-default, transparent);
-  border-style: solid;
   border-width: var(--_swc-button-border-width);
   border-radius: var(--swc-button-border-radius, calc(var(--_swc-button-min-block-size) / 2));
-  overflow: visible;
-  user-select: none;
   transition-timing-function: token("animation-ease-in-out");
   transition-duration: token("animation-duration-100");
   transition-property: outline, border-color, color, background-color, transform;
-
-  --_swc-button-border-width: token("border-width-200");
-  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
-}
-
-.swc-Button:focus-visible {
+}.swc-Button:focus-visible {
+  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
+  outline-offset: token("focus-indicator-gap");
   color: var(--swc-button-content-color-focus, token("gray-25"));
   background-color: var(--swc-button-background-color-focus, token("neutral-background-color-key-focus"));
   border-color: var(--swc-button-border-color-focus, transparent);
-  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
-  outline-offset: token("focus-indicator-gap");
-}
-
-.swc-Button:disabled:is(*, :hover) {
+}.swc-Button:disabled:is(*, :hover) {
   color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
   background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
   border-color: var(--swc-button-border-color-disabled, transparent);
   transform: none;
-}
-
-.swc-Button--disabled .swc-Button-icon {
+}.swc-Button--disabled .swc-Button-icon {
   pointer-events: none;
-}
-
-.swc-Button:hover {
+}.swc-Button:hover {
   color: var(--swc-button-content-color-hover, token("gray-25"));
   background-color: var(--swc-button-background-color-hover, token("neutral-background-color-hover"));
   border-color: var(--swc-button-border-color-hover, transparent);
-}
-
-.swc-Button:active {
+}.swc-Button:active {
   color: var(--swc-button-content-color-down, token("gray-25"));
   background-color: var(--swc-button-background-color-down, token("neutral-background-color-down"));
   border-color: var(--swc-button-border-color-down, transparent);
   transform: var(--swc-button-down-state-transform, perspective(var(--_swc-button-min-block-size)) translate3d(0, 0, token("component-size-difference-down")));
   will-change: transform;
-}
-
-.swc-Button-label {
+}.swc-Button-label {
   text-align: center;
-}
-
-.swc-Button--hasIcon .swc-Button-label {
+}.swc-Button--hasIcon .swc-Button-label {
   text-align: start;
-}
-
-.swc-Button-icon,
+}.swc-Button-icon,
 .swc-PendingSpinner {
   --_swc-button-icon-size: var(--swc-button-icon-size, token("workflow-icon-size-100"));
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
@@ -105,14 +87,10 @@
   block-size: var(--_swc-button-icon-block-size);
   margin-block: calc((var(--_swc-button-icon-block-size) - 1lh) / 2 * -1);
   margin-inline-start: calc(var(--swc-button-edge-to-visual, token("component-pill-edge-to-visual-100")) - var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")));
-}
-
-.swc-Button-icon {
+}.swc-Button-icon {
   color: inherit;
   fill: currentcolor;
-}
-
-.swc-Button--sizeS {
+}.swc-Button--sizeS {
   --swc-button-min-block-size: token("component-height-75");
   --swc-button-font-size: token("font-size-75");
   --swc-button-gap: token("text-to-visual-75");
@@ -121,9 +99,7 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-75");
   --swc-button-padding-vertical: token("component-padding-vertical-75");
   --swc-button-icon-size: token("workflow-icon-size-75");
-}
-
-.swc-Button--sizeL {
+}.swc-Button--sizeL {
   --swc-button-min-block-size: token("component-height-200");
   --swc-button-font-size: token("font-size-200");
   --swc-button-gap: token("text-to-visual-200");
@@ -132,9 +108,7 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-200");
   --swc-button-padding-vertical: token("component-padding-vertical-200");
   --swc-button-icon-size: token("workflow-icon-size-200");
-}
-
-.swc-Button--sizeXl {
+}.swc-Button--sizeXl {
   --swc-button-min-block-size: token("component-height-300");
   --swc-button-font-size: token("font-size-300");
   --swc-button-gap: token("text-to-visual-300");
@@ -143,9 +117,7 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-300");
   --swc-button-padding-vertical: token("component-padding-vertical-300");
   --swc-button-icon-size: token("workflow-icon-size-300");
-}
-
-.swc-Button--accent {
+}.swc-Button--accent {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -154,9 +126,7 @@
   --swc-button-background-color-hover: token("accent-background-color-hover");
   --swc-button-background-color-down: token("accent-background-color-down");
   --swc-button-background-color-focus: token("accent-background-color-key-focus");
-}
-
-.swc-Button--negative {
+}.swc-Button--negative {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -165,9 +135,7 @@
   --swc-button-background-color-hover: token("negative-background-color-hover");
   --swc-button-background-color-down: token("negative-background-color-down");
   --swc-button-background-color-focus: token("negative-background-color-key-focus");
-}
-
-.swc-Button--secondary {
+}.swc-Button--secondary {
   --swc-button-content-color-default: token("neutral-content-color-default");
   --swc-button-content-color-hover: token("neutral-content-color-hover");
   --swc-button-content-color-down: token("neutral-content-color-down");
@@ -176,9 +144,7 @@
   --swc-button-background-color-hover: token("gray-200");
   --swc-button-background-color-down: token("gray-200");
   --swc-button-background-color-focus: token("gray-200");
-}
-
-.swc-Button--primary.swc-Button--outline {
+}.swc-Button--primary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -193,9 +159,7 @@
   --swc-button-content-color-focus: token("neutral-content-color-key-focus");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}
-
-.swc-Button--secondary.swc-Button--outline {
+}.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -206,9 +170,7 @@
   --swc-button-border-color-focus: token("gray-400");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}
-
-.swc-Button--staticWhite {
+}.swc-Button--staticWhite {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-white-800");
   --swc-button-background-color-hover: token("transparent-white-900");
@@ -221,9 +183,7 @@
   --swc-button-background-color-disabled: token("disabled-static-white-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}
-
-.swc-Button--staticWhite.swc-Button--secondary {
+}.swc-Button--staticWhite.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-white-100");
   --swc-button-background-color-hover: token("transparent-white-200");
   --swc-button-background-color-down: token("transparent-white-200");
@@ -232,9 +192,7 @@
   --swc-button-content-color-hover: token("transparent-white-900");
   --swc-button-content-color-down: token("transparent-white-900");
   --swc-button-content-color-focus: token("transparent-white-900");
-}
-
-.swc-Button--staticWhite.swc-Button--outline {
+}.swc-Button--staticWhite.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -250,9 +208,7 @@
   --swc-button-background-color-disabled: token("transparent-white-25");
   --swc-button-border-color-disabled: token("disabled-static-white-border-color");
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}
-
-.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
+}.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -261,9 +217,7 @@
   --swc-button-border-color-hover: token("transparent-white-400");
   --swc-button-border-color-down: token("transparent-white-400");
   --swc-button-border-color-focus: token("transparent-white-400");
-}
-
-.swc-Button--staticBlack {
+}.swc-Button--staticBlack {
   --swc-button-focus-indicator-color: token("static-black-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-black-800");
   --swc-button-background-color-hover: token("transparent-black-900");
@@ -276,9 +230,7 @@
   --swc-button-background-color-disabled: token("disabled-static-black-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}
-
-.swc-Button--staticBlack.swc-Button--secondary {
+}.swc-Button--staticBlack.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-black-100");
   --swc-button-background-color-hover: token("transparent-black-200");
   --swc-button-background-color-down: token("transparent-black-200");
@@ -287,9 +239,7 @@
   --swc-button-content-color-hover: token("transparent-black-900");
   --swc-button-content-color-down: token("transparent-black-900");
   --swc-button-content-color-focus: token("transparent-black-900");
-}
-
-.swc-Button--staticBlack.swc-Button--outline {
+}.swc-Button--staticBlack.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -305,9 +255,7 @@
   --swc-button-background-color-disabled: token("transparent-black-25");
   --swc-button-border-color-disabled: token("disabled-static-black-border-color");
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}
-
-.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
+}.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -316,40 +264,30 @@
   --swc-button-border-color-hover: token("transparent-black-400");
   --swc-button-border-color-down: token("transparent-black-400");
   --swc-button-border-color-focus: token("transparent-black-400");
-}
-
-.swc-Button--iconOnly {
+}.swc-Button--iconOnly {
   --swc-button-border-radius: token("corner-radius-full");
   --swc-button-gap: 0;
 
   padding-inline: calc(var(--swc-button-edge-to-visual-only, token("component-pill-edge-to-visual-only-100")) - var(--_swc-button-border-width));
-}
-
-.swc-Button--iconOnly .swc-Button-icon {
+}.swc-Button--iconOnly .swc-Button-icon {
   --swc-button-edge-to-visual: 0;
 
   align-self: center;
-}
-
-.swc-Button--truncate .swc-Button-label {
+}.swc-Button--truncate .swc-Button-label {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.swc-Button--justified {
+}.swc-Button--justified {
   flex-grow: 1;
   justify-self: stretch;
   inline-size: 100%;
-}
-
-@media (prefers-reduced-motion: reduce) {
+}@media (prefers-reduced-motion: reduce) {
   .swc-Button {
     transition-duration: 0ms;
   }
 }
-}
-
-.swc-Button {
+}.swc-Button,
+.swc-Button-label,
+.swc-Button-icon {
 all: revert-layer !important;
 }

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -16,66 +16,84 @@
 
 @layer swc-global-elements {.swc-Button, .swc-Button * {
   box-sizing: border-box;
-}.swc-Button {
+}
+
+.swc-Button {
   -webkit-tap-highlight-color: transparent;
   display: inline-flex;
   position: relative;
+  gap: var(--swc-button-gap, token("text-to-visual-100"));
   align-items: center;
   justify-content: center;
-  margin: 0;
-  text-transform: none;
-  text-decoration: none;
-  border-style: solid;
-  overflow: visible;
-  user-select: none;
-  --_swc-button-border-width: token("border-width-200");
-  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
-
-  gap: var(--swc-button-gap, token("text-to-visual-100"));
   max-inline-size: var(--swc-button-max-inline-size, inherit);
   min-block-size: var(--_swc-button-min-block-size);
   padding-block: calc(var(--swc-button-padding-vertical, token("component-padding-vertical-100")) - var(--_swc-button-border-width));
   padding-inline: calc(var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")) - var(--_swc-button-border-width));
+  margin: 0;
   font-family: token("sans-serif-font");
   font-size: var(--swc-button-font-size, token("font-size-100"));
   font-weight: token("bold-font-weight");
   line-height: round(down, calc(token("line-height-100") * 1em), 1px);
   color: var(--swc-button-content-color-default, token("gray-25"));
+  text-transform: none;
+  text-decoration: none;
   background-color: var(--swc-button-background-color-default, token("neutral-background-color-default"));
   border-color: var(--swc-button-border-color-default, transparent);
+  border-style: solid;
   border-width: var(--_swc-button-border-width);
   border-radius: var(--swc-button-border-radius, calc(var(--_swc-button-min-block-size) / 2));
+  overflow: visible;
+  user-select: none;
   transition-timing-function: token("animation-ease-in-out");
   transition-duration: token("animation-duration-100");
   transition-property: outline, border-color, color, background-color, transform;
-}.swc-Button:focus-visible {
-  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
-  outline-offset: token("focus-indicator-gap");
+
+  --_swc-button-border-width: token("border-width-200");
+  --_swc-button-min-block-size: var(--swc-button-min-block-size, token("component-height-100"));
+}
+
+.swc-Button:focus-visible {
   color: var(--swc-button-content-color-focus, token("gray-25"));
   background-color: var(--swc-button-background-color-focus, token("neutral-background-color-key-focus"));
   border-color: var(--swc-button-border-color-focus, transparent);
-}.swc-Button:disabled:is(*, :hover) {
+  outline: token("focus-indicator-thickness") solid var(--swc-button-focus-indicator-color, token("focus-indicator-color"));
+  outline-offset: token("focus-indicator-gap");
+}
+
+.swc-Button:disabled:is(*, :hover) {
   color: var(--swc-button-content-color-disabled, token("disabled-content-color"));
   background-color: var(--swc-button-background-color-disabled, token("disabled-background-color"));
   border-color: var(--swc-button-border-color-disabled, transparent);
   transform: none;
-}.swc-Button--disabled .swc-Button-icon {
+}
+
+.swc-Button--disabled .swc-Button-icon {
   pointer-events: none;
-}.swc-Button:hover {
+}
+
+.swc-Button:hover {
   color: var(--swc-button-content-color-hover, token("gray-25"));
   background-color: var(--swc-button-background-color-hover, token("neutral-background-color-hover"));
   border-color: var(--swc-button-border-color-hover, transparent);
-}.swc-Button:active {
+}
+
+.swc-Button:active {
   color: var(--swc-button-content-color-down, token("gray-25"));
   background-color: var(--swc-button-background-color-down, token("neutral-background-color-down"));
   border-color: var(--swc-button-border-color-down, transparent);
   transform: var(--swc-button-down-state-transform, perspective(var(--_swc-button-min-block-size)) translate3d(0, 0, token("component-size-difference-down")));
   will-change: transform;
-}.swc-Button-label {
+}
+
+.swc-Button-label {
   text-align: center;
-}.swc-Button--hasIcon .swc-Button-label {
+}
+
+.swc-Button--hasIcon .swc-Button-label {
   text-align: start;
-}.swc-Button-icon,
+}
+
+.swc-Button-icon,
 .swc-PendingSpinner {
   --_swc-button-icon-size: var(--swc-button-icon-size, token("workflow-icon-size-100"));
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
@@ -87,10 +105,14 @@
   block-size: var(--_swc-button-icon-block-size);
   margin-block: calc((var(--_swc-button-icon-block-size) - 1lh) / 2 * -1);
   margin-inline-start: calc(var(--swc-button-edge-to-visual, token("component-pill-edge-to-visual-100")) - var(--swc-button-edge-to-text, token("component-pill-edge-to-text-100")));
-}.swc-Button-icon {
+}
+
+.swc-Button-icon {
   color: inherit;
   fill: currentcolor;
-}.swc-Button--sizeS {
+}
+
+.swc-Button--sizeS {
   --swc-button-min-block-size: token("component-height-75");
   --swc-button-font-size: token("font-size-75");
   --swc-button-gap: token("text-to-visual-75");
@@ -99,7 +121,9 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-75");
   --swc-button-padding-vertical: token("component-padding-vertical-75");
   --swc-button-icon-size: token("workflow-icon-size-75");
-}.swc-Button--sizeL {
+}
+
+.swc-Button--sizeL {
   --swc-button-min-block-size: token("component-height-200");
   --swc-button-font-size: token("font-size-200");
   --swc-button-gap: token("text-to-visual-200");
@@ -108,7 +132,9 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-200");
   --swc-button-padding-vertical: token("component-padding-vertical-200");
   --swc-button-icon-size: token("workflow-icon-size-200");
-}.swc-Button--sizeXl {
+}
+
+.swc-Button--sizeXl {
   --swc-button-min-block-size: token("component-height-300");
   --swc-button-font-size: token("font-size-300");
   --swc-button-gap: token("text-to-visual-300");
@@ -117,7 +143,9 @@
   --swc-button-edge-to-visual-only: token("component-pill-edge-to-visual-only-300");
   --swc-button-padding-vertical: token("component-padding-vertical-300");
   --swc-button-icon-size: token("workflow-icon-size-300");
-}.swc-Button--accent {
+}
+
+.swc-Button--accent {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -126,7 +154,9 @@
   --swc-button-background-color-hover: token("accent-background-color-hover");
   --swc-button-background-color-down: token("accent-background-color-down");
   --swc-button-background-color-focus: token("accent-background-color-key-focus");
-}.swc-Button--negative {
+}
+
+.swc-Button--negative {
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -135,7 +165,9 @@
   --swc-button-background-color-hover: token("negative-background-color-hover");
   --swc-button-background-color-down: token("negative-background-color-down");
   --swc-button-background-color-focus: token("negative-background-color-key-focus");
-}.swc-Button--secondary {
+}
+
+.swc-Button--secondary {
   --swc-button-content-color-default: token("neutral-content-color-default");
   --swc-button-content-color-hover: token("neutral-content-color-hover");
   --swc-button-content-color-down: token("neutral-content-color-down");
@@ -144,7 +176,9 @@
   --swc-button-background-color-hover: token("gray-200");
   --swc-button-background-color-down: token("gray-200");
   --swc-button-background-color-focus: token("gray-200");
-}.swc-Button--primary.swc-Button--outline {
+}
+
+.swc-Button--primary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -159,7 +193,9 @@
   --swc-button-content-color-focus: token("neutral-content-color-key-focus");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}.swc-Button--secondary.swc-Button--outline {
+}
+
+.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: transparent;
   --swc-button-background-color-hover: token("gray-100");
   --swc-button-background-color-down: token("gray-100");
@@ -170,7 +206,9 @@
   --swc-button-border-color-focus: token("gray-400");
   --swc-button-background-color-disabled: transparent;
   --swc-button-border-color-disabled: token("disabled-border-color");
-}.swc-Button--staticWhite {
+}
+
+.swc-Button--staticWhite {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-white-800");
   --swc-button-background-color-hover: token("transparent-white-900");
@@ -183,7 +221,9 @@
   --swc-button-background-color-disabled: token("disabled-static-white-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}.swc-Button--staticWhite.swc-Button--secondary {
+}
+
+.swc-Button--staticWhite.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-white-100");
   --swc-button-background-color-hover: token("transparent-white-200");
   --swc-button-background-color-down: token("transparent-white-200");
@@ -192,7 +232,9 @@
   --swc-button-content-color-hover: token("transparent-white-900");
   --swc-button-content-color-down: token("transparent-white-900");
   --swc-button-content-color-focus: token("transparent-white-900");
-}.swc-Button--staticWhite.swc-Button--outline {
+}
+
+.swc-Button--staticWhite.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -208,7 +250,9 @@
   --swc-button-background-color-disabled: token("transparent-white-25");
   --swc-button-border-color-disabled: token("disabled-static-white-border-color");
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
-}.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
+}
+
+.swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
   --swc-button-background-color-hover: token("transparent-white-100");
   --swc-button-background-color-down: token("transparent-white-100");
@@ -217,7 +261,9 @@
   --swc-button-border-color-hover: token("transparent-white-400");
   --swc-button-border-color-down: token("transparent-white-400");
   --swc-button-border-color-focus: token("transparent-white-400");
-}.swc-Button--staticBlack {
+}
+
+.swc-Button--staticBlack {
   --swc-button-focus-indicator-color: token("static-black-focus-indicator-color");
   --swc-button-background-color-default: token("transparent-black-800");
   --swc-button-background-color-hover: token("transparent-black-900");
@@ -230,7 +276,9 @@
   --swc-button-background-color-disabled: token("disabled-static-black-background-color");
   --swc-button-border-color-disabled: transparent;
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}.swc-Button--staticBlack.swc-Button--secondary {
+}
+
+.swc-Button--staticBlack.swc-Button--secondary {
   --swc-button-background-color-default: token("transparent-black-100");
   --swc-button-background-color-hover: token("transparent-black-200");
   --swc-button-background-color-down: token("transparent-black-200");
@@ -239,7 +287,9 @@
   --swc-button-content-color-hover: token("transparent-black-900");
   --swc-button-content-color-down: token("transparent-black-900");
   --swc-button-content-color-focus: token("transparent-black-900");
-}.swc-Button--staticBlack.swc-Button--outline {
+}
+
+.swc-Button--staticBlack.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -255,7 +305,9 @@
   --swc-button-background-color-disabled: token("transparent-black-25");
   --swc-button-border-color-disabled: token("disabled-static-black-border-color");
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
-}.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
+}
+
+.swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
   --swc-button-background-color-hover: token("transparent-black-100");
   --swc-button-background-color-down: token("transparent-black-100");
@@ -264,30 +316,41 @@
   --swc-button-border-color-hover: token("transparent-black-400");
   --swc-button-border-color-down: token("transparent-black-400");
   --swc-button-border-color-focus: token("transparent-black-400");
-}.swc-Button--iconOnly {
+}
+
+.swc-Button--iconOnly {
   --swc-button-border-radius: token("corner-radius-full");
   --swc-button-gap: 0;
 
   padding-inline: calc(var(--swc-button-edge-to-visual-only, token("component-pill-edge-to-visual-only-100")) - var(--_swc-button-border-width));
-}.swc-Button--iconOnly .swc-Button-icon {
+}
+
+.swc-Button--iconOnly .swc-Button-icon {
   --swc-button-edge-to-visual: 0;
 
   align-self: center;
-}.swc-Button--truncate .swc-Button-label {
+}
+
+.swc-Button--truncate .swc-Button-label {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}.swc-Button--justified {
+}
+
+.swc-Button--justified {
   flex-grow: 1;
   justify-self: stretch;
   inline-size: 100%;
-}@media (prefers-reduced-motion: reduce) {
+}
+
+@media (prefers-reduced-motion: reduce) {
   .swc-Button {
     transition-duration: 0ms;
   }
 }
-}.swc-Button,
-.swc-Button-label,
-.swc-Button-icon {
+}
+
+.swc-Button,
+.swc-Button-label {
 all: revert-layer !important;
 }

--- a/2nd-gen/packages/swc/vite.config.ts
+++ b/2nd-gen/packages/swc/vite.config.ts
@@ -71,8 +71,8 @@ export default defineConfig({
   plugins: [
     globalElementCSS({
       elements: [
-        { component: 'button', textElements: ['label', 'icon'] },
-        { component: 'action-button', textElements: ['label', 'icon'] },
+        { component: 'button', textElements: ['label'] },
+        { component: 'action-button', textElements: ['label'] },
       ],
     }),
     litCss({

--- a/2nd-gen/packages/swc/vite.config.ts
+++ b/2nd-gen/packages/swc/vite.config.ts
@@ -70,7 +70,10 @@ function processStylesheets(): Plugin {
 export default defineConfig({
   plugins: [
     globalElementCSS({
-      elements: [{ component: 'button' }, { component: 'action-button' }],
+      elements: [
+        { component: 'button', textElements: ['label', 'icon'] },
+        { component: 'action-button', textElements: ['label', 'icon'] },
+      ],
     }),
     litCss({
       exclude: [

--- a/2nd-gen/packages/tools/vite-global-elements-css/README.md
+++ b/2nd-gen/packages/tools/vite-global-elements-css/README.md
@@ -117,8 +117,7 @@ The generated stylesheet wraps all rules inside `@layer swc-global-elements`:
 }
 
 .swc-Button,
-.swc-Button-label,
-.swc-Button-icon { all: revert-layer !important; }
+.swc-Button-label { all: revert-layer !important; }
 ```
 
 This provides encapsulation similar to shadow DOM to prevent application styles affecting these global element style utilities. The `all: revert-layer` escape-hatch rule is written outside the layer so page styles on those selectors revert to the layer-defined values rather than inheriting from unlayered application CSS.
@@ -168,8 +167,8 @@ export default defineConfig({
   plugins: [
     globalElementCSS({
       elements: [
-        { component: 'button', textElements: ['label', 'icon'] },
-        { component: 'action-button', textElements: ['label', 'icon'] },
+        { component: 'button', textElements: ['label'] },
+        { component: 'action-button', textElements: ['label'] },
       ],
     }),
     // ... other plugins
@@ -194,12 +193,12 @@ Wrap any block that should not appear in the global stylesheet:
 
 Array of component entries. Each entry:
 
-| Option                | Type       | Required | Description                                                                                                                                                                                                             |
-| --------------------- | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `component`           | `string`   | yes      | Component name, e.g. `'button'`. Derives all paths and the block class.                                                                                                                                                 |
-| `source`              | `string`   | no       | Override source CSS filename when it differs from `component`.                                                                                                                                                          |
-| `rootElementSelector` | `string`   | no       | Override the derived BEM block class (e.g. `'swc-Button'`).                                                                                                                                                             |
-| `textElements`        | `string[]` | no       | Child element suffixes (e.g. `['label', 'icon']`) that receive `all: revert-layer !important` alongside the root block. Use this for light-DOM child elements vulnerable to inherited overrides from unlayered app CSS. |
+| Option                | Type       | Required | Description                                                                                                                                                                                                                  |
+| --------------------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `component`           | `string`   | yes      | Component name, e.g. `'button'`. Derives all paths and the block class.                                                                                                                                                      |
+| `source`              | `string`   | no       | Override source CSS filename when it differs from `component`.                                                                                                                                                               |
+| `rootElementSelector` | `string`   | no       | Override the derived BEM block class (e.g. `'swc-Button'`).                                                                                                                                                                  |
+| `textElements`        | `string[]` | no       | Child element suffixes (e.g. `['label']`) that receive `all: revert-layer !important` alongside the root block. Use this for light-DOM text-bearing child elements vulnerable to inherited overrides from unlayered app CSS. |
 
 The `source` option is only needed for naming discrepancies:
 

--- a/2nd-gen/packages/tools/vite-global-elements-css/README.md
+++ b/2nd-gen/packages/tools/vite-global-elements-css/README.md
@@ -116,10 +116,16 @@ The generated stylesheet wraps all rules inside `@layer swc-global-elements`:
   .swc-Button--accent { … }
 }
 
-.swc-Button { all: revert-layer !important; }
+.swc-Button,
+.swc-Button-label,
+.swc-Button-icon { all: revert-layer !important; }
 ```
 
-This provides encapsulation similar to shadow DOM to prevent application styles affecting these global element style utilities.
+This provides encapsulation similar to shadow DOM to prevent application styles affecting these global element style utilities. The `all: revert-layer` escape-hatch rule is written outside the layer so page styles on those selectors revert to the layer-defined values rather than inheriting from unlayered application CSS.
+
+Child element classes (e.g. `.swc-Button-label`) receive the same escape hatch when listed in `textElements`. This protects light-DOM child nodes from broad typographic resets like `body * { font-family: sans-serif }`.
+
+**Limitation:** the CSS `all` shorthand explicitly excludes custom properties (`--*`). Unlayered application rules that set custom properties on these selectors will not be cleared by the escape hatch.
 
 ## Base file auto-detection
 
@@ -161,7 +167,10 @@ import { globalElementCSS } from '@adobe/vite-global-elements-css';
 export default defineConfig({
   plugins: [
     globalElementCSS({
-      elements: [{ component: 'button' }, { component: 'action-button' }],
+      elements: [
+        { component: 'button', textElements: ['label', 'icon'] },
+        { component: 'action-button', textElements: ['label', 'icon'] },
+      ],
     }),
     // ... other plugins
   ],
@@ -185,11 +194,12 @@ Wrap any block that should not appear in the global stylesheet:
 
 Array of component entries. Each entry:
 
-| Option                | Type     | Required | Description                                                             |
-| --------------------- | -------- | -------- | ----------------------------------------------------------------------- |
-| `component`           | `string` | yes      | Component name, e.g. `'button'`. Derives all paths and the block class. |
-| `source`              | `string` | no       | Override source CSS filename when it differs from `component`.          |
-| `rootElementSelector` | `string` | no       | Override the derived BEM block class (e.g. `'swc-Button'`).             |
+| Option                | Type       | Required | Description                                                                                                                                                                                                             |
+| --------------------- | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `component`           | `string`   | yes      | Component name, e.g. `'button'`. Derives all paths and the block class.                                                                                                                                                 |
+| `source`              | `string`   | no       | Override source CSS filename when it differs from `component`.                                                                                                                                                          |
+| `rootElementSelector` | `string`   | no       | Override the derived BEM block class (e.g. `'swc-Button'`).                                                                                                                                                             |
+| `textElements`        | `string[]` | no       | Child element suffixes (e.g. `['label', 'icon']`) that receive `all: revert-layer !important` alongside the root block. Use this for light-DOM child elements vulnerable to inherited overrides from unlayered app CSS. |
 
 The `source` option is only needed for naming discrepancies:
 

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.d.ts
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.d.ts
@@ -57,8 +57,8 @@ export interface GlobalElementEntry {
    * If unlayered application CSS sets a custom property on a selector matching these child
    * element classes, `all: revert-layer` will not clear it.
    *
-   * @example ['label', 'icon']
-   * @example ['label', 'icon', 'description']
+   * @example ['label']
+   * @example ['label', 'description']
    */
   textElements?: string[];
 }

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.d.ts
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.d.ts
@@ -42,6 +42,25 @@ export interface GlobalElementEntry {
    * @example 'swc-Button'
    */
   rootElementSelector?: string;
+
+  /**
+   * Child element suffixes whose classes should also receive `all: revert-layer !important`
+   * alongside the root block class.
+   *
+   * Use this for child elements rendered as real DOM nodes in the light-DOM context of a
+   * global element (e.g. label, icon) that would otherwise be vulnerable to inherited
+   * property overrides from unlayered application CSS.
+   *
+   * Each suffix is appended to the block class: `'label'` → `.swc-Button-label`.
+   *
+   * **Limitation:** the CSS `all` shorthand explicitly excludes custom properties (`--*`).
+   * If unlayered application CSS sets a custom property on a selector matching these child
+   * element classes, `all: revert-layer` will not clear it.
+   *
+   * @example ['label', 'icon']
+   * @example ['label', 'icon', 'description']
+   */
+  textElements?: string[];
 }
 
 export interface GlobalElementCSSOptions {
@@ -80,4 +99,8 @@ export declare function transformSelector(list: string, block: string): string;
  * rules, and wraps in the cascade layer. Token calls are left intact for the
  * PostCSS pipeline to resolve.
  */
-export declare function deriveCSS(sourceCss: string, block: string): string;
+export declare function deriveCSS(
+  sourceCss: string,
+  block: string,
+  textElements?: string[]
+): string;

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.js
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.js
@@ -382,8 +382,16 @@ function mergeRules(container) {
  *
  * @param {import('postcss').Root} root
  * @param {string} block
+ * @param {string[]} textElements - Child element suffixes (e.g. ['label']) whose
+ *   classes should also receive all:revert-layer, protecting inherited typographic
+ *   properties on light-DOM text nodes from unlayered application CSS.
  */
-function wrapInLayer(root, block) {
+function wrapInLayer(root, block, textElements = []) {
+  if (!Array.isArray(textElements)) {
+    throw new TypeError(
+      `[vite-global-elements-css] textElements must be a string array (got ${typeof textElements})`
+    );
+  }
   /** @type {import('postcss').ChildNode[]} */
   const children = [];
   root.each((node) => children.push(node));
@@ -402,10 +410,14 @@ function wrapInLayer(root, block) {
   }
   root.append(layer);
 
-  // Escape-hatch rule outside the layer. Allows page styles on .block to
-  // revert any property to the layer-defined value rather than being
-  // overridden by unlayered application CSS.
-  const revert = postcss.rule({ selector: `.${block}` });
+  // Escape-hatch rule outside the layer. Allows page styles on .block (and any
+  // listed text-bearing child element classes) to revert any property to the
+  // layer-defined value rather than being overridden by unlayered application CSS.
+  const revertSelectors = [
+    `.${block}`,
+    ...textElements.map((suffix) => `.${block}-${suffix}`),
+  ].join(',\n');
+  const revert = postcss.rule({ selector: revertSelectors });
   revert.raws.before = '\n\n';
   revert.append(
     postcss.decl({ prop: 'all', value: 'revert-layer !important' })
@@ -425,9 +437,11 @@ function wrapInLayer(root, block) {
  *
  * @param {string} sourceCss - Concatenated raw CSS (base + component, token() calls intact).
  * @param {string} block - BEM block class name, e.g. 'swc-Button'.
+ * @param {string[]} [textElements] - Child element suffixes (e.g. ['label']) whose classes
+ *   should also receive all:revert-layer alongside the root block.
  * @returns {string}
  */
-export function deriveCSS(sourceCss, block) {
+export function deriveCSS(sourceCss, block, textElements = []) {
   const root = postcss.parse(sourceCss);
   if (!stripExcludedBlocks(root)) {
     throw new Error(
@@ -437,7 +451,7 @@ export function deriveCSS(sourceCss, block) {
   stripComments(root);
   applySelectTransform(root, block);
   mergeRules(root);
-  wrapInLayer(root, block);
+  wrapInLayer(root, block, textElements);
   return root.toResult({ map: false }).css;
 }
 
@@ -560,7 +574,13 @@ function generateEntry(entry, projectRoot) {
     .join('\n\n');
 
   const block = getBlock(entry);
-  const derived = deriveCSS(combined, block);
+  const textElements = entry.textElements ?? [];
+  if (!Array.isArray(textElements)) {
+    throw new TypeError(
+      `[vite-global-elements-css] entry.textElements must be a string array (got ${typeof textElements} for component '${entry.component}')`
+    );
+  }
+  const derived = deriveCSS(combined, block, textElements);
   const out = getOutputPath(entry, projectRoot);
   const sourcePath = relative(projectRoot, src);
 

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.test.js
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.test.js
@@ -367,6 +367,57 @@ describe('deriveCSS — layer wrapping', () => {
     const result = deriveCSS(':host { color: red; }', 'swc-Button');
     expect(result).toContain('all: revert-layer !important');
   });
+
+  it('includes only the root block selector when textElements is omitted', () => {
+    const result = deriveCSS(':host { color: red; }', 'swc-Button');
+    expect(result).toContain('.swc-Button');
+    expect(result).not.toContain('.swc-Button-label');
+  });
+
+  it('includes only the root block selector when textElements is an empty array', () => {
+    const result = deriveCSS(':host { color: red; }', 'swc-Button', []);
+    expect(result).toContain('.swc-Button');
+    expect(result).not.toContain('.swc-Button-label');
+  });
+
+  it('adds a child element class to the revert-layer selector when one textElement is provided', () => {
+    const result = deriveCSS(':host { color: red; }', 'swc-Button', ['label']);
+    // Verify the child class appears in a rule carrying all: revert-layer.
+    // This input produces no .swc-Button-label rules inside the layer, so any
+    // occurrence must be in the revert selector outside the layer.
+    expect(result).toMatch(
+      /\.swc-Button,\n\.swc-Button-label \{[\s\S]*?all: revert-layer !important/
+    );
+  });
+
+  it('adds multiple child element classes when several textElements are provided', () => {
+    const result = deriveCSS(':host { color: red; }', 'swc-Button', [
+      'label',
+      'description',
+    ]);
+    // Each child class must appear before the revert-layer declaration, regardless
+    // of whether the implementation uses one combined rule or separate rules.
+    const revertIdx = result.lastIndexOf('all: revert-layer !important');
+    expect(result.slice(0, revertIdx)).toContain('.swc-Button-label');
+    expect(result.slice(0, revertIdx)).toContain('.swc-Button-description');
+  });
+
+  it('does not alter output for components that do not specify textElements', () => {
+    const without = deriveCSS(':host { color: red; }', 'swc-Button');
+    const withEmpty = deriveCSS(':host { color: red; }', 'swc-Button', []);
+    expect(without).toBe(withEmpty);
+  });
+});
+
+// ── deriveCSS — textElements input validation ────────────────────────────────
+
+describe('deriveCSS — textElements input validation', () => {
+  it('throws TypeError with a helpful message when textElements is not an array', () => {
+    expect(() =>
+      // @ts-expect-error intentional wrong type for test
+      deriveCSS(':host { color: red; }', 'swc-Button', 'label')
+    ).toThrow('[vite-global-elements-css] textElements must be a string array');
+  });
 });
 
 // ── deriveCSS — selector transformation ─────────────────────────────────────


### PR DESCRIPTION
## Description

Extends the `vite-global-elements-css` generator to emit `all: revert-layer !important` on child element classes alongside the root block class. A new `textElements` option on `GlobalElementEntry` accepts an array of BEM element suffixes; the generator appends each as `.${block}-${suffix}` to the escape-hatch rule's selector:

```css
.swc-Button,
.swc-Button-label,
.swc-Button-icon {
  all: revert-layer !important;
}
```

`button` and `action-button` are updated with `textElements: ['label', 'icon']` and their global stylesheets regenerated. The option defaults to `[]` so existing components that don't specify it are unaffected.

## Motivation and context

The escape-hatch rule previously targeted only the root block class (`.swc-Button`). Child element classes like `.swc-Button-label` and `.swc-Button-icon` exist as real DOM nodes in the light-DOM global-element pattern, making them vulnerable to unlayered application CSS (e.g. `body * { font-family: sans-serif; color: red }`). Because those rules are unlayered, they win over the `@layer swc-global-elements` declarations for any inherited property, breaking the typographic and color tokens defined for those child elements.

## Related issue(s)

- fixes SWC-2303

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Child element classes receive `all: revert-layer` protection in the generated global stylesheet
  1. Open `2nd-gen/packages/swc/stylesheets/global/global-button.css`
  2. Confirm the final rule's selector includes `.swc-Button-label` and `.swc-Button-icon` alongside `.swc-Button`
  3. Confirm all three share `all: revert-layer !important`

- [ ] Button label text reflects design tokens, not broad application overrides
  1. Create a test page that loads `global-button.css` and includes an unlayered rule: `body * { font-family: monospace; color: hotpink }`
  2. Render an `<a class="swc-Button"><span class="swc-Button-label">Click</span></a>` element
  3. Confirm the label renders in the SWC-defined font and color, not `monospace`/`hotpink`

- [ ] Components without `textElements` are unaffected
  1. Open `global-link.css` (no `textElements` configured)
  2. Confirm its revert rule is unchanged: single selector `.swc-Link { all: revert-layer !important; }`

### Device review

*N/A — this change is to a CSS build tool and generated stylesheets only; no interactive or layout behavior changed.*

## Accessibility testing checklist

*N/A — this change does not affect component semantics, ARIA roles, focus management, or keyboard behavior. It corrects cascade inheritance for visual properties (typography, color) in the global stylesheet; no assistive-technology-facing behavior is introduced or modified.*