### PR TITLE
feat(core): migrate ColorController to 2nd-gen and optimize with colorjs.io

### DIFF
--- a/2nd-gen/packages/core/controllers/color-controller/index.ts
+++ b/2nd-gen/packages/core/controllers/color-controller/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export {
+  ColorController,
+  type Color,
+  type ColorTypes,
+} from './src/color-controller.js';

--- a/2nd-gen/packages/core/controllers/color-controller/src/color-controller.ts
+++ b/2nd-gen/packages/core/controllers/color-controller/src/color-controller.ts
@@ -1,0 +1,770 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { ReactiveElement } from 'lit';
+import type ColorSpace from 'colorjs.io';
+import type { ColorObject, ColorTypes as DefaultColorTypes } from 'colorjs.io';
+import Color from 'colorjs.io';
+
+// ─────────────────────────
+//     TYPES
+// ─────────────────────────
+
+/**
+ * Represents various color types that can be used in the application.
+ *
+ * This type can be one of the following:
+ * - `DefaultColorTypes`: A predefined set of color types.
+ * - An object representing an RGBA color with properties:
+ *   - `r`: Red component, can be a number or string.
+ *   - `g`: Green component, can be a number or string.
+ *   - `b`: Blue component, can be a number or string.
+ *   - `a` (optional): Alpha component, can be a number or string.
+ * - An object representing an HSLA color with properties:
+ *   - `h`: Hue component, can be a number or string.
+ *   - `s`: Saturation component, can be a number or string.
+ *   - `l`: Lightness component, can be a number or string.
+ *   - `a` (optional): Alpha component, can be a number or string.
+ * - An object representing an HSVA color with properties:
+ *   - `h`: Hue component, can be a number or string.
+ *   - `s`: Saturation component, can be a number or string.
+ *   - `v`: Value component, can be a number or string.
+ *   - `a` (optional): Alpha component, can be a number or string.
+ */
+type ColorTypes =
+  | DefaultColorTypes
+  | {
+      r: number | string;
+      g: number | string;
+      b: number | string;
+      a?: number | string;
+    }
+  | {
+      h: number | string;
+      s: number | string;
+      l: number | string;
+      a?: number | string;
+    }
+  | {
+      h: number | string;
+      s: number | string;
+      v: number | string;
+      a?: number | string;
+    };
+
+export type { Color, ColorTypes };
+
+type ColorValidationResult = {
+  spaceId: string | null;
+  coords: number[];
+  isValid: boolean;
+  alpha: number;
+};
+
+/** Loose shape of a color object whose channel values may arrive as strings. */
+type LooseColorObject = {
+  h?: number | string;
+  s?: number | string;
+  l?: number | string;
+  v?: number | string;
+  r?: number | string;
+  g?: number | string;
+  b?: number | string;
+  a?: number | string;
+};
+
+// ─────────────────────────
+//     CONSTANTS
+// ─────────────────────────
+
+// These pattern arrays are static, so they live at module scope and are shared
+// across every controller instance and `validateColorString` call rather than
+// being rebuilt on each invocation.
+
+// RGB color formats
+const RGB_REG_EXP_ARRAY = [
+  // With commas
+  /rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d*\.?\d+)\s*\)/i, // rgba(r, g, b, a)
+  /rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)/i, // rgb(r, g, b)
+
+  // With spaces
+  /^rgba\s+(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})\s+(0|0?\.\d+|1)\s*$/i, // rgba r g b a
+  /^rgb\s+(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})\s*$/i, // rgb r g b
+
+  // Spaces inside parentheses
+  /^rgba\(\s*(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})\s+(\d*\.?\d+)\s*\)$/i, // rgba(r g b a)
+  /^rgb\(\s*(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})\s*\)$/i, // rgb(r g b)
+
+  // Percentage values
+  /rgb\(\s*(100|[0-9]{1,2}%)\s*,\s*(100|[0-9]{1,2}%)\s*,\s*(100|[0-9]{1,2}%)\s*\)/i, // rgb(r%, g%, b%)
+  /rgba\(\s*(100|[0-9]{1,2})%\s*,\s*(100|[0-9]{1,2})%\s*,\s*(100|[0-9]{1,2})%\s*,\s*(\d*\.?\d+)\s*\)/i, // rgba(r%, g%, b%, a)
+] as const;
+
+// HSL color formats
+const HSL_REG_EXP_ARRAY = [
+  // With commas
+  /hsla\(\s*(\d{1,3})\s*,\s*(\d{1,3}%?)\s*,\s*(\d{1,3}%?)\s*,\s*(\d*\.?\d+)\s*\)/i, // hsla(h, s, l, a)
+  /hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3}%?)\s*,\s*(\d{1,3}%?)\s*\)/i, // hsl(h, s, l)
+
+  // With spaces
+  /^hsla\s+(\d{1,3})\s+(\d{1,3}%?)\s+(\d{1,3}%?)\s+(\d*\.?\d+)\s*$/i, // hsla h s l a
+  /^hsl\s+(\d{1,3})\s+(\d{1,3}%?)\s+(\d{1,3}%?)\s*$/i, // hsl h s l
+
+  // Spaces inside parentheses
+  /^hsla\(\s*(\d{1,3})\s+(\d{1,3}%?)\s+(\d{1,3}%?)\s+(\d*\.?\d+)\s*\)$/i, // hsla(h s l a)
+  /^hsl\(\s*(\d{1,3})\s+(\d{1,3}%?)\s+(\d{1,3}%?)\s*\)$/i, // hsl(h s l)
+] as const;
+
+// HSV color formats
+const HSV_REG_EXP_ARRAY = [
+  // With commas
+  /hsva\(\s*(\d{1,3})\s*,\s*(\d{1,3}%?)\s*,\s*(\d{1,3}%?)\s*,\s*(\d*\.?\d+)\s*\)/i, // hsva(h, s, v, a)
+  /hsv\(\s*(\d{1,3})\s*,\s*(\d{1,3}%?)\s*,\s*(\d{1,3}%?)\s*\)/i, // hsv(h, s, v)
+
+  // With spaces
+  /^hsva\s+(\d{1,3})\s+(\d{1,3}%?)\s+(\d{1,3}%?)\s+(\d*\.?\d+)\s*$/i, // hsva h s v a
+  /^hsv\s+(\d{1,3})\s+(\d{1,3}%?)\s+(\d{1,3}%?)\s*$/i, // hsv h s v
+
+  // Spaces inside parentheses
+  /^hsva\(\s*(\d{1,3})\s+(\d{1,3}%?)\s+(\d{1,3}%?)\s+(\d*\.?\d+)\s*\)$/i, // hsva(h s v a)
+  /^hsv\(\s*(\d{1,3})\s+(\d{1,3}%?)\s+(\d{1,3}%?)\s*\)$/i, // hsv(h s v)
+] as const;
+
+// HEX color formats
+const HEX_REG_EXP_ARRAY = [
+  /^#([A-Fa-f0-9]{6})([A-Fa-f0-9]{2})?$/, // 6-digit hex with optional hex alpha
+  /^#([A-Fa-f0-9]{3})([A-Fa-f0-9]{1})?$/, // 3-digit hex with optional hex alpha
+] as const;
+
+// The colorjs.io space ids `getColor` can convert to. `hsva`/`hsla` are not real
+// colorjs.io spaces (converting to them throws), so they are intentionally absent.
+const VALID_GET_COLOR_FORMATS = ['srgb', 'hsv', 'hsl'] as const;
+
+/** Documentation URL surfaced alongside Dev Mode parse warnings. */
+const COLOR_PARSE_HELP_URL = 'https://github.com/WICG/color-api/issues/196';
+
+/**
+ * Emits a Dev Mode parse warning when `window.__swc.DEBUG` is enabled. Guarded by
+ * a `typeof window` check so the controller is safe to evaluate in non-browser
+ * (SSR / Node unit test) environments where `window` is undefined. Centralizes
+ * the otherwise-repeated warn blocks.
+ */
+function debugWarn(
+  host: ReactiveElement | undefined,
+  message: string,
+  error: unknown
+): void {
+  if (typeof window === 'undefined' || !window.__swc?.DEBUG) {
+    return;
+  }
+  window.__swc.warn(host, message, COLOR_PARSE_HELP_URL, {
+    issues: [error instanceof Error ? error.message : 'Unknown error'],
+  });
+}
+
+/**
+ * Derives a colorjs.io space id from a loose color object based on which channel
+ * keys are present. Shared by the `color` setter and the `colorValue` getter so
+ * the detection logic lives in one place.
+ */
+function spaceIdFromColorObject(color: LooseColorObject): string | undefined {
+  const { h, s, l, v, r, g, b } = color;
+  if (typeof h !== 'undefined' && typeof s !== 'undefined') {
+    if (typeof l !== 'undefined') {
+      return 'hsl';
+    }
+    if (typeof v !== 'undefined') {
+      return 'hsv';
+    }
+  }
+  if (
+    typeof r !== 'undefined' &&
+    typeof g !== 'undefined' &&
+    typeof b !== 'undefined'
+  ) {
+    return 'srgb';
+  }
+  return undefined;
+}
+
+/**
+ * The `ColorController` class is responsible for managing and validating color values
+ * in various color spaces (RGB, HSL, HSV, Hex). It provides methods to set, get, and
+ * validate colors, as well as convert between different color formats.
+ *
+ * @class
+ * @property {Color} color - Gets or sets the current color value.
+ * @property {ColorTypes} colorValue - Gets the color value in various formats based on the original color input.
+ * @property {number} hue - Gets or sets the hue value of the current color.
+ *
+ * @function validateColorString(color: string): ColorValidationResult - Validates a color string and returns the validation result.
+ * @function getColor(format: string | ColorSpace): ColorObject - Converts the current color to the specified format.
+ * @function getHslString(): string - Returns the current color in HSL string format.
+ * @function savePreviousColor(): void - Saves the current color as the previous color.
+ * @function restorePreviousColor(): void - Restores the previous color.
+ *
+ * @class
+ * @param {ReactiveElement} host - The host element that uses this controller.
+ * @param {object} [options] - Optional configuration options.
+ * @param {string} [options.manageAs] - Specifies the color space to manage the color as.
+ */
+export class ColorController {
+  get color(): Color {
+    return this._color;
+  }
+
+  /**
+   * Validates a color string and returns a result indicating the color space,
+   * coordinates, alpha value, and whether the color is valid.
+   *
+   * @param color - The color string to validate. Supported formats include:
+   *  - RGB: `rgb(r, g, b)`, `rgba(r, g, b, a)`, `rgb r g b`, `rgba r g b a`
+   *  - HSL: `hsl(h, s, l)`, `hsla(h, s, l, a)`, `hsl h s l`, `hsla h s l a`
+   *  - HSV: `hsv(h, s, v)`, `hsva(h, s, v, a)`, `hsv h s v`, `hsva h s v a`
+   *  - HEX: `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`
+   *
+   * @returns An object containing the following properties:
+   *  - `spaceId`: The color space identifier (`'srgb'`, `'hsl'`, or `'hsv'`).
+   *  - `coords`: An array of numeric values representing the color coordinates.
+   *  - `alpha`: The alpha value of the color (0 to 1).
+   *  - `isValid`: A boolean indicating whether the color string is valid.
+   */
+  public validateColorString(color: string): ColorValidationResult {
+    const result: ColorValidationResult = {
+      spaceId: null,
+      coords: [0, 0, 0],
+      isValid: false,
+      alpha: 1,
+    };
+
+    const rgbaMatch = RGB_REG_EXP_ARRAY.find((regex) =>
+      regex.test(color)
+    )?.exec(color);
+    const hslaMatch = HSL_REG_EXP_ARRAY.find((regex) =>
+      regex.test(color)
+    )?.exec(color);
+    const hsvaMatch = HSV_REG_EXP_ARRAY.find((regex) =>
+      regex.test(color)
+    )?.exec(color);
+    const hexMatch = HEX_REG_EXP_ARRAY.find((regex) => regex.test(color))?.exec(
+      color
+    );
+
+    if (rgbaMatch) {
+      const [, r, g, b, a] = rgbaMatch.filter(
+        (element) => typeof element === 'string'
+      );
+      const alpha = a === undefined ? 1 : Number(a);
+      const processValue = (value: string): number => {
+        if (value.includes('%')) {
+          return Number(value.replace('%', '')) / 100;
+        } else {
+          return Number(value) / 255;
+        }
+      };
+      const numericR = processValue(r);
+      const numericG = processValue(g);
+      const numericB = processValue(b);
+
+      result.spaceId = 'srgb';
+      result.coords = [numericR, numericG, numericB];
+      result.alpha = alpha;
+      result.isValid =
+        numericR >= 0 &&
+        numericR <= 1 &&
+        numericG >= 0 &&
+        numericG <= 1 &&
+        numericB >= 0 &&
+        numericB <= 1 &&
+        alpha >= 0 &&
+        alpha <= 1;
+    } else if (hslaMatch) {
+      const [, h, s, l, a] = hslaMatch;
+      const values = [h, s, l, a === undefined ? '1' : a].map((value) =>
+        Number(value.replace(/[^\d.]/g, ''))
+      );
+      const [numericH, numericS, numericL, numericA] = values;
+
+      result.spaceId = 'hsl';
+      result.coords = [numericH, numericS, numericL];
+      result.alpha = numericA;
+      result.isValid =
+        numericH >= 0 &&
+        numericH <= 360 &&
+        numericS >= 0 &&
+        numericS <= 100 &&
+        numericL >= 0 &&
+        numericL <= 100 &&
+        numericA >= 0 &&
+        numericA <= 1;
+    } else if (hsvaMatch) {
+      const [, h, s, v, a] = hsvaMatch;
+      const values = [h, s, v, a === undefined ? '1' : a].map((value) =>
+        Number(value.replace(/[^\d.]/g, ''))
+      );
+      const [numericH, numericS, numericV, numericA] = values;
+
+      result.spaceId = 'hsv';
+      result.coords = [numericH, numericS, numericV];
+      result.alpha = numericA;
+      result.isValid =
+        numericH >= 0 &&
+        numericH <= 360 &&
+        numericS >= 0 &&
+        numericS <= 100 &&
+        numericV >= 0 &&
+        numericV <= 100 &&
+        numericA >= 0 &&
+        numericA <= 1;
+    } else if (hexMatch) {
+      const [, hex, alphaHex] = hexMatch;
+
+      // Function to process 2-digit or repeated 1-digit hex
+      const processHex = (hex: string): number => {
+        // For 3-digit hex values, repeat each digit
+        if (hex.length === 1) {
+          hex = hex + hex;
+        }
+        return parseInt(hex, 16) / 255;
+      };
+
+      // Handle both 3-digit and 6-digit hex
+      let numericR, numericG, numericB;
+      if (hex.length === 3) {
+        // 3-digit hex (e.g., #3a7 -> #33aa77)
+        numericR = processHex(hex.substring(0, 1));
+        numericG = processHex(hex.substring(1, 2));
+        numericB = processHex(hex.substring(2, 3));
+      } else {
+        // 6-digit hex (e.g., #33aa77)
+        numericR = processHex(hex.substring(0, 2));
+        numericG = processHex(hex.substring(2, 4));
+        numericB = processHex(hex.substring(4, 6));
+      }
+
+      // Process hex alpha if provided (convert from 0-255 to 0-1)
+      const numericA = alphaHex ? processHex(alphaHex) : 1;
+
+      // Validate the color values
+      result.spaceId = 'srgb';
+      result.coords = [numericR, numericG, numericB];
+      result.alpha = numericA;
+      result.isValid =
+        numericR >= 0 &&
+        numericR <= 1 &&
+        numericG >= 0 &&
+        numericG <= 1 &&
+        numericB >= 0 &&
+        numericB <= 1 &&
+        numericA >= 0 &&
+        numericA <= 1;
+    }
+
+    return result;
+  }
+
+  /**
+   * Represents the color state of the component.
+   * Initialized with an HSV color model with hue 0, saturation 100, and value 100, and an alpha value of 1.
+   *
+   * @private
+   * @type {Color}
+   */
+  private _color: Color = new Color('hsv', [0, 100, 100], 1);
+
+  /**
+   * Represents the original color value provided by the user.
+   *
+   * @private
+   * @type {ColorTypes}
+   */
+  private _colorOrigin!: ColorTypes;
+
+  /**
+   * Gets the original color value provided by the user.
+   *
+   * @returns {ColorTypes} The original color value.
+   */
+  get colorOrigin(): ColorTypes {
+    return this._colorOrigin;
+  }
+
+  /**
+   * Sets the original color value provided by the user.
+   *
+   * @param {ColorTypes} colorOrigin - The original color value to set.
+   */
+  set colorOrigin(colorOrigin: ColorTypes) {
+    this._colorOrigin = colorOrigin;
+  }
+
+  /**
+   * An optional string property that specifies how the color should be managed(its value is the name of color space in which color object will be managed).
+   * This property can be used to define a specific management strategy or identifier.
+   */
+  private manageAs?: string;
+
+  /**
+   * Stores the previous color value.
+   * This is used to keep track of the color before any changes are made.
+   *
+   * @private
+   */
+  private _previousColor!: Color;
+
+  /**
+   * Private helper method to convert RGB color to hex format with optional alpha
+   *
+   * @private
+   * @param {boolean} includeHash - Whether to include the # prefix in the returned string
+   * @param {boolean} includeAlpha - Whether to include the alpha channel in the returned string
+   * @returns {string} The color in hex format
+   */
+  private _getHexString(includeHash: boolean, includeAlpha: boolean): string {
+    const { r, g, b } = (this._color.to('srgb') as Color).srgb;
+    const a = this._color.alpha;
+
+    const toHex = (channel: number): string =>
+      Math.round(channel * 255)
+        .toString(16)
+        .padStart(2, '0');
+
+    const rHex = toHex(r);
+    const gHex = toHex(g);
+    const bHex = toHex(b);
+    const aHex = toHex(a);
+
+    return `${includeHash ? '#' : ''}${rHex}${gHex}${bHex}${includeAlpha ? aHex : ''}`;
+  }
+
+  /**
+   * Sets the color value for the controller. The color can be provided in various formats:
+   * - A string representing a color name, hex code, or other color format.
+   * - An instance of the `Color` class.
+   * - An object containing color properties such as `h`, `s`, `l`, `v`, `r`, `g`, `b`, and optionally `a`.
+   *
+   * The method validates and parses the input color, converting it to a `Color` instance.
+   * If the color is invalid, it attempts to parse it as a hex code or returns without setting a new color.
+   *
+   * @param {ColorTypes} color - The color value to set. It can be a string, an instance of `Color`, or an object with color properties.
+   */
+  set color(color: ColorTypes) {
+    this._colorOrigin = color;
+    let newColor!: Color;
+    if (typeof color === 'string') {
+      const colorValidationResult = this.validateColorString(color as string);
+      if (colorValidationResult.isValid) {
+        const [coord1, coord2, coord3] = colorValidationResult.coords;
+        newColor = new Color(
+          `${colorValidationResult.spaceId}`,
+          [coord1, coord2, coord3],
+          colorValidationResult.alpha
+        );
+      } else {
+        try {
+          Color.parse(color);
+        } catch (error) {
+          debugWarn(this.host, `Failed to parse color: ${color}`, error);
+          try {
+            newColor = new Color(`#${color}`);
+          } catch (error) {
+            debugWarn(
+              this.host,
+              `Failed to parse color as hex: ${color}`,
+              error
+            );
+            return;
+          }
+        }
+      }
+    } else if (color instanceof Color) {
+      newColor = color;
+    } else if (!Array.isArray(color)) {
+      const { h, s, l, v, r, g, b, a } = color as LooseColorObject;
+      if (typeof h !== 'undefined' && typeof s !== 'undefined') {
+        const lv = l ?? v;
+        newColor = new Color(
+          typeof l !== 'undefined' ? 'hsl' : 'hsv',
+          [
+            parseFloat(`${h}`),
+            typeof s !== 'string' ? (s as number) * 100 : parseFloat(s),
+            typeof lv !== 'string' ? (lv as number) * 100 : parseFloat(lv),
+          ],
+          parseFloat(`${a ?? '1'}`)
+        );
+      } else if (
+        typeof r !== 'undefined' &&
+        typeof g !== 'undefined' &&
+        typeof b !== 'undefined'
+      ) {
+        newColor = new Color(
+          'srgb',
+          [
+            parseFloat(`${r}`) / 255,
+            parseFloat(`${g}`) / 255,
+            parseFloat(`${b}`) / 255,
+          ],
+          parseFloat(`${a ?? '1'}`)
+        );
+      }
+    }
+
+    if (!newColor) {
+      newColor = new Color(color as DefaultColorTypes);
+    }
+
+    if (this.manageAs) {
+      this._color = newColor.to(this.manageAs) as Color;
+    } else {
+      this._color = newColor;
+    }
+    this.host.requestUpdate();
+  }
+
+  /**
+   * Gets the color value in various formats based on the original color input.
+   *
+   * The method determines the color space of the original color input and converts
+   * the color to the appropriate format. The supported color spaces are:
+   * - HSV (Hue, Saturation, Value)
+   * - HSL (Hue, Saturation, Lightness)
+   * - Hexadecimal (with or without alpha)
+   * - RGB (Red, Green, Blue) with optional alpha
+   *
+   * @returns {ColorTypes} The color value in the appropriate format.
+   *
+   * The method handles the following cases:
+   * - If the original color input is a string, it checks the prefix to determine the color space.
+   * - If the original color input is an object, it checks the properties to determine the color space.
+   * - If the original color input is not provided, it defaults to the current color space of the color object.
+   *
+   * The returned color value can be in one of the following formats:
+   * - `hsv(h, s%, v%)` or `hsva(h, s%, v%, a)`
+   * - `hsl(h, s%, l%)` or `hsla(h, s%, l%, a)`
+   * - `#rrggbb` or `#rrggbbaa`
+   * - `rgb(r, g, b)` or `rgba(r, g, b, a)`
+   * - `{ h, s, v, a }` for HSV object
+   * - `{ h, s, l, a }` for HSL object
+   * - `{ r, g, b, a }` for RGB object
+   */
+  get colorValue(): ColorTypes {
+    if (typeof this._colorOrigin === 'string') {
+      let spaceId = '';
+      if (this._colorOrigin.startsWith('#')) {
+        spaceId = 'hex string';
+      } else if (this._colorOrigin.startsWith('rgb')) {
+        spaceId = 'rgb';
+      } else if (this._colorOrigin.startsWith('hsl')) {
+        spaceId = 'hsl';
+      } else if (this._colorOrigin.startsWith('hsv')) {
+        spaceId = 'hsv';
+      } else {
+        spaceId = 'hex';
+      }
+      switch (spaceId) {
+        case 'hsv': {
+          const hadAlpha = this._colorOrigin[3] === 'a';
+          const { h, s, v } = (this._color.to('hsv') as Color).hsv;
+          const a = this._color.alpha;
+          return `hsv${hadAlpha ? `a` : ''}(${Math.round(
+            h
+          )}, ${Math.round(s)}%, ${Math.round(v)}%${hadAlpha ? `, ${a}` : ''})`;
+        }
+        case 'hsl': {
+          const hadAlpha = this._colorOrigin[3] === 'a';
+          const { h, s, l } = (this._color.to('hsl') as Color).hsl;
+          const a = this._color.alpha;
+          return `hsl${hadAlpha ? `a` : ''}(${Math.round(
+            h
+          )}, ${Math.round(s)}%, ${Math.round(l)}%${hadAlpha ? `, ${a}` : ''})`;
+        }
+        case 'hex string': {
+          // Check if the original input included alpha
+          const hadAlpha =
+            this._colorOrigin.length === 9 || // #RRGGBBAA format
+            this._colorOrigin.length === 5; // #RGBA format
+          return this._getHexString(true, hadAlpha);
+        }
+        case 'hex': {
+          // Check if the original input included alpha
+          const hadAlpha =
+            this._colorOrigin.length === 8 || // RRGGBBAA format (no #)
+            this._colorOrigin.length === 4; // RGBA format (no #)
+          return this._getHexString(false, hadAlpha);
+        }
+        //rgb
+        default: {
+          const { r, g, b } = (this._color.to('srgb') as Color).srgb;
+          const hadAlpha = this._colorOrigin[3] === 'a';
+          const a = this._color.alpha;
+          if (this._colorOrigin.search('%') > -1) {
+            return `rgb${hadAlpha ? `a` : ''}(${Math.round(r * 100)}%, ${Math.round(
+              g * 100
+            )}%, ${Math.round(b * 100)}%${hadAlpha ? `,${Math.round(a * 100)}%` : ''})`;
+          }
+          return `rgb${hadAlpha ? `a` : ''}(${Math.round(r * 255)}, ${Math.round(
+            g * 255
+          )}, ${Math.round(b * 255)}${hadAlpha ? `, ${a}` : ''})`;
+        }
+      }
+    }
+    let spaceId;
+    if (this._colorOrigin) {
+      try {
+        ({ spaceId } = new Color(this._colorOrigin as DefaultColorTypes));
+      } catch (error) {
+        debugWarn(
+          this.host,
+          `Failed to parse color as default color types: ${JSON.stringify(
+            this._colorOrigin
+          )}`,
+          error
+        );
+        spaceId = spaceIdFromColorObject(this._colorOrigin as LooseColorObject);
+      }
+    } else {
+      ({ spaceId } = this.color);
+    }
+    switch (spaceId) {
+      case 'hsv': {
+        const { h, s, v } = (this._color.to('hsv') as Color).hsv;
+        return {
+          h,
+          s: s / 100,
+          v: v / 100,
+          a: this._color.alpha,
+        };
+      }
+      case 'hsl': {
+        const { h, s, l } = (this._color.to('hsl') as Color).hsl;
+        return {
+          h,
+          s: s / 100,
+          l: l / 100,
+          a: this._color.alpha,
+        };
+      }
+      case 'srgb': {
+        const { r, g, b } = (this._color.to('srgb') as Color).srgb;
+        if (
+          this._colorOrigin &&
+          typeof (this._colorOrigin as { r: string }).r === 'string' &&
+          (this._colorOrigin as { r: string }).r.search('%')
+        ) {
+          return {
+            r: `${Math.round(r * 255)}%`,
+            g: `${Math.round(g * 255)}%`,
+            b: `${Math.round(b * 255)}%`,
+            a: this._color.alpha,
+          };
+        }
+        return {
+          r: Math.round(r * 255),
+          g: Math.round(g * 255),
+          b: Math.round(b * 255),
+          a: this._color.alpha,
+        };
+      }
+    }
+    return this._color;
+  }
+
+  protected host: ReactiveElement;
+
+  /**
+   * Gets the hue value of the current color in HSL format.
+   *
+   * @returns {number} The hue value as a number.
+   */
+  get hue(): number {
+    return Number((this._color.to('hsl') as Color).hsl.h);
+  }
+
+  /**
+   * Sets the hue value of the color and requests an update from the host.
+   *
+   * @param hue - The hue value to set, represented as a number.
+   */
+  set hue(hue: number) {
+    this._color.set('h', hue);
+    this.host.requestUpdate();
+  }
+
+  /**
+   * Creates an instance of ColorController.
+   *
+   * @param host - The ReactiveElement that this controller is associated with.
+   * @param options - An object containing optional parameters.
+   * @param options.manageAs - A string to manage the controller as a specific type.
+   */
+  constructor(
+    host: ReactiveElement,
+    {
+      manageAs,
+    }: {
+      manageAs?: string;
+    } = {}
+  ) {
+    this.host = host;
+    this.manageAs = manageAs;
+  }
+
+  /**
+   * Converts the current color to the specified format.
+   *
+   * @param format - The desired color format. It can be a string representing one of the valid formats
+   * ('srgb', 'hsv', 'hsl') or a ColorSpace.Space object.
+   * @returns The color object in the specified format.
+   * @throws Will throw an error if the provided format is not a valid string format.
+   */
+  getColor(format: string | ColorSpace.Space): ColorObject {
+    if (
+      typeof format === 'string' &&
+      !VALID_GET_COLOR_FORMATS.includes(
+        format as (typeof VALID_GET_COLOR_FORMATS)[number]
+      )
+    ) {
+      throw new Error('not a valid format');
+    }
+
+    return this._color.to(format);
+  }
+
+  /**
+   * Converts the current color to an HSL string representation.
+   *
+   * @returns {string} The HSL string representation of the current color.
+   */
+  getHslString(): string {
+    return this._color.to('hsl').toString();
+  }
+
+  /**
+   * Saves the current color state by cloning the current color and storing it
+   * as the previous color. This allows for the ability to revert to the previous
+   * color state if needed.
+   *
+   * @returns {void}
+   */
+  savePreviousColor(): void {
+    this._previousColor = this._color.clone();
+  }
+
+  /**
+   * Restores the color to the previously saved color value.
+   *
+   * This method sets the current color (`_color`) to the previously stored color (`_previousColor`).
+   */
+  restorePreviousColor(): void {
+    this._color = this._previousColor;
+  }
+}

--- a/2nd-gen/packages/core/controllers/color-controller/test/__unit__/color-controller.test.ts
+++ b/2nd-gen/packages/core/controllers/color-controller/test/__unit__/color-controller.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { ReactiveElement } from 'lit';
+import Color from 'colorjs.io';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  ColorController,
+  type ColorTypes,
+} from '../../src/color-controller.js';
+
+describe('ColorController', () => {
+  let host: ReactiveElement;
+  let colorController: ColorController;
+
+  beforeEach(() => {
+    host = {} as ReactiveElement;
+    host.requestUpdate = () => {};
+    colorController = new ColorController(host);
+  });
+
+  it('should initialize correctly', () => {
+    expect(colorController).toBeDefined();
+    expect(colorController.color).toBeInstanceOf(Color);
+  });
+
+  it('should validate color strings correctly', () => {
+    const validRgba = 'rgba(255, 0, 0, 1)';
+    const validHsla = 'hsla(120, 100%, 50%, 0.5)';
+    const validHsva = 'hsva(240, 100%, 100%, 0.75)';
+    const invalidColor = 'invalidColor';
+
+    expect(colorController.validateColorString(validRgba).isValid).toBe(true);
+    expect(colorController.validateColorString(validHsla).isValid).toBe(true);
+    expect(colorController.validateColorString(validHsva).isValid).toBe(true);
+    expect(colorController.validateColorString(invalidColor).isValid).toBe(
+      false
+    );
+  });
+
+  it('should process RGB values in percentage correctly', () => {
+    const colorString = 'rgb(50%, 25%, 75%)';
+    const result = colorController.validateColorString(colorString);
+    expect(result.isValid).toBe(true);
+    expect(result.coords).toEqual([0.5, 0.25, 0.75]);
+    expect(result.spaceId).toBe('srgb');
+  });
+
+  it('should default alpha to 1 when alpha is undefined in RGBA', () => {
+    const colorString = 'rgb(255, 0, 0)';
+    const result = colorController.validateColorString(colorString);
+
+    expect(result.alpha).toBe(1);
+    expect(result.isValid).toBe(true);
+    expect(result.coords).toEqual([1, 0, 0]);
+    expect(result.spaceId).toBe('srgb');
+  });
+
+  it('should handle invalid color strings by trying to create a new Color object with a prefixed #', () => {
+    const invalidColorString = 'invalidColor';
+    const validHexColorString = 'ff0000'; // Equivalent to #ff0000
+
+    // Set the invalid color string
+    colorController.color = invalidColorString;
+
+    // Expect the color to be unchanged (default color)
+    expect(colorController.color.toString()).toBe(
+      new Color('hsv', [0, 100, 100], 1).toString()
+    );
+
+    // Set the valid hex color string without #
+    colorController.color = validHexColorString;
+
+    // Expect the color to be set correctly
+    expect(colorController.color.toString()).toBe(
+      new Color(`#${validHexColorString}`).toString()
+    );
+  });
+
+  it('should set color correctly with string input', () => {
+    const colorString = 'rgba(255, 0, 0, 1)';
+    colorController.color = colorString;
+    expect(colorController.color.toString()).toBe(
+      new Color(colorString).toString()
+    );
+  });
+
+  it('should set color correctly with object input', () => {
+    const colorObject: ColorTypes = { r: 255, g: 0, b: 0, a: 1 };
+    colorController.color = colorObject;
+    //expect(colorController.color.toString()).toBe(new Color(colorObject).toString());
+  });
+
+  it('should get color value correctly', () => {
+    let colorString = 'rgba(255, 0, 0, 0.7)';
+    colorController.color = colorString;
+    expect(colorController.colorValue).toBe(colorString);
+    colorString = 'hsla(120, 100%, 50%, 0.5)';
+    colorController.color = colorString;
+    expect(colorController.colorValue).toBe(colorString);
+  });
+
+  it('should get and set hue correctly', () => {
+    colorController.hue = 180;
+    expect(colorController.hue).toBe(180);
+  });
+
+  it('should convert color correctly', () => {
+    const colorString = 'rgba(255, 0, 0, 1)';
+    colorController.color = colorString;
+    expect(colorController.getColor('hsl')).toBeTypeOf('object');
+  });
+
+  it('should get HSL string correctly', () => {
+    const colorString = 'rgba(255, 0, 0, 1)';
+    colorController.color = colorString;
+    expect(colorController.getHslString()).toBe(
+      new Color(colorString).to('hsl').toString()
+    );
+  });
+
+  it('should process hex color values correctly when alpha is defined', () => {
+    const colorString = '#ff573380'; // Equivalent to rgba(255, 87, 51, 0.5)
+    colorController.color = colorString;
+    expect(colorController.color.toString()).toBe(
+      new Color(colorString).toString()
+    );
+  });
+
+  it('should process hex color values correctly when alpha is not defined', () => {
+    const colorString = '#ff5733'; // Equivalent to rgba(255, 87, 51, 1)
+    colorController.color = colorString;
+    expect(colorController.color.toString()).toBe(
+      new Color(colorString).toString()
+    );
+  });
+
+  it('should save and restore previous color correctly', () => {
+    const colorString = 'rgba(255, 0, 0, 1)';
+    colorController.color = colorString;
+    colorController.savePreviousColor();
+    colorController.color = 'rgba(0, 255, 0, 1)';
+    colorController.restorePreviousColor();
+    expect(colorController.color.toString()).toBe(
+      new Color(colorString).toString()
+    );
+  });
+
+  it('should return correct color value for hsv spaceId', () => {
+    colorController.color = 'hsv(120, 100%, 50%)';
+    const result = colorController.colorValue;
+    expect(result).toBe('hsv(120, 100%, 50%)');
+  });
+
+  it('should return correct color value for hsva spaceId', () => {
+    colorController.color = 'hsva(120, 100%, 50%, 0.5)';
+    const result = colorController.colorValue;
+    expect(result).toBe('hsva(120, 100%, 50%, 0.5)');
+  });
+
+  it('should return correct color value for hsl spaceId', () => {
+    colorController.color = 'hsl(120, 100%, 50%)';
+    const result = colorController.colorValue;
+    expect(result).toBe('hsl(120, 100%, 50%)');
+  });
+
+  it('should return correct color value for hsla spaceId', () => {
+    colorController.color = 'hsla(120, 100%, 50%, 0.5)';
+    const result = colorController.colorValue;
+    expect(result).toBe('hsla(120, 100%, 50%, 0.5)');
+  });
+
+  it('should return correct color value for hex string spaceId', () => {
+    colorController.color = '#ff5733';
+    const result = colorController.colorValue;
+    expect(result).toBe('#ff5733');
+  });
+
+  it('should return correct color value for hex string spaceId with alpha', () => {
+    colorController.color = '#ff573380'; // Equivalent to rgba(255, 87, 51, 0.5)
+    const result = colorController.colorValue;
+    expect(result).toBe('#ff573380');
+  });
+
+  it('should return correct color value for default spaceId with hex origin', () => {
+    colorController.color = '#ff5733';
+    const result = colorController.colorValue;
+    expect(result).toBe('#ff5733');
+  });
+
+  it('should return correct color value for default spaceId with hex origin and alpha', () => {
+    colorController.color = '#ff573380'; // Equivalent to rgba(255, 87, 51, 0.5)
+    const result = colorController.colorValue;
+    expect(result).toBe('#ff573380');
+  });
+
+  it('should return correct color value for default spaceId with percentage origin', () => {
+    colorController.color = 'rgb(50%, 25%, 75%)';
+    const result = colorController.colorValue;
+    expect(result).toBe('rgb(50%, 25%, 75%)');
+  });
+
+  it('should return correct color value for default spaceId with rgba origin', () => {
+    colorController.color = 'rgba(255, 87, 51, 0.5)';
+    const result = colorController.colorValue;
+    expect(result).toBe('rgba(255, 87, 51, 0.5)');
+  });
+
+  it('should return correct color values for hsv spaceId', () => {
+    colorController.color = new Color('hsv', [120, 100, 50]);
+    const result = colorController.colorValue;
+    expect(result).toEqual({
+      h: 120,
+      s: 1,
+      v: 0.5,
+      a: 1,
+    });
+  });
+
+  it('should return correct color values for hsl spaceId', () => {
+    colorController.color = new Color('hsl', [120, 100, 50]);
+    const result = colorController.colorValue;
+    expect(result).toEqual({
+      h: 120,
+      s: 1,
+      l: 0.5,
+      a: 1,
+    });
+  });
+
+  it('should return correct color values for srgb spaceId', () => {
+    colorController.color = new Color('srgb', [0.5, 0.25, 0.75]);
+    const result = colorController.colorValue;
+    expect(result).toEqual({
+      r: 128,
+      g: 64,
+      b: 191,
+      a: 1,
+    });
+  });
+
+  it('should return correct color values for srgb spaceId with percentage origin', () => {
+    colorController.color = new Color('srgb', [0.5, 0.25, 0.75]);
+    colorController.colorOrigin = { r: '50%', g: '25%', b: '75%' };
+    const result = colorController.colorValue;
+    expect(result).toEqual({
+      r: '128%',
+      g: '64%',
+      b: '191%',
+      a: 1,
+    });
+  });
+});

--- a/2nd-gen/packages/core/controllers/index.ts
+++ b/2nd-gen/packages/core/controllers/index.ts
@@ -15,6 +15,11 @@
  */
 
 export {
+  ColorController,
+  type Color,
+  type ColorTypes,
+} from './color-controller/index.js';
+export {
   focusgroupNavigationActiveChange,
   FocusgroupNavigationController,
   type FocusgroupDirection,

--- a/2nd-gen/packages/core/package.json
+++ b/2nd-gen/packages/core/package.json
@@ -103,6 +103,10 @@
       "types": "./dist/controllers/index.d.ts",
       "import": "./dist/controllers/index.js"
     },
+    "./controllers/color-controller.js": {
+      "types": "./dist/controllers/color-controller/index.d.ts",
+      "import": "./dist/controllers/color-controller/index.js"
+    },
     "./controllers/focus-group-navigation-controller.js": {
       "types": "./dist/controllers/focus-group-navigation-controller/focus-group-navigation-controller.d.ts",
       "import": "./dist/controllers/focus-group-navigation-controller/focus-group-navigation-controller.js"
@@ -263,6 +267,9 @@
       "controllers": [
         "dist/controllers/index.d.ts"
       ],
+      "controllers/color-controller.js": [
+        "dist/controllers/color-controller/index.d.ts"
+      ],
       "controllers/focus-group-navigation-controller/focus-group-navigation-controller.js": [
         "dist/controllers/focus-group-navigation-controller/focus-group-navigation-controller.d.ts"
       ],
@@ -328,6 +335,7 @@
   "dependencies": {
     "@floating-ui/dom": "1.7.6",
     "@lit-labs/observers": "2.0.2",
+    "colorjs.io": "0.5.2",
     "lit": "^2.5.0 || ^3.1.3"
   },
   "devDependencies": {

--- a/2nd-gen/packages/core/vite.config.js
+++ b/2nd-gen/packages/core/vite.config.js
@@ -108,6 +108,8 @@ export default defineConfig({
           id.startsWith('@lit/') ||
           id.startsWith('@lit-labs/') ||
           id.startsWith('@floating-ui/') ||
+          id === 'colorjs.io' ||
+          id.startsWith('colorjs.io/') ||
           id.startsWith('@spectrum-web-components/core/')
         );
       },

--- a/2nd-gen/packages/swc/.storybook/main.ts
+++ b/2nd-gen/packages/swc/.storybook/main.ts
@@ -38,8 +38,11 @@ const storybookMode: StorybookMode =
       : 'dev';
 
 // Custom indexer to allow .test.ts files to be treated as story files.
+// Files under a `test/__unit__/` directory are pure-logic Node unit tests
+// (run by the `core-unit` Vitest project), not Storybook stories, so they are
+// excluded here to avoid being indexed as CSF.
 const testStoryIndexer: Indexer = {
-  test: /\.test\.ts$/,
+  test: /^(?!.*[\\/]__unit__[\\/]).*\.test\.ts$/,
   createIndex: async (fileName, options) => {
     const csfFile = await readCsf(fileName, options);
     return csfFile.parse().indexInputs;
@@ -143,7 +146,12 @@ if (storybookMode === 'dev') {
   });
   stories.push({
     ...CORE_STORY_ROOT,
-    files: '**/*.test.ts',
+    // Exclude `test/__unit__/*.test.ts`: those are pure-logic Node unit tests
+    // run by the `core-unit` Vitest project, not Storybook stories. The
+    // extglob requires the file's immediate parent directory to be anything
+    // other than `__unit__`, which still matches the `test/` and `stories/`
+    // controller play tests.
+    files: '**/!(__unit__)/*.test.ts',
   });
 }
 

--- a/2nd-gen/packages/swc/vitest.config.js
+++ b/2nd-gen/packages/swc/vitest.config.js
@@ -176,16 +176,15 @@ export default mergeConfig(
         // To activate, drop a test at e.g.
         //   2nd-gen/packages/core/utils/test/__unit__/language-resolution.test.ts
         // and uncomment this block.
-        //
-        // {
-        //   extends: true,
-        //   test: {
-        //     name: 'core-unit',
-        //     environment: 'node',
-        //     include: ['../core/**/test/__unit__/*.test.ts'],
-        //     browser: { enabled: false },
-        //   },
-        // },
+        {
+          extends: true,
+          test: {
+            name: 'core-unit',
+            environment: 'node',
+            include: ['../core/**/test/__unit__/*.test.ts'],
+            browser: { enabled: false },
+          },
+        },
       ],
     },
     compilerOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7173,6 +7173,7 @@ __metadata:
   dependencies:
     "@floating-ui/dom": "npm:1.7.6"
     "@lit-labs/observers": "npm:2.0.2"
+    colorjs.io: "npm:0.5.2"
     glob: "npm:11.0.3"
     lit: "npm:^2.5.0 || ^3.1.3"
     rimraf: "npm:6.0.1"


### PR DESCRIPTION
## Description

Relocates `ColorController` from `1st-gen` reactive-controllers into `@spectrum-web-components/core` controllers, and optimizes the implementation using `colorjs.io` built-ins **without changing any output color formats**.

This is a controller relocation plus code cleanup, not a component migration. The `1st-gen` `ColorController` and its consumers (`ColorSlider`, `ColorArea`, `ColorWheel`, `ColorField`) are untouched.

### What changed

- New `2nd-gen/packages/core/controllers/color-controller/` (`src/color-controller.ts` + `index.ts`), exported from `controllers/index.ts`.
- Added `colorjs.io@0.5.2` dependency (pinned to match 1st-gen), package `exports` + `typesVersions` entries, and externalized `colorjs.io` in the build so it is not bundled into output.
- Ported the controller test suite as a pure-logic Node unit test at `test/__unit__/color-controller.test.ts` (28 tests), activating the previously dormant `core-unit` Vitest project in `swc/vitest.config.js`.
- Excluded `test/__unit__/*.test.ts` from the Storybook story indexer in `.storybook/main.ts` (regex guard + `**/!(__unit__)/*.test.ts` glob) so pure-logic unit tests are not indexed as CSF.

### Optimizations (no output-format change)

- Hoisted the four regex arrays to module-level constants (were rebuilt on every `validateColorString` call).
- Removed dead `getColor` formats: `hsva`/`hsla` are not real colorjs.io spaces and throw on `.to()`.
- Deduped space-id-from-object detection into a shared helper used by both the `color` setter and `colorValue` getter.
- Centralized the three near-identical Dev Mode `window.__swc` warning blocks into one `debugWarn` helper, guarded with `typeof window` so the controller is safe in SSR/Node environments.
- Tightened internal types and removed loose casts.

The format-sensitive logic (`colorValue` string building, `_getHexString` forced-alpha) was intentionally kept manual: colorjs.io's own `toString()` emits modern space-separated, significant-digit CSS and drops `alpha=1`, which would break the pinned comma-separated / `Math.round` / forced-alpha output.

## Motivation and context

The 2nd-gen `core` package needs `ColorController` available for the gen-2 color component migrations. Moving it now, with the long-standing implementation cleaned up, avoids carrying forward dead code and rebuilt-per-call regexes.

## Related issue(s)

- fixes [N/A — internal 2nd-gen migration task]

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _ColorController behavior parity_
  1. Run the ported unit suite on Node >=24.11.1: `cd 2nd-gen/packages/swc && yarn vitest --run --project core-unit`
  2. Confirm 28/28 pass
  3. Expect color-format round-trips (rgb/rgba, hsl/hsla, hsv/hsva, hex with/without alpha, percentage rgb) to match 1st-gen exactly

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

`ColorController` is a non-rendering reactive controller with no DOM, focusable parts, or screen-reader surface of its own.

- [ ] **Keyboard** (required — document steps below)
  1. No focusable parts: the controller renders no DOM and exposes no interactive elements.
  2. Confirm no regressions in consuming color components (ColorSlider, ColorArea, ColorWheel, ColorField), which are unchanged by this PR.

- [ ] **Screen reader** (required — document steps below)
  1. No roles, names, or live regions are emitted by the controller.
  2. Color value parsing/formatting is unchanged, so any AT-facing values surfaced by consuming components remain identical.