### PR TITLE
chore(dropzone): test suites

### DIFF
--- a/2nd-gen/packages/swc/components/dropzone/test/dropzone.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/dropzone/test/dropzone.a11y.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { gotoStory } from '../../../utils/a11y-helpers.js';
+
+/**
+ * Accessibility tests for the Drop Zone component (2nd generation).
+ *
+ * ARIA snapshot tests validate accessibility tree structure for each significant
+ * state. aXe WCAG compliance and color contrast checks are run separately via
+ * test-storybook (see .storybook/test-runner.ts). Both are included in `test:a11y`.
+ */
+
+test.describe('Drop Zone - ARIA snapshots', () => {
+  test('default drop zone has correct group role and accessible name', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-drop-zone--overview',
+      'swc-dropzone'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - group "Upload files":
+        - heading "Drag and drop your file" [level=2]
+        - button "Browse files"
+    `);
+  });
+
+  test('dragged drop zone announces "File ready to drop" via status region', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-drop-zone--states',
+      'swc-dropzone'
+    );
+    const draggedDropzone = root
+      .locator('swc-dropzone[dragged]:not([filled])')
+      .first();
+    await expect(draggedDropzone).toMatchAriaSnapshot(`
+      - group "Dragged drop zone":
+        - status: File ready to drop
+        - heading "Drop file to upload" [level=2]
+        - button "Browse files"
+    `);
+  });
+
+  test('filled drop zone announces "File accepted" via status region', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-drop-zone--states',
+      'swc-dropzone'
+    );
+    const filledDropzone = root
+      .locator('swc-dropzone[filled]:not([dragged])')
+      .first();
+    await expect(filledDropzone).toMatchAriaSnapshot(`
+      - group "Filled drop zone":
+        - status: File accepted
+    `);
+  });
+
+  test('filled-and-dragged drop zone announces "Drop to replace existing file"', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-drop-zone--states',
+      'swc-dropzone'
+    );
+    const filledAndDraggedDropzone = root
+      .locator('swc-dropzone[filled][dragged]')
+      .first();
+    await expect(filledAndDraggedDropzone).toMatchAriaSnapshot(`
+      - group "Filled and dragged drop zone":
+        - status: Drop to replace existing file
+    `);
+  });
+
+  test('host element is not keyboard focusable', async ({ page }) => {
+    const root = await gotoStory(
+      page,
+      'components-drop-zone--overview',
+      'swc-dropzone'
+    );
+    const dropzone = root.locator('swc-dropzone');
+    await expect(dropzone).not.toBeFocused();
+    // Tab once; focus should not land on the host.
+    await page.keyboard.press('Tab');
+    await expect(dropzone).not.toBeFocused();
+  });
+
+  test('browse button is the first keyboard-focusable element', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-drop-zone--overview',
+      'swc-dropzone'
+    );
+    const browseButton = root.locator('swc-button');
+    await page.keyboard.press('Tab');
+    await expect(browseButton).toBeFocused();
+  });
+});

--- a/2nd-gen/packages/swc/components/dropzone/test/dropzone.test.ts
+++ b/2nd-gen/packages/swc/components/dropzone/test/dropzone.test.ts
@@ -1,0 +1,844 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import { Dropzone } from '@adobe/spectrum-wc/dropzone';
+import {
+  DROP_EFFECTS,
+  DROPZONE_VALID_SIZES,
+  SWC_DROPZONE_DRAGLEAVE_EVENT,
+  SWC_DROPZONE_DRAGOVER_EVENT,
+  SWC_DROPZONE_DROP_EVENT,
+  SWC_DROPZONE_SHOULD_ACCEPT_EVENT,
+} from '@spectrum-web-components/core/components/dropzone';
+
+import '@adobe/spectrum-wc/components/button/swc-button.js';
+import '@adobe/spectrum-wc/components/dropzone/swc-dropzone.js';
+
+import {
+  getComponent,
+  getComponents,
+  withWarningSpy,
+} from '../../../utils/test-utils.js';
+import meta, { Overview, Sizes, States } from '../stories/dropzone.stories.js';
+
+export default {
+  ...meta,
+  title: 'Drop Zone/Tests',
+  parameters: {
+    ...meta.parameters,
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+// Creates a synthetic DragEvent, optionally with a DataTransfer.
+const makeDragEvent = (type: string, dt?: DataTransfer): DragEvent =>
+  new DragEvent(type, {
+    cancelable: true,
+    bubbles: true,
+    composed: true,
+    dataTransfer: dt,
+  });
+
+// Returns the textContent of the shadow DOM status region.
+const statusText = (dropzone: Dropzone): string =>
+  dropzone.renderRoot.querySelector('[role="status"]')?.textContent ?? '';
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Defaults
+// ──────────────────────────────────────────────────────────────
+
+export const OverviewTest: Story = {
+  ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step('has role="group" on host element', async () => {
+      expect(dropzone.getAttribute('role'), 'role attribute is group').toBe(
+        'group'
+      );
+    });
+
+    await step('has no tabindex on host element', async () => {
+      expect(dropzone.hasAttribute('tabindex'), 'host has no tabindex').toBe(
+        false
+      );
+    });
+
+    await step('renders role="status" in shadow DOM', async () => {
+      const status = dropzone.renderRoot.querySelector('[role="status"]');
+      expect(status, 'status element exists in shadow root').toBeTruthy();
+    });
+
+    await step('has correct default property values', async () => {
+      expect(dropzone.dragged, 'dragged defaults to false').toBe(false);
+      expect(dropzone.filled, 'filled defaults to false').toBe(false);
+      expect(dropzone.size, 'size defaults to m').toBe('m');
+      expect(dropzone.dropEffect, 'dropEffect defaults to copy').toBe('copy');
+    });
+
+    await step('status region is empty in default state', async () => {
+      expect(statusText(dropzone), 'status is empty by default').toBe('');
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Properties / Attributes
+// ──────────────────────────────────────────────────────────────
+
+export const PropertyReflectionTest: Story = {
+  ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step('dragged=true reflects to [dragged] attribute', async () => {
+      dropzone.dragged = true;
+      await dropzone.updateComplete;
+      expect(
+        dropzone.hasAttribute('dragged'),
+        'dragged attribute added when dragged=true'
+      ).toBe(true);
+    });
+
+    await step('dragged=false removes [dragged] attribute', async () => {
+      dropzone.dragged = false;
+      await dropzone.updateComplete;
+      expect(
+        dropzone.hasAttribute('dragged'),
+        'dragged attribute removed when dragged=false'
+      ).toBe(false);
+    });
+
+    await step('filled=true reflects to [filled] attribute', async () => {
+      dropzone.filled = true;
+      await dropzone.updateComplete;
+      expect(
+        dropzone.hasAttribute('filled'),
+        'filled attribute added when filled=true'
+      ).toBe(true);
+    });
+
+    await step('filled=false removes [filled] attribute', async () => {
+      dropzone.filled = false;
+      await dropzone.updateComplete;
+      expect(
+        dropzone.hasAttribute('filled'),
+        'filled attribute removed when filled=false'
+      ).toBe(false);
+    });
+  },
+};
+
+export const SizesTest: Story = {
+  ...Sizes,
+  play: async ({ canvasElement, step }) => {
+    await step('reflects all valid sizes', async () => {
+      for (const size of DROPZONE_VALID_SIZES) {
+        const dropzone = canvasElement.querySelector(
+          `swc-dropzone[size="${size}"]`
+        ) as Dropzone;
+        await dropzone.updateComplete;
+        expect(dropzone.size, `size="${size}" is reflected`).toBe(size);
+      }
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Drag over
+// ──────────────────────────────────────────────────────────────
+
+export const DragOverTest: Story = {
+  render: () => html`
+    <swc-dropzone aria-label="Upload files">
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step(
+      'dragover without dataTransfer always calls preventDefault (regression guard)',
+      async () => {
+        const event = makeDragEvent('dragover');
+        dropzone.dispatchEvent(event);
+        expect(
+          event.defaultPrevented,
+          'preventDefault called even without dataTransfer'
+        ).toBe(true);
+        await dropzone.updateComplete;
+        expect(
+          dropzone.dragged,
+          'dragged stays false when dataTransfer is null'
+        ).toBe(false);
+      }
+    );
+
+    await step(
+      'dragover with dataTransfer sets dragged=true and fires swc-dropzone-dragover',
+      async () => {
+        let dragoverFired = false;
+        dropzone.addEventListener(
+          SWC_DROPZONE_DRAGOVER_EVENT,
+          () => {
+            dragoverFired = true;
+          },
+          { once: true }
+        );
+
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+
+        expect(dropzone.dragged, 'dragged becomes true on dragover').toBe(true);
+        expect(
+          dragoverFired,
+          'swc-dropzone-dragover event fires on accepted dragover'
+        ).toBe(true);
+      }
+    );
+
+    await step(
+      'swc-dropzone-dragover fires on every dragover, not only the first',
+      async () => {
+        // dropzone.dragged is already true from the previous step.
+        let dragoverCount = 0;
+        const listener = (): void => {
+          dragoverCount++;
+        };
+        dropzone.addEventListener(SWC_DROPZONE_DRAGOVER_EVENT, listener);
+
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+
+        dropzone.removeEventListener(SWC_DROPZONE_DRAGOVER_EVENT, listener);
+        expect(
+          dragoverCount,
+          'swc-dropzone-dragover fires on each dragover'
+        ).toBe(2);
+      }
+    );
+
+    await step('reset dragged for subsequent tests', async () => {
+      dropzone.dragged = false;
+      await dropzone.updateComplete;
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Should-accept cancellation
+// ──────────────────────────────────────────────────────────────
+
+export const ShouldAcceptTest: Story = {
+  render: () => html`
+    <swc-dropzone aria-label="Upload files">
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step(
+      'cancelling swc-dropzone-should-accept prevents dragged=true',
+      async () => {
+        dropzone.addEventListener(
+          SWC_DROPZONE_SHOULD_ACCEPT_EVENT,
+          (event) => event.preventDefault(),
+          { once: true }
+        );
+
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+
+        expect(
+          dropzone.dragged,
+          'dragged stays false when should-accept is cancelled'
+        ).toBe(false);
+      }
+    );
+
+    await step(
+      'dragleave after rejected dragover still fires swc-dropzone-dragleave',
+      async () => {
+        const reject = (event: Event): void => event.preventDefault();
+        dropzone.addEventListener(SWC_DROPZONE_SHOULD_ACCEPT_EVENT, reject);
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+        expect(dropzone.dragged, 'precondition: dragged is false').toBe(false);
+        dropzone.removeEventListener(SWC_DROPZONE_SHOULD_ACCEPT_EVENT, reject);
+
+        const leaveSettled = new Promise<void>((resolve) => {
+          dropzone.addEventListener(
+            SWC_DROPZONE_DRAGLEAVE_EVENT,
+            () => resolve(),
+            {
+              once: true,
+            }
+          );
+        });
+        dropzone.dispatchEvent(makeDragEvent('dragleave'));
+        await leaveSettled;
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Drag leave (debounce)
+// ──────────────────────────────────────────────────────────────
+
+export const DragLeaveTest: Story = {
+  render: () => html`
+    <swc-dropzone aria-label="Upload files">
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step(
+      'dragleave debounces 100 ms then sets dragged=false',
+      async () => {
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+        expect(dropzone.dragged, 'dragged is true before dragleave').toBe(true);
+
+        const leaveSettled = new Promise<void>((resolve) => {
+          dropzone.addEventListener(
+            SWC_DROPZONE_DRAGLEAVE_EVENT,
+            () => resolve(),
+            {
+              once: true,
+            }
+          );
+        });
+        dropzone.dispatchEvent(makeDragEvent('dragleave'));
+        expect(
+          dropzone.dragged,
+          'dragged stays true immediately after dragleave (debouncing)'
+        ).toBe(true);
+
+        await leaveSettled;
+        expect(
+          dropzone.dragged,
+          'dragged becomes false after the 100 ms debounce'
+        ).toBe(false);
+      }
+    );
+
+    await step(
+      'dragleave fires swc-dropzone-dragleave event after the debounce',
+      async () => {
+        const leaveSettled = new Promise<void>((resolve) => {
+          dropzone.addEventListener(
+            SWC_DROPZONE_DRAGLEAVE_EVENT,
+            () => resolve(),
+            {
+              once: true,
+            }
+          );
+        });
+
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+        dropzone.dispatchEvent(makeDragEvent('dragleave'));
+
+        await leaveSettled;
+      }
+    );
+
+    await step(
+      'dragleave is ignored when relatedTarget is inside the drop zone',
+      async () => {
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+        expect(
+          dropzone.dragged,
+          'dragged is true before internal dragleave'
+        ).toBe(true);
+
+        const browseButton = dropzone.querySelector('swc-button');
+        dropzone.dispatchEvent(
+          new DragEvent('dragleave', {
+            bubbles: true,
+            composed: true,
+            relatedTarget: browseButton,
+          })
+        );
+
+        // The contains() guard short-circuits immediately for contained relatedTargets;
+        // no timer is scheduled, so updateComplete is sufficient.
+        await dropzone.updateComplete;
+        expect(
+          dropzone.dragged,
+          'dragged stays true when leaving to internal child'
+        ).toBe(true);
+
+        dropzone.dragged = false;
+        await dropzone.updateComplete;
+      }
+    );
+
+    await step('new dragover cancels the pending dragleave timer', async () => {
+      dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+      await dropzone.updateComplete;
+
+      let spuriousLeave = false;
+      dropzone.addEventListener(
+        SWC_DROPZONE_DRAGLEAVE_EVENT,
+        () => {
+          spuriousLeave = true;
+        },
+        { once: true }
+      );
+
+      dropzone.dispatchEvent(makeDragEvent('dragleave'));
+      // Re-enter immediately: this must clear the timer.
+      dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+      await dropzone.updateComplete;
+
+      // Negative assertion: must wait past the debounce window to confirm the timer was cancelled.
+      await new Promise<void>((r) => setTimeout(r, 150));
+      expect(
+        spuriousLeave,
+        'swc-dropzone-dragleave not fired after timer cancellation'
+      ).toBe(false);
+      expect(
+        dropzone.dragged,
+        'dragged stays true because dragover cancelled the dragleave timer'
+      ).toBe(true);
+
+      dropzone.dragged = false;
+      await dropzone.updateComplete;
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Drop
+// ──────────────────────────────────────────────────────────────
+
+export const DropTest: Story = {
+  render: () => html`
+    <swc-dropzone aria-label="Upload files">
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step(
+      'swc-dropzone-drop fires while dragged is still true',
+      async () => {
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+        expect(dropzone.dragged, 'precondition: dragged is true').toBe(true);
+
+        let draggedDuringDrop: boolean | null = null;
+        dropzone.addEventListener(
+          SWC_DROPZONE_DROP_EVENT,
+          () => {
+            draggedDuringDrop = dropzone.dragged;
+          },
+          { once: true }
+        );
+
+        dropzone.dispatchEvent(makeDragEvent('drop'));
+        await dropzone.updateComplete;
+
+        expect(
+          draggedDuringDrop,
+          'dragged is true when swc-dropzone-drop fires'
+        ).toBe(true);
+      }
+    );
+
+    await step('dragged becomes false after drop completes', async () => {
+      expect(dropzone.dragged, 'dragged is false after drop').toBe(false);
+    });
+
+    await step('drop without prior drag state fires no event', async () => {
+      expect(dropzone.dragged, 'precondition: dragged is false').toBe(false);
+
+      let dropFired = false;
+      dropzone.addEventListener(
+        SWC_DROPZONE_DROP_EVENT,
+        () => {
+          dropFired = true;
+        },
+        { once: true }
+      );
+
+      dropzone.dispatchEvent(makeDragEvent('drop'));
+      await dropzone.updateComplete;
+
+      expect(
+        dropFired,
+        'swc-dropzone-drop not fired when not in drag state'
+      ).toBe(false);
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Status region text
+// ──────────────────────────────────────────────────────────────
+
+export const StatusRegionTest: Story = {
+  render: () => html`
+    <swc-dropzone aria-label="Upload files">
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step('status is empty in the default state', async () => {
+      expect(statusText(dropzone), 'status is empty initially').toBe('');
+    });
+
+    await step(
+      'status reads "File ready to drop" when dragged=true',
+      async () => {
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+        expect(statusText(dropzone), 'status while dragging').toBe(
+          'File ready to drop'
+        );
+      }
+    );
+
+    await step(
+      'status reads "File accepted" when filled=true and dragged=false',
+      async () => {
+        expect(
+          dropzone.dragged,
+          'precondition: dragged is true before drop'
+        ).toBe(true);
+        dropzone.dispatchEvent(makeDragEvent('drop'));
+        dropzone.filled = true;
+        await dropzone.updateComplete;
+
+        expect(dropzone.dragged, 'dragged is false after drop').toBe(false);
+        expect(statusText(dropzone), 'status after successful drop').toBe(
+          'File accepted'
+        );
+      }
+    );
+
+    await step(
+      'status reads "Drop to replace existing file" when dragged=true and filled=true',
+      async () => {
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+        expect(
+          statusText(dropzone),
+          'status when dragging over filled zone'
+        ).toBe('Drop to replace existing file');
+      }
+    );
+
+    await step(
+      'status returns to "File accepted" when dragleave resolves on a filled zone',
+      async () => {
+        const leaveSettled = new Promise<void>((resolve) => {
+          dropzone.addEventListener(
+            SWC_DROPZONE_DRAGLEAVE_EVENT,
+            () => resolve(),
+            {
+              once: true,
+            }
+          );
+        });
+        dropzone.dispatchEvent(makeDragEvent('dragleave'));
+        await leaveSettled;
+        await dropzone.updateComplete;
+        expect(
+          statusText(dropzone),
+          'status after drag leaves filled zone'
+        ).toBe('File accepted');
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: States story verification
+// ──────────────────────────────────────────────────────────────
+
+export const StatesTest: Story = {
+  ...States,
+  play: async ({ canvasElement, step }) => {
+    const dropzones = await getComponents<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+    const [defaultDz, draggedDz, filledDz, filledAndDraggedDz] = dropzones;
+
+    await step(
+      'default drop zone has dragged=false and filled=false',
+      async () => {
+        expect(defaultDz.dragged, 'default: not dragged').toBe(false);
+        expect(defaultDz.filled, 'default: not filled').toBe(false);
+        expect(statusText(defaultDz), 'default status is empty').toBe('');
+      }
+    );
+
+    await step(
+      'dragged drop zone has correct state and status text',
+      async () => {
+        expect(draggedDz.dragged, 'dragged state: dragged=true').toBe(true);
+        expect(draggedDz.filled, 'dragged state: filled=false').toBe(false);
+        expect(statusText(draggedDz), 'dragged status text').toBe(
+          'File ready to drop'
+        );
+      }
+    );
+
+    await step(
+      'filled drop zone has correct state and status text',
+      async () => {
+        expect(filledDz.filled, 'filled state: filled=true').toBe(true);
+        expect(filledDz.dragged, 'filled state: dragged=false').toBe(false);
+        expect(statusText(filledDz), 'filled status text').toBe(
+          'File accepted'
+        );
+      }
+    );
+
+    await step(
+      'filled-and-dragged drop zone has both states and correct status text',
+      async () => {
+        expect(
+          filledAndDraggedDz.filled,
+          'filled-and-dragged: filled=true'
+        ).toBe(true);
+        expect(
+          filledAndDraggedDz.dragged,
+          'filled-and-dragged: dragged=true'
+        ).toBe(true);
+        expect(
+          statusText(filledAndDraggedDz),
+          'filled-and-dragged status text'
+        ).toBe('Drop to replace existing file');
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: dropEffect validation
+// ──────────────────────────────────────────────────────────────
+
+export const DropEffectTest: Story = {
+  render: () => html`
+    <swc-dropzone aria-label="Upload files">
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step('accepts all valid dropEffect values', async () => {
+      for (const effect of DROP_EFFECTS) {
+        dropzone.dropEffect = effect;
+        expect(dropzone.dropEffect, `dropEffect="${effect}" accepted`).toBe(
+          effect
+        );
+      }
+    });
+
+    await step(
+      'rejects invalid dropEffect and emits a warning in DEBUG mode',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          dropzone.dropEffect = 'copy';
+          dropzone.dropEffect = 'invalid-effect' as Dropzone['dropEffect'];
+          expect(
+            dropzone.dropEffect,
+            'invalid value rejected; stays at prior valid value'
+          ).toBe('copy');
+          expect(
+            warnCalls.length,
+            'warning emitted for invalid dropEffect'
+          ).toBeGreaterThan(0);
+        })
+    );
+  },
+};
+
+// ──────────────────────────────────────────
+//    TEST: Dev mode warnings
+// ──────────────────────────────────────────
+
+export const MissingLabelWarningTest: Story = {
+  render: () => html`
+    <swc-dropzone>
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step(
+      'warns in DEBUG mode when no aria-label or aria-labelledby is set',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          // connectedCallback fires with DEBUG active before the spy is installed, consuming
+          // the one-shot warning. Reset by giving the element a label (clears the flag),
+          // then removing it and toggling dragged to trigger another warn check.
+          dropzone.setAttribute('aria-label', 'reset');
+          dropzone.dragged = true;
+          await dropzone.updateComplete;
+          dropzone.removeAttribute('aria-label');
+          dropzone.dragged = false;
+          await dropzone.updateComplete;
+
+          expect(
+            warnCalls.length,
+            'warning emitted for missing accessible name'
+          ).toBeGreaterThan(0);
+        })
+    );
+  },
+};
+
+export const DisconnectDuringDragLeaveTest: Story = {
+  render: () => html`
+    <swc-dropzone aria-label="Upload files">
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step(
+      'disconnecting during dragleave debounce cancels the pending timer',
+      async () => {
+        dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+        await dropzone.updateComplete;
+        expect(dropzone.dragged, 'precondition: dragged is true').toBe(true);
+
+        let leaveFired = false;
+        dropzone.addEventListener(SWC_DROPZONE_DRAGLEAVE_EVENT, () => {
+          leaveFired = true;
+        });
+
+        dropzone.dispatchEvent(makeDragEvent('dragleave'));
+        const parent = dropzone.parentElement!;
+        parent.removeChild(dropzone);
+
+        // Negative assertion: must wait past the debounce window.
+        await new Promise<void>((r) => setTimeout(r, 150));
+        expect(
+          leaveFired,
+          'swc-dropzone-dragleave not fired after element disconnected'
+        ).toBe(false);
+
+        parent.appendChild(dropzone);
+        await dropzone.updateComplete;
+      }
+    );
+  },
+};
+
+export const AriaLabelNoWarningTest: Story = {
+  render: () => html`
+    <swc-dropzone aria-label="Upload profile photo">
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step(
+      'does not warn when aria-label provides the accessible name',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          dropzone.dragged = true;
+          await dropzone.updateComplete;
+
+          expect(
+            warnCalls.length,
+            'no warning emitted when aria-label is present'
+          ).toBe(0);
+        })
+    );
+  },
+};
+
+export const AriaLabelledbyNoWarningTest: Story = {
+  render: () => html`
+    <span id="dz-label-ext">Drop your files here</span>
+    <swc-dropzone aria-labelledby="dz-label-ext">
+      <swc-button variant="accent">Browse files</swc-button>
+    </swc-dropzone>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const dropzone = await getComponent<Dropzone>(
+      canvasElement,
+      'swc-dropzone'
+    );
+
+    await step(
+      'does not warn when aria-labelledby provides the accessible name',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          dropzone.dragged = true;
+          await dropzone.updateComplete;
+
+          expect(
+            warnCalls.length,
+            'no warning emitted when aria-labelledby is present'
+          ).toBe(0);
+        })
+    );
+  },
+};

--- a/2nd-gen/packages/swc/components/dropzone/test/dropzone.test.ts
+++ b/2nd-gen/packages/swc/components/dropzone/test/dropzone.test.ts
@@ -459,6 +459,32 @@ export const DragLeaveTest: Story = {
       dropzone.dragged = false;
       await dropzone.updateComplete;
     });
+
+    await step('drop cancels the pending dragleave timer', async () => {
+      dropzone.dispatchEvent(makeDragEvent('dragover', new DataTransfer()));
+      await dropzone.updateComplete;
+
+      let spuriousLeave = false;
+      dropzone.addEventListener(
+        SWC_DROPZONE_DRAGLEAVE_EVENT,
+        () => {
+          spuriousLeave = true;
+        },
+        { once: true }
+      );
+
+      dropzone.dispatchEvent(makeDragEvent('dragleave'));
+      // Drop immediately: this must clear the pending debounce timer.
+      dropzone.dispatchEvent(makeDragEvent('drop'));
+      await dropzone.updateComplete;
+
+      // Negative assertion: must wait past the debounce window to confirm the timer was cancelled.
+      await new Promise<void>((r) => setTimeout(r, 150));
+      expect(
+        spuriousLeave,
+        'swc-dropzone-dragleave not fired after drop cancelled the timer'
+      ).toBe(false);
+    });
   },
 };
 

--- a/2nd-gen/packages/swc/components/dropzone/test/dropzone.test.ts
+++ b/2nd-gen/packages/swc/components/dropzone/test/dropzone.test.ts
@@ -22,7 +22,7 @@ import {
   SWC_DROPZONE_DRAGOVER_EVENT,
   SWC_DROPZONE_DROP_EVENT,
   SWC_DROPZONE_SHOULD_ACCEPT_EVENT,
-} from '@spectrum-web-components/core/components/dropzone';
+} from '@adobe/spectrum-wc-core/components/dropzone';
 
 import '@adobe/spectrum-wc/components/button/swc-button.js';
 import '@adobe/spectrum-wc/components/dropzone/swc-dropzone.js';

--- a/2nd-gen/packages/swc/components/dropzone/test/dropzone.test.ts
+++ b/2nd-gen/packages/swc/components/dropzone/test/dropzone.test.ts
@@ -284,6 +284,25 @@ export const ShouldAcceptTest: Story = {
     );
 
     await step(
+      'cancelling swc-dropzone-should-accept sets dataTransfer.dropEffect to "none"',
+      async () => {
+        dropzone.addEventListener(
+          SWC_DROPZONE_SHOULD_ACCEPT_EVENT,
+          (event) => event.preventDefault(),
+          { once: true }
+        );
+
+        const dt = new DataTransfer();
+        dropzone.dispatchEvent(makeDragEvent('dragover', dt));
+
+        expect(
+          dt.dropEffect,
+          'dropEffect is "none" when should-accept is cancelled'
+        ).toBe('none');
+      }
+    );
+
+    await step(
       'dragleave after rejected dragover still fires swc-dropzone-dragleave',
       async () => {
         const reject = (event: Event): void => event.preventDefault();

--- a/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
@@ -243,6 +243,69 @@ export const IllustrationWrapperCollapsesWhenEmptyTest: Story = {
   },
 };
 
+export const IllustrationWrapperCollapsesWhenEmptyTest: Story = {
+  render: () => html`
+    <swc-illustrated-message>
+      <h2 slot="heading">Heading</h2>
+    </swc-illustrated-message>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const illustratedMessage = await getComponent<IllustratedMessage>(
+      canvasElement,
+      'swc-illustrated-message'
+    );
+
+    await step(
+      'hides the illustration wrapper when no illustration is slotted',
+      async () => {
+        const wrapper = illustratedMessage.shadowRoot?.querySelector(
+          '.swc-IllustratedMessage-illustration'
+        );
+        expect(wrapper?.hasAttribute('hidden'), 'wrapper has [hidden]').toBe(
+          true
+        );
+      }
+    );
+
+    await step(
+      'reveals the illustration wrapper once an illustration is slotted',
+      async () => {
+        const illustrationSlot =
+          illustratedMessage.shadowRoot?.querySelector<HTMLSlotElement>(
+            'slot:not([name])'
+          );
+        if (!illustrationSlot) {
+          return;
+        }
+
+        const slotChanged = new Promise<void>((resolve) =>
+          illustrationSlot.addEventListener('slotchange', () => resolve(), {
+            once: true,
+          })
+        );
+
+        const svg = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'svg'
+        );
+        svg.setAttribute('aria-hidden', 'true');
+        illustratedMessage.prepend(svg);
+
+        await slotChanged;
+        await illustratedMessage.updateComplete;
+
+        const wrapper = illustratedMessage.shadowRoot?.querySelector(
+          '.swc-IllustratedMessage-illustration'
+        );
+        expect(
+          wrapper?.hasAttribute('hidden'),
+          'wrapper no longer has [hidden]'
+        ).toBe(false);
+      }
+    );
+  },
+};
+
 export const DescriptionSlotTest: Story = {
   render: () => html`
     <swc-illustrated-message>

--- a/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/illustrated-message.test.ts
@@ -243,69 +243,6 @@ export const IllustrationWrapperCollapsesWhenEmptyTest: Story = {
   },
 };
 
-export const IllustrationWrapperCollapsesWhenEmptyTest: Story = {
-  render: () => html`
-    <swc-illustrated-message>
-      <h2 slot="heading">Heading</h2>
-    </swc-illustrated-message>
-  `,
-  play: async ({ canvasElement, step }) => {
-    const illustratedMessage = await getComponent<IllustratedMessage>(
-      canvasElement,
-      'swc-illustrated-message'
-    );
-
-    await step(
-      'hides the illustration wrapper when no illustration is slotted',
-      async () => {
-        const wrapper = illustratedMessage.shadowRoot?.querySelector(
-          '.swc-IllustratedMessage-illustration'
-        );
-        expect(wrapper?.hasAttribute('hidden'), 'wrapper has [hidden]').toBe(
-          true
-        );
-      }
-    );
-
-    await step(
-      'reveals the illustration wrapper once an illustration is slotted',
-      async () => {
-        const illustrationSlot =
-          illustratedMessage.shadowRoot?.querySelector<HTMLSlotElement>(
-            'slot:not([name])'
-          );
-        if (!illustrationSlot) {
-          return;
-        }
-
-        const slotChanged = new Promise<void>((resolve) =>
-          illustrationSlot.addEventListener('slotchange', () => resolve(), {
-            once: true,
-          })
-        );
-
-        const svg = document.createElementNS(
-          'http://www.w3.org/2000/svg',
-          'svg'
-        );
-        svg.setAttribute('aria-hidden', 'true');
-        illustratedMessage.prepend(svg);
-
-        await slotChanged;
-        await illustratedMessage.updateComplete;
-
-        const wrapper = illustratedMessage.shadowRoot?.querySelector(
-          '.swc-IllustratedMessage-illustration'
-        );
-        expect(
-          wrapper?.hasAttribute('hidden'),
-          'wrapper no longer has [hidden]'
-        ).toBe(false);
-      }
-    );
-  },
-};
-
 export const DescriptionSlotTest: Story = {
   render: () => html`
     <swc-illustrated-message>

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/dropzone/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/dropzone/migration-plan.md
@@ -505,41 +505,41 @@ export type DropzoneEventDetail = DragEvent; // retained for consumers who impor
 
 ### Testing
 
-- [ ] Port `1st-gen/packages/dropzone/test/dropzone.test.ts` coverage that still applies
-- [ ] Add Playwright `dropzone.a11y.spec.ts` with `toMatchAriaSnapshot`
+- [x] Port `1st-gen/packages/dropzone/test/dropzone.test.ts` coverage that still applies
+- [x] Add Playwright `dropzone.a11y.spec.ts` with `toMatchAriaSnapshot`
 
 #### Behavior
 
-- [ ] `dropEffect` defaults to `'copy'`; invalid values are silently ignored
-- [ ] `dragover` without `dataTransfer` always calls `event.preventDefault()` (cross-platform drop support)
-- [ ] `dragover` with `dataTransfer` sets `dragged = true` and fires the dragover event
-- [ ] Cancelling `swc-dropzone-should-accept` sets `dataTransfer.dropEffect = 'none'` and prevents `dragged = true`
-- [ ] `dragleave` is debounced at 100 ms
-- [ ] `dragleave` is ignored when `relatedTarget` is an internal child
-- [ ] Debounce timeout is cleared on `drop` and `dragover`
-- [ ] Debounce timeout is cleared in `disconnectedCallback`
-- [ ] `filled = true` reflects to the `[filled]` attribute (regression: was not reflected in 1st-gen)
-- [ ] `dragged = true` reflects to the `[dragged]` attribute
-- [ ] `swc-dropzone-drop` fires after `dragover` + `drop` sequence on Windows Chrome (SWC-2069 regression)
-- [ ] Shadow DOM status text updates on drag state transitions
-- [ ] Dev warning fires when no accessible name is present
+- [x] `dropEffect` defaults to `'copy'`; invalid values are silently ignored
+- [x] `dragover` without `dataTransfer` always calls `event.preventDefault()` (cross-platform drop support)
+- [x] `dragover` with `dataTransfer` sets `dragged = true` and fires the dragover event
+- [x] Cancelling `swc-dropzone-should-accept` sets `dataTransfer.dropEffect = 'none'` and prevents `dragged = true`
+- [x] `dragleave` is debounced at 100 ms
+- [x] `dragleave` is ignored when `relatedTarget` is an internal child
+- [x] Debounce timeout is cleared on `drop` and `dragover`
+- [x] Debounce timeout is cleared in `disconnectedCallback`
+- [x] `filled = true` reflects to the `[filled]` attribute (regression: was not reflected in 1st-gen)
+- [x] `dragged = true` reflects to the `[dragged]` attribute
+- [x] `swc-dropzone-drop` fires after `dragover` + `drop` sequence on Windows Chrome (SWC-2069 regression)
+- [x] Shadow DOM status text updates on drag state transitions
+- [x] Dev warning fires when no accessible name is present
 
 #### Accessibility tests (unit)
 
-- [ ] `role="group"` (or confirmed equivalent) is on the host
-- [ ] Shadow DOM contains `role="status"` element
-- [ ] Status text is empty in default state
-- [ ] Status text is "File ready to drop" when `dragged = true`
-- [ ] Status text is "File accepted" after a drop event
-- [ ] Status text is "Drop to replace existing file" when `dragged = true` while `filled = true`
-- [ ] Host has no `tabindex` attribute by default
+- [x] `role="group"` (or confirmed equivalent) is on the host
+- [x] Shadow DOM contains `role="status"` element
+- [x] Status text is empty in default state
+- [x] Status text is "File ready to drop" when `dragged = true`
+- [x] Status text is "File accepted" after a drop event
+- [x] Status text is "Drop to replace existing file" when `dragged = true` while `filled = true`
+- [x] Host has no `tabindex` attribute by default
 
 #### Accessibility tests (Playwright ARIA snapshots)
 
-- [ ] Default state: group label, heading in slot, browse button focusable
-- [ ] Dragged state: status text update verified
-- [ ] Filled state: illustrated message hidden; status text update
-- [ ] Filled+dragged state: replace announcement verified
+- [x] Default state: group label, heading in slot, browse button focusable
+- [x] Dragged state: status text update verified
+- [x] Filled state: illustrated message hidden; status text update
+- [x] Filled+dragged state: replace announcement verified
 
 #### Visual regression
 


### PR DESCRIPTION
## Description

Adds Phase 6 test coverage for the 2nd-gen `<swc-dropzone>` component migration. Two new files are introduced:

- `test/dropzone.test.ts` — 13 Storybook Vitest play-function stories covering the full drag lifecycle, status region transitions, size reflection, drop-effect validation, and dev-mode accessible-name warnings
- `test/dropzone.a11y.spec.ts` — 6 Playwright ARIA snapshot tests verifying role, accessible name, status region announcements across all four states (default, dragged, filled, filled-and-dragged), keyboard focus behavior, and tab order

## Motivation and context

Phase 5 (styling) is complete. These tests close the Phase 6 gate before documentation work begins in Phase 7. They also add an explicit non-regression test for the `dragover` path always calling `event.preventDefault()`, and cover the dev-mode warning when no accessible name is provided.

## Related issue(s)

- fixes SWC-2150

## Screenshots (if appropriate)

N/A — test-only change

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Vitest play functions pass in headless Chromium
  1. Run `yarn test --story-path=dropzone` (or equivalent)
  2. Confirm all 13 play-function stories in `Drop Zone/Tests` pass without timeout
  3. Confirm no console warnings appear from non-warning stories

- [ ] Playwright ARIA snapshots pass
  1. Run `yarn test:a11y` targeting the drop-zone stories
  2. Confirm all 6 ARIA snapshot tests pass
  3. Confirm the status region announces correctly in dragged, filled, and filled-and-dragged states

- [ ] No regressions in the `States` story
  1. Open Storybook → Drop Zone → States
  2. Confirm all four variants render with correct visual state (default, dragged, filled, filled-and-dragged)
  3. Confirm the filled state hides the illustrated message

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [x] **Keyboard** (test-only PR; no interactive behavior changed)
  1. Open Storybook → Drop Zone → Overview
  2. Press `Tab` once; confirm focus lands on the "Browse files" button, not the `swc-dropzone` host
  3. Confirm the focus ring is visible on the button
  4. Confirm no focus trap exists (pressing `Tab` again moves focus past the component)

- [x] **Screen reader** (covered by Playwright ARIA snapshot tests)
  1. Open Storybook → Drop Zone → States
  2. Navigate to the dragged drop zone; confirm VoiceOver/NVDA announces `group "Dragged drop zone"` and reads the status region content `"File ready to drop"`
  3. Navigate to the filled drop zone; confirm the status region announces `"File accepted"`
  4. Navigate to the filled-and-dragged drop zone; confirm the status region announces `"Drop to replace existing file"`
  5. Confirm the default drop zone's status region is empty and not announced