### PR TITLE
refactor(button): collapse pending into a single PendingMixin

### DIFF
--- a/.changeset/pending-single-mixin.md
+++ b/.changeset/pending-single-mixin.md
@@ -1,0 +1,9 @@
+---
+'@spectrum-web-components/core': minor
+'@adobe/spectrum-wc': patch
+---
+
+Extract the pending (busy) state into a single `PendingMixin` and a shared `renderPendingSpinner` directive so any component can adopt pending without subclassing `ButtonBase`.
+
+- **`@spectrum-web-components/core`**: adds `PendingMixin` (`/mixins`) which owns all pending state: the 1-second-delayed `pendingActive` flag, inline-size freeze via `--swc-pending-inline-size`, accessible-name derivation, and capture-phase click suppression. Adds the `renderPendingSpinner` directive (`/directives/pending-spinner`), relocated from the button package to `core` so non-button components can reuse it without coupling to button. `ButtonBase` no longer owns pending state.
+- **`@adobe/spectrum-wc`**: `swc-button` and `swc-action-button` now opt in via `PendingMixin`. No public API change — `pending`, `pending-label`, and the busy behavior are unchanged.

--- a/2nd-gen/packages/core/components/button/Button.base.ts
+++ b/2nd-gen/packages/core/components/button/Button.base.ts
@@ -11,7 +11,7 @@
  */
 
 import { PropertyValues } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
 
 import { SpectrumElement } from '@spectrum-web-components/core/element/index.js';
 import {
@@ -31,6 +31,9 @@ import { BUTTON_VALID_SIZES } from './Button.types.js';
  * is intentionally absent so that ActionButton, ClearButton, CloseButton,
  * PickerButton, and InfieldButton can extend this base without inheriting
  * the `swc-button` visual surface.
+ *
+ * Pending (busy) state is not owned here; components that need it apply
+ * `PendingMixin` so non-pending subclasses (e.g. CloseButton) are unaffected.
  *
  * @slot - Visible button label.
  * @slot icon - Optional leading icon.
@@ -61,41 +64,15 @@ export abstract class ButtonBase extends SizedMixin(
   public disabled: boolean = false;
 
   /**
-   * Whether the button is in a pending (busy) state. The button remains
-   * focusable but activation is suppressed.
-   */
-  @property({ type: Boolean, reflect: true })
-  public pending: boolean = false;
-
-  /**
    * Accessible label forwarded to the internal `<button>` element as
    * `aria-label`. Required for icon-only buttons, which have no visible text.
    */
   @property({ type: String, attribute: 'accessible-label' })
   public accessibleLabel?: string;
 
-  /**
-   * Custom accessible label used during the pending state. When omitted,
-   * the pending label is derived from the resolved non-busy accessible name
-   * plus a busy suffix (e.g. "Save, busy").
-   */
-  @property({ type: String, attribute: 'pending-label' })
-  public pendingLabel?: string;
-
-  /**
-   * Tracks whether the pending visual (disabled colors + spinner) is currently
-   * active. Set to `true` after a 1-second delay once `pending` becomes true,
-   * so the button does not immediately flash to its unavailable appearance.
-   * Protected so subclasses can reference it in their `classMap` binding.
-   */
-  @state()
-  protected pendingActive: boolean = false;
-
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────
-
-  private _pendingTimer: ReturnType<typeof setTimeout> | null = null;
 
   protected get hasIcon(): boolean {
     return this.slotContentIsPresent;
@@ -117,21 +94,6 @@ export abstract class ButtonBase extends SizedMixin(
   }
 
   /**
-   * Derives the pending-state accessible label. Prefers an explicit
-   * `pendingLabel`, then falls back to the resolved non-busy accessible
-   * name plus a ", busy" suffix, then a fixed "Busy" fallback.
-   *
-   * @internal
-   */
-  protected getPendingAccessibleName(): string {
-    if (this.pendingLabel) {
-      return this.pendingLabel;
-    }
-    const resolvedName = this.getResolvedAccessibleName();
-    return resolvedName ? `${resolvedName}, busy` : 'Busy';
-  }
-
-  /**
    * Returns the set of attributes that should be forwarded to the internal
    * semantic `<button>` element, if not otherwise directly managed.
    *
@@ -143,7 +105,6 @@ export abstract class ButtonBase extends SizedMixin(
   > {
     return {
       disabled: this.disabled,
-      'aria-disabled': this.pending && !this.disabled ? 'true' : undefined,
     };
   }
 
@@ -156,65 +117,26 @@ export abstract class ButtonBase extends SizedMixin(
 
   public override disconnectedCallback(): void {
     this.removeEventListener('click', this.handleClick, true);
-    if (this._pendingTimer !== null) {
-      clearTimeout(this._pendingTimer);
-      this._pendingTimer = null;
-    }
-    this.pendingActive = false;
     super.disconnectedCallback();
   }
 
   /**
-   * Suppresses click activation while the button is `disabled` or `pending`.
+   * Suppresses click activation while the button is `disabled`.
    *
    * Slotted icon content lives in the light DOM, so pointer clicks on icons
    * bypass the disabled inner `<button>` and bubble on the host. The host
    * listener (capture) and inner `@click` binding both call this handler.
    */
   protected readonly handleClick = (event: Event): void => {
-    if (this.disabled || this.pending) {
+    if (this.disabled) {
       event.preventDefault();
       event.stopImmediatePropagation();
     }
   };
 
   protected override update(changedProperties: PropertyValues): void {
-    if (changedProperties.has('pending')) {
-      if (this.pending) {
-        this._pendingTimer = setTimeout(() => {
-          if (this.pending) {
-            const internalButton = this.renderRoot.querySelector('button');
-            if (internalButton) {
-              internalButton.style.setProperty(
-                '--_swc-button-pending-inline-size',
-                `${internalButton.offsetWidth}px`
-              );
-            }
-            this.pendingActive = true;
-          }
-          this._pendingTimer = null;
-        }, 1000);
-      } else {
-        if (this._pendingTimer !== null) {
-          clearTimeout(this._pendingTimer);
-          this._pendingTimer = null;
-        }
-        this.renderRoot
-          .querySelector('button')
-          ?.style.removeProperty('--_swc-button-pending-inline-size');
-        this.pendingActive = false;
-      }
-    }
     super.update(changedProperties);
     if (window.__swc?.DEBUG) {
-      if (this.pending && this.disabled) {
-        window.__swc.warn(
-          this,
-          `<${this.localName}> should not set both "pending" and "disabled" simultaneously. Use "pending" to keep the button focusable while unavailable, or "disabled" to fully remove it from the tab order.`,
-          'https://opensource.adobe.com/spectrum-web-components/components/button/#pending',
-          { issues: ['pending + disabled'] }
-        );
-      }
       if (this.hasIcon && !this.hasLabel && !this.accessibleLabel) {
         window.__swc.warn(
           this,

--- a/2nd-gen/packages/core/directives/index.ts
+++ b/2nd-gen/packages/core/directives/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Public exports for render-only Lit template directives shared across 2nd-gen packages.
+ */
+
+export { renderPendingSpinner } from './pending-spinner/index.js';

--- a/2nd-gen/packages/core/directives/pending-spinner/index.ts
+++ b/2nd-gen/packages/core/directives/pending-spinner/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export { renderPendingSpinner } from './src/pending-spinner.js';

--- a/2nd-gen/packages/core/directives/pending-spinner/src/pending-spinner.ts
+++ b/2nd-gen/packages/core/directives/pending-spinner/src/pending-spinner.ts
@@ -10,14 +10,21 @@
  * governing permissions and limitations under the License.
  */
 
-import { html, nothing, TemplateResult } from 'lit';
+import { html, nothing, type TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 
 /**
- * Shared pending-spinner SVG template used by both swc-button and
- * swc-action-button. Returns `nothing` when `pending` is false so callers
- * can interpolate unconditionally: `${renderPendingSpinner(this.pending,
- * this.pendingActive)}`.
+ * Renders the shared pending-spinner SVG used by pending-capable components.
+ * Returns `nothing` when `pending` is false so callers can interpolate
+ * unconditionally: `${renderPendingSpinner(this.pending, this.pendingActive)}`.
+ *
+ * This is render-only and carries no design-token dependency. Pair it with
+ * `PendingMixin` (state) and the shared `pending-spinner.css` style fragment,
+ * which themes the `swc-PendingSpinner*` classes this emits.
+ *
+ * @param pending - Whether the host is in the pending (busy) state.
+ * @param pendingActive - Whether the delayed busy visual is active; toggles the
+ * `swc-PendingSpinner--active` class that runs the spin animation.
  */
 export function renderPendingSpinner(
   pending: boolean,

--- a/2nd-gen/packages/core/mixins/index.ts
+++ b/2nd-gen/packages/core/mixins/index.ts
@@ -29,6 +29,7 @@ export {
   ObserveSlotText,
   type SlotTextObservingInterface,
 } from './observe-slot-text.js';
+export { PendingMixin, type PendingInterface } from './pending-mixin.js';
 export {
   DEFAULT_ELEMENT_SIZES,
   ELEMENT_SIZES,

--- a/2nd-gen/packages/core/mixins/pending-mixin.ts
+++ b/2nd-gen/packages/core/mixins/pending-mixin.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { PropertyValues, ReactiveElement } from 'lit';
+import { property, state } from 'lit/decorators.js';
+
+type Constructor<T = Record<string, unknown>> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): T;
+  prototype: T;
+};
+
+export interface PendingInterface {
+  pending: boolean;
+  pendingLabel?: string;
+  readonly pendingActive: boolean;
+  getPendingAccessibleName(): string;
+}
+
+const PENDING_INLINE_SIZE_PROPERTY = '--swc-pending-inline-size';
+const PENDING_TARGET_SELECTOR = 'button';
+const PENDING_DELAY_MS = 1000;
+
+/**
+ * A mixin that adds the pending (busy) state to a host element: the reactive
+ * `pending` and `pending-label` properties, a 1-second-delayed `pendingActive`
+ * flag with inline-size freeze, an accessible-name derivation helper, and
+ * capture-phase click suppression so activation is blocked while pending.
+ *
+ * The host stays focusable while pending; the mixin never sets the native
+ * `disabled` attribute. The host's template is responsible for applying
+ * `aria-disabled` and the pending `aria-label` (read from
+ * {@link PendingInterface.getPendingAccessibleName}), and for rendering the
+ * spinner with the `renderPendingSpinner` directive.
+ *
+ * Hosts override {@link resolvePendingAccessibleName} to supply their non-busy
+ * accessible name; the default uses trimmed `textContent`.
+ *
+ * @example
+ * ```typescript
+ * class MyButton extends PendingMixin(SpectrumElement) {
+ *   render() {
+ *     return html`<button
+ *       aria-disabled=${ifDefined(this.pending ? 'true' : undefined)}
+ *       aria-label=${ifDefined(this.pending ? this.getPendingAccessibleName() : undefined)}
+ *     >
+ *       <slot></slot>
+ *       ${renderPendingSpinner(this.pending, this.pendingActive)}
+ *     </button>`;
+ *   }
+ * }
+ * ```
+ */
+export function PendingMixin<T extends Constructor<ReactiveElement>>(
+  Base: T
+): T & Constructor<PendingInterface> {
+  class PendingElement extends Base implements PendingInterface {
+    /**
+     * Whether the element is in a pending (busy) state. The element remains
+     * focusable but activation is suppressed.
+     */
+    @property({ type: Boolean, reflect: true })
+    public pending = false;
+
+    /**
+     * Custom accessible label used during the pending state. When omitted, the
+     * pending label is derived from the resolved non-busy accessible name plus
+     * a busy suffix (e.g. "Save, busy").
+     */
+    @property({ type: String, attribute: 'pending-label' })
+    public pendingLabel?: string;
+
+    /**
+     * Tracks whether the pending visual (disabled colors + spinner) is active.
+     * Becomes `true` after a 1-second delay once `pending` becomes true, so the
+     * element does not immediately flash to its unavailable appearance. Read
+     * this in `render()` to apply busy styling.
+     */
+    @state()
+    protected pendingActive = false;
+
+    private _pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+    /**
+     * Returns the host's non-busy accessible name, used to derive the default
+     * busy label. Hosts override this to supply a richer name (e.g. an
+     * `accessible-label` fallback); the default uses trimmed `textContent`.
+     */
+    protected resolvePendingAccessibleName(): string | null {
+      return this.textContent?.trim() || null;
+    }
+
+    /** Derives the pending-state accessible label. */
+    public getPendingAccessibleName(): string {
+      if (this.pendingLabel) {
+        return this.pendingLabel;
+      }
+      const resolved = this.resolvePendingAccessibleName();
+      return resolved ? `${resolved}, busy` : 'Busy';
+    }
+
+    /**
+     * Suppresses click activation while pending. Capture phase so slotted
+     * light-DOM clicks are suppressed before host listeners run.
+     */
+    private readonly _suppressPendingActivation = (event: Event): void => {
+      if (this.pending) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+    };
+
+    public override connectedCallback(): void {
+      super.connectedCallback();
+      this.addEventListener('click', this._suppressPendingActivation, true);
+    }
+
+    public override disconnectedCallback(): void {
+      this.removeEventListener('click', this._suppressPendingActivation, true);
+      if (this._pendingTimer !== null) {
+        clearTimeout(this._pendingTimer);
+        this._pendingTimer = null;
+      }
+      this.pendingActive = false;
+      super.disconnectedCallback();
+    }
+
+    protected override update(changedProperties: PropertyValues): void {
+      if (changedProperties.has('pending')) {
+        if (this.pending) {
+          this._pendingTimer = setTimeout(() => {
+            this._pendingTimer = null;
+            if (!this.pending) {
+              return;
+            }
+            const target = this.renderRoot.querySelector<HTMLElement>(
+              PENDING_TARGET_SELECTOR
+            );
+            if (target) {
+              target.style.setProperty(
+                PENDING_INLINE_SIZE_PROPERTY,
+                `${target.offsetWidth}px`
+              );
+            }
+            this.pendingActive = true;
+          }, PENDING_DELAY_MS);
+        } else {
+          if (this._pendingTimer !== null) {
+            clearTimeout(this._pendingTimer);
+            this._pendingTimer = null;
+          }
+          this.renderRoot
+            .querySelector<HTMLElement>(PENDING_TARGET_SELECTOR)
+            ?.style.removeProperty(PENDING_INLINE_SIZE_PROPERTY);
+          this.pendingActive = false;
+        }
+      }
+      super.update(changedProperties);
+      if (window.__swc?.DEBUG) {
+        if (
+          this.pending &&
+          'disabled' in this &&
+          (this as unknown as { disabled: boolean }).disabled
+        ) {
+          window.__swc.warn(
+            this,
+            `<${this.localName}> should not set both "pending" and "disabled" simultaneously. Use "pending" to keep the element focusable while unavailable, or "disabled" to fully remove it from the tab order.`,
+            'https://opensource.adobe.com/spectrum-web-components/components/button/#pending',
+            { issues: ['pending + disabled'] }
+          );
+        }
+      }
+    }
+  }
+  return PendingElement as unknown as T & Constructor<PendingInterface>;
+}

--- a/2nd-gen/packages/core/package.json
+++ b/2nd-gen/packages/core/package.json
@@ -147,6 +147,22 @@
       "types": "./dist/element/version.d.ts",
       "import": "./dist/element/version.js"
     },
+    "./directives": {
+      "types": "./dist/directives/index.d.ts",
+      "import": "./dist/directives/index.js"
+    },
+    "./directives/index.js": {
+      "types": "./dist/directives/index.d.ts",
+      "import": "./dist/directives/index.js"
+    },
+    "./directives/pending-spinner": {
+      "types": "./dist/directives/pending-spinner/index.d.ts",
+      "import": "./dist/directives/pending-spinner/index.js"
+    },
+    "./directives/pending-spinner/index.js": {
+      "types": "./dist/directives/pending-spinner/index.d.ts",
+      "import": "./dist/directives/pending-spinner/index.js"
+    },
     "./mixins": {
       "types": "./dist/mixins/index.d.ts",
       "import": "./dist/mixins/index.js"
@@ -295,6 +311,18 @@
       ],
       "element/version.js": [
         "dist/element/version.d.ts"
+      ],
+      "directives": [
+        "dist/directives/index.d.ts"
+      ],
+      "directives/index.js": [
+        "dist/directives/index.d.ts"
+      ],
+      "directives/pending-spinner": [
+        "dist/directives/pending-spinner/index.d.ts"
+      ],
+      "directives/pending-spinner/index.js": [
+        "dist/directives/pending-spinner/index.d.ts"
       ],
       "mixins": [
         "dist/mixins/index.d.ts"

--- a/2nd-gen/packages/core/vite.config.js
+++ b/2nd-gen/packages/core/vite.config.js
@@ -80,6 +80,12 @@ function getEntries() {
     scanTsFiles(resolve(__dirname, 'controllers'), 'controllers')
   );
 
+  // Find all directives/*.ts files
+  Object.assign(
+    entries,
+    scanTsFiles(resolve(__dirname, 'directives'), 'directives')
+  );
+
   // Find all utils/*.ts files
   Object.assign(entries, scanTsFiles(resolve(__dirname, 'utils'), 'utils'));
 

--- a/2nd-gen/packages/swc/components/action-button/ActionButton.ts
+++ b/2nd-gen/packages/swc/components/action-button/ActionButton.ts
@@ -21,8 +21,8 @@ import {
   type ActionButtonStaticColor,
 } from '@spectrum-web-components/core/components/action-button';
 import { ButtonBase } from '@spectrum-web-components/core/components/button';
-
-import { renderPendingSpinner } from '../button/pending-spinner.js';
+import { renderPendingSpinner } from '@spectrum-web-components/core/directives/pending-spinner';
+import { PendingMixin } from '@spectrum-web-components/core/mixins';
 
 import pendingSpinnerStyles from '../../stylesheets/_lit-styles/pending-spinner.css';
 import styles from './action-button.css';
@@ -72,7 +72,7 @@ import styles from './action-button.css';
  *   Edit
  * </swc-action-button>
  */
-export class ActionButton extends ButtonBase {
+export class ActionButton extends PendingMixin(ButtonBase) {
   // ────────────────────
   //     API OVERRIDES
   // ────────────────────
@@ -159,6 +159,11 @@ export class ActionButton extends ButtonBase {
 
   public static override get styles(): CSSResultArray {
     return [pendingSpinnerStyles, styles];
+  }
+
+  /** The busy accessible name derives from the button's resolved accessible name. */
+  protected override resolvePendingAccessibleName(): string | null {
+    return this.getResolvedAccessibleName();
   }
 
   protected override render(): TemplateResult {

--- a/2nd-gen/packages/swc/components/action-button/action-button.css
+++ b/2nd-gen/packages/swc/components/action-button/action-button.css
@@ -236,7 +236,7 @@ slot[name="icon"]::slotted(*) {
 
   align-items: center;
   justify-content: center;
-  inline-size: var(--_swc-button-pending-inline-size);
+  inline-size: var(--swc-pending-inline-size);
 
   /* Disabled colors reference the already-resolved disabled vars so static-color
      variants automatically get their correct unavailable appearance. */

--- a/2nd-gen/packages/swc/components/button/Button.ts
+++ b/2nd-gen/packages/swc/components/button/Button.ts
@@ -23,8 +23,8 @@ import {
   type ButtonStaticColor,
   type ButtonVariant,
 } from '@spectrum-web-components/core/components/button';
-
-import { renderPendingSpinner } from './pending-spinner.js';
+import { renderPendingSpinner } from '@spectrum-web-components/core/directives/pending-spinner';
+import { PendingMixin } from '@spectrum-web-components/core/mixins';
 
 import pendingSpinnerStyles from '../../stylesheets/_lit-styles/pending-spinner.css';
 import styles from './button.css';
@@ -73,7 +73,7 @@ import baseStyles from './button-base.css';
  * @example
  * <swc-button variant="secondary" fill-style="outline">Cancel</swc-button>
  */
-export class Button extends ButtonBase {
+export class Button extends PendingMixin(ButtonBase) {
   // ───────────────────
   //     API ADDITIONS
   // ───────────────────
@@ -122,6 +122,11 @@ export class Button extends ButtonBase {
 
   public static override get styles(): CSSResultArray {
     return [baseStyles, pendingSpinnerStyles, styles];
+  }
+
+  /** The busy accessible name derives from the button's resolved accessible name. */
+  protected override resolvePendingAccessibleName(): string | null {
+    return this.getResolvedAccessibleName();
   }
 
   // @todo SWC-2034: handle form-associated types reset / submit

--- a/2nd-gen/packages/swc/components/button/button.css
+++ b/2nd-gen/packages/swc/components/button/button.css
@@ -328,7 +328,7 @@ slot[name="icon"]::slotted(*) {
   --swc-button-down-state-transform: none;
 
   justify-content: center;
-  inline-size: var(--_swc-button-pending-inline-size); /* Preserve measured inline size to avoid impacting layout, set via JS when state changes */
+  inline-size: var(--swc-pending-inline-size); /* Preserve measured inline size to avoid impacting layout, set via the PendingMixin when state changes */
 
   /* Disabled colors reference the already-resolved disabled vars so outline and
    static-color variants automatically get their correct unavailable appearance. */


### PR DESCRIPTION
Replaces the three-piece design from #6439 (PendingController + PendingMixin + renderPendingSpinner) with two pieces:

- PendingMixin (core/mixins) — owns all pending state directly: 1-second-delayed pendingActive via @state(), inline-size freeze, accessible-name derivation, and click suppression. Uses Lit's changedProperties.has('pending') instead of a _wasPending tracker.
- renderPendingSpinner (core/directives/pending-spinner) — relocated from the button package so non-button components can reuse it.

ButtonBase is fully pending-agnostic. swc-button and swc-action-button opt in via PendingMixin. No public API change — pending, pending-label, and busy behavior are identical to before.

Key differences vs. #6439:
- No PendingController or PendingControllerHost (phantom abstraction that delegated entirely to the mixin anyway).
- pendingActive restored as @state() (idiomatic Lit; no manual requestUpdate calls needed).
- Pending+disabled guard uses 'disabled' in this instead of a type cast.
- Changeset is minor (additive public API surface).

<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->
