### PR TITLE
feat(conversational-ai): improve artifact previews and scrolling

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
@@ -641,6 +641,9 @@ class ConversationFullPatternDemo extends LitElement {
             @swc-prompt-field-upload-click=${this.handleUploadClick}
           >
             ${this.renderArtifacts()}
+            <p slot="legal" class="swc-PromptField-legal-disclaimer">
+              AI output may be inaccurate. Verify before using.
+            </p>
           </swc-prompt-field>
           <input
             id=${this.fileInputId}
@@ -701,6 +704,9 @@ const fullPatternSource = `<div style="max-width:800px; margin:auto; padding:24p
       ></div>
       <span slot="badge">PDF</span>
     </swc-upload-artifact>
+    <p slot="legal" class="swc-PromptField-legal-disclaimer">
+      AI output may be inaccurate. Verify before using.
+    </p>
   </swc-prompt-field>
 </div>`;
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
@@ -642,7 +642,13 @@ class ConversationFullPatternDemo extends LitElement {
           >
             ${this.renderArtifacts()}
             <p slot="legal" class="swc-PromptField-legal-disclaimer">
-              AI output may be inaccurate. Verify before using.
+              Responses are generated using AI, and may be inaccurate. Check
+              before using.
+              <a
+                href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html"
+              >
+                AI User Guidelines
+              </a>
             </p>
           </swc-prompt-field>
           <input
@@ -705,7 +711,13 @@ const fullPatternSource = `<div style="max-width:800px; margin:auto; padding:24p
       <span slot="badge">PDF</span>
     </swc-upload-artifact>
     <p slot="legal" class="swc-PromptField-legal-disclaimer">
-      AI output may be inaccurate. Verify before using.
+      Responses are generated using AI, and may be inaccurate. Check before
+      using.
+      <a
+        href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html"
+      >
+        AI User Guidelines
+      </a>
     </p>
   </swc-prompt-field>
 </div>`;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/conversation-thread/stories/conversation-thread.stories.ts
@@ -132,10 +132,51 @@ type DemoArtifact = {
   id: string;
   title: string;
   subtitle: string;
-  /** Present only for image uploads; used to render `type="media"` in the thread. */
+  /** Image preview URL when the attachment is a visual file. */
   thumbnailUrl?: string;
   objectUrl?: string;
+  /** File-type label for non-image media tiles (for example, "PDF"). */
+  badge?: string;
 };
+
+const getFileBadge = (fileName: string): string | undefined => {
+  const match = fileName.toLowerCase().match(/\.([a-z0-9]+)$/);
+  if (!match) {
+    return 'FILE';
+  }
+
+  const extension = match[1];
+  if (/^(png|jpe?g|gif|webp|bmp|svg|avif)$/.test(extension)) {
+    return undefined;
+  }
+
+  if (extension === 'pdf') {
+    return 'PDF';
+  }
+
+  return extension.toUpperCase();
+};
+
+const renderDemoArtifactThumbnail = (
+  artifact: DemoArtifact
+): ReturnType<typeof html> =>
+  artifact.thumbnailUrl
+    ? html`
+        <img
+          slot="thumbnail"
+          src=${artifact.thumbnailUrl}
+          alt=${artifact.title}
+          style="inline-size:100%;block-size:100%;object-fit:cover;"
+        />
+      `
+    : html`
+        <div
+          slot="thumbnail"
+          role="img"
+          aria-label=${artifact.title}
+          style="inline-size:100%;block-size:100%;background:#f3f3f3;"
+        ></div>
+      `;
 
 type DemoTurn = {
   id: string;
@@ -341,12 +382,15 @@ class ConversationFullPatternDemo extends LitElement {
         typeof file.size === 'number'
           ? `${Math.max(1, Math.round(file.size / 1024))} KB`
           : 'Attachment';
+      const fileName = file.name || 'Attachment';
+
       return {
         id: uniqueId(`artifact-${index}`),
-        title: file.name || 'Attachment',
+        title: fileName,
         subtitle: sizeLabel,
         thumbnailUrl: objectUrl,
         objectUrl,
+        badge: isImage ? undefined : getFileBadge(fileName),
       } satisfies DemoArtifact;
     });
 
@@ -427,31 +471,16 @@ class ConversationFullPatternDemo extends LitElement {
     return this.turns.map((turn) => {
       if (turn.role === 'user') {
         return html`
-          ${(turn.artifacts ?? []).map((artifact) =>
-            artifact.thumbnailUrl
-              ? html`
-                  <swc-conversation-turn type="user">
-                    <swc-user-message type="media">
-                      <img
-                        slot="thumbnail"
-                        src=${artifact.thumbnailUrl}
-                        alt=${artifact.title}
-                        style="inline-size:100%;block-size:100%;object-fit:cover;"
-                      />
-                      <span slot="title">${artifact.title}</span>
-                      <span slot="subtitle">${artifact.subtitle}</span>
-                    </swc-user-message>
-                  </swc-conversation-turn>
-                `
-              : html`
-                  <swc-conversation-turn type="user">
-                    <swc-user-message type="card">
-                      <div slot="thumbnail" role="img" aria-label="File"></div>
-                      <span slot="title">${artifact.title}</span>
-                      <span slot="subtitle">${artifact.subtitle}</span>
-                    </swc-user-message>
-                  </swc-conversation-turn>
-                `
+          ${(turn.artifacts ?? []).map(
+            (artifact) => html`
+              <swc-conversation-turn type="user">
+                <swc-user-message type="media">
+                  ${renderDemoArtifactThumbnail(artifact)}
+                  <span slot="title">${artifact.title}</span>
+                  <span slot="subtitle">${artifact.subtitle}</span>
+                </swc-user-message>
+              </swc-conversation-turn>
+            `
           )}
           ${turn.text
             ? html`
@@ -535,32 +564,16 @@ class ConversationFullPatternDemo extends LitElement {
       (artifact) => html`
         <swc-upload-artifact
           slot="artifact"
-          type=${artifact.thumbnailUrl ? 'media' : 'card'}
+          type="media"
           dismissible
           data-artifact-id=${artifact.id}
         >
-          ${artifact.thumbnailUrl
+          ${renderDemoArtifactThumbnail(artifact)}
+          ${artifact.badge
             ? html`
-                <img
-                  slot="thumbnail"
-                  src=${artifact.thumbnailUrl}
-                  alt=${artifact.title}
-                  style="inline-size:100%;block-size:100%;object-fit:cover;"
-                />
+                <span slot="badge">${artifact.badge}</span>
               `
-            : html`
-                <div
-                  slot="thumbnail"
-                  role="img"
-                  aria-label="File thumbnail"
-                ></div>
-              `}
-          ${artifact.thumbnailUrl
-            ? ''
-            : html`
-                <span slot="title">${artifact.title}</span>
-                <span slot="subtitle">${artifact.subtitle}</span>
-              `}
+            : ''}
         </swc-upload-artifact>
       `
     );
@@ -679,14 +692,14 @@ const fullPatternSource = `<div style="max-width:800px; margin:auto; padding:24p
   </swc-conversation-thread>
 
   <swc-prompt-field>
-    <swc-upload-artifact slot="artifact" type="card" dismissible>
+    <swc-upload-artifact slot="artifact" type="media" dismissible>
       <div
         slot="thumbnail"
         role="img"
-        aria-label="File thumbnail"
+        aria-label="Hilton commercial assets"
+        style="inline-size:100%;block-size:100%;background:#f3f3f3;"
       ></div>
-      <span slot="title">Hilton commercial assets</span>
-      <span slot="subtitle">2026</span>
+      <span slot="badge">PDF</span>
     </swc-upload-artifact>
   </swc-prompt-field>
 </div>`;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
@@ -58,7 +58,11 @@ A minimal composition tree:
   </swc-conversation-turn>
 </swc-conversation-thread>
 
-<swc-prompt-field></swc-prompt-field>
+<swc-prompt-field>
+  <p slot="legal" class="swc-PromptField-legal-disclaimer">
+    AI output may be inaccurate. Verify before using.
+  </p>
+</swc-prompt-field>
 ```
 
 ---
@@ -93,7 +97,7 @@ Text input with built-in `default`, `loading`, and `generation-complete` modes. 
 
 #### `swc-upload-artifact`
 
-Renders a staged attachment inside `swc-prompt-field` before the message is sent. Use one type per strip: media tiles only, with an optional `badge` for file-type labels.
+Renders a staged attachment inside `swc-prompt-field` before the message is sent. Use one layout type per strip (`card` or `media`). For mixed image and document uploads, normalize to media tiles with thumbnails and optional badges.
 
 <Canvas
   of={UploadArtifactStories.MediaWithBadge}

--- a/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
@@ -60,7 +60,12 @@ A minimal composition tree:
 
 <swc-prompt-field>
   <p slot="legal" class="swc-PromptField-legal-disclaimer">
-    AI output may be inaccurate. Verify before using.
+    Responses are generated using AI, and may be inaccurate. Check before using.
+    <a
+      href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html"
+    >
+      AI User Guidelines
+    </a>
   </p>
 </swc-prompt-field>
 ```

--- a/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
@@ -93,10 +93,10 @@ Text input with built-in `default`, `loading`, and `generation-complete` modes. 
 
 #### `swc-upload-artifact`
 
-Renders a staged attachment inside `swc-prompt-field` before the message is sent. Supports `card` and `media` types and an optional `dismissible` affordance.
+Renders a staged attachment inside `swc-prompt-field` before the message is sent. Use one type per strip: media tiles only, with an optional `badge` for file-type labels.
 
 <Canvas
-  of={UploadArtifactStories.Overview}
+  of={UploadArtifactStories.MediaWithBadge}
   additionalActions={[
     {
       title: 'Component docs',

--- a/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
@@ -84,6 +84,8 @@ The composer surface where the user types a prompt and attaches files.
 
 Text input with built-in `default`, `loading`, and `generation-complete` modes. Emits submit, input, stop, and upload-click events so products can drive their own generation pipeline.
 
+The **`+`** button should open a menu with, at minimum, **Add from Adobe cloud storage** and **Attach files**. See [Upload action menu](/docs/patterns-conversational-ai-prompt-field--docs#upload-action-menu) for the full guidance.
+
 <Canvas
   of={PromptFieldStories.Overview}
   additionalActions={[

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -45,7 +45,7 @@ export type PromptFieldMode = 'default' | 'loading' | 'disabled';
  * @element swc-prompt-field
  *
  * @slot artifact - Optional attachment preview(s). Use one `swc-upload-artifact` type per session (cards only, or media only).
- * @slot legal - Optional legal/footer content.
+ * @slot legal - Legal disclaimer content. Required in product implementations; provide Legal-approved copy.
  * @fires swc-prompt-field-input - Dispatched after the textarea value is internally updated.
  * Detail: `{ value: string }`
  * @fires swc-prompt-field-submit - Dispatched when send is triggered.
@@ -347,6 +347,8 @@ export class PromptField extends SpectrumElement {
 
   private _warnedMixedArtifactTypes = false;
 
+  private _warnedMissingLegalContent = false;
+
   private _warnIfMixedArtifactTypes(): void {
     const elements = this._assignedArtifactElements ?? [];
     const types = new Set(
@@ -369,7 +371,25 @@ export class PromptField extends SpectrumElement {
 
     this._warnedMixedArtifactTypes = true;
     console.warn(
-      '[swc-prompt-field] The artifact slot contains both card and media upload artifacts. Use one type per composer session: cards only, or media tiles only (with or without badge). See upload-artifact documentation.'
+      '[swc-prompt-field] The artifact slot contains both card and media upload artifacts. Use one layout type per composer session (all card or all media). When uploads mix images and documents, normalize to media tiles with thumbnails and optional badges. See upload-artifact documentation.'
+    );
+  }
+
+  private _warnIfMissingLegalContent(): void {
+    const elements = this._assignedLegalElements ?? [];
+
+    if (elements.length > 0) {
+      this._warnedMissingLegalContent = false;
+      return;
+    }
+
+    if (this._warnedMissingLegalContent) {
+      return;
+    }
+
+    this._warnedMissingLegalContent = true;
+    console.warn(
+      '[swc-prompt-field] The legal slot is empty. Product implementations must provide Legal-approved disclaimer content via the legal slot. See prompt-field documentation.'
     );
   }
 
@@ -400,6 +420,7 @@ export class PromptField extends SpectrumElement {
   }
 
   private _handleLegalSlotChange(): void {
+    this._warnIfMissingLegalContent();
     this.requestUpdate();
   }
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -544,11 +544,12 @@ export class PromptField extends SpectrumElement {
       this._markArtifactScrollFromButtons();
 
       if (last >= children.length - 1) {
-        children[children.length - 1].scrollIntoView({
-          behavior: 'smooth',
-          block: 'nearest',
-          inline: 'end',
-        });
+        // Land on the exact numeric maxScroll rather than a geometry-based
+        // scrollIntoView alignment: aligning the last tile's end edge can
+        // land a subpixel short of maxScroll (unlike aligning to the first
+        // tile's start, which is trivially exact at 0), leaving the next
+        // chevron stuck visible since it compares against this same maxScroll.
+        scrollEl.scrollTo({ left: maxScroll, behavior: 'smooth' });
         return;
       }
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -165,6 +165,12 @@ export class PromptField extends SpectrumElement {
    * Roving tabindex + arrow-key focus movement across artifact tiles (Figma
    * focus-order spec §3). One step per Arrow Left/Right; chevron buttons
    * separately page by a full set (§6-7), unrelated to this controller.
+   *
+   * `getItems` returns no items until the strip has been "entered" (see
+   * `_artifactStripEntered`): the tiles must stay out of the Tab order so the
+   * container's own focus stop (`.swc-PromptField-artifacts-row`,
+   * `tabindex="0"`) is what Tab reaches first, with Enter/Space diving into
+   * the tiles from there.
    */
   private readonly _artifactNavigation = new FocusgroupNavigationController(
     this,
@@ -172,15 +178,18 @@ export class PromptField extends SpectrumElement {
       direction: 'horizontal',
       wrap: false,
       memory: true,
-      getItems: () => this._assignedArtifactElements ?? [],
+      getItems: () =>
+        this._artifactStripEntered ? (this._assignedArtifactElements ?? []) : [],
       onActiveItemChange: () => this.requestUpdate(),
     }
   );
 
   /**
-   * Whether the user has interacted with the artifact strip via Arrow keys or
-   * Enter/Space (Figma focus-order spec §4). Gates whether Tab from the active
-   * tile reveals its Close button, and resets when focus leaves the strip.
+   * Whether the user has "entered" the artifact strip past its container
+   * focus stop, via Enter/Space on the container or Arrow keys/Enter/Space on
+   * a tile (Figma focus-order spec §4). Gates whether tiles are in the Tab
+   * order at all, and whether Tab from the active tile reveals its Close
+   * button. Resets when focus leaves the strip entirely.
    */
   @state()
   private _artifactStripEntered = false;
@@ -467,15 +476,43 @@ export class PromptField extends SpectrumElement {
   private _handleArtifactRowFocusOut(event: FocusEvent): void {
     if (!this._isArtifactStripFocusTarget(event.relatedTarget as Node | null)) {
       this._artifactStripEntered = false;
+      // `getItems` returns [] while not entered, so the roving controller's
+      // own tabindex bookkeeping never touches these tiles again; clear their
+      // leftover tabindex from the last time the strip was entered directly
+      // so a tile can never be reached by a plain Tab into the strip.
+      for (const el of this._assignedArtifactElements ?? []) {
+        el.tabIndex = -1;
+      }
     }
+  }
+
+  /** Moves focus into the artifact strip's active (or first) tile, entering it. */
+  private _enterArtifactStrip(): void {
+    const artifacts = this._assignedArtifactElements ?? [];
+    if (artifacts.length === 0) {
+      return;
+    }
+    this._artifactStripEntered = true;
+    this._artifactNavigation.refresh();
+    const target = this._artifactNavigation.getActiveItem() ?? artifacts[0];
+    this._focusArtifact(target);
   }
 
   private _handleArtifactRowKeydown(event: KeyboardEvent): void {
     const isEnterOrSpace = event.key === 'Enter' || event.key === ' ';
     const isArrow = event.key === 'ArrowLeft' || event.key === 'ArrowRight';
+    const active = getActiveElement();
+    const stripContainer = this.shadowRoot?.querySelector(
+      '.swc-PromptField-artifacts-viewport'
+    );
+
+    if (isEnterOrSpace && active === stripContainer) {
+      event.preventDefault();
+      this._enterArtifactStrip();
+      return;
+    }
 
     if (isEnterOrSpace || isArrow) {
-      const active = getActiveElement();
       const isTile = (this._assignedArtifactElements ?? []).includes(
         active as HTMLElement
       );
@@ -520,6 +557,13 @@ export class PromptField extends SpectrumElement {
     // From the active thumbnail: Tab reveals its Close button, but only once
     // the user has "entered" the strip (Arrow keys or Enter/Space).
     if (artifacts.includes(active as HTMLElement)) {
+      // Shift+Tab from the first tile exits the strip entirely rather than
+      // landing back on the container's own focus stop or the "<" button;
+      // there is no re-entry ring on the way out.
+      if (event.shiftKey && artifacts.indexOf(active as HTMLElement) === 0) {
+        this._skipArtifactStripContainerForShiftTab();
+        return;
+      }
       if (!event.shiftKey && this._artifactStripEntered) {
         const dismiss = (
           active as HTMLElement
@@ -576,6 +620,26 @@ export class PromptField extends SpectrumElement {
         this._focusArtifact(target);
       }
     }
+  }
+
+  /**
+   * Temporarily takes the strip container out of the Tab order so the
+   * browser's own (un-prevented) Shift+Tab default action lands on the "<"
+   * button (if rendered) or whatever precedes the strip, rather than
+   * re-triggering the container's own ring on the way out. Restores it on
+   * the next frame once the browser has already moved focus.
+   */
+  private _skipArtifactStripContainerForShiftTab(): void {
+    const stripContainer = this.shadowRoot?.querySelector<HTMLElement>(
+      '.swc-PromptField-artifacts-viewport'
+    );
+    if (!stripContainer) {
+      return;
+    }
+    stripContainer.tabIndex = -1;
+    requestAnimationFrame(() => {
+      stripContainer.tabIndex = 0;
+    });
   }
 
   private _captureArtifactChevronFocusRedirect(
@@ -1028,8 +1092,6 @@ export class PromptField extends SpectrumElement {
       >
         <div
           class="swc-PromptField-artifacts-row"
-          role="region"
-          aria-label=${this.artifactStripLabel}
           @keydown=${this._handleArtifactRowKeydown}
           @focusout=${this._handleArtifactRowFocusOut}
         >
@@ -1047,13 +1109,19 @@ export class PromptField extends SpectrumElement {
                 </button>
               `
             : nothing}
-          <div class="swc-PromptField-artifacts-viewport">
+          <div
+            class="swc-PromptField-artifacts-viewport"
+            role="region"
+            tabindex="0"
+            aria-label=${this.artifactStripLabel}
+          >
             <div
               class=${classMap({
                 'swc-PromptField-artifacts-scroll': true,
                 'is-artifact-scroll-from-buttons':
                   this._artifactScrollFromButtons,
               })}
+              tabindex="-1"
               @scroll=${this._handleArtifactScroll}
               @wheel=${this._handleArtifactWheel}
               @touchstart=${this._showArtifactScrollbarFromInteraction}
@@ -1107,7 +1175,6 @@ export class PromptField extends SpectrumElement {
                 <button
                   type="button"
                   class="swc-PromptField-artifacts-scroll-next"
-                  tabindex="-1"
                   aria-label=${this.artifactScrollNextLabel}
                   @click=${() => this._scrollArtifactsByPage(1)}
                 >

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -10,7 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import { CSSResultArray, html, nothing, TemplateResult } from 'lit';
+import {
+  CSSResultArray,
+  html,
+  nothing,
+  PropertyValues,
+  TemplateResult,
+} from 'lit';
 import {
   property,
   query,
@@ -22,7 +28,16 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { Chevron75Icon } from '@adobe/spectrum-wc/icon/elements/index.js';
+import {
+  focusgroupNavigationActiveChange,
+  type FocusgroupNavigationActiveChangeDetail,
+  FocusgroupNavigationController,
+} from '@adobe/spectrum-wc-core/controllers/index.js';
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
+import {
+  deepContains,
+  getActiveElement,
+} from '@adobe/spectrum-wc-core/utils/index.js';
 
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 
@@ -90,6 +105,10 @@ export class PromptField extends SpectrumElement {
   @property({ type: String, attribute: 'artifact-scroll-next-label' })
   public artifactScrollNextLabel = 'Show more attachments';
 
+  /** Accessible name for the uploaded-artifacts strip landmark. */
+  @property({ type: String, attribute: 'artifact-strip-label' })
+  public artifactStripLabel = 'Uploaded assets strip';
+
   /** Placeholder text shown inside the textarea. */
   @property({ type: String })
   public placeholder =
@@ -142,12 +161,47 @@ export class PromptField extends SpectrumElement {
 
   private _artifactScrollButtonResetTimer?: number;
 
+  /**
+   * Roving tabindex + arrow-key focus movement across artifact tiles (Figma
+   * focus-order spec §3). One step per Arrow Left/Right; chevron buttons
+   * separately page by a full set (§6-7), unrelated to this controller.
+   */
+  private readonly _artifactNavigation = new FocusgroupNavigationController(
+    this,
+    {
+      direction: 'horizontal',
+      wrap: false,
+      memory: true,
+      getItems: () => this._assignedArtifactElements ?? [],
+      onActiveItemChange: () => this.requestUpdate(),
+    }
+  );
+
+  /**
+   * Whether the user has interacted with the artifact strip via Arrow keys or
+   * Enter/Space (Figma focus-order spec §4). Gates whether Tab from the active
+   * tile reveals its Close button, and resets when focus leaves the strip.
+   */
+  @state()
+  private _artifactStripEntered = false;
+
+  /** Set in `willUpdate` when a chevron about to disappear currently has focus; consumed in `updated`. */
+  private _pendingArtifactFocusRedirect: 'first' | 'last' | null = null;
+
   private _artifactScrollbarInteractTimer?: number;
 
   private _artifactScrollbarThumbDragOffset = 0;
 
   public static override get styles(): CSSResultArray {
     return [styles];
+  }
+
+  public constructor() {
+    super();
+    this.addEventListener(
+      focusgroupNavigationActiveChange,
+      this._handleArtifactActiveChange as EventListener
+    );
   }
 
   public override disconnectedCallback(): void {
@@ -162,8 +216,13 @@ export class PromptField extends SpectrumElement {
     super.disconnectedCallback();
   }
 
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    this._captureArtifactChevronFocusRedirect(changed);
+  }
+
   protected override updated(): void {
     this._warnIfMissingLegalContent();
+    this._applyArtifactChevronFocusRedirect();
 
     if ((this._assignedArtifactElements?.length ?? 0) < 2) {
       this._artifactScrollObserver?.disconnect();
@@ -256,6 +315,7 @@ export class PromptField extends SpectrumElement {
 
   private _handleArtifactSlotChange(): void {
     this._warnIfMixedArtifactTypes();
+    this._artifactNavigation.refresh();
     this.requestUpdate();
     void this.updateComplete.then(() => {
       requestAnimationFrame(() => {
@@ -335,16 +395,224 @@ export class PromptField extends SpectrumElement {
     }, 1000);
   }
 
-  private _handleArtifactScrollKeydown(event: KeyboardEvent): void {
-    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+  private _prefersReducedMotion(): boolean {
+    return (
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    );
+  }
+
+  private _focusArtifact(el: HTMLElement): void {
+    this._artifactNavigation.setActiveItem(el);
+    el.scrollIntoView({
+      behavior: this._prefersReducedMotion() ? 'auto' : 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+    el.focus();
+  }
+
+  private _findFullyVisibleArtifact(
+    direction: 'first' | 'last'
+  ): HTMLElement | null {
+    const scrollEl = this._artifactScrollEl;
+    const artifacts = this._assignedArtifactElements ?? [];
+    if (!scrollEl || artifacts.length === 0) {
+      return null;
+    }
+    const ordered =
+      direction === 'first' ? artifacts : [...artifacts].reverse();
+    for (const el of ordered) {
+      if (this._getArtifactTileVisibleFraction(el, scrollEl) >= 0.999) {
+        return el;
+      }
+    }
+    return null;
+  }
+
+  /** Reacts to `swc-focusgroup-navigation-active-change` from `_artifactNavigation`. */
+  private _handleArtifactActiveChange = (
+    event: CustomEvent<FocusgroupNavigationActiveChangeDetail>
+  ): void => {
+    const { activeElement, source } = event.detail;
+    if (!activeElement || (source !== 'keyboard' && source !== 'focus')) {
+      return;
+    }
+    if (source === 'keyboard') {
+      this._artifactStripEntered = true;
+    }
+    activeElement.scrollIntoView({
+      behavior: this._prefersReducedMotion() ? 'auto' : 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  };
+
+  /** Whether `node` is a focus target that belongs to the artifact strip (tiles, their dismiss buttons, or the chevrons). */
+  private _isArtifactStripFocusTarget(node: Node | null): boolean {
+    if (!node) {
+      return false;
+    }
+    const row = this.shadowRoot?.querySelector(
+      '.swc-PromptField-artifacts-row'
+    );
+    if (row && deepContains(row, node)) {
+      return true;
+    }
+    return (this._assignedArtifactElements ?? []).some((el) =>
+      deepContains(el, node)
+    );
+  }
+
+  private _handleArtifactRowFocusOut(event: FocusEvent): void {
+    if (!this._isArtifactStripFocusTarget(event.relatedTarget as Node | null)) {
+      this._artifactStripEntered = false;
+    }
+  }
+
+  private _handleArtifactRowKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      const active = getActiveElement();
+      if (
+        (this._assignedArtifactElements ?? []).includes(active as HTMLElement)
+      ) {
+        // Marks the strip as "entered" per the focus-order spec. Opening a
+        // Spotlight preview here is a follow-up; for now this only unlocks
+        // Tab access to the tile's Close button.
+        event.preventDefault();
+        this._artifactStripEntered = true;
+      }
       return;
     }
 
-    // Prevent the browser's native small-step scroll on this overflow-x:auto
-    // container so ArrowLeft/ArrowRight always trigger the same set-based
-    // paging as the chevron buttons.
-    event.preventDefault();
-    this._scrollArtifactsByPage(event.key === 'ArrowRight' ? 1 : -1);
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    this._handleArtifactTabKey(event);
+  }
+
+  private _handleArtifactTabKey(event: KeyboardEvent): void {
+    const active = getActiveElement();
+    if (!active) {
+      return;
+    }
+
+    const artifacts = this._assignedArtifactElements ?? [];
+    const prevButton = this.shadowRoot?.querySelector<HTMLButtonElement>(
+      '.swc-PromptField-artifacts-scroll-prev'
+    );
+    const nextButton = this.shadowRoot?.querySelector<HTMLButtonElement>(
+      '.swc-PromptField-artifacts-scroll-next'
+    );
+
+    // From the active thumbnail: Tab reveals its Close button, but only once
+    // the user has "entered" the strip (Arrow keys or Enter/Space).
+    if (artifacts.includes(active as HTMLElement)) {
+      if (!event.shiftKey && this._artifactStripEntered) {
+        const dismiss = (
+          active as HTMLElement
+        ).shadowRoot?.querySelector<HTMLButtonElement>(
+          '.swc-UploadArtifact-dismiss'
+        );
+        if (dismiss && !dismiss.hidden) {
+          event.preventDefault();
+          dismiss.focus();
+        }
+      }
+      return;
+    }
+
+    // From a tile's Close button.
+    const root = active.getRootNode();
+    if (
+      root instanceof ShadowRoot &&
+      artifacts.includes(root.host as HTMLElement) &&
+      active.classList.contains('swc-UploadArtifact-dismiss')
+    ) {
+      const tile = root.host as HTMLElement;
+      if (event.shiftKey) {
+        event.preventDefault();
+        tile.focus();
+        return;
+      }
+      if (nextButton) {
+        event.preventDefault();
+        nextButton.focus();
+      }
+      return;
+    }
+
+    // From the "<" (previous set) button: Tab enters the strip at the first
+    // fully-visible thumbnail beside it.
+    if (active === prevButton) {
+      if (!event.shiftKey) {
+        const target = this._findFullyVisibleArtifact('first');
+        if (target) {
+          event.preventDefault();
+          this._focusArtifact(target);
+        }
+      }
+      return;
+    }
+
+    // From the ">" (next set) button: Shift+Tab re-enters the strip at the
+    // last fully-visible thumbnail beside it.
+    if (active === nextButton && event.shiftKey) {
+      const target = this._findFullyVisibleArtifact('last');
+      if (target) {
+        event.preventDefault();
+        this._focusArtifact(target);
+      }
+    }
+  }
+
+  private _captureArtifactChevronFocusRedirect(
+    changed: PropertyValues<this>
+  ): void {
+    const active = getActiveElement();
+
+    if (
+      changed.has('_artifactCanScrollPrev') &&
+      changed.get('_artifactCanScrollPrev') === true &&
+      !this._artifactCanScrollPrev
+    ) {
+      const prevButton = this.shadowRoot?.querySelector(
+        '.swc-PromptField-artifacts-scroll-prev'
+      );
+      if (active === prevButton) {
+        this._pendingArtifactFocusRedirect = 'first';
+      }
+    }
+
+    if (
+      changed.has('_artifactCanScrollNext') &&
+      changed.get('_artifactCanScrollNext') === true &&
+      !this._artifactCanScrollNext
+    ) {
+      const nextButton = this.shadowRoot?.querySelector(
+        '.swc-PromptField-artifacts-scroll-next'
+      );
+      if (active === nextButton) {
+        this._pendingArtifactFocusRedirect = 'last';
+      }
+    }
+  }
+
+  private _applyArtifactChevronFocusRedirect(): void {
+    if (!this._pendingArtifactFocusRedirect) {
+      return;
+    }
+
+    const artifacts = this._assignedArtifactElements ?? [];
+    const target =
+      this._pendingArtifactFocusRedirect === 'first'
+        ? artifacts[0]
+        : artifacts[artifacts.length - 1];
+    this._pendingArtifactFocusRedirect = null;
+    if (target) {
+      this._focusArtifact(target);
+    }
   }
 
   private _handleArtifactWheel(event: WheelEvent): void {
@@ -749,7 +1017,10 @@ export class PromptField extends SpectrumElement {
       >
         <div
           class="swc-PromptField-artifacts-row"
-          @keydown=${this._handleArtifactScrollKeydown}
+          role="region"
+          aria-label=${this.artifactStripLabel}
+          @keydown=${this._handleArtifactRowKeydown}
+          @focusout=${this._handleArtifactRowFocusOut}
         >
           ${this._artifactScrollOverflow && this._artifactCanScrollPrev
             ? html`

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -166,11 +166,10 @@ export class PromptField extends SpectrumElement {
    * focus-order spec §3). One step per Arrow Left/Right; chevron buttons
    * separately page by a full set (§6-7), unrelated to this controller.
    *
-   * `getItems` returns no items until the strip has been "entered" (see
-   * `_artifactStripEntered`): the tiles must stay out of the Tab order so the
-   * container's own focus stop (`.swc-PromptField-artifacts-row`,
-   * `tabindex="0"`) is what Tab reaches first, with Enter/Space diving into
-   * the tiles from there.
+   * Always active so the roving tab stop (tile 0 by default) is a normal Tab
+   * target; `.swc-PromptField-artifacts-row` is only an ARIA `region`
+   * landmark, not a separate focus stop. `_artifactStripEntered` gates the
+   * Tab-reveals-Close-button behavior below, not the roving tabindex itself.
    */
   private readonly _artifactNavigation = new FocusgroupNavigationController(
     this,
@@ -178,8 +177,7 @@ export class PromptField extends SpectrumElement {
       direction: 'horizontal',
       wrap: false,
       memory: true,
-      getItems: () =>
-        this._artifactStripEntered ? (this._assignedArtifactElements ?? []) : [],
+      getItems: () => this._assignedArtifactElements ?? [],
       onActiveItemChange: () => this.requestUpdate(),
     }
   );
@@ -476,13 +474,6 @@ export class PromptField extends SpectrumElement {
   private _handleArtifactRowFocusOut(event: FocusEvent): void {
     if (!this._isArtifactStripFocusTarget(event.relatedTarget as Node | null)) {
       this._artifactStripEntered = false;
-      // `getItems` returns [] while not entered, so the roving controller's
-      // own tabindex bookkeeping never touches these tiles again; clear their
-      // leftover tabindex from the last time the strip was entered directly
-      // so a tile can never be reached by a plain Tab into the strip.
-      for (const el of this._assignedArtifactElements ?? []) {
-        el.tabIndex = -1;
-      }
     }
   }
 
@@ -1092,6 +1083,8 @@ export class PromptField extends SpectrumElement {
       >
         <div
           class="swc-PromptField-artifacts-row"
+          role="region"
+          aria-label=${this.artifactStripLabel}
           @keydown=${this._handleArtifactRowKeydown}
           @focusout=${this._handleArtifactRowFocusOut}
         >
@@ -1109,12 +1102,7 @@ export class PromptField extends SpectrumElement {
                 </button>
               `
             : nothing}
-          <div
-            class="swc-PromptField-artifacts-viewport"
-            role="region"
-            tabindex="0"
-            aria-label=${this.artifactStripLabel}
-          >
+          <div class="swc-PromptField-artifacts-viewport" tabindex="0">
             <div
               class=${classMap({
                 'swc-PromptField-artifacts-scroll': true,
@@ -1175,6 +1163,7 @@ export class PromptField extends SpectrumElement {
                 <button
                   type="button"
                   class="swc-PromptField-artifacts-scroll-next"
+                  tabindex="-1"
                   aria-label=${this.artifactScrollNextLabel}
                   @click=${() => this._scrollArtifactsByPage(1)}
                 >

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -166,10 +166,11 @@ export class PromptField extends SpectrumElement {
    * focus-order spec §3). One step per Arrow Left/Right; chevron buttons
    * separately page by a full set (§6-7), unrelated to this controller.
    *
-   * Always active so the roving tab stop (tile 0 by default) is a normal Tab
-   * target; `.swc-PromptField-artifacts-row` is only an ARIA `region`
-   * landmark, not a separate focus stop. `_artifactStripEntered` gates the
-   * Tab-reveals-Close-button behavior below, not the roving tabindex itself.
+   * `getItems` returns no items until the strip has been "entered" (see
+   * `_artifactStripEntered`): the tiles must stay out of the Tab order so the
+   * container's own focus stop (`.swc-PromptField-artifacts-row`,
+   * `tabindex="0"`) is what Tab reaches first, with Enter/Space diving into
+   * the tiles from there.
    */
   private readonly _artifactNavigation = new FocusgroupNavigationController(
     this,
@@ -177,7 +178,10 @@ export class PromptField extends SpectrumElement {
       direction: 'horizontal',
       wrap: false,
       memory: true,
-      getItems: () => this._assignedArtifactElements ?? [],
+      getItems: () =>
+        this._artifactStripEntered
+          ? (this._assignedArtifactElements ?? [])
+          : [],
       onActiveItemChange: () => this.requestUpdate(),
     }
   );
@@ -474,6 +478,13 @@ export class PromptField extends SpectrumElement {
   private _handleArtifactRowFocusOut(event: FocusEvent): void {
     if (!this._isArtifactStripFocusTarget(event.relatedTarget as Node | null)) {
       this._artifactStripEntered = false;
+      // `getItems` returns [] while not entered, so the roving controller's
+      // own tabindex bookkeeping never touches these tiles again; clear their
+      // leftover tabindex from the last time the strip was entered directly
+      // so a tile can never be reached by a plain Tab into the strip.
+      for (const el of this._assignedArtifactElements ?? []) {
+        el.tabIndex = -1;
+      }
     }
   }
 
@@ -1083,8 +1094,6 @@ export class PromptField extends SpectrumElement {
       >
         <div
           class="swc-PromptField-artifacts-row"
-          role="region"
-          aria-label=${this.artifactStripLabel}
           @keydown=${this._handleArtifactRowKeydown}
           @focusout=${this._handleArtifactRowFocusOut}
         >
@@ -1102,7 +1111,12 @@ export class PromptField extends SpectrumElement {
                 </button>
               `
             : nothing}
-          <div class="swc-PromptField-artifacts-viewport" tabindex="0">
+          <div
+            class="swc-PromptField-artifacts-viewport"
+            role="region"
+            tabindex="0"
+            aria-label=${this.artifactStripLabel}
+          >
             <div
               class=${classMap({
                 'swc-PromptField-artifacts-scroll': true,
@@ -1163,7 +1177,6 @@ export class PromptField extends SpectrumElement {
                 <button
                   type="button"
                   class="swc-PromptField-artifacts-scroll-next"
-                  tabindex="-1"
                   aria-label=${this.artifactScrollNextLabel}
                   @click=${() => this._scrollArtifactsByPage(1)}
                 >

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -423,24 +423,6 @@ export class PromptField extends SpectrumElement {
     el.focus();
   }
 
-  private _findFullyVisibleArtifact(
-    direction: 'first' | 'last'
-  ): HTMLElement | null {
-    const scrollEl = this._artifactScrollEl;
-    const artifacts = this._assignedArtifactElements ?? [];
-    if (!scrollEl || artifacts.length === 0) {
-      return null;
-    }
-    const ordered =
-      direction === 'first' ? artifacts : [...artifacts].reverse();
-    for (const el of ordered) {
-      if (this._getArtifactTileVisibleFraction(el, scrollEl) >= 0.999) {
-        return el;
-      }
-    }
-    return null;
-  }
-
   /** Reacts to `swc-focusgroup-navigation-active-change` from `_artifactNavigation`. */
   private _handleArtifactActiveChange = (
     event: CustomEvent<FocusgroupNavigationActiveChangeDetail>
@@ -549,9 +531,6 @@ export class PromptField extends SpectrumElement {
     }
 
     const artifacts = this._assignedArtifactElements ?? [];
-    const prevButton = this.shadowRoot?.querySelector<HTMLButtonElement>(
-      '.swc-PromptField-artifacts-scroll-prev'
-    );
     const nextButton = this.shadowRoot?.querySelector<HTMLButtonElement>(
       '.swc-PromptField-artifacts-scroll-next'
     );
@@ -596,30 +575,6 @@ export class PromptField extends SpectrumElement {
       if (nextButton) {
         event.preventDefault();
         nextButton.focus();
-      }
-      return;
-    }
-
-    // From the "<" (previous set) button: Tab enters the strip at the first
-    // fully-visible thumbnail beside it.
-    if (active === prevButton) {
-      if (!event.shiftKey) {
-        const target = this._findFullyVisibleArtifact('first');
-        if (target) {
-          event.preventDefault();
-          this._focusArtifact(target);
-        }
-      }
-      return;
-    }
-
-    // From the ">" (next set) button: Shift+Tab re-enters the strip at the
-    // last fully-visible thumbnail beside it.
-    if (active === nextButton && event.shiftKey) {
-      const target = this._findFullyVisibleArtifact('last');
-      if (target) {
-        event.preventDefault();
-        this._focusArtifact(target);
       }
     }
   }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -335,6 +335,18 @@ export class PromptField extends SpectrumElement {
     }, 1000);
   }
 
+  private _handleArtifactScrollKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+      return;
+    }
+
+    // Prevent the browser's native small-step scroll on this overflow-x:auto
+    // container so ArrowLeft/ArrowRight always trigger the same set-based
+    // paging as the chevron buttons.
+    event.preventDefault();
+    this._scrollArtifactsByPage(event.key === 'ArrowRight' ? 1 : -1);
+  }
+
   private _handleArtifactWheel(event: WheelEvent): void {
     if (Math.abs(event.deltaX) > 0 || Math.abs(event.deltaY) > 0) {
       this._showArtifactScrollbarFromInteraction();
@@ -494,6 +506,25 @@ export class PromptField extends SpectrumElement {
     return Math.max(0, scrollEl.scrollWidth - scrollEl.clientWidth);
   }
 
+  private _getArtifactTileVisibleFraction(
+    child: HTMLElement,
+    scrollEl: HTMLDivElement
+  ): number {
+    const tileWidth = this._getArtifactTileWidth(child);
+    if (!tileWidth) {
+      return 0;
+    }
+
+    const offset = this._getArtifactScrollOffset(child);
+    const right = offset + tileWidth;
+    const scrollLeft = scrollEl.scrollLeft;
+    const viewportRight = scrollLeft + scrollEl.clientWidth;
+    const visibleWidth =
+      Math.min(right, viewportRight) - Math.max(offset, scrollLeft);
+
+    return Math.max(0, visibleWidth) / tileWidth;
+  }
+
   private _scrollArtifactsByPage(direction: -1 | 1): void {
     const scrollEl = this._artifactScrollEl;
     const children = this._assignedArtifactElements ?? [];
@@ -521,7 +552,17 @@ export class PromptField extends SpectrumElement {
         return;
       }
 
-      children[last].scrollIntoView({
+      // last < children.length - 1 here (the "already at the end" case
+      // returned above), so an ambiguous edge tile (< 50% visible) is
+      // carried over as the next page's anchor; otherwise page fully.
+      const lastVisibleFraction = this._getArtifactTileVisibleFraction(
+        children[last],
+        scrollEl
+      );
+      const nextStart =
+        lastVisibleFraction >= 0.5 ? children[last + 1] : children[last];
+
+      nextStart.scrollIntoView({
         behavior: 'smooth',
         block: 'nearest',
         inline: 'start',
@@ -534,7 +575,24 @@ export class PromptField extends SpectrumElement {
     }
 
     this._markArtifactScrollFromButtons();
-    children[first].scrollIntoView({
+
+    if (first <= 0) {
+      children[0].scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'start',
+      });
+      return;
+    }
+
+    const firstVisibleFraction = this._getArtifactTileVisibleFraction(
+      children[first],
+      scrollEl
+    );
+    const prevEnd =
+      firstVisibleFraction >= 0.5 ? children[first - 1] : children[first];
+
+    prevEnd.scrollIntoView({
       behavior: 'smooth',
       block: 'nearest',
       inline: 'end',
@@ -688,7 +746,10 @@ export class PromptField extends SpectrumElement {
       <div
         class="swc-PromptField-artifacts swc-PromptField-artifacts--multiple"
       >
-        <div class="swc-PromptField-artifacts-row">
+        <div
+          class="swc-PromptField-artifacts-row"
+          @keydown=${this._handleArtifactScrollKeydown}
+        >
           ${this._artifactScrollOverflow && this._artifactCanScrollPrev
             ? html`
                 <button

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -38,7 +38,7 @@ export type PromptFieldMode = 'default' | 'loading' | 'disabled';
  *
  * @element swc-prompt-field
  *
- * @slot artifact - Optional attachment preview(s); supports multiple slotted artifacts.
+ * @slot artifact - Optional attachment preview(s). Use one `swc-upload-artifact` type per session (cards only, or media only).
  * @slot legal - Optional legal/footer content.
  * @fires swc-prompt-field-input - Dispatched after the textarea value is internally updated.
  * Detail: `{ value: string }`
@@ -189,7 +189,36 @@ export class PromptField extends SpectrumElement {
   }
 
   private _handleArtifactSlotChange(): void {
+    this._warnIfMixedArtifactTypes();
     this.requestUpdate();
+  }
+
+  private _warnedMixedArtifactTypes = false;
+
+  private _warnIfMixedArtifactTypes(): void {
+    const elements = this._assignedArtifactElements ?? [];
+    const types = new Set(
+      elements
+        .map((element) => element.getAttribute('type'))
+        .filter(
+          (type): type is 'card' | 'media' =>
+            type === 'card' || type === 'media'
+        )
+    );
+
+    if (types.size <= 1) {
+      this._warnedMixedArtifactTypes = false;
+      return;
+    }
+
+    if (this._warnedMixedArtifactTypes) {
+      return;
+    }
+
+    this._warnedMixedArtifactTypes = true;
+    console.warn(
+      '[swc-prompt-field] The artifact slot contains both card and media upload artifacts. Use one type per composer session: cards only, or media tiles only (with or without badge). See upload-artifact documentation.'
+    );
   }
 
   private get _isPopulated(): boolean {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -1096,6 +1096,7 @@ export class PromptField extends SpectrumElement {
                 <button
                   type="button"
                   class="swc-PromptField-artifacts-scroll-next"
+                  tabindex="-1"
                   aria-label=${this.artifactScrollNextLabel}
                   @click=${() => this._scrollArtifactsByPage(1)}
                 >

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -471,18 +471,29 @@ export class PromptField extends SpectrumElement {
   }
 
   private _handleArtifactRowKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Enter' || event.key === ' ') {
+    const isEnterOrSpace = event.key === 'Enter' || event.key === ' ';
+    const isArrow = event.key === 'ArrowLeft' || event.key === 'ArrowRight';
+
+    if (isEnterOrSpace || isArrow) {
       const active = getActiveElement();
-      if (
-        (this._assignedArtifactElements ?? []).includes(active as HTMLElement)
-      ) {
-        // Marks the strip as "entered" per the focus-order spec. Opening a
-        // Spotlight preview here is a follow-up; for now this only unlocks
+      const isTile = (this._assignedArtifactElements ?? []).includes(
+        active as HTMLElement
+      );
+      if (isTile) {
+        // Marks the strip as "entered" per the focus-order spec, even when an
+        // Arrow key is a no-op at the first/last tile boundary (the roving
+        // controller only fires its active-change event on an actual move,
+        // so relying on that alone misses this case). Opening a Spotlight
+        // preview on Enter/Space is a follow-up; for now this only unlocks
         // Tab access to the tile's Close button.
-        event.preventDefault();
         this._artifactStripEntered = true;
+        if (isEnterOrSpace) {
+          event.preventDefault();
+        }
       }
-      return;
+      if (isEnterOrSpace) {
+        return;
+      }
     }
 
     if (event.key !== 'Tab') {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -17,6 +17,7 @@ import {
   queryAssignedElements,
   state,
 } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -133,6 +134,18 @@ export class PromptField extends SpectrumElement {
 
   private _artifactScrollObserver?: ResizeObserver;
 
+  @state()
+  private _artifactScrollFromButtons = false;
+
+  @state()
+  private _artifactScrollbarInteracting = false;
+
+  private _artifactScrollButtonResetTimer?: number;
+
+  private _artifactScrollbarInteractTimer?: number;
+
+  private _artifactScrollbarThumbDragOffset = 0;
+
   public static override get styles(): CSSResultArray {
     return [styles];
   }
@@ -140,10 +153,18 @@ export class PromptField extends SpectrumElement {
   public override disconnectedCallback(): void {
     this._artifactScrollObserver?.disconnect();
     this._artifactScrollObserver = undefined;
+    if (this._artifactScrollButtonResetTimer !== undefined) {
+      window.clearTimeout(this._artifactScrollButtonResetTimer);
+    }
+    if (this._artifactScrollbarInteractTimer !== undefined) {
+      window.clearTimeout(this._artifactScrollbarInteractTimer);
+    }
     super.disconnectedCallback();
   }
 
   protected override updated(): void {
+    this._warnIfMissingLegalContent();
+
     if ((this._assignedArtifactElements?.length ?? 0) < 2) {
       this._artifactScrollObserver?.disconnect();
       return;
@@ -246,6 +267,156 @@ export class PromptField extends SpectrumElement {
 
   private _handleArtifactScroll(): void {
     this._updateArtifactScrollState();
+    this.requestUpdate();
+  }
+
+  private _getArtifactScrollbarThumbStyle(): Record<string, string> {
+    const scrollEl = this._artifactScrollEl;
+    if (!scrollEl) {
+      return { width: '0px', insetInlineStart: '0px' };
+    }
+
+    const { scrollWidth, clientWidth, scrollLeft } = scrollEl;
+    const tolerance = 1;
+    if (scrollWidth <= clientWidth + tolerance) {
+      return { width: '0px', insetInlineStart: '0px' };
+    }
+
+    const thumbWidth = Math.max((clientWidth / scrollWidth) * clientWidth, 24);
+    const maxScroll = this._getArtifactMaxScroll(scrollEl);
+    const maxThumbOffset = Math.max(0, clientWidth - thumbWidth);
+    const thumbOffset =
+      maxScroll > 0 ? (scrollLeft / maxScroll) * maxThumbOffset : 0;
+
+    return {
+      width: `${thumbWidth}px`,
+      insetInlineStart: `${thumbOffset}px`,
+    };
+  }
+
+  private _setArtifactScrollFromThumbOffset(
+    thumbOffset: number,
+    trackWidth: number
+  ): void {
+    const scrollEl = this._artifactScrollEl;
+    if (!scrollEl) {
+      return;
+    }
+
+    const thumbWidth = Math.max(
+      (scrollEl.clientWidth / scrollEl.scrollWidth) * scrollEl.clientWidth,
+      24
+    );
+    const maxThumbOffset = Math.max(0, trackWidth - thumbWidth);
+    const clampedOffset = Math.max(0, Math.min(maxThumbOffset, thumbOffset));
+    const maxScroll = this._getArtifactMaxScroll(scrollEl);
+    const ratio = maxThumbOffset > 0 ? clampedOffset / maxThumbOffset : 0;
+
+    scrollEl.scrollLeft = ratio * maxScroll;
+    this._updateArtifactScrollState();
+    this.requestUpdate();
+  }
+
+  private _showArtifactScrollbarFromInteraction(): void {
+    if (this._artifactScrollFromButtons) {
+      return;
+    }
+
+    this._artifactScrollbarInteracting = true;
+
+    if (this._artifactScrollbarInteractTimer !== undefined) {
+      window.clearTimeout(this._artifactScrollbarInteractTimer);
+    }
+
+    this._artifactScrollbarInteractTimer = window.setTimeout(() => {
+      this._artifactScrollbarInteracting = false;
+      this._artifactScrollbarInteractTimer = undefined;
+      this.requestUpdate();
+    }, 1000);
+  }
+
+  private _handleArtifactWheel(event: WheelEvent): void {
+    if (Math.abs(event.deltaX) > 0 || Math.abs(event.deltaY) > 0) {
+      this._showArtifactScrollbarFromInteraction();
+      this.requestUpdate();
+    }
+  }
+
+  private _handleArtifactScrollbarLanePointerDown(event: PointerEvent): void {
+    if (this._artifactScrollFromButtons) {
+      return;
+    }
+
+    const lane = event.currentTarget as HTMLElement;
+    const laneRect = lane.getBoundingClientRect();
+    const thumbStyle = this._getArtifactScrollbarThumbStyle();
+    const thumbWidth = Number.parseFloat(thumbStyle.width) || 0;
+    const clickOffset = event.clientX - laneRect.left - thumbWidth / 2;
+
+    this._setArtifactScrollFromThumbOffset(clickOffset, laneRect.width);
+    this._showArtifactScrollbarFromInteraction();
+  }
+
+  private _handleArtifactScrollbarThumbPointerDown(event: PointerEvent): void {
+    event.stopPropagation();
+
+    if (this._artifactScrollFromButtons) {
+      return;
+    }
+
+    const thumb = event.currentTarget as HTMLElement;
+    const lane = thumb.parentElement;
+    if (!lane) {
+      return;
+    }
+
+    const thumbRect = thumb.getBoundingClientRect();
+    this._artifactScrollbarThumbDragOffset = event.clientX - thumbRect.left;
+    this._showArtifactScrollbarFromInteraction();
+
+    const onPointerMove = (moveEvent: PointerEvent): void => {
+      const laneRect = lane.getBoundingClientRect();
+      const thumbOffset =
+        moveEvent.clientX -
+        laneRect.left -
+        this._artifactScrollbarThumbDragOffset;
+      this._setArtifactScrollFromThumbOffset(thumbOffset, laneRect.width);
+      this._showArtifactScrollbarFromInteraction();
+    };
+
+    const onPointerUp = (): void => {
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+      window.removeEventListener('pointercancel', onPointerUp);
+    };
+
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('pointercancel', onPointerUp);
+  }
+
+  private _markArtifactScrollFromButtons(): void {
+    const scrollEl = this._artifactScrollEl;
+    this._artifactScrollFromButtons = true;
+    this._artifactScrollbarInteracting = false;
+
+    if (this._artifactScrollbarInteractTimer !== undefined) {
+      window.clearTimeout(this._artifactScrollbarInteractTimer);
+      this._artifactScrollbarInteractTimer = undefined;
+    }
+
+    if (this._artifactScrollButtonResetTimer !== undefined) {
+      window.clearTimeout(this._artifactScrollButtonResetTimer);
+    }
+
+    const reset = (): void => {
+      this._artifactScrollFromButtons = false;
+      this._artifactScrollButtonResetTimer = undefined;
+      scrollEl?.removeEventListener('scrollend', reset);
+    };
+
+    scrollEl?.addEventListener('scrollend', reset, { once: true });
+    this._artifactScrollButtonResetTimer = window.setTimeout(reset, 600);
   }
 
   private _observeArtifactScrollViewport(): void {
@@ -282,47 +453,91 @@ export class PromptField extends SpectrumElement {
     );
   }
 
-  private _findLeadingArtifactIndex(): number {
+  private _getArtifactTileWidth(child: HTMLElement): number {
+    return child.getBoundingClientRect().width || child.offsetWidth;
+  }
+
+  private _getVisibleArtifactRange(): { first: number; last: number } {
     const scrollEl = this._artifactScrollEl;
     const children = this._assignedArtifactElements ?? [];
     if (!scrollEl || !children.length) {
-      return 0;
+      return { first: 0, last: 0 };
     }
 
     const scrollLeft = scrollEl.scrollLeft;
-    let index = 0;
+    const viewportRight = scrollLeft + scrollEl.clientWidth;
+    const tolerance = 1;
+    let first = -1;
+    let last = -1;
 
     for (let i = 0; i < children.length; i += 1) {
       const offset = this._getArtifactScrollOffset(children[i]);
-      if (offset >= scrollLeft - 1) {
-        return i;
+      const right = offset + this._getArtifactTileWidth(children[i]);
+      if (
+        right > scrollLeft + tolerance &&
+        offset < viewportRight - tolerance
+      ) {
+        if (first === -1) {
+          first = i;
+        }
+        last = i;
       }
-      index = i;
     }
 
-    return index;
+    return {
+      first: first === -1 ? 0 : first,
+      last: last === -1 ? children.length - 1 : last,
+    };
   }
 
-  private _scrollArtifactsByTile(direction: -1 | 1): void {
+  private _getArtifactMaxScroll(scrollEl: HTMLDivElement): number {
+    return Math.max(0, scrollEl.scrollWidth - scrollEl.clientWidth);
+  }
+
+  private _scrollArtifactsByPage(direction: -1 | 1): void {
     const scrollEl = this._artifactScrollEl;
     const children = this._assignedArtifactElements ?? [];
     if (!scrollEl || children.length < 2) {
       return;
     }
 
-    const currentIndex = this._findLeadingArtifactIndex();
-    const nextIndex = Math.max(
-      0,
-      Math.min(children.length - 1, currentIndex + direction)
-    );
+    const tolerance = 1;
+    const maxScroll = this._getArtifactMaxScroll(scrollEl);
+    const { first, last } = this._getVisibleArtifactRange();
 
-    if (nextIndex === currentIndex) {
+    if (direction === 1) {
+      if (scrollEl.scrollLeft >= maxScroll - tolerance) {
+        return;
+      }
+
+      this._markArtifactScrollFromButtons();
+
+      if (last >= children.length - 1) {
+        children[children.length - 1].scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+          inline: 'end',
+        });
+        return;
+      }
+
+      children[last].scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'start',
+      });
       return;
     }
 
-    scrollEl.scrollTo({
-      left: this._getArtifactScrollOffset(children[nextIndex]),
+    if (first <= 0 && scrollEl.scrollLeft <= tolerance) {
+      return;
+    }
+
+    this._markArtifactScrollFromButtons();
+    children[first].scrollIntoView({
       behavior: 'smooth',
+      block: 'nearest',
+      inline: 'end',
     });
   }
 
@@ -338,11 +553,12 @@ export class PromptField extends SpectrumElement {
     const { scrollLeft, scrollWidth, clientWidth } = scrollEl;
     const tolerance = 1;
     const overflow = scrollWidth > clientWidth + tolerance;
+    const maxScroll = this._getArtifactMaxScroll(scrollEl);
 
     this._artifactScrollOverflow = overflow;
     this._artifactCanScrollPrev = overflow && scrollLeft > tolerance;
     this._artifactCanScrollNext =
-      overflow && scrollLeft + clientWidth < scrollWidth - tolerance;
+      overflow && scrollLeft < maxScroll - tolerance;
   }
 
   private _warnedMixedArtifactTypes = false;
@@ -479,7 +695,7 @@ export class PromptField extends SpectrumElement {
                   type="button"
                   class="swc-PromptField-artifacts-scroll-prev"
                   aria-label=${this.artifactScrollPrevLabel}
-                  @click=${() => this._scrollArtifactsByTile(-1)}
+                  @click=${() => this._scrollArtifactsByPage(-1)}
                 >
                   <swc-icon size="s" aria-hidden="true">
                     ${Chevron75Icon()}
@@ -489,14 +705,58 @@ export class PromptField extends SpectrumElement {
             : nothing}
           <div class="swc-PromptField-artifacts-viewport">
             <div
-              class="swc-PromptField-artifacts-scroll"
+              class=${classMap({
+                'swc-PromptField-artifacts-scroll': true,
+                'is-artifact-scroll-from-buttons':
+                  this._artifactScrollFromButtons,
+              })}
               @scroll=${this._handleArtifactScroll}
+              @wheel=${this._handleArtifactWheel}
+              @touchstart=${this._showArtifactScrollbarFromInteraction}
             >
-              <slot
-                name="artifact"
-                @slotchange=${this._handleArtifactSlotChange}
-              ></slot>
+              <div class="swc-PromptField-artifacts-tiles">
+                <slot
+                  name="artifact"
+                  @slotchange=${this._handleArtifactSlotChange}
+                ></slot>
+              </div>
             </div>
+            ${this._artifactScrollOverflow
+              ? html`
+                  <div
+                    class=${classMap({
+                      'swc-PromptField-artifacts-scrollbar-lane': true,
+                      'is-artifact-scrollbar-interacting':
+                        this._artifactScrollbarInteracting &&
+                        !this._artifactScrollFromButtons,
+                    })}
+                    @pointerdown=${this._handleArtifactScrollbarLanePointerDown}
+                  >
+                    <div
+                      class="swc-PromptField-artifacts-scrollbar-thumb"
+                      style=${styleMap(this._getArtifactScrollbarThumbStyle())}
+                      @pointerdown=${this
+                        ._handleArtifactScrollbarThumbPointerDown}
+                    ></div>
+                  </div>
+                `
+              : nothing}
+            ${this._artifactCanScrollPrev
+              ? html`
+                  <div
+                    class="swc-PromptField-artifacts-fade swc-PromptField-artifacts-fade--start"
+                    aria-hidden="true"
+                  ></div>
+                `
+              : nothing}
+            ${this._artifactCanScrollNext
+              ? html`
+                  <div
+                    class="swc-PromptField-artifacts-fade swc-PromptField-artifacts-fade--end"
+                    aria-hidden="true"
+                  ></div>
+                `
+              : nothing}
           </div>
           ${this._artifactScrollOverflow && this._artifactCanScrollNext
             ? html`
@@ -504,7 +764,7 @@ export class PromptField extends SpectrumElement {
                   type="button"
                   class="swc-PromptField-artifacts-scroll-next"
                   aria-label=${this.artifactScrollNextLabel}
-                  @click=${() => this._scrollArtifactsByTile(1)}
+                  @click=${() => this._scrollArtifactsByPage(1)}
                 >
                   <swc-icon size="s" aria-hidden="true">
                     ${Chevron75Icon()}

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -10,11 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import { CSSResultArray, html, TemplateResult } from 'lit';
-import { property, queryAssignedElements, state } from 'lit/decorators.js';
+import { CSSResultArray, html, nothing, TemplateResult } from 'lit';
+import {
+  property,
+  query,
+  queryAssignedElements,
+  state,
+} from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
+import { Chevron75Icon } from '@adobe/spectrum-wc/icon/elements/index.js';
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
 
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
@@ -75,6 +81,14 @@ export class PromptField extends SpectrumElement {
   @property({ type: String, attribute: 'upload-label' })
   public uploadLabel = 'Add attachment';
 
+  /** Accessible label for the previous-artifact scroll button. */
+  @property({ type: String, attribute: 'artifact-scroll-prev-label' })
+  public artifactScrollPrevLabel = 'Show previous attachments';
+
+  /** Accessible label for the next-artifact scroll button. */
+  @property({ type: String, attribute: 'artifact-scroll-next-label' })
+  public artifactScrollNextLabel = 'Show more attachments';
+
   /** Placeholder text shown inside the textarea. */
   @property({ type: String })
   public placeholder =
@@ -95,6 +109,9 @@ export class PromptField extends SpectrumElement {
   @queryAssignedElements({ slot: 'artifact', flatten: true })
   private _assignedArtifactElements!: HTMLElement[];
 
+  @query('.swc-PromptField-artifacts-scroll')
+  private _artifactScrollEl?: HTMLDivElement;
+
   @queryAssignedElements({ slot: 'legal', flatten: true })
   private _assignedLegalElements!: HTMLElement[];
 
@@ -105,8 +122,36 @@ export class PromptField extends SpectrumElement {
   @state()
   private _promptBoxKeyboardFocusRing = false;
 
+  @state()
+  private _artifactScrollOverflow = false;
+
+  @state()
+  private _artifactCanScrollPrev = false;
+
+  @state()
+  private _artifactCanScrollNext = false;
+
+  private _artifactScrollObserver?: ResizeObserver;
+
   public static override get styles(): CSSResultArray {
     return [styles];
+  }
+
+  public override disconnectedCallback(): void {
+    this._artifactScrollObserver?.disconnect();
+    this._artifactScrollObserver = undefined;
+    super.disconnectedCallback();
+  }
+
+  protected override updated(): void {
+    if ((this._assignedArtifactElements?.length ?? 0) < 2) {
+      this._artifactScrollObserver?.disconnect();
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      this._observeArtifactScrollViewport();
+    });
   }
 
   private _handleInput(event: Event): void {
@@ -191,6 +236,113 @@ export class PromptField extends SpectrumElement {
   private _handleArtifactSlotChange(): void {
     this._warnIfMixedArtifactTypes();
     this.requestUpdate();
+    void this.updateComplete.then(() => {
+      requestAnimationFrame(() => {
+        this._observeArtifactScrollViewport();
+        this._updateArtifactScrollState();
+      });
+    });
+  }
+
+  private _handleArtifactScroll(): void {
+    this._updateArtifactScrollState();
+  }
+
+  private _observeArtifactScrollViewport(): void {
+    const scrollEl = this._artifactScrollEl;
+    if (!scrollEl) {
+      this._artifactScrollObserver?.disconnect();
+      return;
+    }
+
+    if (!this._artifactScrollObserver) {
+      this._artifactScrollObserver = new ResizeObserver(() => {
+        this._updateArtifactScrollState();
+      });
+    }
+
+    this._artifactScrollObserver.disconnect();
+    this._artifactScrollObserver.observe(scrollEl);
+    for (const element of this._assignedArtifactElements ?? []) {
+      this._artifactScrollObserver.observe(element);
+    }
+    this._updateArtifactScrollState();
+  }
+
+  private _getArtifactScrollOffset(child: HTMLElement): number {
+    const scrollEl = this._artifactScrollEl;
+    if (!scrollEl) {
+      return 0;
+    }
+
+    return (
+      child.getBoundingClientRect().left -
+      scrollEl.getBoundingClientRect().left +
+      scrollEl.scrollLeft
+    );
+  }
+
+  private _findLeadingArtifactIndex(): number {
+    const scrollEl = this._artifactScrollEl;
+    const children = this._assignedArtifactElements ?? [];
+    if (!scrollEl || !children.length) {
+      return 0;
+    }
+
+    const scrollLeft = scrollEl.scrollLeft;
+    let index = 0;
+
+    for (let i = 0; i < children.length; i += 1) {
+      const offset = this._getArtifactScrollOffset(children[i]);
+      if (offset >= scrollLeft - 1) {
+        return i;
+      }
+      index = i;
+    }
+
+    return index;
+  }
+
+  private _scrollArtifactsByTile(direction: -1 | 1): void {
+    const scrollEl = this._artifactScrollEl;
+    const children = this._assignedArtifactElements ?? [];
+    if (!scrollEl || children.length < 2) {
+      return;
+    }
+
+    const currentIndex = this._findLeadingArtifactIndex();
+    const nextIndex = Math.max(
+      0,
+      Math.min(children.length - 1, currentIndex + direction)
+    );
+
+    if (nextIndex === currentIndex) {
+      return;
+    }
+
+    scrollEl.scrollTo({
+      left: this._getArtifactScrollOffset(children[nextIndex]),
+      behavior: 'smooth',
+    });
+  }
+
+  private _updateArtifactScrollState(): void {
+    const scrollEl = this._artifactScrollEl;
+    if (!scrollEl) {
+      this._artifactScrollOverflow = false;
+      this._artifactCanScrollPrev = false;
+      this._artifactCanScrollNext = false;
+      return;
+    }
+
+    const { scrollLeft, scrollWidth, clientWidth } = scrollEl;
+    const tolerance = 1;
+    const overflow = scrollWidth > clientWidth + tolerance;
+
+    this._artifactScrollOverflow = overflow;
+    this._artifactCanScrollPrev = overflow && scrollLeft > tolerance;
+    this._artifactCanScrollNext =
+      overflow && scrollLeft + clientWidth < scrollWidth - tolerance;
   }
 
   private _warnedMixedArtifactTypes = false;
@@ -270,17 +422,76 @@ export class PromptField extends SpectrumElement {
 
   private _renderArtifact(): TemplateResult {
     const artifactCount = this._assignedArtifactElements?.length ?? 0;
-    const artifactClass =
-      artifactCount <= 1
-        ? 'swc-PromptField-artifacts swc-PromptField-artifacts--single'
-        : 'swc-PromptField-artifacts swc-PromptField-artifacts--multiple';
+
+    if (artifactCount === 0) {
+      return html`
+        <div class="swc-PromptField-artifacts" hidden>
+          <slot
+            name="artifact"
+            @slotchange=${this._handleArtifactSlotChange}
+          ></slot>
+        </div>
+      `;
+    }
+
+    if (artifactCount === 1) {
+      return html`
+        <div
+          class="swc-PromptField-artifacts swc-PromptField-artifacts--single"
+        >
+          <slot
+            name="artifact"
+            @slotchange=${this._handleArtifactSlotChange}
+          ></slot>
+        </div>
+      `;
+    }
 
     return html`
-      <div class=${artifactClass} ?hidden=${artifactCount === 0}>
-        <slot
-          name="artifact"
-          @slotchange=${this._handleArtifactSlotChange}
-        ></slot>
+      <div
+        class="swc-PromptField-artifacts swc-PromptField-artifacts--multiple"
+      >
+        <div class="swc-PromptField-artifacts-row">
+          ${this._artifactScrollOverflow && this._artifactCanScrollPrev
+            ? html`
+                <button
+                  type="button"
+                  class="swc-PromptField-artifacts-scroll-prev"
+                  aria-label=${this.artifactScrollPrevLabel}
+                  @click=${() => this._scrollArtifactsByTile(-1)}
+                >
+                  <swc-icon size="s" aria-hidden="true">
+                    ${Chevron75Icon()}
+                  </swc-icon>
+                </button>
+              `
+            : nothing}
+          <div class="swc-PromptField-artifacts-viewport">
+            <div
+              class="swc-PromptField-artifacts-scroll"
+              @scroll=${this._handleArtifactScroll}
+            >
+              <slot
+                name="artifact"
+                @slotchange=${this._handleArtifactSlotChange}
+              ></slot>
+            </div>
+          </div>
+          ${this._artifactScrollOverflow && this._artifactCanScrollNext
+            ? html`
+                <button
+                  type="button"
+                  class="swc-PromptField-artifacts-scroll-next"
+                  aria-label=${this.artifactScrollNextLabel}
+                  @click=${() => this._scrollArtifactsByTile(1)}
+                >
+                  <swc-icon size="s" aria-hidden="true">
+                    ${Chevron75Icon()}
+                  </swc-icon>
+                </button>
+              `
+            : nothing}
+        </div>
       </div>
     `;
   }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -196,6 +196,14 @@ export class PromptField extends SpectrumElement {
   @state()
   private _artifactStripEntered = false;
 
+  /**
+   * Whether the strip has ever been entered before. On the very first entry
+   * there is no roving-controller memory yet, so `_enterArtifactStrip` lands
+   * on the first fully-visible tile instead of always tile 0; on every entry
+   * after that, the controller's own memory of the last-active tile wins.
+   */
+  private _artifactStripHasBeenEntered = false;
+
   /** Set in `willUpdate` when a chevron about to disappear currently has focus; consumed in `updated`. */
   private _pendingArtifactFocusRedirect: 'first' | 'last' | null = null;
 
@@ -470,15 +478,41 @@ export class PromptField extends SpectrumElement {
     }
   }
 
-  /** Moves focus into the artifact strip's active (or first) tile, entering it. */
+  /** The first tile that is fully (not partially) within the current scroll viewport. */
+  private _firstFullyVisibleArtifact(): HTMLElement | null {
+    const scrollEl = this._artifactScrollEl;
+    if (!scrollEl) {
+      return null;
+    }
+    return (
+      (this._assignedArtifactElements ?? []).find(
+        (el) => this._getArtifactTileVisibleFraction(el, scrollEl) >= 0.999
+      ) ?? null
+    );
+  }
+
+  /**
+   * Moves focus into the artifact strip, entering it. Prefers the tile the
+   * roving controller already remembers as active (e.g. re-entering after
+   * tabbing away); otherwise lands on the first fully-visible tile for the
+   * strip's current scroll position rather than always tile 0, so entering
+   * after scrolling doesn't jump focus off-screen.
+   */
   private _enterArtifactStrip(): void {
     const artifacts = this._assignedArtifactElements ?? [];
     if (artifacts.length === 0) {
       return;
     }
     this._artifactStripEntered = true;
+    // Read before `refresh()`: with no prior memory, `refresh()` itself
+    // defaults to tile 0, which would make it indistinguishable from a
+    // genuinely-remembered tile 0 once read back afterward.
+    const isFirstEntry = !this._artifactStripHasBeenEntered;
+    this._artifactStripHasBeenEntered = true;
     this._artifactNavigation.refresh();
-    const target = this._artifactNavigation.getActiveItem() ?? artifacts[0];
+    const target = isFirstEntry
+      ? (this._firstFullyVisibleArtifact() ?? artifacts[0])
+      : (this._artifactNavigation.getActiveItem() ?? artifacts[0]);
     this._focusArtifact(target);
   }
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -23,7 +23,6 @@ import {
   queryAssignedElements,
   state,
 } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -151,20 +150,13 @@ export class PromptField extends SpectrumElement {
 
   private _artifactScrollObserver?: ResizeObserver;
 
-  @state()
-  private _artifactScrollFromButtons = false;
-
-  @state()
-  private _artifactScrollbarInteracting = false;
-
-  private _artifactScrollButtonResetTimer?: number;
-
   /**
    * Roving tabindex + arrow-key focus movement across artifact tiles. The
    * first (or last-active, via `memory`) tile always carries `tabindex="0"`,
    * so it is Tab's first stop into the strip with no separate entry step;
    * Arrow Left/Right move that roving stop one tile at a time. Chevron
-   * buttons separately page by a full set, unrelated to this controller.
+   * buttons separately page by the scroll viewport, unrelated to this
+   * controller.
    */
   private readonly _artifactNavigation = new FocusgroupNavigationController(
     this,
@@ -179,12 +171,6 @@ export class PromptField extends SpectrumElement {
 
   /** Set in `willUpdate` when a chevron about to disappear currently has focus; consumed in `updated`. */
   private _pendingArtifactFocusRedirect: 'first' | 'last' | null = null;
-
-  private _artifactScrollbarInteractTimer?: number;
-
-  private _artifactScrollbarThumbDragOffset = 0;
-
-  private _artifactScrollbarDragCleanup?: () => void;
 
   private _pendingArtifactDismiss?: { artifact: HTMLElement; index: number };
 
@@ -207,13 +193,6 @@ export class PromptField extends SpectrumElement {
     );
     this._artifactScrollObserver?.disconnect();
     this._artifactScrollObserver = undefined;
-    if (this._artifactScrollButtonResetTimer !== undefined) {
-      window.clearTimeout(this._artifactScrollButtonResetTimer);
-    }
-    if (this._artifactScrollbarInteractTimer !== undefined) {
-      window.clearTimeout(this._artifactScrollbarInteractTimer);
-    }
-    this._artifactScrollbarDragCleanup?.();
     super.disconnectedCallback();
   }
 
@@ -224,15 +203,6 @@ export class PromptField extends SpectrumElement {
   protected override updated(): void {
     this._warnIfMissingLegalContent();
     this._applyArtifactChevronFocusRedirect();
-
-    if ((this._assignedArtifactElements?.length ?? 0) < 2) {
-      this._artifactScrollObserver?.disconnect();
-      return;
-    }
-
-    requestAnimationFrame(() => {
-      this._observeArtifactScrollViewport();
-    });
   }
 
   private _handleInput(event: Event): void {
@@ -366,71 +336,6 @@ export class PromptField extends SpectrumElement {
   private _handleArtifactScroll(): void {
     this._updateArtifactScrollState();
     this.requestUpdate();
-  }
-
-  private _getArtifactScrollbarThumbStyle(): Record<string, string> {
-    const scrollEl = this._artifactScrollEl;
-    if (!scrollEl) {
-      return { width: '0px', insetInlineStart: '0px' };
-    }
-
-    const { scrollWidth, clientWidth, scrollLeft } = scrollEl;
-    const tolerance = 1;
-    if (scrollWidth <= clientWidth + tolerance) {
-      return { width: '0px', insetInlineStart: '0px' };
-    }
-
-    const thumbWidth = Math.max((clientWidth / scrollWidth) * clientWidth, 24);
-    const maxScroll = this._getArtifactMaxScroll(scrollEl);
-    const maxThumbOffset = Math.max(0, clientWidth - thumbWidth);
-    const thumbOffset =
-      maxScroll > 0 ? (scrollLeft / maxScroll) * maxThumbOffset : 0;
-
-    return {
-      width: `${thumbWidth}px`,
-      insetInlineStart: `${thumbOffset}px`,
-    };
-  }
-
-  private _setArtifactScrollFromThumbOffset(
-    thumbOffset: number,
-    trackWidth: number
-  ): void {
-    const scrollEl = this._artifactScrollEl;
-    if (!scrollEl) {
-      return;
-    }
-
-    const thumbWidth = Math.max(
-      (scrollEl.clientWidth / scrollEl.scrollWidth) * scrollEl.clientWidth,
-      24
-    );
-    const maxThumbOffset = Math.max(0, trackWidth - thumbWidth);
-    const clampedOffset = Math.max(0, Math.min(maxThumbOffset, thumbOffset));
-    const maxScroll = this._getArtifactMaxScroll(scrollEl);
-    const ratio = maxThumbOffset > 0 ? clampedOffset / maxThumbOffset : 0;
-
-    scrollEl.scrollLeft = ratio * maxScroll;
-    this._updateArtifactScrollState();
-    this.requestUpdate();
-  }
-
-  private _showArtifactScrollbarFromInteraction(): void {
-    if (this._artifactScrollFromButtons) {
-      return;
-    }
-
-    this._artifactScrollbarInteracting = true;
-
-    if (this._artifactScrollbarInteractTimer !== undefined) {
-      window.clearTimeout(this._artifactScrollbarInteractTimer);
-    }
-
-    this._artifactScrollbarInteractTimer = window.setTimeout(() => {
-      this._artifactScrollbarInteracting = false;
-      this._artifactScrollbarInteractTimer = undefined;
-      this.requestUpdate();
-    }, 1000);
   }
 
   private _prefersReducedMotion(): boolean {
@@ -654,101 +559,6 @@ export class PromptField extends SpectrumElement {
     }
   }
 
-  private _handleArtifactWheel(event: WheelEvent): void {
-    if (Math.abs(event.deltaX) > 0 || Math.abs(event.deltaY) > 0) {
-      this._showArtifactScrollbarFromInteraction();
-      this.requestUpdate();
-    }
-  }
-
-  private _handleArtifactScrollbarLanePointerDown(event: PointerEvent): void {
-    if (this._artifactScrollFromButtons) {
-      return;
-    }
-
-    const lane = event.currentTarget as HTMLElement;
-    const laneRect = lane.getBoundingClientRect();
-    const thumbStyle = this._getArtifactScrollbarThumbStyle();
-    const thumbWidth = Number.parseFloat(thumbStyle.width) || 0;
-    const clickOffset = event.clientX - laneRect.left - thumbWidth / 2;
-
-    this._setArtifactScrollFromThumbOffset(clickOffset, laneRect.width);
-    this._showArtifactScrollbarFromInteraction();
-  }
-
-  private _handleArtifactScrollbarThumbPointerDown(event: PointerEvent): void {
-    event.stopPropagation();
-
-    if (this._artifactScrollFromButtons) {
-      return;
-    }
-
-    const thumb = event.currentTarget as HTMLElement;
-    const lane = thumb.parentElement;
-    if (!lane) {
-      return;
-    }
-
-    const thumbRect = thumb.getBoundingClientRect();
-    this._artifactScrollbarThumbDragOffset = event.clientX - thumbRect.left;
-    this._showArtifactScrollbarFromInteraction();
-
-    const onPointerMove = (moveEvent: PointerEvent): void => {
-      const laneRect = lane.getBoundingClientRect();
-      const thumbOffset =
-        moveEvent.clientX -
-        laneRect.left -
-        this._artifactScrollbarThumbDragOffset;
-      this._setArtifactScrollFromThumbOffset(thumbOffset, laneRect.width);
-      this._showArtifactScrollbarFromInteraction();
-    };
-
-    let onPointerUp: (() => void) | undefined;
-    const cleanup = (): void => {
-      window.removeEventListener('pointermove', onPointerMove);
-      if (onPointerUp) {
-        window.removeEventListener('pointerup', onPointerUp);
-        window.removeEventListener('pointercancel', onPointerUp);
-      }
-      if (this._artifactScrollbarDragCleanup === cleanup) {
-        this._artifactScrollbarDragCleanup = undefined;
-      }
-    };
-
-    onPointerUp = (): void => cleanup();
-
-    this._artifactScrollbarDragCleanup?.();
-    this._artifactScrollbarDragCleanup = cleanup;
-    window.addEventListener('pointermove', onPointerMove);
-    window.addEventListener('pointerup', onPointerUp);
-    window.addEventListener('pointercancel', onPointerUp);
-  }
-
-  private _markArtifactScrollFromButtons(): void {
-    const scrollEl = this._artifactScrollEl;
-    this._artifactScrollFromButtons = true;
-    this._artifactScrollbarInteracting = false;
-
-    if (this._artifactScrollbarInteractTimer !== undefined) {
-      window.clearTimeout(this._artifactScrollbarInteractTimer);
-      this._artifactScrollbarInteractTimer = undefined;
-    }
-
-    if (this._artifactScrollButtonResetTimer !== undefined) {
-      window.clearTimeout(this._artifactScrollButtonResetTimer);
-    }
-
-    const reset = (): void => {
-      this._artifactScrollFromButtons = false;
-      this._artifactScrollButtonResetTimer = undefined;
-      scrollEl?.removeEventListener('scrollend', reset);
-      this.requestUpdate();
-    };
-
-    scrollEl?.addEventListener('scrollend', reset, { once: true });
-    this._artifactScrollButtonResetTimer = window.setTimeout(reset, 600);
-  }
-
   private _observeArtifactScrollViewport(): void {
     const scrollEl = this._artifactScrollEl;
     if (!scrollEl) {
@@ -770,77 +580,30 @@ export class PromptField extends SpectrumElement {
     this._updateArtifactScrollState();
   }
 
-  private _getArtifactScrollOffset(child: HTMLElement): number {
-    const scrollEl = this._artifactScrollEl;
-    if (!scrollEl) {
-      return 0;
-    }
-
-    return (
-      child.getBoundingClientRect().left -
-      scrollEl.getBoundingClientRect().left +
-      scrollEl.scrollLeft
-    );
+  private _isRtl(): boolean {
+    return getComputedStyle(this).direction === 'rtl';
   }
 
-  private _getArtifactTileWidth(child: HTMLElement): number {
-    return child.getBoundingClientRect().width || child.offsetWidth;
-  }
-
-  private _getVisibleArtifactRange(): { first: number; last: number } {
+  private _getArtifactAtPageStart(direction: -1 | 1): HTMLElement {
     const scrollEl = this._artifactScrollEl;
     const children = this._assignedArtifactElements ?? [];
-    if (!scrollEl || !children.length) {
-      return { first: 0, last: 0 };
+    if (!scrollEl) {
+      return children[0]!;
     }
 
-    const scrollLeft = scrollEl.scrollLeft;
-    const viewportRight = scrollLeft + scrollEl.clientWidth;
-    const tolerance = 1;
-    let first = -1;
-    let last = -1;
+    const scrollRect = scrollEl.getBoundingClientRect();
+    const rtl = this._isRtl();
+    const pageStart = rtl
+      ? scrollRect.right - direction * scrollEl.clientWidth
+      : scrollRect.left + direction * scrollEl.clientWidth;
 
-    for (let i = 0; i < children.length; i += 1) {
-      const offset = this._getArtifactScrollOffset(children[i]);
-      const right = offset + this._getArtifactTileWidth(children[i]);
-      if (
-        right > scrollLeft + tolerance &&
-        offset < viewportRight - tolerance
-      ) {
-        if (first === -1) {
-          first = i;
-        }
-        last = i;
-      }
-    }
-
-    return {
-      first: first === -1 ? 0 : first,
-      last: last === -1 ? children.length - 1 : last,
-    };
-  }
-
-  private _getArtifactMaxScroll(scrollEl: HTMLDivElement): number {
-    return Math.max(0, scrollEl.scrollWidth - scrollEl.clientWidth);
-  }
-
-  private _getArtifactTileVisibleFraction(
-    child: HTMLElement,
-    scrollEl: HTMLDivElement
-  ): number {
-    const tileWidth = this._getArtifactTileWidth(child);
-    if (!tileWidth) {
-      return 0;
-    }
-
-    const offset = this._getArtifactScrollOffset(child);
-    const right = offset + tileWidth;
-    const scrollLeft = scrollEl.scrollLeft;
-    const viewportRight = scrollLeft + scrollEl.clientWidth;
-    const visibleWidth =
-      Math.min(right, viewportRight) - Math.max(offset, scrollLeft);
-
-    return Math.max(0, visibleWidth) / tileWidth;
+    return (
+      children.find((child) =>
+        rtl
+          ? child.getBoundingClientRect().right <= pageStart + 1
+          : child.getBoundingClientRect().left >= pageStart - 1
+      ) ?? children[children.length - 1]
+    );
   }
 
   private _scrollArtifactsByPage(direction: -1 | 1): void {
@@ -850,89 +613,21 @@ export class PromptField extends SpectrumElement {
       return;
     }
 
-    const tolerance = 1;
-    const maxScroll = this._getArtifactMaxScroll(scrollEl);
-    const { first, last } = this._getVisibleArtifactRange();
-
-    if (direction === 1) {
-      if (scrollEl.scrollLeft >= maxScroll - tolerance) {
-        return;
-      }
-
-      this._markArtifactScrollFromButtons();
-
-      if (last >= children.length - 1) {
-        // Land on the exact numeric maxScroll rather than a geometry-based
-        // scrollIntoView alignment: aligning the last tile's end edge can
-        // land a subpixel short of maxScroll (unlike aligning to the first
-        // tile's start, which is trivially exact at 0), leaving the next
-        // chevron stuck visible since it compares against this same maxScroll.
-        scrollEl.scrollTo({
-          left: maxScroll,
-          behavior: 'auto',
-        });
-        // Points the roving tab stop at the now-visible last tile, without
-        // moving focus off the Next button, so Shift+Tab from Next lands in
-        // the newly displayed set rather than wherever focus was left before
-        // paging.
-        this._artifactNavigation.setActiveItem(children[children.length - 1]);
-        return;
-      }
-
-      // last < children.length - 1 here (the "already at the end" case
-      // returned above), so an ambiguous edge tile (< 50% visible) is
-      // carried over as the next page's anchor; otherwise page fully.
-      const lastVisibleFraction = this._getArtifactTileVisibleFraction(
-        children[last],
-        scrollEl
-      );
-      const nextStart =
-        lastVisibleFraction >= 0.5 ? children[last + 1] : children[last];
-
-      nextStart.scrollIntoView({
-        behavior: this._artifactScrollBehavior(),
-        block: 'nearest',
-        inline: 'start',
-      });
-      // See the comment on the exact-maxScroll branch above.
-      this._artifactNavigation.setActiveItem(nextStart);
-      return;
-    }
-
-    if (first <= 0 && scrollEl.scrollLeft <= tolerance) {
-      return;
-    }
-
-    this._markArtifactScrollFromButtons();
-
-    if (first <= 0) {
-      children[0].scrollIntoView({
-        behavior: this._artifactScrollBehavior(),
-        block: 'nearest',
-        inline: 'start',
-      });
-      // Points the roving tab stop at the now-visible first tile, without
-      // moving focus off the Prev button, so Tab from Prev lands in the
-      // newly displayed set rather than wherever focus was left before
-      // paging.
-      this._artifactNavigation.setActiveItem(children[0]);
-      return;
-    }
-
-    const firstVisibleFraction = this._getArtifactTileVisibleFraction(
-      children[first],
-      scrollEl
-    );
-    const prevEnd =
-      firstVisibleFraction >= 0.5 ? children[first - 1] : children[first];
-
-    prevEnd.scrollIntoView({
+    scrollEl.scrollBy({
+      left: direction * scrollEl.clientWidth * (this._isRtl() ? -1 : 1),
       behavior: this._artifactScrollBehavior(),
-      block: 'nearest',
-      inline: 'end',
     });
-    // See the comment on the "first <= 0" branch above.
-    this._artifactNavigation.setActiveItem(prevEnd);
+    this._artifactNavigation.setActiveItem(
+      this._getArtifactAtPageStart(direction)
+    );
+  }
+
+  private _handleArtifactScrollPrev(): void {
+    this._scrollArtifactsByPage(-1);
+  }
+
+  private _handleArtifactScrollNext(): void {
+    this._scrollArtifactsByPage(1);
   }
 
   private _updateArtifactScrollState(): void {
@@ -944,15 +639,31 @@ export class PromptField extends SpectrumElement {
       return;
     }
 
-    const { scrollLeft, scrollWidth, clientWidth } = scrollEl;
+    const { scrollWidth, clientWidth } = scrollEl;
     const tolerance = 1;
     const overflow = scrollWidth > clientWidth + tolerance;
-    const maxScroll = this._getArtifactMaxScroll(scrollEl);
+    const children = this._assignedArtifactElements ?? [];
+    const firstArtifact = children[0];
+    const lastArtifact = children[children.length - 1];
 
     this._artifactScrollOverflow = overflow;
-    this._artifactCanScrollPrev = overflow && scrollLeft > tolerance;
-    this._artifactCanScrollNext =
-      overflow && scrollLeft < maxScroll - tolerance;
+    if (!overflow || !firstArtifact || !lastArtifact) {
+      this._artifactCanScrollPrev = false;
+      this._artifactCanScrollNext = false;
+      return;
+    }
+
+    const scrollRect = scrollEl.getBoundingClientRect();
+    const firstRect = firstArtifact.getBoundingClientRect();
+    const lastRect = lastArtifact.getBoundingClientRect();
+    const rtl = this._isRtl();
+
+    this._artifactCanScrollPrev = rtl
+      ? firstRect.right > scrollRect.right + tolerance
+      : firstRect.left < scrollRect.left - tolerance;
+    this._artifactCanScrollNext = rtl
+      ? lastRect.left < scrollRect.left - tolerance
+      : lastRect.right > scrollRect.right + tolerance;
   }
 
   private _warnedMixedArtifactTypes = false;
@@ -1107,7 +818,7 @@ export class PromptField extends SpectrumElement {
                   type="button"
                   class="swc-PromptField-artifacts-scroll-prev"
                   aria-label=${this.artifactScrollPrevLabel}
-                  @click=${() => this._scrollArtifactsByPage(-1)}
+                  @click=${this._handleArtifactScrollPrev}
                 >
                   <swc-icon size="s" aria-hidden="true">
                     ${Chevron75Icon()}
@@ -1121,15 +832,9 @@ export class PromptField extends SpectrumElement {
             aria-label=${this.artifactStripLabel}
           >
             <div
-              class=${classMap({
-                'swc-PromptField-artifacts-scroll': true,
-                'is-artifact-scroll-from-buttons':
-                  this._artifactScrollFromButtons,
-              })}
+              class="swc-PromptField-artifacts-scroll"
               tabindex="-1"
               @scroll=${this._handleArtifactScroll}
-              @wheel=${this._handleArtifactWheel}
-              @touchstart=${this._showArtifactScrollbarFromInteraction}
             >
               <div class="swc-PromptField-artifacts-tiles">
                 <slot
@@ -1138,26 +843,6 @@ export class PromptField extends SpectrumElement {
                 ></slot>
               </div>
             </div>
-            ${this._artifactScrollOverflow
-              ? html`
-                  <div
-                    class=${classMap({
-                      'swc-PromptField-artifacts-scrollbar-lane': true,
-                      'is-artifact-scrollbar-interacting':
-                        this._artifactScrollbarInteracting &&
-                        !this._artifactScrollFromButtons,
-                    })}
-                    @pointerdown=${this._handleArtifactScrollbarLanePointerDown}
-                  >
-                    <div
-                      class="swc-PromptField-artifacts-scrollbar-thumb"
-                      style=${styleMap(this._getArtifactScrollbarThumbStyle())}
-                      @pointerdown=${this
-                        ._handleArtifactScrollbarThumbPointerDown}
-                    ></div>
-                  </div>
-                `
-              : nothing}
             ${this._artifactCanScrollPrev
               ? html`
                   <div
@@ -1181,7 +866,7 @@ export class PromptField extends SpectrumElement {
                   type="button"
                   class="swc-PromptField-artifacts-scroll-next"
                   aria-label=${this.artifactScrollNextLabel}
-                  @click=${() => this._scrollArtifactsByPage(1)}
+                  @click=${this._handleArtifactScrollNext}
                 >
                   <swc-icon size="s" aria-hidden="true">
                     ${Chevron75Icon()}

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -60,6 +60,11 @@ export type PromptFieldMode = 'default' | 'loading' | 'disabled';
  *
  * @element swc-prompt-field
  *
+ * @example
+ * <swc-prompt-field label="Prompt">
+ *   <div slot="legal">Responses are generated using AI and may be inaccurate.</div>
+ * </swc-prompt-field>
+ *
  * @slot artifact - Optional attachment preview(s). Use one `swc-upload-artifact` type per session (cards only, or media only).
  * @slot legal - Legal disclaimer content. Required in product implementations; provide Legal-approved copy.
  * @fires swc-prompt-field-input - Dispatched after the textarea value is internally updated.
@@ -215,8 +220,8 @@ export class PromptField extends SpectrumElement {
     return [styles];
   }
 
-  public constructor() {
-    super();
+  public override connectedCallback(): void {
+    super.connectedCallback();
     this.addEventListener(
       focusgroupNavigationActiveChange,
       this._handleArtifactActiveChange as EventListener
@@ -224,6 +229,10 @@ export class PromptField extends SpectrumElement {
   }
 
   public override disconnectedCallback(): void {
+    this.removeEventListener(
+      focusgroupNavigationActiveChange,
+      this._handleArtifactActiveChange as EventListener
+    );
     this._artifactScrollObserver?.disconnect();
     this._artifactScrollObserver = undefined;
     if (this._artifactScrollButtonResetTimer !== undefined) {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -349,6 +349,17 @@ export class PromptField extends SpectrumElement {
   private _handleArtifactSlotChange(): void {
     this._warnIfMixedArtifactTypes();
     this._artifactNavigation.refresh();
+    // A single artifact has no row wrapper to act as its Tab stop (unlike the
+    // 2+ roving-tabindex strip), so it must carry its own tabindex directly;
+    // ponytail: reachable via Tab, not yet wired into arrow-key navigation.
+    const artifacts = this._assignedArtifactElements ?? [];
+    if (artifacts.length === 1) {
+      artifacts[0].tabIndex = 0;
+    } else {
+      for (const el of artifacts) {
+        el.tabIndex = -1;
+      }
+    }
     const dismissedArtifact = this._pendingArtifactDismiss;
     const dismissedArtifactWasRemoved =
       dismissedArtifact !== undefined &&

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -693,6 +693,51 @@ export class PromptField extends SpectrumElement {
   }
 
   /**
+   * A single artifact has no row wrapper or roving-tabindex controller (see
+   * `_handleArtifactRowKeydown`/`_handleArtifactTabKey`), so Tab from the
+   * tile would otherwise fall through to the next default tab stop (the
+   * textarea) and skip its Close button entirely.
+   */
+  private _handleSingleArtifactKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const tile = (this._assignedArtifactElements ?? [])[0];
+    if (!tile) {
+      return;
+    }
+
+    const active = getActiveElement();
+    if (active === tile) {
+      if (event.shiftKey) {
+        return;
+      }
+      const dismiss = tile.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-UploadArtifact-dismiss'
+      );
+      if (dismiss && !dismiss.hidden) {
+        event.preventDefault();
+        dismiss.focus();
+      }
+      return;
+    }
+
+    if (!event.shiftKey || !active) {
+      return;
+    }
+    const root = active.getRootNode();
+    if (
+      root instanceof ShadowRoot &&
+      root.host === tile &&
+      active.classList.contains('swc-UploadArtifact-dismiss')
+    ) {
+      event.preventDefault();
+      tile.focus();
+    }
+  }
+
+  /**
    * Temporarily takes the strip container out of the Tab order so the
    * browser's own (un-prevented) Shift+Tab default action lands on the "<"
    * button (if rendered) or whatever precedes the strip, rather than
@@ -1174,6 +1219,7 @@ export class PromptField extends SpectrumElement {
         <div
           class="swc-PromptField-artifacts swc-PromptField-artifacts--single"
           @swc-upload-artifact-dismiss=${this._handleArtifactDismiss}
+          @keydown=${this._handleSingleArtifactKeydown}
         >
           <slot
             name="artifact"

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -216,6 +216,10 @@ export class PromptField extends SpectrumElement {
 
   private _artifactScrollbarThumbDragOffset = 0;
 
+  private _artifactScrollbarDragCleanup?: () => void;
+
+  private _pendingArtifactDismiss?: { artifact: HTMLElement; index: number };
+
   public static override get styles(): CSSResultArray {
     return [styles];
   }
@@ -241,6 +245,7 @@ export class PromptField extends SpectrumElement {
     if (this._artifactScrollbarInteractTimer !== undefined) {
       window.clearTimeout(this._artifactScrollbarInteractTimer);
     }
+    this._artifactScrollbarDragCleanup?.();
     super.disconnectedCallback();
   }
 
@@ -344,13 +349,63 @@ export class PromptField extends SpectrumElement {
   private _handleArtifactSlotChange(): void {
     this._warnIfMixedArtifactTypes();
     this._artifactNavigation.refresh();
+    const dismissedArtifact = this._pendingArtifactDismiss;
+    const dismissedArtifactWasRemoved =
+      dismissedArtifact !== undefined &&
+      !(this._assignedArtifactElements ?? []).includes(
+        dismissedArtifact.artifact
+      );
+    if (dismissedArtifactWasRemoved) {
+      this._pendingArtifactDismiss = undefined;
+    }
     this.requestUpdate();
     void this.updateComplete.then(() => {
       requestAnimationFrame(() => {
         this._observeArtifactScrollViewport();
         this._updateArtifactScrollState();
+        if (dismissedArtifactWasRemoved && dismissedArtifact) {
+          this._restoreArtifactFocusAfterDismiss(dismissedArtifact.index);
+        }
       });
     });
+  }
+
+  private _handleArtifactDismiss(event: Event): void {
+    const active = getActiveElement();
+    const artifact = event.composedPath().find(
+      (node): node is HTMLElement =>
+        node instanceof HTMLElement &&
+        (this._assignedArtifactElements ?? []).includes(node)
+    );
+    if (!artifact || !active || !deepContains(artifact, active)) {
+      return;
+    }
+
+    this._pendingArtifactDismiss = {
+      artifact,
+      index: (this._assignedArtifactElements ?? []).indexOf(artifact),
+    };
+  }
+
+  private _restoreArtifactFocusAfterDismiss(index: number): void {
+    const artifacts = this._assignedArtifactElements ?? [];
+    if (artifacts.length === 0) {
+      this.shadowRoot
+        ?.querySelector<HTMLTextAreaElement>('.swc-PromptField-textarea')
+        ?.focus();
+      return;
+    }
+
+    const target = artifacts[Math.min(index, artifacts.length - 1)];
+    if (artifacts.length === 1) {
+      target.tabIndex = 0;
+      target.focus();
+      return;
+    }
+
+    this._artifactStripEntered = true;
+    this._artifactNavigation.refresh();
+    this._focusArtifact(target);
   }
 
   private _handleArtifactScroll(): void {
@@ -430,10 +485,14 @@ export class PromptField extends SpectrumElement {
     );
   }
 
+  private _artifactScrollBehavior(): ScrollBehavior {
+    return this._prefersReducedMotion() ? 'auto' : 'smooth';
+  }
+
   private _focusArtifact(el: HTMLElement): void {
     this._artifactNavigation.setActiveItem(el);
     el.scrollIntoView({
-      behavior: this._prefersReducedMotion() ? 'auto' : 'smooth',
+      behavior: this._artifactScrollBehavior(),
       block: 'nearest',
       inline: 'nearest',
     });
@@ -452,7 +511,7 @@ export class PromptField extends SpectrumElement {
       this._artifactStripEntered = true;
     }
     activeElement.scrollIntoView({
-      behavior: this._prefersReducedMotion() ? 'auto' : 'smooth',
+      behavior: this._artifactScrollBehavior(),
       block: 'nearest',
       inline: 'nearest',
     });
@@ -739,12 +798,22 @@ export class PromptField extends SpectrumElement {
       this._showArtifactScrollbarFromInteraction();
     };
 
-    const onPointerUp = (): void => {
+    let onPointerUp: (() => void) | undefined;
+    const cleanup = (): void => {
       window.removeEventListener('pointermove', onPointerMove);
-      window.removeEventListener('pointerup', onPointerUp);
-      window.removeEventListener('pointercancel', onPointerUp);
+      if (onPointerUp) {
+        window.removeEventListener('pointerup', onPointerUp);
+        window.removeEventListener('pointercancel', onPointerUp);
+      }
+      if (this._artifactScrollbarDragCleanup === cleanup) {
+        this._artifactScrollbarDragCleanup = undefined;
+      }
     };
 
+    onPointerUp = (): void => cleanup();
+
+    this._artifactScrollbarDragCleanup?.();
+    this._artifactScrollbarDragCleanup = cleanup;
     window.addEventListener('pointermove', onPointerMove);
     window.addEventListener('pointerup', onPointerUp);
     window.addEventListener('pointercancel', onPointerUp);
@@ -768,6 +837,7 @@ export class PromptField extends SpectrumElement {
       this._artifactScrollFromButtons = false;
       this._artifactScrollButtonResetTimer = undefined;
       scrollEl?.removeEventListener('scrollend', reset);
+      this.requestUpdate();
     };
 
     scrollEl?.addEventListener('scrollend', reset, { once: true });
@@ -892,7 +962,10 @@ export class PromptField extends SpectrumElement {
         // land a subpixel short of maxScroll (unlike aligning to the first
         // tile's start, which is trivially exact at 0), leaving the next
         // chevron stuck visible since it compares against this same maxScroll.
-        scrollEl.scrollTo({ left: maxScroll, behavior: 'smooth' });
+        scrollEl.scrollTo({
+          left: maxScroll,
+          behavior: this._artifactScrollBehavior(),
+        });
         return;
       }
 
@@ -907,7 +980,7 @@ export class PromptField extends SpectrumElement {
         lastVisibleFraction >= 0.5 ? children[last + 1] : children[last];
 
       nextStart.scrollIntoView({
-        behavior: 'smooth',
+        behavior: this._artifactScrollBehavior(),
         block: 'nearest',
         inline: 'start',
       });
@@ -922,7 +995,7 @@ export class PromptField extends SpectrumElement {
 
     if (first <= 0) {
       children[0].scrollIntoView({
-        behavior: 'smooth',
+        behavior: this._artifactScrollBehavior(),
         block: 'nearest',
         inline: 'start',
       });
@@ -937,7 +1010,7 @@ export class PromptField extends SpectrumElement {
       firstVisibleFraction >= 0.5 ? children[first - 1] : children[first];
 
     prevEnd.scrollIntoView({
-      behavior: 'smooth',
+      behavior: this._artifactScrollBehavior(),
       block: 'nearest',
       inline: 'end',
     });
@@ -968,6 +1041,10 @@ export class PromptField extends SpectrumElement {
   private _warnedMissingLegalContent = false;
 
   private _warnIfMixedArtifactTypes(): void {
+    if (!window.__swc?.DEBUG) {
+      return;
+    }
+
     const elements = this._assignedArtifactElements ?? [];
     const types = new Set(
       elements
@@ -988,12 +1065,18 @@ export class PromptField extends SpectrumElement {
     }
 
     this._warnedMixedArtifactTypes = true;
-    console.warn(
-      '[swc-prompt-field] The artifact slot contains both card and media upload artifacts. Use one layout type per composer session (all card or all media). When uploads mix images and documents, normalize to media tiles with thumbnails and optional badges. See upload-artifact documentation.'
+    window.__swc.warn(
+      this,
+      'The artifact slot contains both card and media upload artifacts. Use one layout type per composer session (all card or all media). When uploads mix images and documents, normalize to media tiles with thumbnails and optional badges.',
+      'https://opensource.adobe.com/spectrum-web-components/patterns/conversational-ai/prompt-field/'
     );
   }
 
   private _warnIfMissingLegalContent(): void {
+    if (!window.__swc?.DEBUG) {
+      return;
+    }
+
     const elements = this._assignedLegalElements ?? [];
 
     if (elements.length > 0) {
@@ -1006,8 +1089,10 @@ export class PromptField extends SpectrumElement {
     }
 
     this._warnedMissingLegalContent = true;
-    console.warn(
-      '[swc-prompt-field] The legal slot is empty. Product implementations must provide Legal-approved disclaimer content via the legal slot. See prompt-field documentation.'
+    window.__swc.warn(
+      this,
+      'The legal slot is empty. Product implementations must provide Legal-approved disclaimer content via the legal slot.',
+      'https://opensource.adobe.com/spectrum-web-components/patterns/conversational-ai/prompt-field/'
     );
   }
 
@@ -1077,6 +1162,7 @@ export class PromptField extends SpectrumElement {
       return html`
         <div
           class="swc-PromptField-artifacts swc-PromptField-artifacts--single"
+          @swc-upload-artifact-dismiss=${this._handleArtifactDismiss}
         >
           <slot
             name="artifact"
@@ -1089,6 +1175,7 @@ export class PromptField extends SpectrumElement {
     return html`
       <div
         class="swc-PromptField-artifacts swc-PromptField-artifacts--multiple"
+        @swc-upload-artifact-dismiss=${this._handleArtifactDismiss}
       >
         <div
           class="swc-PromptField-artifacts-row"

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -23,6 +23,7 @@ import {
   queryAssignedElements,
   state,
 } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -165,7 +166,6 @@ export class PromptField extends SpectrumElement {
       wrap: false,
       memory: true,
       getItems: () => this._assignedArtifactElements ?? [],
-      onActiveItemChange: () => this.requestUpdate(),
     }
   );
 
@@ -336,6 +336,74 @@ export class PromptField extends SpectrumElement {
   private _handleArtifactScroll(): void {
     this._updateArtifactScrollState();
     this.requestUpdate();
+  }
+
+  /**
+   * `scrollend`, not `scroll`: paging/scrollbar-drag animate over several
+   * frames, and `scroll` fires on every one of them. Checking visibility
+   * mid-animation can see a tile transiently pass through the visible
+   * region and lock it in as active before the scroll settles on its
+   * actual destination (`_scrollArtifactsByPage` already sets the correct
+   * active tile up front, but this can still race and clobber it).
+   * `scrollend` only fires once scrolling has actually stopped.
+   */
+  private _handleArtifactScrollEnd(): void {
+    this._syncArtifactActiveItemToVisible();
+  }
+
+  /**
+   * `memory` keeps the roving tab stop on whichever tile was last active,
+   * with no awareness of scroll position. Left alone, Tab from a chevron
+   * (or back into the strip generally) can land on a tile that's no longer
+   * visible, having scrolled out from under it. Re-point the roving stop
+   * at a currently visible tile whenever the strip scrolls, so Tab always
+   * lands somewhere the user can see.
+   */
+  private _syncArtifactActiveItemToVisible(): void {
+    const scrollEl = this._artifactScrollEl;
+    const artifacts = this._assignedArtifactElements ?? [];
+    if (!scrollEl || artifacts.length < 2) {
+      return;
+    }
+
+    const active = this._artifactNavigation.getActiveItem();
+    if (active && this._isArtifactVisible(active, scrollEl)) {
+      return;
+    }
+
+    const firstVisible = artifacts.find((artifact) =>
+      this._isArtifactVisible(artifact, scrollEl)
+    );
+    if (firstVisible) {
+      this._artifactNavigation.setActiveItem(firstVisible);
+    }
+  }
+
+  /**
+   * A tile clear of the chevron overlays on both sides, not just inside
+   * the scroll container's own clipping bounds. Reads the same
+   * `scroll-padding-inline` the `has-scroll-prev`/`has-scroll-next` CSS
+   * rules set (prompt-field.css) as the single source of truth for how
+   * much clearance a visible chevron needs, instead of duplicating that
+   * math here.
+   */
+  private _isArtifactVisible(
+    artifact: HTMLElement,
+    scrollEl: HTMLElement
+  ): boolean {
+    const scrollRect = scrollEl.getBoundingClientRect();
+    const scrollStyle = getComputedStyle(scrollEl);
+    const paddingLeft = parseFloat(scrollStyle.scrollPaddingLeft) || 0;
+    const paddingRight = parseFloat(scrollStyle.scrollPaddingRight) || 0;
+    const visibleLeft = scrollRect.left + paddingLeft;
+    const visibleRight = scrollRect.right - paddingRight;
+
+    const rect = artifact.getBoundingClientRect();
+    const tolerance = 1;
+    return (
+      rect.left >= visibleLeft - tolerance &&
+      rect.right <= visibleRight + tolerance
+    );
   }
 
   private _prefersReducedMotion(): boolean {
@@ -832,9 +900,14 @@ export class PromptField extends SpectrumElement {
             aria-label=${this.artifactStripLabel}
           >
             <div
-              class="swc-PromptField-artifacts-scroll"
+              class=${classMap({
+                'swc-PromptField-artifacts-scroll': true,
+                'has-scroll-prev': this._artifactCanScrollPrev,
+                'has-scroll-next': this._artifactCanScrollNext,
+              })}
               tabindex="-1"
               @scroll=${this._handleArtifactScroll}
+              @scrollend=${this._handleArtifactScrollEnd}
             >
               <div class="swc-PromptField-artifacts-tiles">
                 <slot

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -140,13 +140,6 @@ export class PromptField extends SpectrumElement {
   @queryAssignedElements({ slot: 'legal', flatten: true })
   private _assignedLegalElements!: HTMLElement[];
 
-  /** Next textarea focus follows pointerdown on the textarea (click/touch). */
-  private _textareaFocusFromPointer = false;
-
-  /** Outer card ring: Tab / non-pointer focus only (see prompt-field.css). */
-  @state()
-  private _promptBoxKeyboardFocusRing = false;
-
   @state()
   private _artifactScrollOverflow = false;
 
@@ -252,27 +245,6 @@ export class PromptField extends SpectrumElement {
         detail: { value: this.value },
       })
     );
-  }
-
-  private _handleTextareaPointerDown(event: PointerEvent): void {
-    const textarea = event.currentTarget as HTMLTextAreaElement;
-    if (textarea.matches(':focus')) {
-      this._promptBoxKeyboardFocusRing = false;
-      return;
-    }
-
-    this._textareaFocusFromPointer = true;
-  }
-
-  private _handleTextareaFocusIn(): void {
-    const showRing = !this._textareaFocusFromPointer;
-    this._textareaFocusFromPointer = false;
-    this._promptBoxKeyboardFocusRing = showRing;
-  }
-
-  private _handleTextareaFocusOut(): void {
-    this._promptBoxKeyboardFocusRing = false;
-    this._textareaFocusFromPointer = false;
   }
 
   private _handleTextareaKeydown(event: KeyboardEvent): void {
@@ -1253,11 +1225,7 @@ export class PromptField extends SpectrumElement {
 
     return html`
       <div class="swc-PromptField">
-        <div
-          class="swc-PromptField-box${this._promptBoxKeyboardFocusRing
-            ? ' swc-PromptField-box--keyboard-focus'
-            : ''}"
-        >
+        <div class="swc-PromptField-box">
           <div
             class="swc-PromptField-input-area${hasArtifacts
               ? ' has-artifact'
@@ -1291,9 +1259,6 @@ export class PromptField extends SpectrumElement {
                 })}
                 @input=${this._handleInput}
                 @keydown=${this._handleTextareaKeydown}
-                @pointerdown=${this._handleTextareaPointerDown}
-                @focusin=${this._handleTextareaFocusIn}
-                @focusout=${this._handleTextareaFocusOut}
               ></textarea>
             </div>
           </div>

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -144,6 +144,17 @@ export class PromptField extends SpectrumElement {
   @state()
   private _artifactCanScrollNext = false;
 
+  // `scrollend` support isn't a reliable gate on its own: browsers that
+  // report support (feature-detected via `'onscrollend' in window`) can
+  // still skip firing it for particular scroll triggers (observed on both
+  // this project's WebKit and Firefox test runners). So this always races
+  // a poll against the real event instead of trusting either alone —
+  // bumped on every `scroll` tick, on a real `scrollend`, and on
+  // disconnect, so a stale poll (superseded by a newer scroll, a real
+  // `scrollend` winning first, or the host going away) is a no-op instead
+  // of firing late.
+  private _artifactScrollFallbackGeneration = 0;
+
   // Observed targets accumulate across slot changes (dismissed tiles are
   // never explicitly unobserved); the browser drops a target's callbacks
   // once it leaves the DOM, so this is a bounded, harmless handful of
@@ -194,6 +205,7 @@ export class PromptField extends SpectrumElement {
       focusgroupNavigationActiveChange,
       this._handleArtifactActiveChange as EventListener
     );
+    this._artifactScrollFallbackGeneration++;
     super.disconnectedCallback();
   }
 
@@ -329,8 +341,38 @@ export class PromptField extends SpectrumElement {
     this._focusArtifact(target);
   }
 
+  // Restarts a poll on every `scroll` tick that settles once `scrollLeft`
+  // holds steady for a few frames — racing the real `scrollend` listener
+  // below, not gated behind feature detection (see
+  // `_artifactScrollFallbackGeneration`'s doc for why). A fixed setTimeout
+  // delay would race against a real scroll's own frame cadence instead
+  // (fire early mid-gesture, or late enough to feel unresponsive); polling
+  // for actual stability can't.
   private _handleArtifactScroll(): void {
-    this.requestUpdate();
+    const scrollEl = this._artifactScrollEl;
+    if (!scrollEl) {
+      return;
+    }
+
+    const generation = ++this._artifactScrollFallbackGeneration;
+    let lastScrollLeft = scrollEl.scrollLeft;
+    let stableFrames = 0;
+    const poll = (): void => {
+      if (generation !== this._artifactScrollFallbackGeneration) {
+        return;
+      }
+      if (scrollEl.scrollLeft !== lastScrollLeft) {
+        lastScrollLeft = scrollEl.scrollLeft;
+        stableFrames = 0;
+      } else if (++stableFrames < 3) {
+        // not yet settled
+      } else {
+        this._handleArtifactScrollEnd();
+        return;
+      }
+      requestAnimationFrame(poll);
+    };
+    requestAnimationFrame(poll);
   }
 
   /**
@@ -339,8 +381,14 @@ export class PromptField extends SpectrumElement {
    * can lock in a tile that's only transiently passing through the
    * visible region as active, or flip the chevrons' aria-disabled state
    * back and forth for no reason a user would ever see settled.
+   *
+   * Also reachable from `_handleArtifactScroll`'s poll, which is why this
+   * bumps the generation counter itself: whichever of the two (a real
+   * `scrollend`, or the poll settling) happens first wins, and that
+   * invalidates the other so it can't also fire.
    */
   private _handleArtifactScrollEnd(): void {
+    this._artifactScrollFallbackGeneration++;
     this._updateArtifactScrollState();
     void this.updateComplete.then(() =>
       this._syncArtifactActiveItemToVisible()
@@ -362,40 +410,42 @@ export class PromptField extends SpectrumElement {
       return;
     }
 
+    const { left, right } = this._artifactVisibleBounds(scrollEl);
     const active = this._artifactNavigation.getActiveItem();
-    if (active && this._isArtifactVisible(active, scrollEl)) {
+    if (active && this._isArtifactVisible(active, left, right)) {
       return;
     }
 
-    const scrollRect = scrollEl.getBoundingClientRect();
-    const scrollStyle = getComputedStyle(scrollEl);
-    const visibleStart = this._isRtl()
-      ? scrollRect.right - (parseFloat(scrollStyle.scrollPaddingRight) || 0)
-      : scrollRect.left + (parseFloat(scrollStyle.scrollPaddingLeft) || 0);
     this._artifactNavigation.setActiveItem(
-      this._findArtifactAtOrPastBoundary(visibleStart)
+      this._findArtifactAtOrPastBoundary(this._isRtl() ? right : left)
     );
   }
 
   /**
-   * A tile clear of the chevron overlays on both sides, not just inside
-   * the scroll container's own clipping bounds. Reads the same
-   * `scroll-padding-inline` the `has-scroll-prev`/`has-scroll-next` CSS
-   * rules set (prompt-field.css) as the single source of truth for how
-   * much clearance a visible chevron needs, instead of duplicating that
-   * math here.
+   * The scroll viewport's own bounds, clear of the chevron overlays on
+   * both sides. Reads the same `scroll-padding-inline` the
+   * `has-scroll-prev`/`has-scroll-next` CSS rules set (prompt-field.css)
+   * as the single source of truth for how much clearance a visible
+   * chevron needs, instead of duplicating that math here.
    */
-  private _isArtifactVisible(
-    artifact: HTMLElement,
-    scrollEl: HTMLElement
-  ): boolean {
+  private _artifactVisibleBounds(scrollEl: HTMLElement): {
+    left: number;
+    right: number;
+  } {
     const scrollRect = scrollEl.getBoundingClientRect();
     const scrollStyle = getComputedStyle(scrollEl);
-    const paddingLeft = parseFloat(scrollStyle.scrollPaddingLeft) || 0;
-    const paddingRight = parseFloat(scrollStyle.scrollPaddingRight) || 0;
-    const visibleLeft = scrollRect.left + paddingLeft;
-    const visibleRight = scrollRect.right - paddingRight;
+    return {
+      left: scrollRect.left + (parseFloat(scrollStyle.scrollPaddingLeft) || 0),
+      right:
+        scrollRect.right - (parseFloat(scrollStyle.scrollPaddingRight) || 0),
+    };
+  }
 
+  private _isArtifactVisible(
+    artifact: HTMLElement,
+    visibleLeft: number,
+    visibleRight: number
+  ): boolean {
     const rect = artifact.getBoundingClientRect();
     const tolerance = 1;
     return (

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -330,17 +330,18 @@ export class PromptField extends SpectrumElement {
   }
 
   private _handleArtifactScroll(): void {
-    this._updateArtifactScrollState();
     this.requestUpdate();
   }
 
   /**
    * `scrollend`, not `scroll`: paging/scrollbar-drag animate over several
-   * frames, and `scroll` fires on every one of them. Checking visibility
-   * mid-animation can lock in a tile that's only transiently passing
-   * through the visible region.
+   * frames, and `scroll` fires on every one of them. Reacting mid-gesture
+   * can lock in a tile that's only transiently passing through the
+   * visible region as active, or flip the chevrons' aria-disabled state
+   * back and forth for no reason a user would ever see settled.
    */
   private _handleArtifactScrollEnd(): void {
+    this._updateArtifactScrollState();
     void this.updateComplete.then(() =>
       this._syncArtifactActiveItemToVisible()
     );
@@ -403,21 +404,9 @@ export class PromptField extends SpectrumElement {
     );
   }
 
-  private _prefersReducedMotion(): boolean {
-    return (
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    );
-  }
-
-  private _artifactScrollBehavior(): ScrollBehavior {
-    return this._prefersReducedMotion() ? 'auto' : 'smooth';
-  }
-
   private _focusArtifact(el: HTMLElement): void {
     this._artifactNavigation.setActiveItem(el);
     el.scrollIntoView({
-      behavior: this._artifactScrollBehavior(),
       block: 'nearest',
       inline: 'nearest',
     });
@@ -433,7 +422,6 @@ export class PromptField extends SpectrumElement {
       return;
     }
     activeElement.scrollIntoView({
-      behavior: this._artifactScrollBehavior(),
       block: 'nearest',
       inline: 'nearest',
     });
@@ -624,7 +612,6 @@ export class PromptField extends SpectrumElement {
 
     scrollEl.scrollBy({
       left: direction * scrollEl.clientWidth * (this._isRtl() ? -1 : 1),
-      behavior: this._artifactScrollBehavior(),
     });
 
     const scrollRect = scrollEl.getBoundingClientRect();

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -26,6 +26,7 @@ import {
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import { ResizeController } from '@lit-labs/observers/resize-controller.js';
 
 import { Chevron75Icon } from '@adobe/spectrum-wc/icon/elements/index.js';
 import {
@@ -149,7 +150,18 @@ export class PromptField extends SpectrumElement {
   @state()
   private _artifactCanScrollNext = false;
 
-  private _artifactScrollObserver?: ResizeObserver;
+  // Observed targets accumulate across slot changes (dismissed tiles are
+  // never explicitly unobserved); the browser drops a target's callbacks
+  // once it leaves the DOM, so this is a bounded, harmless handful of
+  // stale references for a chat composer's tile count, not an unbounded
+  // leak. Revisit with explicit unobserve() bookkeeping if this is ever
+  // reused somewhere with much larger, longer-lived tile counts.
+  private readonly _artifactScrollObserver = new ResizeController(this, {
+    target: null,
+    callback: () => {
+      this._updateArtifactScrollState();
+    },
+  });
 
   /**
    * Roving tabindex + arrow-key focus movement across artifact tiles. The
@@ -191,8 +203,6 @@ export class PromptField extends SpectrumElement {
       focusgroupNavigationActiveChange,
       this._handleArtifactActiveChange as EventListener
     );
-    this._artifactScrollObserver?.disconnect();
-    this._artifactScrollObserver = undefined;
     super.disconnectedCallback();
   }
 
@@ -371,12 +381,14 @@ export class PromptField extends SpectrumElement {
       return;
     }
 
-    const firstVisible = artifacts.find((artifact) =>
-      this._isArtifactVisible(artifact, scrollEl)
+    const scrollRect = scrollEl.getBoundingClientRect();
+    const scrollStyle = getComputedStyle(scrollEl);
+    const visibleStart = this._isRtl()
+      ? scrollRect.right - (parseFloat(scrollStyle.scrollPaddingRight) || 0)
+      : scrollRect.left + (parseFloat(scrollStyle.scrollPaddingLeft) || 0);
+    this._artifactNavigation.setActiveItem(
+      this._findArtifactAtOrPastBoundary(visibleStart)
     );
-    if (firstVisible) {
-      this._artifactNavigation.setActiveItem(firstVisible);
-    }
   }
 
   /**
@@ -630,17 +642,9 @@ export class PromptField extends SpectrumElement {
   private _observeArtifactScrollViewport(): void {
     const scrollEl = this._artifactScrollEl;
     if (!scrollEl) {
-      this._artifactScrollObserver?.disconnect();
       return;
     }
 
-    if (!this._artifactScrollObserver) {
-      this._artifactScrollObserver = new ResizeObserver(() => {
-        this._updateArtifactScrollState();
-      });
-    }
-
-    this._artifactScrollObserver.disconnect();
     this._artifactScrollObserver.observe(scrollEl);
     for (const element of this._assignedArtifactElements ?? []) {
       this._artifactScrollObserver.observe(element);
@@ -652,25 +656,25 @@ export class PromptField extends SpectrumElement {
     return getComputedStyle(this).direction === 'rtl';
   }
 
-  private _getArtifactAtPageStart(direction: -1 | 1): HTMLElement {
-    const scrollEl = this._artifactScrollEl;
+  /**
+   * First artifact whose leading (reading-direction-start) edge is at or
+   * past the physical viewport x-coordinate `boundary`. Falls back to the
+   * last artifact if none qualify. Shared by `_scrollArtifactsByPage`
+   * (`boundary` is where the next/previous page will start) and
+   * `_syncArtifactActiveItemToVisible` (`boundary` is the visible
+   * window's own start edge) so both "find the first artifact at a given
+   * point" needs go through one RTL-aware comparison instead of two.
+   */
+  private _findArtifactAtOrPastBoundary(boundary: number): HTMLElement {
     const children = this._assignedArtifactElements ?? [];
-    if (!scrollEl) {
-      return children[0]!;
-    }
-
-    const scrollRect = scrollEl.getBoundingClientRect();
     const rtl = this._isRtl();
-    const pageStart = rtl
-      ? scrollRect.right - direction * scrollEl.clientWidth
-      : scrollRect.left + direction * scrollEl.clientWidth;
-
+    const tolerance = 1;
     return (
       children.find((child) =>
         rtl
-          ? child.getBoundingClientRect().right <= pageStart + 1
-          : child.getBoundingClientRect().left >= pageStart - 1
-      ) ?? children[children.length - 1]
+          ? child.getBoundingClientRect().right <= boundary + tolerance
+          : child.getBoundingClientRect().left >= boundary - tolerance
+      ) ?? children[children.length - 1]!
     );
   }
 
@@ -685,8 +689,13 @@ export class PromptField extends SpectrumElement {
       left: direction * scrollEl.clientWidth * (this._isRtl() ? -1 : 1),
       behavior: this._artifactScrollBehavior(),
     });
+
+    const scrollRect = scrollEl.getBoundingClientRect();
+    const pageStart = this._isRtl()
+      ? scrollRect.right - direction * scrollEl.clientWidth
+      : scrollRect.left + direction * scrollEl.clientWidth;
     this._artifactNavigation.setActiveItem(
-      this._getArtifactAtPageStart(direction)
+      this._findArtifactAtOrPastBoundary(pageStart)
     );
   }
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -357,26 +357,26 @@ export class PromptField extends SpectrumElement {
       );
     if (dismissedArtifactWasRemoved) {
       this._pendingArtifactDismiss = undefined;
+      this._restoreArtifactFocusAfterDismiss(dismissedArtifact.index);
     }
     this.requestUpdate();
     void this.updateComplete.then(() => {
       requestAnimationFrame(() => {
         this._observeArtifactScrollViewport();
         this._updateArtifactScrollState();
-        if (dismissedArtifactWasRemoved && dismissedArtifact) {
-          this._restoreArtifactFocusAfterDismiss(dismissedArtifact.index);
-        }
       });
     });
   }
 
   private _handleArtifactDismiss(event: Event): void {
     const active = getActiveElement();
-    const artifact = event.composedPath().find(
-      (node): node is HTMLElement =>
-        node instanceof HTMLElement &&
-        (this._assignedArtifactElements ?? []).includes(node)
-    );
+    const artifact = event
+      .composedPath()
+      .find(
+        (node): node is HTMLElement =>
+          node instanceof HTMLElement &&
+          (this._assignedArtifactElements ?? []).includes(node)
+      );
     if (!artifact || !active || !deepContains(artifact, active)) {
       return;
     }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -167,15 +167,11 @@ export class PromptField extends SpectrumElement {
   private _artifactScrollButtonResetTimer?: number;
 
   /**
-   * Roving tabindex + arrow-key focus movement across artifact tiles (Figma
-   * focus-order spec §3). One step per Arrow Left/Right; chevron buttons
-   * separately page by a full set (§6-7), unrelated to this controller.
-   *
-   * `getItems` returns no items until the strip has been "entered" (see
-   * `_artifactStripEntered`): the tiles must stay out of the Tab order so the
-   * container's own focus stop (`.swc-PromptField-artifacts-row`,
-   * `tabindex="0"`) is what Tab reaches first, with Enter/Space diving into
-   * the tiles from there.
+   * Roving tabindex + arrow-key focus movement across artifact tiles. The
+   * first (or last-active, via `memory`) tile always carries `tabindex="0"`,
+   * so it is Tab's first stop into the strip with no separate entry step;
+   * Arrow Left/Right move that roving stop one tile at a time. Chevron
+   * buttons separately page by a full set, unrelated to this controller.
    */
   private readonly _artifactNavigation = new FocusgroupNavigationController(
     this,
@@ -183,31 +179,10 @@ export class PromptField extends SpectrumElement {
       direction: 'horizontal',
       wrap: false,
       memory: true,
-      getItems: () =>
-        this._artifactStripEntered
-          ? (this._assignedArtifactElements ?? [])
-          : [],
+      getItems: () => this._assignedArtifactElements ?? [],
       onActiveItemChange: () => this.requestUpdate(),
     }
   );
-
-  /**
-   * Whether the user has "entered" the artifact strip past its container
-   * focus stop, via Enter/Space on the container or Arrow keys/Enter/Space on
-   * a tile (Figma focus-order spec §4). Gates whether tiles are in the Tab
-   * order at all, and whether Tab from the active tile reveals its Close
-   * button. Resets when focus leaves the strip entirely.
-   */
-  @state()
-  private _artifactStripEntered = false;
-
-  /**
-   * Whether the strip has ever been entered before. On the very first entry
-   * there is no roving-controller memory yet, so `_enterArtifactStrip` lands
-   * on the first fully-visible tile instead of always tile 0; on every entry
-   * after that, the controller's own memory of the last-active tile wins.
-   */
-  private _artifactStripHasBeenEntered = false;
 
   /** Set in `willUpdate` when a chevron about to disappear currently has focus; consumed in `updated`. */
   private _pendingArtifactFocusRedirect: 'first' | 'last' | null = null;
@@ -349,16 +324,14 @@ export class PromptField extends SpectrumElement {
   private _handleArtifactSlotChange(): void {
     this._warnIfMixedArtifactTypes();
     this._artifactNavigation.refresh();
-    // A single artifact has no row wrapper to act as its Tab stop (unlike the
-    // 2+ roving-tabindex strip), so it must carry its own tabindex directly;
-    // ponytail: reachable via Tab, not yet wired into arrow-key navigation.
+    // A single artifact has no row wrapper or roving-tabindex controller
+    // (that only manages 2+ tiles), so it must carry its own tabindex
+    // directly; ponytail: reachable via Tab, not yet wired into arrow-key
+    // navigation. For 2+ tiles, `refresh()` above already owns every tile's
+    // tabindex.
     const artifacts = this._assignedArtifactElements ?? [];
     if (artifacts.length === 1) {
       artifacts[0].tabIndex = 0;
-    } else {
-      for (const el of artifacts) {
-        el.tabIndex = -1;
-      }
     }
     const dismissedArtifact = this._pendingArtifactDismiss;
     const dismissedArtifactWasRemoved =
@@ -414,7 +387,6 @@ export class PromptField extends SpectrumElement {
       return;
     }
 
-    this._artifactStripEntered = true;
     this._artifactNavigation.refresh();
     this._focusArtifact(target);
   }
@@ -518,9 +490,6 @@ export class PromptField extends SpectrumElement {
     if (!activeElement || (source !== 'keyboard' && source !== 'focus')) {
       return;
     }
-    if (source === 'keyboard') {
-      this._artifactStripEntered = true;
-    }
     activeElement.scrollIntoView({
       behavior: this._artifactScrollBehavior(),
       block: 'nearest',
@@ -528,108 +497,7 @@ export class PromptField extends SpectrumElement {
     });
   };
 
-  /** Whether `node` is a focus target that belongs to the artifact strip (tiles, their dismiss buttons, or the chevrons). */
-  private _isArtifactStripFocusTarget(node: Node | null): boolean {
-    if (!node) {
-      return false;
-    }
-    const row = this.shadowRoot?.querySelector(
-      '.swc-PromptField-artifacts-row'
-    );
-    if (row && deepContains(row, node)) {
-      return true;
-    }
-    return (this._assignedArtifactElements ?? []).some((el) =>
-      deepContains(el, node)
-    );
-  }
-
-  private _handleArtifactRowFocusOut(event: FocusEvent): void {
-    if (!this._isArtifactStripFocusTarget(event.relatedTarget as Node | null)) {
-      this._artifactStripEntered = false;
-      // `getItems` returns [] while not entered, so the roving controller's
-      // own tabindex bookkeeping never touches these tiles again; clear their
-      // leftover tabindex from the last time the strip was entered directly
-      // so a tile can never be reached by a plain Tab into the strip.
-      for (const el of this._assignedArtifactElements ?? []) {
-        el.tabIndex = -1;
-      }
-    }
-  }
-
-  /** The first tile that is fully (not partially) within the current scroll viewport. */
-  private _firstFullyVisibleArtifact(): HTMLElement | null {
-    const scrollEl = this._artifactScrollEl;
-    if (!scrollEl) {
-      return null;
-    }
-    return (
-      (this._assignedArtifactElements ?? []).find(
-        (el) => this._getArtifactTileVisibleFraction(el, scrollEl) >= 0.999
-      ) ?? null
-    );
-  }
-
-  /**
-   * Moves focus into the artifact strip, entering it. Prefers the tile the
-   * roving controller already remembers as active (e.g. re-entering after
-   * tabbing away); otherwise lands on the first fully-visible tile for the
-   * strip's current scroll position rather than always tile 0, so entering
-   * after scrolling doesn't jump focus off-screen.
-   */
-  private _enterArtifactStrip(): void {
-    const artifacts = this._assignedArtifactElements ?? [];
-    if (artifacts.length === 0) {
-      return;
-    }
-    this._artifactStripEntered = true;
-    // Read before `refresh()`: with no prior memory, `refresh()` itself
-    // defaults to tile 0, which would make it indistinguishable from a
-    // genuinely-remembered tile 0 once read back afterward.
-    const isFirstEntry = !this._artifactStripHasBeenEntered;
-    this._artifactStripHasBeenEntered = true;
-    this._artifactNavigation.refresh();
-    const target = isFirstEntry
-      ? (this._firstFullyVisibleArtifact() ?? artifacts[0])
-      : (this._artifactNavigation.getActiveItem() ?? artifacts[0]);
-    this._focusArtifact(target);
-  }
-
   private _handleArtifactRowKeydown(event: KeyboardEvent): void {
-    const isEnterOrSpace = event.key === 'Enter' || event.key === ' ';
-    const isArrow = event.key === 'ArrowLeft' || event.key === 'ArrowRight';
-    const active = getActiveElement();
-    const stripContainer = this.shadowRoot?.querySelector(
-      '.swc-PromptField-artifacts-viewport'
-    );
-
-    if (isEnterOrSpace && active === stripContainer) {
-      event.preventDefault();
-      this._enterArtifactStrip();
-      return;
-    }
-
-    if (isEnterOrSpace || isArrow) {
-      const isTile = (this._assignedArtifactElements ?? []).includes(
-        active as HTMLElement
-      );
-      if (isTile) {
-        // Marks the strip as "entered" per the focus-order spec, even when an
-        // Arrow key is a no-op at the first/last tile boundary (the roving
-        // controller only fires its active-change event on an actual move,
-        // so relying on that alone misses this case). Opening a Spotlight
-        // preview on Enter/Space is a follow-up; for now this only unlocks
-        // Tab access to the tile's Close button.
-        this._artifactStripEntered = true;
-        if (isEnterOrSpace) {
-          event.preventDefault();
-        }
-      }
-      if (isEnterOrSpace) {
-        return;
-      }
-    }
-
     if (event.key !== 'Tab') {
       return;
     }
@@ -647,32 +515,27 @@ export class PromptField extends SpectrumElement {
     const nextButton = this.shadowRoot?.querySelector<HTMLButtonElement>(
       '.swc-PromptField-artifacts-scroll-next'
     );
+    const prevButton = this.shadowRoot?.querySelector<HTMLButtonElement>(
+      '.swc-PromptField-artifacts-scroll-prev'
+    );
 
-    // From the active thumbnail: Tab reveals its Close button, but only once
-    // the user has "entered" the strip (Arrow keys or Enter/Space).
+    // From the active tile: Tab reveals its Close button. Shift+Tab is left
+    // to native default, which (roving tabindex leaves every other tile at
+    // -1) exits the group entirely regardless of which tile is active.
     if (artifacts.includes(active as HTMLElement)) {
-      // Shift+Tab from the first tile exits the strip entirely rather than
-      // landing back on the container's own focus stop or the "<" button;
-      // there is no re-entry ring on the way out.
-      if (event.shiftKey && artifacts.indexOf(active as HTMLElement) === 0) {
-        this._skipArtifactStripContainerForShiftTab();
+      if (event.shiftKey) {
         return;
       }
-      if (!event.shiftKey && this._artifactStripEntered) {
-        const dismiss = (
-          active as HTMLElement
-        ).shadowRoot?.querySelector<HTMLButtonElement>(
-          '.swc-UploadArtifact-dismiss'
-        );
-        if (dismiss && !dismiss.hidden) {
-          event.preventDefault();
-          dismiss.focus();
-        }
+      const dismiss = this._artifactDismissButton(active as HTMLElement);
+      if (dismiss) {
+        event.preventDefault();
+        dismiss.focus();
       }
       return;
     }
 
-    // From a tile's Close button.
+    // From a tile's Close button: Tab moves to the Next chevron (if
+    // rendered); Shift+Tab returns to the tile.
     const root = active.getRootNode();
     if (
       root instanceof ShadowRoot &&
@@ -689,7 +552,41 @@ export class PromptField extends SpectrumElement {
         event.preventDefault();
         nextButton.focus();
       }
+      return;
     }
+
+    // From the Next chevron: Shift+Tab moves backward into the roving
+    // controller's current active tile (updated by `_scrollArtifactsByPage`
+    // after paging, so this lands in the newly displayed set rather than
+    // wherever focus was before the page turned) — its Close button when
+    // visible, mirroring the forward tile -> Close -> Next chain in reverse,
+    // otherwise the tile itself.
+    if (active === nextButton && event.shiftKey) {
+      const activeTile = this._artifactNavigation.getActiveItem();
+      if (activeTile) {
+        event.preventDefault();
+        (this._artifactDismissButton(activeTile) ?? activeTile).focus();
+      }
+      return;
+    }
+
+    // From the Prev chevron: plain Tab moves forward into the roving
+    // controller's current active tile, for the same reason as above.
+    if (active === prevButton && !event.shiftKey) {
+      const activeTile = this._artifactNavigation.getActiveItem();
+      if (activeTile) {
+        event.preventDefault();
+        activeTile.focus();
+      }
+    }
+  }
+
+  /** `tile`'s Close button, or `null` when absent or not currently shown. */
+  private _artifactDismissButton(tile: HTMLElement): HTMLButtonElement | null {
+    const dismiss = tile.shadowRoot?.querySelector<HTMLButtonElement>(
+      '.swc-UploadArtifact-dismiss'
+    );
+    return dismiss && !dismiss.hidden ? dismiss : null;
   }
 
   /**
@@ -735,26 +632,6 @@ export class PromptField extends SpectrumElement {
       event.preventDefault();
       tile.focus();
     }
-  }
-
-  /**
-   * Temporarily takes the strip container out of the Tab order so the
-   * browser's own (un-prevented) Shift+Tab default action lands on the "<"
-   * button (if rendered) or whatever precedes the strip, rather than
-   * re-triggering the container's own ring on the way out. Restores it on
-   * the next frame once the browser has already moved focus.
-   */
-  private _skipArtifactStripContainerForShiftTab(): void {
-    const stripContainer = this.shadowRoot?.querySelector<HTMLElement>(
-      '.swc-PromptField-artifacts-viewport'
-    );
-    if (!stripContainer) {
-      return;
-    }
-    stripContainer.tabIndex = -1;
-    requestAnimationFrame(() => {
-      stripContainer.tabIndex = 0;
-    });
   }
 
   private _captureArtifactChevronFocusRedirect(
@@ -1022,6 +899,11 @@ export class PromptField extends SpectrumElement {
           left: maxScroll,
           behavior: 'auto',
         });
+        // Points the roving tab stop at the now-visible last tile, without
+        // moving focus off the Next button, so Shift+Tab from Next lands in
+        // the newly displayed set rather than wherever focus was left before
+        // paging.
+        this._artifactNavigation.setActiveItem(children[children.length - 1]);
         return;
       }
 
@@ -1040,6 +922,8 @@ export class PromptField extends SpectrumElement {
         block: 'nearest',
         inline: 'start',
       });
+      // See the comment on the exact-maxScroll branch above.
+      this._artifactNavigation.setActiveItem(nextStart);
       return;
     }
 
@@ -1055,6 +939,11 @@ export class PromptField extends SpectrumElement {
         block: 'nearest',
         inline: 'start',
       });
+      // Points the roving tab stop at the now-visible first tile, without
+      // moving focus off the Prev button, so Tab from Prev lands in the
+      // newly displayed set rather than wherever focus was left before
+      // paging.
+      this._artifactNavigation.setActiveItem(children[0]);
       return;
     }
 
@@ -1070,6 +959,8 @@ export class PromptField extends SpectrumElement {
       block: 'nearest',
       inline: 'end',
     });
+    // See the comment on the "first <= 0" branch above.
+    this._artifactNavigation.setActiveItem(prevEnd);
   }
 
   private _updateArtifactScrollState(): void {
@@ -1237,7 +1128,6 @@ export class PromptField extends SpectrumElement {
         <div
           class="swc-PromptField-artifacts-row"
           @keydown=${this._handleArtifactRowKeydown}
-          @focusout=${this._handleArtifactRowFocusOut}
         >
           ${this._artifactScrollOverflow && this._artifactCanScrollPrev
             ? html`
@@ -1256,7 +1146,6 @@ export class PromptField extends SpectrumElement {
           <div
             class="swc-PromptField-artifacts-viewport"
             role="region"
-            tabindex="0"
             aria-label=${this.artifactStripLabel}
           >
             <div

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -975,7 +975,7 @@ export class PromptField extends SpectrumElement {
         // chevron stuck visible since it compares against this same maxScroll.
         scrollEl.scrollTo({
           left: maxScroll,
-          behavior: this._artifactScrollBehavior(),
+          behavior: 'auto',
         });
         return;
       }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -10,13 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {
-  CSSResultArray,
-  html,
-  nothing,
-  PropertyValues,
-  TemplateResult,
-} from 'lit';
+import { CSSResultArray, html, nothing, TemplateResult } from 'lit';
 import {
   property,
   query,
@@ -181,9 +175,6 @@ export class PromptField extends SpectrumElement {
     }
   );
 
-  /** Set in `willUpdate` when a chevron about to disappear currently has focus; consumed in `updated`. */
-  private _pendingArtifactFocusRedirect: 'first' | 'last' | null = null;
-
   private _pendingArtifactDismiss?: { artifact: HTMLElement; index: number };
 
   public static override get styles(): CSSResultArray {
@@ -206,13 +197,8 @@ export class PromptField extends SpectrumElement {
     super.disconnectedCallback();
   }
 
-  protected override willUpdate(changed: PropertyValues<this>): void {
-    this._captureArtifactChevronFocusRedirect(changed);
-  }
-
   protected override updated(): void {
     this._warnIfMissingLegalContent();
-    this._applyArtifactChevronFocusRedirect();
   }
 
   private _handleInput(event: Event): void {
@@ -351,14 +337,13 @@ export class PromptField extends SpectrumElement {
   /**
    * `scrollend`, not `scroll`: paging/scrollbar-drag animate over several
    * frames, and `scroll` fires on every one of them. Checking visibility
-   * mid-animation can see a tile transiently pass through the visible
-   * region and lock it in as active before the scroll settles on its
-   * actual destination (`_scrollArtifactsByPage` already sets the correct
-   * active tile up front, but this can still race and clobber it).
-   * `scrollend` only fires once scrolling has actually stopped.
+   * mid-animation can lock in a tile that's only transiently passing
+   * through the visible region.
    */
   private _handleArtifactScrollEnd(): void {
-    this._syncArtifactActiveItemToVisible();
+    void this.updateComplete.then(() =>
+      this._syncArtifactActiveItemToVisible()
+    );
   }
 
   /**
@@ -505,7 +490,7 @@ export class PromptField extends SpectrumElement {
         tile.focus();
         return;
       }
-      if (nextButton) {
+      if (nextButton && this._artifactCanScrollNext) {
         event.preventDefault();
         nextButton.focus();
       }
@@ -591,54 +576,6 @@ export class PromptField extends SpectrumElement {
     }
   }
 
-  private _captureArtifactChevronFocusRedirect(
-    changed: PropertyValues<this>
-  ): void {
-    const active = getActiveElement();
-
-    if (
-      changed.has('_artifactCanScrollPrev') &&
-      changed.get('_artifactCanScrollPrev') === true &&
-      !this._artifactCanScrollPrev
-    ) {
-      const prevButton = this.shadowRoot?.querySelector(
-        '.swc-PromptField-artifacts-scroll-prev'
-      );
-      if (active === prevButton) {
-        this._pendingArtifactFocusRedirect = 'first';
-      }
-    }
-
-    if (
-      changed.has('_artifactCanScrollNext') &&
-      changed.get('_artifactCanScrollNext') === true &&
-      !this._artifactCanScrollNext
-    ) {
-      const nextButton = this.shadowRoot?.querySelector(
-        '.swc-PromptField-artifacts-scroll-next'
-      );
-      if (active === nextButton) {
-        this._pendingArtifactFocusRedirect = 'last';
-      }
-    }
-  }
-
-  private _applyArtifactChevronFocusRedirect(): void {
-    if (!this._pendingArtifactFocusRedirect) {
-      return;
-    }
-
-    const artifacts = this._assignedArtifactElements ?? [];
-    const target =
-      this._pendingArtifactFocusRedirect === 'first'
-        ? artifacts[0]
-        : artifacts[artifacts.length - 1];
-    this._pendingArtifactFocusRedirect = null;
-    if (target) {
-      this._focusArtifact(target);
-    }
-  }
-
   private _observeArtifactScrollViewport(): void {
     const scrollEl = this._artifactScrollEl;
     if (!scrollEl) {
@@ -699,11 +636,21 @@ export class PromptField extends SpectrumElement {
     );
   }
 
+  // aria-disabled, not disabled: a chevron the user just activated stays
+  // focused instead of being blurred by the browser's own disabled-element
+  // handling. That leaves it keyboard-activatable in the brief window
+  // before its aria-disabled state actually updates, hence these guards.
   private _handleArtifactScrollPrev(): void {
+    if (!this._artifactCanScrollPrev) {
+      return;
+    }
     this._scrollArtifactsByPage(-1);
   }
 
   private _handleArtifactScrollNext(): void {
+    if (!this._artifactCanScrollNext) {
+      return;
+    }
     this._scrollArtifactsByPage(1);
   }
 
@@ -889,12 +836,14 @@ export class PromptField extends SpectrumElement {
           class="swc-PromptField-artifacts-row"
           @keydown=${this._handleArtifactRowKeydown}
         >
-          ${this._artifactScrollOverflow && this._artifactCanScrollPrev
+          ${this._artifactScrollOverflow
             ? html`
                 <button
                   type="button"
                   class="swc-PromptField-artifacts-scroll-prev"
                   aria-label=${this.artifactScrollPrevLabel}
+                  aria-disabled=${!this._artifactCanScrollPrev}
+                  tabindex=${this._artifactCanScrollPrev ? nothing : -1}
                   @click=${this._handleArtifactScrollPrev}
                 >
                   <swc-icon size="s" aria-hidden="true">
@@ -942,12 +891,14 @@ export class PromptField extends SpectrumElement {
                 `
               : nothing}
           </div>
-          ${this._artifactScrollOverflow && this._artifactCanScrollNext
+          ${this._artifactScrollOverflow
             ? html`
                 <button
                   type="button"
                   class="swc-PromptField-artifacts-scroll-next"
                   aria-label=${this.artifactScrollNextLabel}
+                  aria-disabled=${!this._artifactCanScrollNext}
+                  tabindex=${this._artifactCanScrollNext ? nothing : -1}
                   @click=${this._handleArtifactScrollNext}
                 >
                   <swc-icon size="s" aria-hidden="true">

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -88,7 +88,7 @@
   display: contents;
 }
 
-/* Mixed card/media artifacts support horizontal flow with wrapping. */
+/* Artifact strip: one upload-artifact type per session (cards or media). */
 .swc-PromptField-artifacts > slot::slotted(*) {
   flex: 0 0 auto;
 }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -114,6 +114,7 @@
   min-inline-size: 0;
 
   --swc-prompt-field-artifact-scrollbar-size: 8px;
+  --swc-prompt-field-artifact-scrollbar-gap: 4px;
 }
 
 .swc-PromptField-artifacts-row {
@@ -127,10 +128,8 @@
   position: relative;
   flex: 1 1 auto;
   min-inline-size: 0;
-  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
-  padding-block-start: 6px;
-  margin-block-start: -6px;
-  margin-block-end: calc(-1 * var(--swc-prompt-field-artifact-scrollbar-size, 8px));
+  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
+  margin-block-end: calc(-1 * (var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px)));
   overflow: visible;
 
   --swc-prompt-field-artifact-fade-solid: color-mix(in srgb, token("background-layer-2-color") 80%, transparent);
@@ -138,7 +137,7 @@
 
 .swc-PromptField-artifacts-fade {
   position: absolute;
-  inset-block-start: 6px;
+  inset-block-start: 0;
   z-index: 3;
   inline-size: 16px;
   block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -112,6 +112,8 @@
 
 .swc-PromptField-artifacts--multiple {
   min-inline-size: 0;
+
+  --swc-prompt-field-artifact-scrollbar-size: 8px;
 }
 
 .swc-PromptField-artifacts-row {
@@ -125,18 +127,40 @@
   position: relative;
   flex: 1 1 auto;
   min-inline-size: 0;
+  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
   padding-block-start: 6px;
   margin-block-start: -6px;
-  overflow: hidden;
+  margin-block-end: calc(-1 * var(--swc-prompt-field-artifact-scrollbar-size, 8px));
+  overflow: visible;
+
+  --swc-prompt-field-artifact-fade-solid: color-mix(in srgb, token("background-layer-2-color") 80%, transparent);
+}
+
+.swc-PromptField-artifacts-fade {
+  position: absolute;
+  inset-block-start: 6px;
+  z-index: 3;
+  inline-size: 16px;
+  block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
+  pointer-events: none;
+}
+
+.swc-PromptField-artifacts-fade--start {
+  inset-inline-start: 0;
+  background: linear-gradient(to right, var(--swc-prompt-field-artifact-fade-solid), transparent);
+}
+
+.swc-PromptField-artifacts-fade--end {
+  inset-inline-end: 0;
+  background: linear-gradient(to left, var(--swc-prompt-field-artifact-fade-solid), transparent);
 }
 
 .swc-PromptField-artifacts-scroll {
   -ms-overflow-style: none;
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: start;
+  box-sizing: border-box;
   inline-size: 100%;
   max-inline-size: 100%;
+  block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
   padding-inline-end: token("spacing-50");
   overflow-x: auto;
   overflow-y: hidden;
@@ -148,7 +172,44 @@
   display: none;
 }
 
-.swc-PromptField-artifacts-scroll > slot {
+.swc-PromptField-artifacts-tiles {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: start;
+  inline-size: max-content;
+  min-inline-size: 100%;
+  block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
+}
+
+.swc-PromptField-artifacts-scrollbar-lane {
+  position: absolute;
+  inset-block-end: 0;
+  inset-inline: 0;
+  block-size: var(--swc-prompt-field-artifact-scrollbar-size, 8px);
+  border-radius: calc(var(--swc-prompt-field-artifact-scrollbar-size, 8px) / 2);
+  touch-action: none;
+  cursor: pointer;
+}
+
+.swc-PromptField-artifacts-scrollbar-thumb {
+  position: absolute;
+  inset-block-start: 0;
+  block-size: var(--swc-prompt-field-artifact-scrollbar-size, 8px);
+  background: transparent;
+  border-radius: calc(var(--swc-prompt-field-artifact-scrollbar-size, 8px) / 2);
+  touch-action: none;
+  cursor: grab;
+}
+
+.swc-PromptField-artifacts-scrollbar-thumb:active {
+  cursor: grabbing;
+}
+
+.swc-PromptField-artifacts-scrollbar-lane.is-artifact-scrollbar-interacting .swc-PromptField-artifacts-scrollbar-thumb {
+  background: token("gray-600");
+}
+
+.swc-PromptField-artifacts-tiles > slot {
   display: flex;
   flex: 0 0 auto;
   flex-wrap: nowrap;
@@ -156,17 +217,17 @@
   align-items: start;
 }
 
-.swc-PromptField-artifacts-scroll > slot::slotted(*) {
+.swc-PromptField-artifacts-tiles > slot::slotted(*) {
   flex: 0 0 auto;
 }
 
-.swc-PromptField-artifacts-scroll > slot::slotted([type="card"]) {
+.swc-PromptField-artifacts-tiles > slot::slotted([type="card"]) {
   inline-size: var(--swc-prompt-field-artifact-card-inline-size, 240px);
   min-inline-size: var(--swc-prompt-field-artifact-card-inline-size, 240px);
   max-inline-size: var(--swc-prompt-field-artifact-card-inline-size, 240px);
 }
 
-.swc-PromptField-artifacts-scroll > slot::slotted([type="media"]) {
+.swc-PromptField-artifacts-tiles > slot::slotted([type="media"]) {
   inline-size: var(--swc-prompt-field-artifact-media-inline-size, 68px);
   min-inline-size: var(--swc-prompt-field-artifact-media-min-inline-size, 68px);
   max-inline-size: var(--swc-prompt-field-artifact-media-inline-size, 68px);
@@ -211,7 +272,7 @@
 .swc-PromptField-artifacts-scroll-prev:focus-visible,
 .swc-PromptField-artifacts-scroll-next:focus-visible {
   outline: token("focus-indicator-thickness") solid token("focus-indicator-color");
-  outline-offset: token("focus-indicator-gap");
+  outline-offset: token("focus-ring-gap");
 }
 
 /* ─────────────────────────────────────

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -115,6 +115,10 @@
 
   --swc-prompt-field-artifact-scrollbar-size: 8px;
   --swc-prompt-field-artifact-scrollbar-gap: 4px;
+
+  /* Room for the 2px outline + 2px offset focus ring (upload-artifact.css) so
+   * overflow-y: hidden below doesn't clip it top/bottom on the tiles. */
+  --swc-prompt-field-artifact-focus-ring-clearance: 4px;
 }
 
 .swc-PromptField-artifacts-row {
@@ -128,8 +132,9 @@
   position: relative;
   flex: 1 1 auto;
   min-inline-size: 0;
-  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
-  margin-block-end: calc(-1 * (var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px)));
+  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + (2 * var(--swc-prompt-field-artifact-focus-ring-clearance)) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
+  margin-block-start: calc(-1 * var(--swc-prompt-field-artifact-focus-ring-clearance));
+  margin-block-end: calc(-1 * (var(--swc-prompt-field-artifact-focus-ring-clearance) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px)));
   overflow: visible;
 
   --swc-prompt-field-artifact-fade-solid: color-mix(in srgb, token("background-layer-2-color") 80%, transparent);
@@ -137,7 +142,7 @@
 
 .swc-PromptField-artifacts-fade {
   position: absolute;
-  inset-block-start: 0;
+  inset-block-start: var(--swc-prompt-field-artifact-focus-ring-clearance);
   z-index: 3;
   inline-size: 16px;
   block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
@@ -154,13 +159,19 @@
   background: linear-gradient(to left, var(--swc-prompt-field-artifact-fade-solid), transparent);
 }
 
+/* Figma focus-order spec (node 243-9156, §9): padding on all sides keeps the
+ * thumbnail focus ring from being clipped by this container's overflow
+ * boundary at the first/last visible tile (inline) and top/bottom (block).
+ * block-size is inflated by the same clearance so the tiles themselves stay
+ * exactly --swc-prompt-field-artifact-media-block-size tall. */
 .swc-PromptField-artifacts-scroll {
   -ms-overflow-style: none;
   box-sizing: border-box;
   inline-size: 100%;
   max-inline-size: 100%;
-  block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
-  padding-inline-end: token("spacing-50");
+  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + (2 * var(--swc-prompt-field-artifact-focus-ring-clearance)));
+  padding-block: var(--swc-prompt-field-artifact-focus-ring-clearance);
+  padding-inline: token("spacing-75");
   overflow-x: auto;
   overflow-y: hidden;
   scroll-behavior: smooth;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -115,10 +115,6 @@
 
   --swc-prompt-field-artifact-scrollbar-size: 8px;
   --swc-prompt-field-artifact-scrollbar-gap: 4px;
-
-  /* Room for the 2px outline + 2px offset focus ring (upload-artifact.css) so
-   * overflow-y: hidden below doesn't clip it top/bottom on the tiles. */
-  --swc-prompt-field-artifact-focus-ring-clearance: 4px;
 }
 
 .swc-PromptField-artifacts-row {
@@ -132,9 +128,8 @@
   position: relative;
   flex: 1 1 auto;
   min-inline-size: 0;
-  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + (2 * var(--swc-prompt-field-artifact-focus-ring-clearance)) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
-  margin-block-start: calc(-1 * var(--swc-prompt-field-artifact-focus-ring-clearance));
-  margin-block-end: calc(-1 * (var(--swc-prompt-field-artifact-focus-ring-clearance) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px)));
+  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
+  margin-block-end: calc(-1 * (var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px)));
   overflow: visible;
 
   --swc-prompt-field-artifact-fade-solid: color-mix(in srgb, token("background-layer-2-color") 80%, transparent);
@@ -142,7 +137,7 @@
 
 .swc-PromptField-artifacts-fade {
   position: absolute;
-  inset-block-start: var(--swc-prompt-field-artifact-focus-ring-clearance);
+  inset-block-start: 0;
   z-index: 3;
   inline-size: 16px;
   block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
@@ -159,18 +154,15 @@
   background: linear-gradient(to left, var(--swc-prompt-field-artifact-fade-solid), transparent);
 }
 
-/* Figma focus-order spec (node 243-9156, §9): padding on all sides keeps the
- * thumbnail focus ring from being clipped by this container's overflow
- * boundary at the first/last visible tile (inline) and top/bottom (block).
- * block-size is inflated by the same clearance so the tiles themselves stay
- * exactly --swc-prompt-field-artifact-media-block-size tall. */
+/* Horizontal padding only: the focus ring (upload-artifact.css) is drawn
+ * inward now, so it never extends past the tile's own box and needs no
+ * vertical clearance here. */
 .swc-PromptField-artifacts-scroll {
   -ms-overflow-style: none;
   box-sizing: border-box;
   inline-size: 100%;
   max-inline-size: 100%;
-  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + (2 * var(--swc-prompt-field-artifact-focus-ring-clearance)));
-  padding-block: var(--swc-prompt-field-artifact-focus-ring-clearance);
+  block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
   padding-inline: token("spacing-75");
   overflow-x: auto;
   overflow-y: hidden;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -130,9 +130,18 @@
   min-inline-size: 0;
   block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
   margin-block-end: calc(-1 * (var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px)));
+  border-radius: token("corner-radius-100");
   overflow: visible;
 
   --swc-prompt-field-artifact-fade-solid: color-mix(in srgb, token("background-layer-2-color") 80%, transparent);
+}
+
+/* Container-level focus stop: Tab reaches the strip itself (between the "<"
+ * and ">" buttons, which sit outside this ring), distinct from a tile's own
+ * ring; Enter/Space then moves focus into a tile. */
+.swc-PromptField-artifacts-viewport:focus-visible {
+  outline: token("focus-indicator-thickness") solid token("focus-indicator-color");
+  outline-offset: token("focus-ring-gap");
 }
 
 .swc-PromptField-artifacts-fade {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -64,8 +64,9 @@
   display: flex;
   flex-direction: column;
   gap: token("spacing-300");
+  min-inline-size: 0;
   padding-block-start: 0;
-  padding-inline: token("spacing-100");
+  padding-inline: 0;
 }
 
 /* Figma: input area uses 8px top padding only when an artifact row is shown. */
@@ -77,19 +78,22 @@
    Uploaded artifacts
    ───────────────────────────────────── */
 
-.swc-PromptField-artifacts {
+.swc-PromptField-artifacts[hidden] {
+  display: none !important;
+}
+
+.swc-PromptField-artifacts--single {
   display: flex;
   flex-wrap: wrap;
   gap: token("spacing-300");
   align-items: start;
 }
 
-.swc-PromptField-artifacts > slot {
+.swc-PromptField-artifacts--single > slot {
   display: contents;
 }
 
-/* Artifact strip: one upload-artifact type per session (cards or media). */
-.swc-PromptField-artifacts > slot::slotted(*) {
+.swc-PromptField-artifacts--single > slot::slotted(*) {
   flex: 0 0 auto;
 }
 
@@ -98,19 +102,116 @@
   flex-basis: auto;
 }
 
-/* Multi-artifact card layout targets 3+ cards per row responsively. */
-.swc-PromptField-artifacts--multiple > slot::slotted([type="card"]) {
-  flex-shrink: 1;
-  flex-basis: auto;
-}
-
-/* Prompt-field media artifact uses 68×68 preview tile. */
-.swc-PromptField-artifacts > slot::slotted([type="media"]) {
+.swc-PromptField-artifacts--single > slot::slotted([type="media"]) {
   inline-size: var(--swc-prompt-field-artifact-media-inline-size, 68px);
   min-inline-size: var(--swc-prompt-field-artifact-media-min-inline-size, 68px);
   block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
   min-block-size: var(--swc-prompt-field-artifact-media-min-block-size, 68px);
   aspect-ratio: 1 / 1;
+}
+
+.swc-PromptField-artifacts--multiple {
+  min-inline-size: 0;
+}
+
+.swc-PromptField-artifacts-row {
+  display: flex;
+  gap: token("spacing-100");
+  align-items: center;
+  inline-size: 100%;
+}
+
+.swc-PromptField-artifacts-viewport {
+  position: relative;
+  flex: 1 1 auto;
+  min-inline-size: 0;
+  padding-block-start: 6px;
+  margin-block-start: -6px;
+  overflow: hidden;
+}
+
+.swc-PromptField-artifacts-scroll {
+  -ms-overflow-style: none;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: start;
+  inline-size: 100%;
+  max-inline-size: 100%;
+  padding-inline-end: token("spacing-50");
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+}
+
+.swc-PromptField-artifacts-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.swc-PromptField-artifacts-scroll > slot {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  gap: token("spacing-100");
+  align-items: start;
+}
+
+.swc-PromptField-artifacts-scroll > slot::slotted(*) {
+  flex: 0 0 auto;
+}
+
+.swc-PromptField-artifacts-scroll > slot::slotted([type="card"]) {
+  inline-size: var(--swc-prompt-field-artifact-card-inline-size, 240px);
+  min-inline-size: var(--swc-prompt-field-artifact-card-inline-size, 240px);
+  max-inline-size: var(--swc-prompt-field-artifact-card-inline-size, 240px);
+}
+
+.swc-PromptField-artifacts-scroll > slot::slotted([type="media"]) {
+  inline-size: var(--swc-prompt-field-artifact-media-inline-size, 68px);
+  min-inline-size: var(--swc-prompt-field-artifact-media-min-inline-size, 68px);
+  max-inline-size: var(--swc-prompt-field-artifact-media-inline-size, 68px);
+  block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
+  min-block-size: var(--swc-prompt-field-artifact-media-min-block-size, 68px);
+  aspect-ratio: 1 / 1;
+}
+
+.swc-PromptField-artifacts-scroll-prev,
+.swc-PromptField-artifacts-scroll-next {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  inline-size: var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px);
+  block-size: var(--swc-prompt-field-artifact-scroll-button-block-size, 32px);
+  padding: 0;
+  line-height: 0;
+  color: token("gray-800");
+  background: token("gray-100");
+  border: 1px solid transparent;
+  border-radius: token("corner-radius-800");
+  cursor: pointer;
+}
+
+.swc-PromptField-artifacts-scroll-prev:hover,
+.swc-PromptField-artifacts-scroll-next:hover {
+  background: token("gray-200");
+}
+
+.swc-PromptField-artifacts-scroll-prev swc-icon,
+.swc-PromptField-artifacts-scroll-next swc-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.swc-PromptField-artifacts-scroll-prev swc-icon {
+  transform: scaleX(-1);
+}
+
+.swc-PromptField-artifacts-scroll-prev:focus-visible,
+.swc-PromptField-artifacts-scroll-next:focus-visible {
+  outline: token("focus-indicator-thickness") solid token("focus-indicator-color");
+  outline-offset: token("focus-indicator-gap");
 }
 
 /* ─────────────────────────────────────
@@ -121,6 +222,7 @@
   display: flex;
   flex-direction: column;
   gap: token("spacing-75");
+  padding-inline: token("spacing-100");
 }
 
 .swc-PromptField-label {
@@ -297,8 +399,4 @@
 
 .swc-PromptField-legal-disclaimer a {
   color: inherit;
-}
-
-.swc-PromptField-artifacts[hidden] {
-  display: none !important;
 }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -171,6 +171,7 @@
   padding-inline: token("spacing-75");
   overflow-x: auto;
   overflow-y: hidden;
+  scroll-behavior: smooth;
   scroll-snap-type: inline mandatory;
   scroll-padding-inline: token("spacing-75");
   scrollbar-color: token("gray-400") transparent;
@@ -546,4 +547,10 @@
 
 .swc-PromptField-legal-disclaimer a {
   color: inherit;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .swc-PromptField-artifacts-scroll {
+    scroll-behavior: auto;
+  }
 }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -78,10 +78,6 @@
    Uploaded artifacts
    ───────────────────────────────────── */
 
-.swc-PromptField-artifacts[hidden] {
-  display: none !important;
-}
-
 .swc-PromptField-artifacts--single {
   display: flex;
   flex-wrap: wrap;
@@ -115,6 +111,12 @@
 
   --swc-prompt-field-artifact-scrollbar-size: 8px;
   --swc-prompt-field-artifact-scrollbar-gap: 4px;
+
+  /* Dismiss badges are centered on each tile's top-right corner (see
+   * upload-artifact.css), so half of the larger (32px media) badge floats
+   * above the tile. Reserve that much clearance above the row so the
+   * scroll container's overflow-y: hidden doesn't clip it flat. */
+  --swc-prompt-field-artifact-badge-clearance: 16px;
 }
 
 .swc-PromptField-artifacts-row {
@@ -128,7 +130,7 @@
   position: relative;
   flex: 1 1 auto;
   min-inline-size: 0;
-  block-size: calc(var(--swc-prompt-field-artifact-media-block-size, 68px) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
+  block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
   margin-block-end: calc(-1 * (var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px)));
   border-radius: token("corner-radius-100");
   overflow: visible;
@@ -144,12 +146,17 @@
   outline-offset: token("focus-ring-gap");
 }
 
+/* Spans the badge-clearance strip too (not just the tile height): a
+ * scrolling tile's corner badge lives partly in that clearance zone, and a
+ * fade that stopped at the tile's own top edge would leave the badge's
+ * upper half unmasked while its lower half fades, splitting it visually
+ * in two. */
 .swc-PromptField-artifacts-fade {
   position: absolute;
   inset-block-start: 0;
   z-index: 3;
   inline-size: 16px;
-  block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
+  block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px));
   pointer-events: none;
 }
 
@@ -163,15 +170,17 @@
   background: linear-gradient(to left, var(--swc-prompt-field-artifact-fade-solid), transparent);
 }
 
-/* Horizontal padding only: the focus ring (upload-artifact.css) is drawn
- * inward now, so it never extends past the tile's own box and needs no
- * vertical clearance here. */
+/* padding-block-start reserves room for the dismiss badge, which is
+ * centered on each tile's top-right corner (upload-artifact.css) and so
+ * floats half outside the tile; overflow-y: hidden below would otherwise
+ * clip it flat. */
 .swc-PromptField-artifacts-scroll {
   -ms-overflow-style: none;
   box-sizing: border-box;
   inline-size: 100%;
   max-inline-size: 100%;
-  block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
+  block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px));
+  padding-block-start: var(--swc-prompt-field-artifact-badge-clearance, 0);
   padding-inline: token("spacing-75");
   overflow-x: auto;
   overflow-y: hidden;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -136,18 +136,18 @@
   position: absolute;
   inset-block-start: 0;
   z-index: 3;
-  inline-size: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + token("spacing-100"));
+  inline-size: token("spacing-400");
   block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px));
   pointer-events: none;
 }
 
 .swc-PromptField-artifacts-fade--start {
-  inset-inline-start: 0;
+  inset-inline-start: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + (token("spacing-400") / 2));
   background: linear-gradient(to right, var(--swc-prompt-field-artifact-fade-solid), transparent);
 }
 
 .swc-PromptField-artifacts-fade--end {
-  inset-inline-end: 0;
+  inset-inline-end: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + (token("spacing-400") / 2));
   background: linear-gradient(to left, var(--swc-prompt-field-artifact-fade-solid), transparent);
 }
 
@@ -174,6 +174,22 @@
   scroll-snap-type: inline mandatory;
   scroll-padding-inline: token("spacing-75");
   scrollbar-color: token("gray-400") transparent;
+}
+
+/* Chevrons and their opaque mask are overlay siblings positioned outside
+ * this scroll container, not part of its own clipping bounds, so the
+ * native scrollIntoView() call in _focusArtifact() (PromptField.ts) has no
+ * awareness of them: it can treat a tile as "already in view" while a
+ * chevron is still visually covering it, leaving keyboard focus (and its
+ * ring) hidden behind an opaque circle. Reserving that much scroll-padding
+ * on the side a chevron is showing makes the browser bring a tile fully
+ * clear of it before considering it in view. */
+.swc-PromptField-artifacts-scroll.has-scroll-prev {
+  scroll-padding-inline-start: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + token("spacing-400") + token("spacing-75"));
+}
+
+.swc-PromptField-artifacts-scroll.has-scroll-next {
+  scroll-padding-inline-end: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + token("spacing-400") + token("spacing-75"));
 }
 
 .swc-PromptField-artifacts-scroll::-webkit-scrollbar {
@@ -225,7 +241,7 @@
 .swc-PromptField-artifacts-scroll-next {
   display: inline-flex;
   position: absolute;
-  inset-block-start: 50%;
+  inset-block-start: calc((var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px)) / 2);
   z-index: 4;
   flex: 0 0 auto;
   align-items: center;
@@ -244,12 +260,25 @@
   --_swc-prompt-field-artifact-scroll-icon-transform: none;
 }
 
+/* inline-size matches the fade's own inset (button + half of spacing-400)
+ * so the mask's inner edge lines up exactly with where the fade begins,
+ * with no dead opaque zone between them; the extra 2px and the outer edge
+ * (inset-inline-start/end below) overlapping 2px past the row's own edge
+ * are unrelated to that and only guard against calc()-derived positions
+ * not landing on a clean device pixel, which can leave a 1px unpainted
+ * sliver at a mask boundary that touches its edge exactly.
+ *
+ * z-index: -1, not 0: the button's own :focus-visible outline paints with
+ * its background/border layer, before z-index: 0 positioned descendants,
+ * so a z-index: 0 mask paints over (hides) the outline. A negative z-index
+ * puts this mask in the layer painted before that, so the outline is never
+ * covered. */
 .swc-PromptField-artifacts-scroll-prev::before,
 .swc-PromptField-artifacts-scroll-next::before {
   position: absolute;
   inset-block-start: calc((var(--swc-prompt-field-artifact-scroll-button-block-size, 32px) - var(--swc-prompt-field-artifact-badge-clearance, 0) - var(--swc-prompt-field-artifact-media-block-size, 68px)) / 2);
-  z-index: 0;
-  inline-size: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + token("spacing-400"));
+  z-index: -1;
+  inline-size: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + (token("spacing-400") / 2) + 2px);
   block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px));
   pointer-events: none;
   content: "";
@@ -273,8 +302,8 @@
 }
 
 .swc-PromptField-artifacts-scroll-prev::before {
-  inset-inline-start: 0;
-  background: linear-gradient(to right, token("background-layer-2-color") 0%, token("background-layer-2-color") 50%, transparent 100%);
+  inset-inline-start: -2px;
+  background: token("background-layer-2-color");
 }
 
 .swc-PromptField-artifacts-scroll-next {
@@ -282,16 +311,8 @@
 }
 
 .swc-PromptField-artifacts-scroll-next::before {
-  inset-inline-end: 0;
-  background: linear-gradient(to left, token("background-layer-2-color") 0%, token("background-layer-2-color") 50%, transparent 100%);
-}
-
-:host(:dir(rtl)) .swc-PromptField-artifacts-scroll-prev::before {
-  background: linear-gradient(to left, token("background-layer-2-color") 0%, token("background-layer-2-color") 50%, transparent 100%);
-}
-
-:host(:dir(rtl)) .swc-PromptField-artifacts-scroll-next::before {
-  background: linear-gradient(to right, token("background-layer-2-color") 0%, token("background-layer-2-color") 50%, transparent 100%);
+  inset-inline-end: -2px;
+  background: token("background-layer-2-color");
 }
 
 .swc-PromptField-artifacts-scroll-prev:hover,

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -175,7 +175,6 @@
   padding-inline: token("spacing-75");
   overflow-x: auto;
   overflow-y: hidden;
-  scroll-behavior: smooth;
   scrollbar-width: none;
 }
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -48,6 +48,10 @@
   overflow: hidden;
 }
 
+.swc-PromptField-box:has(.swc-PromptField-input-area.has-artifact) {
+  padding-block-start: token("spacing-100");
+}
+
 /* ─────────────────────────────────────
    Input area (artifact + text area)
    ───────────────────────────────────── */
@@ -61,12 +65,9 @@
   padding-inline: 0;
 }
 
-/* Figma: input area uses 8px top padding, and 8px (not the default 16px)
- * between the artifact strip and the textarea, only when an artifact row
- * is shown. */
+/* Keep the compact 8px gap between the artifact strip and textarea. */
 .swc-PromptField-input-area.has-artifact {
   gap: token("spacing-100");
-  padding-block-start: token("spacing-100");
 }
 
 /* ─────────────────────────────────────
@@ -104,9 +105,6 @@
 .swc-PromptField-artifacts--multiple {
   min-inline-size: 0;
 
-  --swc-prompt-field-artifact-scrollbar-size: 8px;
-  --swc-prompt-field-artifact-scrollbar-gap: 4px;
-
   /* Dismiss badges are centered on each tile's top-right corner (see
    * upload-artifact.css), so half of the larger (32px media) badge floats
    * above the tile. Reserve that much clearance above the row so the
@@ -115,9 +113,7 @@
 }
 
 .swc-PromptField-artifacts-row {
-  display: flex;
-  gap: token("spacing-100");
-  align-items: center;
+  position: relative;
   inline-size: 100%;
 }
 
@@ -125,12 +121,10 @@
   position: relative;
   flex: 1 1 auto;
   min-inline-size: 0;
-  block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px) + var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px));
-  margin-block-end: calc(-1 * (var(--swc-prompt-field-artifact-scrollbar-gap, 4px) + var(--swc-prompt-field-artifact-scrollbar-size, 8px)));
   border-radius: token("corner-radius-100");
   overflow: visible;
 
-  --swc-prompt-field-artifact-fade-solid: color-mix(in srgb, token("background-layer-2-color") 80%, transparent);
+  --swc-prompt-field-artifact-fade-solid: token("background-layer-2-color");
 }
 
 /* Spans the badge-clearance strip too (not just the tile height): a
@@ -142,7 +136,7 @@
   position: absolute;
   inset-block-start: 0;
   z-index: 3;
-  inline-size: 16px;
+  inline-size: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + token("spacing-100"));
   block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px));
   pointer-events: none;
 }
@@ -157,25 +151,37 @@
   background: linear-gradient(to left, var(--swc-prompt-field-artifact-fade-solid), transparent);
 }
 
+:host(:dir(rtl)) .swc-PromptField-artifacts-fade--start {
+  background: linear-gradient(to left, var(--swc-prompt-field-artifact-fade-solid), transparent);
+}
+
+:host(:dir(rtl)) .swc-PromptField-artifacts-fade--end {
+  background: linear-gradient(to right, var(--swc-prompt-field-artifact-fade-solid), transparent);
+}
+
 /* padding-block-start reserves room for the dismiss badge, which is
  * centered on each tile's top-right corner (upload-artifact.css) and so
  * floats half outside the tile; overflow-y: hidden below would otherwise
  * clip it flat. */
 .swc-PromptField-artifacts-scroll {
-  -ms-overflow-style: none;
   box-sizing: border-box;
   inline-size: 100%;
   max-inline-size: 100%;
-  block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px));
   padding-block-start: var(--swc-prompt-field-artifact-badge-clearance, 0);
   padding-inline: token("spacing-75");
   overflow-x: auto;
   overflow-y: hidden;
-  scrollbar-width: none;
+  scroll-snap-type: inline mandatory;
+  scroll-padding-inline: token("spacing-75");
+  scrollbar-color: token("gray-400") transparent;
 }
 
 .swc-PromptField-artifacts-scroll::-webkit-scrollbar {
-  display: none;
+  background: transparent;
+}
+
+.swc-PromptField-artifacts-scroll::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .swc-PromptField-artifacts-tiles {
@@ -185,34 +191,6 @@
   inline-size: max-content;
   min-inline-size: 100%;
   block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
-}
-
-.swc-PromptField-artifacts-scrollbar-lane {
-  position: absolute;
-  inset-block-end: 0;
-  inset-inline: 0;
-  block-size: var(--swc-prompt-field-artifact-scrollbar-size, 8px);
-  border-radius: calc(var(--swc-prompt-field-artifact-scrollbar-size, 8px) / 2);
-  touch-action: none;
-  cursor: pointer;
-}
-
-.swc-PromptField-artifacts-scrollbar-thumb {
-  position: absolute;
-  inset-block-start: 0;
-  block-size: var(--swc-prompt-field-artifact-scrollbar-size, 8px);
-  background: transparent;
-  border-radius: calc(var(--swc-prompt-field-artifact-scrollbar-size, 8px) / 2);
-  touch-action: none;
-  cursor: grab;
-}
-
-.swc-PromptField-artifacts-scrollbar-thumb:active {
-  cursor: grabbing;
-}
-
-.swc-PromptField-artifacts-scrollbar-lane.is-artifact-scrollbar-interacting .swc-PromptField-artifacts-scrollbar-thumb {
-  background: token("gray-600");
 }
 
 .swc-PromptField-artifacts-tiles > slot {
@@ -225,6 +203,7 @@
 
 .swc-PromptField-artifacts-tiles > slot::slotted(*) {
   flex: 0 0 auto;
+  scroll-snap-align: start;
 }
 
 .swc-PromptField-artifacts-tiles > slot::slotted([type="card"]) {
@@ -245,6 +224,9 @@
 .swc-PromptField-artifacts-scroll-prev,
 .swc-PromptField-artifacts-scroll-next {
   display: inline-flex;
+  position: absolute;
+  inset-block-start: 50%;
+  z-index: 4;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
@@ -252,32 +234,93 @@
   block-size: var(--swc-prompt-field-artifact-scroll-button-block-size, 32px);
   padding: 0;
   color: token("gray-800");
-  background: token("gray-100");
+  background: var(--_swc-prompt-field-artifact-scroll-button-background);
   border: 1px solid transparent;
   border-radius: token("corner-radius-800");
   cursor: pointer;
+  transform: translateY(-50%);
+
+  --_swc-prompt-field-artifact-scroll-button-background: token("gray-100");
+  --_swc-prompt-field-artifact-scroll-icon-transform: none;
+}
+
+.swc-PromptField-artifacts-scroll-prev::before,
+.swc-PromptField-artifacts-scroll-next::before {
+  position: absolute;
+  inset-block-start: calc((var(--swc-prompt-field-artifact-scroll-button-block-size, 32px) - var(--swc-prompt-field-artifact-badge-clearance, 0) - var(--swc-prompt-field-artifact-media-block-size, 68px)) / 2);
+  z-index: 0;
+  inline-size: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + token("spacing-400"));
+  block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px));
+  pointer-events: none;
+  content: "";
+}
+
+.swc-PromptField-artifacts-scroll-prev::after,
+.swc-PromptField-artifacts-scroll-next::after {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: var(--_swc-prompt-field-artifact-scroll-button-background);
+  border-radius: inherit;
+  pointer-events: none;
+  content: "";
+}
+
+.swc-PromptField-artifacts-scroll-prev {
+  inset-inline-start: 0;
+
+  --_swc-prompt-field-artifact-scroll-icon-transform: scaleX(-1);
+}
+
+.swc-PromptField-artifacts-scroll-prev::before {
+  inset-inline-start: 0;
+  background: linear-gradient(to right, token("background-layer-2-color") 0%, token("background-layer-2-color") 50%, transparent 100%);
+}
+
+.swc-PromptField-artifacts-scroll-next {
+  inset-inline-end: 0;
+}
+
+.swc-PromptField-artifacts-scroll-next::before {
+  inset-inline-end: 0;
+  background: linear-gradient(to left, token("background-layer-2-color") 0%, token("background-layer-2-color") 50%, transparent 100%);
+}
+
+:host(:dir(rtl)) .swc-PromptField-artifacts-scroll-prev::before {
+  background: linear-gradient(to left, token("background-layer-2-color") 0%, token("background-layer-2-color") 50%, transparent 100%);
+}
+
+:host(:dir(rtl)) .swc-PromptField-artifacts-scroll-next::before {
+  background: linear-gradient(to right, token("background-layer-2-color") 0%, token("background-layer-2-color") 50%, transparent 100%);
 }
 
 .swc-PromptField-artifacts-scroll-prev:hover,
 .swc-PromptField-artifacts-scroll-next:hover {
-  background: token("gray-200");
+  --_swc-prompt-field-artifact-scroll-button-background: token("gray-200");
 }
 
 .swc-PromptField-artifacts-scroll-prev swc-icon,
 .swc-PromptField-artifacts-scroll-next swc-icon {
   display: inline-flex;
+  position: relative;
+  z-index: 2;
   align-items: center;
   justify-content: center;
-}
-
-.swc-PromptField-artifacts-scroll-prev swc-icon {
-  transform: scaleX(-1);
+  transform: var(--_swc-prompt-field-artifact-scroll-icon-transform);
 }
 
 .swc-PromptField-artifacts-scroll-prev:focus-visible,
 .swc-PromptField-artifacts-scroll-next:focus-visible {
   outline: token("focus-indicator-thickness") solid token("focus-indicator-color");
   outline-offset: token("focus-ring-gap");
+}
+
+:host(:dir(rtl)) .swc-PromptField-artifacts-scroll-prev {
+  --_swc-prompt-field-artifact-scroll-icon-transform: none;
+}
+
+:host(:dir(rtl)) .swc-PromptField-artifacts-scroll-next {
+  --_swc-prompt-field-artifact-scroll-icon-transform: scaleX(-1);
 }
 
 /* ─────────────────────────────────────

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -48,14 +48,6 @@
   overflow: hidden;
 }
 
-/* Outer ring only for keyboard focus on the textarea (PromptField toggles
- * `.swc-PromptField-box--keyboard-focus`; `:focus-visible` alone cannot
- * distinguish Tab vs click on text inputs). */
-.swc-PromptField-box.swc-PromptField-box--keyboard-focus {
-  outline: token("focus-indicator-thickness") solid token("focus-indicator-color");
-  outline-offset: token("focus-ring-gap");
-}
-
 /* ─────────────────────────────────────
    Input area (artifact + text area)
    ───────────────────────────────────── */
@@ -69,8 +61,11 @@
   padding-inline: 0;
 }
 
-/* Figma: input area uses 8px top padding only when an artifact row is shown. */
+/* Figma: input area uses 8px top padding, and 8px (not the default 16px)
+ * between the artifact strip and the textarea, only when an artifact row
+ * is shown. */
 .swc-PromptField-input-area.has-artifact {
+  gap: token("spacing-100");
   padding-block-start: token("spacing-100");
 }
 
@@ -330,6 +325,12 @@
 .swc-PromptField-textarea:disabled {
   color: token("gray-500");
   cursor: default;
+}
+
+.swc-PromptField-textarea:focus-visible {
+  border-radius: token("corner-radius-75");
+  outline: token("focus-indicator-thickness") solid token("focus-indicator-color");
+  outline-offset: token("focus-ring-gap");
 }
 
 /* ─────────────────────────────────────

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -260,6 +260,17 @@
   --_swc-prompt-field-artifact-scroll-icon-transform: none;
 }
 
+/* aria-disabled, not the disabled attribute, and hidden with opacity, not
+ * display/visibility: a chevron at the end of the strip stays mounted and
+ * keeps any focus it already has (native disabled and display/visibility
+ * removal both blur it), so the button never needs a manual focus-redirect
+ * when scrolling makes it unusable. */
+.swc-PromptField-artifacts-scroll-prev[aria-disabled="true"],
+.swc-PromptField-artifacts-scroll-next[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0;
+}
+
 /* inline-size matches the fade's own inset (button + half of spacing-400)
  * so the mask's inner edge lines up exactly with where the fade begins,
  * with no dead opaque zone between them; the extra 2px and the outer edge

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -138,14 +138,6 @@
   --swc-prompt-field-artifact-fade-solid: color-mix(in srgb, token("background-layer-2-color") 80%, transparent);
 }
 
-/* Container-level focus stop: Tab reaches the strip itself (between the "<"
- * and ">" buttons, which sit outside this ring), distinct from a tile's own
- * ring; Enter/Space then moves focus into a tile. */
-.swc-PromptField-artifacts-viewport:focus-visible {
-  outline: token("focus-indicator-thickness") solid token("focus-indicator-color");
-  outline-offset: token("focus-ring-gap");
-}
-
 /* Spans the badge-clearance strip too (not just the tile height): a
  * scrolling tile's corner badge lives partly in that clearance zone, and a
  * fade that stopped at the tile's own top edge would leave the badge's

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -256,7 +256,6 @@
   inline-size: var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px);
   block-size: var(--swc-prompt-field-artifact-scroll-button-block-size, 32px);
   padding: 0;
-  line-height: 0;
   color: token("gray-800");
   background: token("gray-100");
   border: 1px solid transparent;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -14,7 +14,7 @@ A prompt field consists of:
 1. **Box**: white card container with shadow and 16px border radius.
 2. **Input area**: visible label + textarea.
 3. **Action bar**: upload trigger (left) and send/stop action (right).
-4. **Footer**: optional legal content rendered below the prompt surface.
+4. **Footer**: legal disclaimer rendered below the prompt surface. Required in product implementations.
 
 <Canvas of={PromptFieldStories.Anatomy} />
 
@@ -32,6 +32,12 @@ The send button enablement is derived internally from prompt content (value or a
 
 <Canvas of={PromptFieldStories.Modes} />
 
+### Legal disclaimer
+
+Every prompt field in production must include Legal-approved disclaimer copy below the composer. Slot your product's approved text into **`legal`** — wording, links, and locale are consumer-owned, not baked into the component.
+
+Apply the `.swc-PromptField-legal-disclaimer` class for default footer typography. `swc-prompt-field` logs a development warning when the `legal` slot is empty.
+
 ### Artifact
 
 Artifact layout is inferred from the **`artifact`** slot content:
@@ -40,7 +46,13 @@ Artifact layout is inferred from the **`artifact`** slot content:
 - **`swc-upload-artifact type="card"`**: file-style card artifacts (one or more)
 - **`swc-upload-artifact type="media"`**: media tile artifacts (one or more, with or without badge)
 
-**Use one type per composer session.** Slot multiple artifacts of the same type — for example, several cards or several media tiles — but do not mix card and media in the same strip. `swc-prompt-field` logs a development warning when both types are detected.
+**Use one layout type per composer session** (`card` or `media`). Slot multiple artifacts of that same type — for example, several cards or several media tiles. Do not mix `card` and `media` in the same strip; `swc-prompt-field` logs a development warning when both are detected.
+
+This rule is about **component layout**, not file MIME type. You can attach many files in one session as long as they share the same layout:
+
+- **Document-only uploads** where title and subtitle carry meaning → all **`type="card"`**
+- **Visual previews** (photos, storyboard frames) → all **`type="media"`**
+- **Mixed images and documents in one batch** → normalize to all **`type="media"`**: image previews in `thumbnail`, and document tiles with a preview or icon in `thumbnail` plus an optional **`badge`** (for example, "PDF"). See **[Media with badge](/docs/patterns-conversational-ai-upload-artifact--readme#media-with-badge)**.
 
 **Populate the attachment strip** by slotting **one `<swc-upload-artifact>` per file**, each with **`slot="artifact"`** (same slot name repeated).
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -111,6 +111,16 @@ The `<swc-prompt-field>` element implements the following accessibility features
 - All icon buttons carry descriptive `aria-label` attributes
 - The send button uses `disabled` natively when the prompt has no content
 
+#### Artifact strip keyboard navigation
+
+The artifact strip is a `role="region"` landmark (labeled `artifact-strip-label`, default "Uploaded assets strip") with roving-tabindex thumbnails:
+
+- **Tab**: moves to the active thumbnail (one tile is ever a tab stop); once you've interacted with a thumbnail via Arrow keys or Enter/Space, Tab additionally reveals that tile's Close button before continuing
+- **Arrow Left/Right**: move the active thumbnail one tile at a time and scroll it into view (distinct from the `<`/`>` chevrons, which page by a full set)
+- **Enter/Space** on a thumbnail: marks the strip as interacted with, unlocking Tab access to Close
+- **Shift+Tab** from Close: returns to the thumbnail; **Tab** from Close reaches the `>` chevron when more content is scrolled out of view, otherwise continues to the prompt textarea
+- The `<`/`>` chevrons redirect focus to the nearest thumbnail instead of losing it if they disappear while focused (for example, paging all the way to one end)
+
 ### Best practices
 
 - Always provide a meaningful `label` value

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -34,15 +34,17 @@ The send button enablement is derived internally from prompt content (value or a
 
 ### Artifact
 
-Artifact layout is inferred from the **`artifact`** slot content and supports multiple mixed items:
+Artifact layout is inferred from the **`artifact`** slot content:
 
 - No slot content: no artifact region
-- **`swc-upload-artifact type="card"`**: file-style card artifact
-- **`swc-upload-artifact type="media"`**: media tile artifact
+- **`swc-upload-artifact type="card"`**: file-style card artifacts (one or more)
+- **`swc-upload-artifact type="media"`**: media tile artifacts (one or more, with or without badge)
 
-**Populate the attachment strip** by slotting **one `<swc-upload-artifact>` per file**, each with **`slot="artifact"`** (same slot name repeated). Mixed card + media entries wrap inside the composer like this story's first example.
+**Use one type per composer session.** Slot multiple artifacts of the same type — for example, several cards or several media tiles — but do not mix card and media in the same strip. `swc-prompt-field` logs a development warning when both types are detected.
 
-For additional combinations, like narrow widths, ellipsis, or more tiles, see **[Multi-artifact](/docs/patterns-conversational-ai-upload-artifact--docs#multi-artifact)**.
+**Populate the attachment strip** by slotting **one `<swc-upload-artifact>` per file**, each with **`slot="artifact"`** (same slot name repeated).
+
+For additional card and media gallery examples, see **[Multi-card](/docs/patterns-conversational-ai-upload-artifact--docs#multi-card)** and **[Multi-media](/docs/patterns-conversational-ai-upload-artifact--docs#multi-media)**.
 
 Upload button behavior:
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -69,7 +69,9 @@ Artifacts own dismiss behavior via **`dismissible`** and emit **`swc-upload-arti
 
 ### Multi-artifact scroll
 
-When several attachments exceed the composer width, the strip scrolls horizontally at full width with hidden scrollbars. Chevron buttons flank the strip (32px gray circles) and render only when scrolling is possible in that direction. Each click advances by one tile. Trackpad or touch scrolling still works.
+When several attachments exceed the composer width, the strip scrolls horizontally at full width. Chevron buttons flank the strip (32px gray circles) and render only when scrolling is possible in that direction. Each click advances by one **set** of tiles: the last visible tile becomes the first tile in the next set so the carousel keeps continuity. On the final set, the strip right-aligns to stay full. Edge fades on both sides signal overflow and hide at the ends of the list.
+
+Trackpad, wheel, touch scrolling, and the overlay scrollbar lane below the tiles all work on the artifact strip. The lane is always reserved in the gap below the tiles so composer height stays fixed; the thumb appears only during physical interaction (wheel, touch, or dragging the scrollbar). Chevron paging does not reveal the scrollbar.
 
 <Canvas of={PromptFieldStories.MultiArtifactScroll} />
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -55,6 +55,12 @@ Artifacts own dismiss behavior via **`dismissible`** and emit **`swc-upload-arti
 
 <Canvas of={PromptFieldStories.Artifact} />
 
+### Multi-artifact scroll
+
+When several attachments exceed the composer width, the strip scrolls horizontally at full width with hidden scrollbars. Chevron buttons flank the strip (32px gray circles) and render only when scrolling is possible in that direction. Each click advances by one tile. Trackpad or touch scrolling still works.
+
+<Canvas of={PromptFieldStories.MultiArtifactScroll} />
+
 ## Behaviors
 
 ### Handling events

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -75,6 +75,15 @@ Trackpad, wheel, touch scrolling, and the overlay scrollbar lane below the tiles
 
 <Canvas of={PromptFieldStories.MultiArtifactScroll} />
 
+### Upload action menu
+
+`swc-prompt-field` fires `swc-prompt-field-upload-click` from the **`+`** button and leaves the resulting UI entirely to the consuming product; the component has no opinion on what opens. Design recommends the **`+`** button open a menu with, at minimum:
+
+- **Add from Adobe cloud storage**
+- **Attach files**
+
+Product teams control the exact menu contents and may add more sources, but these two are the recommended baseline. Attachments added through either path should surface as staged artifacts using the same **`swc-upload-artifact`** error/invalid state as a directly-dropped file, since the artifact strip does not distinguish attachments by origin.
+
 ## Behaviors
 
 ### Handling events

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -113,9 +113,9 @@ The `<swc-prompt-field>` element implements the following accessibility features
 
 #### Artifact strip keyboard navigation
 
-The artifact strip is a `role="region"` landmark (labeled `artifact-strip-label`, default "Uploaded assets strip") with roving-tabindex thumbnails:
+The artifact strip is a `role="region"` landmark (labeled `artifact-strip-label`, default "Uploaded assets strip") with a container-level focus stop and roving-tabindex thumbnails:
 
-- **Tab**: moves to the active thumbnail (one tile is ever a tab stop); once you've interacted with a thumbnail via Arrow keys or Enter/Space, Tab additionally reveals that tile's Close button before continuing
+- **Tab**: moves through the previous chevron when present, then the strip landmark, then the next chevron when present. Press Enter or Space on the landmark to enter the active thumbnail; once you've interacted with a thumbnail via Arrow keys or Enter/Space, Tab additionally reveals that tile's Close button before continuing
 - **Arrow Left/Right**: move the active thumbnail one tile at a time and scroll it into view (distinct from the `<`/`>` chevrons, which page by a full set)
 - **Enter/Space** on a thumbnail: marks the strip as interacted with, unlocking Tab access to Close
 - **Shift+Tab** from Close: returns to the thumbnail; **Tab** from Close reaches the `>` chevron when more content is scrolled out of view, otherwise continues to the prompt textarea

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -34,7 +34,7 @@ The send button enablement is derived internally from prompt content (value or a
 
 ### Legal disclaimer
 
-Every prompt field in production must include Legal-approved disclaimer copy below the composer. Slot your product's approved text into **`legal`** — wording, links, and locale are consumer-owned, not baked into the component.
+Every prompt field in production must include Legal-approved disclaimer copy below the composer. Slot your product's approved text into **`legal`**: wording, links, and locale are consumer-owned, not baked into the component.
 
 Apply the `.swc-PromptField-legal-disclaimer` class for default footer typography. `swc-prompt-field` logs a development warning when the `legal` slot is empty.
 
@@ -46,7 +46,7 @@ Artifact layout is inferred from the **`artifact`** slot content:
 - **`swc-upload-artifact type="card"`**: file-style card artifacts (one or more)
 - **`swc-upload-artifact type="media"`**: media tile artifacts (one or more, with or without badge)
 
-**Use one layout type per composer session** (`card` or `media`). Slot multiple artifacts of that same type — for example, several cards or several media tiles. Do not mix `card` and `media` in the same strip; `swc-prompt-field` logs a development warning when both are detected.
+**Use one layout type per composer session** (`card` or `media`). Slot multiple artifacts of that same type: for example, several cards or several media tiles. Do not mix `card` and `media` in the same strip; `swc-prompt-field` logs a development warning when both are detected.
 
 This rule is about **component layout**, not file MIME type. You can attach many files in one session as long as they share the same layout:
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -109,6 +109,7 @@ The `<swc-prompt-field>` element implements the following accessibility features
 - The `<textarea>` uses `aria-labelledby` when label text is visible
 - `accessible-label` can override the accessible name when needed
 - All icon buttons carry descriptive `aria-label` attributes
+- `artifact-scroll-prev-label` and `artifact-scroll-next-label` let consumers localize the artifact-strip chevrons
 - The send button uses `disabled` natively when the prompt has no content
 
 #### Artifact strip keyboard navigation

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -52,7 +52,7 @@ This rule is about **component layout**, not file MIME type. You can attach many
 
 - **Document-only uploads** where title and subtitle carry meaning → all **`type="card"`**
 - **Visual previews** (photos, storyboard frames) → all **`type="media"`**
-- **Mixed images and documents in one batch** → normalize to all **`type="media"`**: image previews in `thumbnail`, and document tiles with a preview or icon in `thumbnail` plus an optional **`badge`** (for example, "PDF"). See **[Media with badge](/docs/patterns-conversational-ai-upload-artifact--readme#media-with-badge)**.
+- **Mixed images and documents in one batch** → normalize to all **`type="media"`**: image previews in `thumbnail`, and document tiles with a preview or icon in `thumbnail` plus an optional **`badge`** (for example, "PDF"). See **[Media with badge](/docs/patterns-conversational-ai-upload-artifact--docs#media-with-badge)**.
 
 **Populate the attachment strip** by slotting **one `<swc-upload-artifact>` per file**, each with **`slot="artifact"`** (same slot name repeated).
 
@@ -69,9 +69,9 @@ Artifacts own dismiss behavior via **`dismissible`** and emit **`swc-upload-arti
 
 ### Multi-artifact scroll
 
-When several attachments exceed the composer width, the strip scrolls horizontally at full width. Chevron buttons flank the strip (32px gray circles) and render only when scrolling is possible in that direction. Each click advances by one **set** of tiles: the last visible tile becomes the first tile in the next set so the carousel keeps continuity. On the final set, the strip right-aligns to stay full. Edge fades on both sides signal overflow and hide at the ends of the list.
+When several attachments exceed the composer width, the strip scrolls horizontally at full width. Chevron buttons flank the strip (32px gray circles) and render only when scrolling is possible in that direction. Each click advances by one viewport width and settles on a tile boundary; the browser's native scroll clamping keeps the final page from overshooting the end. Edge fades on both sides signal overflow and hide at the ends of the list.
 
-Trackpad, wheel, touch scrolling, and the overlay scrollbar lane below the tiles all work on the artifact strip. The lane is always reserved in the gap below the tiles so composer height stays fixed; the thumb appears only during physical interaction (wheel, touch, or dragging the scrollbar). Chevron paging does not reveal the scrollbar.
+Trackpad, wheel, touch scrolling, and the platform's native scrollbar all work on the artifact strip. Chevron paging does not reveal the scrollbar.
 
 <Canvas of={PromptFieldStories.MultiArtifactScroll} />
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -113,12 +113,12 @@ The `<swc-prompt-field>` element implements the following accessibility features
 
 #### Artifact strip keyboard navigation
 
-The artifact strip is a `role="region"` landmark (labeled `artifact-strip-label`, default "Uploaded assets strip") with a container-level focus stop and roving-tabindex thumbnails:
+The artifact strip is a `role="region"` landmark (labeled `artifact-strip-label`, default "Uploaded assets strip") wrapping roving-tabindex thumbnails; the landmark itself is not a tab stop:
 
-- **Tab**: moves through the previous chevron when present, then the strip landmark, then the next chevron when present. Press Enter or Space on the landmark to enter the active thumbnail; once you've interacted with a thumbnail via Arrow keys or Enter/Space, Tab additionally reveals that tile's Close button before continuing
+- **Tab**: moves through the previous chevron when present, then directly to the active thumbnail (the first one, until Arrow keys move that roving stop elsewhere), then that thumbnail's Close button, then the next chevron when present, then out of the strip
 - **Arrow Left/Right**: move the active thumbnail one tile at a time and scroll it into view (distinct from the `<`/`>` chevrons, which page by a full set)
-- **Enter/Space** on a thumbnail: marks the strip as interacted with, unlocking Tab access to Close
-- **Shift+Tab** from Close: returns to the thumbnail; **Tab** from Close reaches the `>` chevron when more content is scrolled out of view, otherwise continues to the prompt textarea
+- **Shift+Tab** from Close: returns to the thumbnail; **Shift+Tab** from a thumbnail exits the strip entirely
+- Activating the `>` chevron (click, Enter, or Space) keeps focus on the chevron and scrolls the next set of tiles into view; **Shift+Tab** from it then moves into that newly displayed set (its active thumbnail's Close button when shown, otherwise the thumbnail). The `<` chevron is the mirror: activating it keeps focus there, and **Tab** moves into the newly displayed set
 - The `<`/`>` chevrons redirect focus to the nearest thumbnail instead of losing it if they disappear while focused (for example, paging all the way to one end)
 
 ### Best practices

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -120,7 +120,7 @@ The artifact strip is a `role="region"` landmark (labeled `artifact-strip-label`
 - **Arrow Left/Right**: move the active thumbnail one tile at a time and scroll it into view (distinct from the `<`/`>` chevrons, which page by a full set)
 - **Shift+Tab** from Close: returns to the thumbnail; **Shift+Tab** from a thumbnail exits the strip entirely
 - Activating the `>` chevron (click, Enter, or Space) keeps focus on the chevron and scrolls the next set of tiles into view; **Shift+Tab** from it then moves into that newly displayed set (its active thumbnail's Close button when shown, otherwise the thumbnail). The `<` chevron is the mirror: activating it keeps focus there, and **Tab** moves into the newly displayed set
-- The `<`/`>` chevrons redirect focus to the nearest thumbnail instead of losing it if they disappear while focused (for example, paging all the way to one end)
+- At either end of the strip, the `<`/`>` chevron becomes `aria-disabled` rather than being removed, so a chevron that has focus when scrolling reaches that end keeps it instead of losing it to the browser's default focus handling
 
 ### Best practices
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -134,10 +134,7 @@ export const Anatomy: Story = {
   render: () => html`
     <div style="display:flex;flex-direction:column;gap:24px;">
       <div style="display:flex;flex-direction:column;gap:8px;">
-        <swc-prompt-field
-          label="Prompt"
-          placeholder=${defaultPlaceholder}
-        >
+        <swc-prompt-field label="Prompt" placeholder=${defaultPlaceholder}>
           ${legalDisclaimerSlot}
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">Base structure</span>
@@ -155,10 +152,7 @@ export const Modes: Story = {
   render: () => html`
     <div style="display:flex;flex-direction:column;gap:32px;">
       <div style="display:flex;flex-direction:column;gap:8px;">
-        <swc-prompt-field
-          label="Prompt"
-          placeholder=${defaultPlaceholder}
-        >
+        <swc-prompt-field label="Prompt" placeholder=${defaultPlaceholder}>
           ${legalDisclaimerSlot}
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">
@@ -215,8 +209,9 @@ export const Artifact: Story = {
         <strong>artifact</strong>
         — Slot one or more
         <code>&lt;swc-upload-artifact slot="artifact"&gt;</code>
-        nodes above the textarea. Use one layout type per session (card or media).
-        When uploads mix images and documents, normalize to media tiles with badges. See
+        nodes above the textarea. Use one layout type per session (card or
+        media). When uploads mix images and documents, normalize to media tiles
+        with badges. See
         <strong>Multi-card</strong>
         and
         <strong>Multi-media</strong>
@@ -272,10 +267,7 @@ export const Artifact: Story = {
         </span>
       </div>
       <div style="display:flex;flex-direction:column;gap:8px;">
-        <swc-prompt-field
-          label="Prompt"
-          placeholder=${defaultPlaceholder}
-        >
+        <swc-prompt-field label="Prompt" placeholder=${defaultPlaceholder}>
           ${legalDisclaimerSlot}
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">None</span>
@@ -310,14 +302,25 @@ export const Artifact: Story = {
   tags: ['options'],
 };
 
-const multiArtifactScrollMediaIds = [
-  64, 56, 823, 237, 429, 326, 180, 119, 366, 452, 15, 188,
+const multiArtifactScrollGradients = [
+  'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+  'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)',
+  'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)',
+  'linear-gradient(135deg, #fa709a 0%, #fee140 100%)',
+  'linear-gradient(135deg, #30cfd0 0%, #330867 100%)',
+  'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)',
+  'linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%)',
+  'linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%)',
+  'linear-gradient(135deg, #ff6e7f 0%, #bfe9ff 100%)',
+  'linear-gradient(135deg, #e0c3fc 0%, #8ec5fc 100%)',
+  'linear-gradient(135deg, #f77062 0%, #fe5196 100%)',
 ] as const;
 
 const multiArtifactScrollBadges: Record<number, string> = {
-  452: 'MP4',
-  15: 'MP4',
-  188: 'PDF',
+  9: 'MP4',
+  10: 'MP4',
+  11: 'PDF',
 };
 
 export const MultiArtifactScroll: Story = {
@@ -325,25 +328,26 @@ export const MultiArtifactScroll: Story = {
     <div style="display:flex;flex-direction:column;gap:16px;inline-size:100%;">
       <p class="swc-Detail swc-Detail--sizeS" style="margin:0;">
         Full-width composer with twelve media tiles. Chevron controls flank the
-        strip when scrolling is possible; each click scrolls by one tile.
-        Trackpad scrolling works with no persistent scrollbar.
+        strip when scrolling is possible; each click advances by one set with
+        the last visible tile anchoring the next view. Edge fades signal
+        overflow. An overlay scrollbar lane below the tiles appears during
+        wheel, touch, or drag.
       </p>
-      <swc-prompt-field
-        label="Prompt"
-        value="Review these storyboard frames."
-      >
-        ${multiArtifactScrollMediaIds.map(
-          (id) => html`
+      <swc-prompt-field label="Prompt" value="Review these storyboard frames.">
+        ${multiArtifactScrollGradients.map(
+          (gradient, index) => html`
             <swc-upload-artifact slot="artifact" type="media" dismissible>
-              <img
+              <div
                 slot="thumbnail"
-                src="https://picsum.photos/id/${id}/68/68"
-                alt="Storyboard frame ${id}"
-                style="inline-size:100%;block-size:100%;object-fit:cover;"
-              />
-              ${multiArtifactScrollBadges[id]
+                role="img"
+                aria-label="Storyboard frame ${index + 1}"
+                style="inline-size:100%;block-size:100%;background:${gradient};"
+              ></div>
+              ${multiArtifactScrollBadges[index]
                 ? html`
-                    <span slot="badge">${multiArtifactScrollBadges[id]}</span>
+                    <span slot="badge">
+                      ${multiArtifactScrollBadges[index]}
+                    </span>
                   `
                 : nothing}
             </swc-upload-artifact>

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -25,8 +25,14 @@ import '../swc-prompt-field.js';
 const { args, argTypes } = getStorybookHelpers('swc-prompt-field');
 const defaultPlaceholder =
   'Ready to get started? Ask a question, share an idea, or add a task.';
-const defaultLegalDisclaimer =
-  'AI output may be inaccurate. Verify before using.';
+const defaultLegalDisclaimer = html`
+  Responses are generated using AI, and may be inaccurate. Check before using.
+  <a
+    href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html"
+  >
+    AI User Guidelines
+  </a>
+`;
 
 const legalDisclaimerSlot = html`
   <p slot="legal" class="swc-PromptField-legal-disclaimer">

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -22,9 +22,45 @@ import '../swc-prompt-field.js';
 //    METADATA
 // ────────────────
 
-const { args, argTypes, template } = getStorybookHelpers('swc-prompt-field');
+const { args, argTypes } = getStorybookHelpers('swc-prompt-field');
 const defaultPlaceholder =
   'Ready to get started? Ask a question, share an idea, or add a task.';
+const defaultLegalDisclaimer =
+  'AI output may be inaccurate. Verify before using.';
+
+const legalDisclaimerSlot = html`
+  <p slot="legal" class="swc-PromptField-legal-disclaimer">
+    ${defaultLegalDisclaimer}
+  </p>
+`;
+
+type PromptFieldStoryArgs = typeof args;
+
+function renderPromptField(
+  storyArgs: PromptFieldStoryArgs,
+  slots: unknown = legalDisclaimerSlot
+) {
+  return html`
+    <swc-prompt-field
+      label=${storyArgs.label ?? 'Prompt'}
+      placeholder=${storyArgs.placeholder ?? defaultPlaceholder}
+      .value=${storyArgs.value ?? ''}
+      mode=${storyArgs.mode ?? 'default'}
+      accessible-label=${storyArgs['accessible-label'] ?? ''}
+      send-label=${storyArgs['send-label'] ?? 'Send'}
+      stop-label=${storyArgs['stop-label'] ?? 'Stop generating'}
+      upload-label=${storyArgs['upload-label'] ?? 'Add attachment'}
+      artifact-scroll-prev-label=${storyArgs['artifact-scroll-prev-label'] ??
+      'Show previous attachments'}
+      artifact-scroll-next-label=${storyArgs['artifact-scroll-next-label'] ??
+      'Show more attachments'}
+      min-rows=${storyArgs['min-rows'] ?? 1}
+      max-rows=${storyArgs['max-rows'] ?? 4}
+    >
+      ${slots}
+    </swc-prompt-field>
+  `;
+}
 
 argTypes.mode = {
   ...argTypes.mode,
@@ -46,7 +82,7 @@ const meta: Meta = {
   component: 'swc-prompt-field',
   args,
   argTypes,
-  render: (args) => template(args),
+  render: (storyArgs) => renderPromptField(storyArgs),
   parameters: {
     docs: {
       packagePath: 'patterns/conversational-ai/prompt-field',
@@ -101,16 +137,10 @@ export const Anatomy: Story = {
         <swc-prompt-field
           label="Prompt"
           placeholder=${defaultPlaceholder}
-        ></swc-prompt-field>
-        <span class="swc-Detail swc-Detail--sizeS">Base structure</span>
-      </div>
-      <div style="display:flex;flex-direction:column;gap:8px;">
-        <swc-prompt-field label="Prompt" placeholder=${defaultPlaceholder}>
-          <div slot="legal">
-            AI output may be inaccurate. Verify before using.
-          </div>
+        >
+          ${legalDisclaimerSlot}
         </swc-prompt-field>
-        <span class="swc-Detail swc-Detail--sizeS">legal slot only</span>
+        <span class="swc-Detail swc-Detail--sizeS">Base structure</span>
       </div>
     </div>
   `,
@@ -128,7 +158,9 @@ export const Modes: Story = {
         <swc-prompt-field
           label="Prompt"
           placeholder=${defaultPlaceholder}
-        ></swc-prompt-field>
+        >
+          ${legalDisclaimerSlot}
+        </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">
           mode="default" with empty value
         </span>
@@ -137,7 +169,9 @@ export const Modes: Story = {
         <swc-prompt-field
           label="Prompt"
           value="Summarize the API changes in this branch."
-        ></swc-prompt-field>
+        >
+          ${legalDisclaimerSlot}
+        </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">
           mode="default" with entered value
         </span>
@@ -147,7 +181,9 @@ export const Modes: Story = {
           mode="loading"
           label="Prompt"
           value="Summarize the API changes in this branch."
-        ></swc-prompt-field>
+        >
+          ${legalDisclaimerSlot}
+        </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">
           mode="loading" (input remains editable)
         </span>
@@ -157,7 +193,9 @@ export const Modes: Story = {
           mode="disabled"
           label="Prompt"
           value="This input is disabled."
-        ></swc-prompt-field>
+        >
+          ${legalDisclaimerSlot}
+        </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">
           mode="disabled" (input and controls disabled)
         </span>
@@ -177,8 +215,8 @@ export const Artifact: Story = {
         <strong>artifact</strong>
         — Slot one or more
         <code>&lt;swc-upload-artifact slot="artifact"&gt;</code>
-        nodes above the textarea. Use one type per session: cards only, or media
-        tiles only (with or without badge). See
+        nodes above the textarea. Use one layout type per session (card or media).
+        When uploads mix images and documents, normalize to media tiles with badges. See
         <strong>Multi-card</strong>
         and
         <strong>Multi-media</strong>
@@ -199,6 +237,7 @@ export const Artifact: Story = {
             <span slot="title">Q2 metrics draft</span>
             <span slot="subtitle">XLSX</span>
           </swc-upload-artifact>
+          ${legalDisclaimerSlot}
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">
           Multi-card strip (cards only)
@@ -226,6 +265,7 @@ export const Artifact: Story = {
             />
             <span slot="badge">PDF</span>
           </swc-upload-artifact>
+          ${legalDisclaimerSlot}
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">
           Multi-media strip (media only, with and without badge)
@@ -235,7 +275,9 @@ export const Artifact: Story = {
         <swc-prompt-field
           label="Prompt"
           placeholder=${defaultPlaceholder}
-        ></swc-prompt-field>
+        >
+          ${legalDisclaimerSlot}
+        </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">None</span>
       </div>
       <div style="display:flex;flex-direction:column;gap:8px;">
@@ -245,6 +287,7 @@ export const Artifact: Story = {
             <span slot="title">Hilton commercial assets</span>
             <span slot="subtitle">2026</span>
           </swc-upload-artifact>
+          ${legalDisclaimerSlot}
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">Single card</span>
       </div>
@@ -258,6 +301,7 @@ export const Artifact: Story = {
               style="inline-size:100%;block-size:100%;object-fit:cover;"
             />
           </swc-upload-artifact>
+          ${legalDisclaimerSlot}
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">Single media</span>
       </div>
@@ -305,6 +349,7 @@ export const MultiArtifactScroll: Story = {
             </swc-upload-artifact>
           `
         )}
+        ${legalDisclaimerSlot}
       </swc-prompt-field>
     </div>
   `,
@@ -320,6 +365,12 @@ interface PromptFieldBehaviorArtifact {
   fileName: string;
   sizeLabel: string;
   thumbnailUrl?: string;
+  badgeLabel?: string;
+}
+
+function fileBadgeLabel(fileName: string): string | undefined {
+  const extension = fileName.match(/\.([a-z0-9]+)$/i)?.[1];
+  return extension ? extension.toUpperCase() : undefined;
 }
 
 @customElement('swc-prompt-field-behavior-demo')
@@ -389,11 +440,12 @@ class PromptFieldBehaviorDemo extends LitElement {
         fileName: file.name || 'Attachment',
         sizeLabel: `${Math.max(1, Math.round(file.size / 1024))} KB`,
         thumbnailUrl: isImage ? URL.createObjectURL(file) : undefined,
+        badgeLabel: isImage ? undefined : fileBadgeLabel(file.name),
       } satisfies PromptFieldBehaviorArtifact;
     });
 
     this.artifacts = [...this.artifacts, ...nextArtifacts];
-    this.readout = `External picker selected ${files.length} file${files.length === 1 ? '' : 's'} and the consumer slotted upload artifacts into the prompt.`;
+    this.readout = `External picker selected ${files.length} file${files.length === 1 ? '' : 's'} and the consumer slotted media upload artifacts into the prompt.`;
     input.value = '';
   }
 
@@ -428,44 +480,40 @@ class PromptFieldBehaviorDemo extends LitElement {
             @swc-prompt-field-upload-click=${this._handleUploadClick}
             @swc-upload-artifact-dismiss=${this._handleArtifactDismiss}
           >
-            ${this.artifacts.map((artifact) =>
-              artifact.thumbnailUrl
-                ? html`
-                    <swc-upload-artifact
-                      slot="artifact"
-                      type="media"
-                      dismissible
-                      data-artifact-id=${artifact.id}
-                    >
-                      <img
-                        slot="thumbnail"
-                        src=${artifact.thumbnailUrl}
-                        alt=${artifact.fileName}
-                        style="inline-size:100%;block-size:100%;object-fit:cover;"
-                      />
-                    </swc-upload-artifact>
-                  `
-                : html`
-                    <swc-upload-artifact
-                      slot="artifact"
-                      type="card"
-                      dismissible
-                      data-artifact-id=${artifact.id}
-                    >
-                      <div
-                        slot="thumbnail"
-                        role="img"
-                        aria-label="File thumbnail"
-                        style="inline-size:40px;block-size:40px;"
-                      ></div>
-                      <span slot="title">${artifact.fileName}</span>
-                      <span slot="subtitle">${artifact.sizeLabel}</span>
-                    </swc-upload-artifact>
-                  `
+            ${this.artifacts.map(
+              (artifact) => html`
+                <swc-upload-artifact
+                  slot="artifact"
+                  type="media"
+                  dismissible
+                  data-artifact-id=${artifact.id}
+                >
+                  ${artifact.thumbnailUrl
+                    ? html`
+                        <img
+                          slot="thumbnail"
+                          src=${artifact.thumbnailUrl}
+                          alt=${artifact.fileName}
+                          style="inline-size:100%;block-size:100%;object-fit:cover;"
+                        />
+                      `
+                    : html`
+                        <div
+                          slot="thumbnail"
+                          role="img"
+                          aria-label=${artifact.fileName}
+                          style="inline-size:100%;block-size:100%;background:#f3f3f3;"
+                        ></div>
+                      `}
+                  ${artifact.badgeLabel
+                    ? html`
+                        <span slot="badge">${artifact.badgeLabel}</span>
+                      `
+                    : nothing}
+                </swc-upload-artifact>
+              `
             )}
-            <div slot="legal">
-              AI output may be inaccurate. Verify before using.
-            </div>
+            ${legalDisclaimerSlot}
           </swc-prompt-field>
           <input
             data-file-input

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -193,20 +193,20 @@ export const Artifact: Story = {
             <span slot="subtitle">PDF</span>
           </swc-upload-artifact>
           <swc-upload-artifact slot="artifact" type="media" dismissible>
-            <div
+            <img
               slot="thumbnail"
-              style="background:linear-gradient(135deg,#6366f1,#ec4899);"
-              role="img"
-              aria-label="Campaign still"
-            ></div>
+              src="https://picsum.photos/id/64/68/68"
+              alt="Campaign still"
+              style="inline-size:100%;block-size:100%;object-fit:cover;"
+            />
           </swc-upload-artifact>
           <swc-upload-artifact slot="artifact" type="media" dismissible>
-            <div
+            <img
               slot="thumbnail"
-              style="background:linear-gradient(135deg,#0ea5e9,#22c55e);"
-              role="img"
-              aria-label="Storyboard frame"
-            ></div>
+              src="https://picsum.photos/id/56/68/68"
+              alt="Storyboard frame"
+              style="inline-size:100%;block-size:100%;object-fit:cover;"
+            />
           </swc-upload-artifact>
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">
@@ -235,8 +235,9 @@ export const Artifact: Story = {
           <swc-upload-artifact slot="artifact" type="media" dismissible>
             <img
               slot="thumbnail"
-              src="https://placehold.co/160x120/png"
+              src="https://picsum.photos/id/823/68/68"
               alt="Attachment preview"
+              style="inline-size:100%;block-size:100%;object-fit:cover;"
             />
           </swc-upload-artifact>
         </swc-prompt-field>

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -207,6 +207,7 @@ export const Artifact: Story = {
               alt="Storyboard frame"
               style="inline-size:100%;block-size:100%;object-fit:cover;"
             />
+            <span slot="badge">PDF</span>
           </swc-upload-artifact>
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -175,12 +175,14 @@ export const Artifact: Story = {
         style="margin:0;max-inline-size:720px;"
       >
         <strong>artifact</strong>
-        — Slot multiple
+        — Slot one or more
         <code>&lt;swc-upload-artifact slot="artifact"&gt;</code>
-        nodes; the field lays them out in a wrapping row above the textarea.
-        More variants:
-        <strong>Multi-artifacts</strong>
-        .
+        nodes above the textarea. Use one type per session: cards only, or media
+        tiles only (with or without badge). See
+        <strong>Multi-card</strong>
+        and
+        <strong>Multi-media</strong>
+        on the upload-artifact page.
       </p>
       <div style="display:flex;flex-direction:column;gap:8px;">
         <swc-prompt-field
@@ -192,6 +194,21 @@ export const Artifact: Story = {
             <span slot="title">Brand guidelines</span>
             <span slot="subtitle">PDF</span>
           </swc-upload-artifact>
+          <swc-upload-artifact slot="artifact" type="card" dismissible>
+            <div slot="thumbnail" role="img" aria-label="Spreadsheet"></div>
+            <span slot="title">Q2 metrics draft</span>
+            <span slot="subtitle">XLSX</span>
+          </swc-upload-artifact>
+        </swc-prompt-field>
+        <span class="swc-Detail swc-Detail--sizeS">
+          Multi-card strip (cards only)
+        </span>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:8px;">
+        <swc-prompt-field
+          label="Prompt"
+          value="Review these storyboard frames."
+        >
           <swc-upload-artifact slot="artifact" type="media" dismissible>
             <img
               slot="thumbnail"
@@ -211,7 +228,7 @@ export const Artifact: Story = {
           </swc-upload-artifact>
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">
-          Mixed multi-artifact (card + media, wrapping strip)
+          Multi-media strip (media only, with and without badge)
         </span>
       </div>
       <div style="display:flex;flex-direction:column;gap:8px;">

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { html, LitElement } from 'lit';
+import { html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
@@ -261,6 +261,51 @@ export const Artifact: Story = {
         </swc-prompt-field>
         <span class="swc-Detail swc-Detail--sizeS">Single media</span>
       </div>
+    </div>
+  `,
+  tags: ['options'],
+};
+
+const multiArtifactScrollMediaIds = [
+  64, 56, 823, 237, 429, 326, 180, 119, 366, 452, 15, 188,
+] as const;
+
+const multiArtifactScrollBadges: Record<number, string> = {
+  452: 'MP4',
+  15: 'MP4',
+  188: 'PDF',
+};
+
+export const MultiArtifactScroll: Story = {
+  render: () => html`
+    <div style="display:flex;flex-direction:column;gap:16px;inline-size:100%;">
+      <p class="swc-Detail swc-Detail--sizeS" style="margin:0;">
+        Full-width composer with twelve media tiles. Chevron controls flank the
+        strip when scrolling is possible; each click scrolls by one tile.
+        Trackpad scrolling works with no persistent scrollbar.
+      </p>
+      <swc-prompt-field
+        label="Prompt"
+        value="Review these storyboard frames."
+      >
+        ${multiArtifactScrollMediaIds.map(
+          (id) => html`
+            <swc-upload-artifact slot="artifact" type="media" dismissible>
+              <img
+                slot="thumbnail"
+                src="https://picsum.photos/id/${id}/68/68"
+                alt="Storyboard frame ${id}"
+                style="inline-size:100%;block-size:100%;object-fit:cover;"
+              />
+              ${multiArtifactScrollBadges[id]
+                ? html`
+                    <span slot="badge">${multiArtifactScrollBadges[id]}</span>
+                  `
+                : nothing}
+            </swc-upload-artifact>
+          `
+        )}
+      </swc-prompt-field>
     </div>
   `,
   tags: ['options'],

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -212,8 +212,7 @@ export const Artifact: Story = {
         class="swc-Detail swc-Detail--sizeS"
         style="margin:0;max-inline-size:720px;"
       >
-        <strong>artifact</strong>
-        — Slot one or more
+        <strong>artifact</strong>: Slot one or more
         <code>&lt;swc-upload-artifact slot="artifact"&gt;</code>
         nodes above the textarea. Use one layout type per session (card or
         media). When uploads mix images and documents, normalize to media tiles

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -334,10 +334,9 @@ export const MultiArtifactScroll: Story = {
     <div style="display:flex;flex-direction:column;gap:16px;inline-size:100%;">
       <p class="swc-Detail swc-Detail--sizeS" style="margin:0;">
         Full-width composer with twelve media tiles. Chevron controls flank the
-        strip when scrolling is possible; each click advances by one set with
-        the last visible tile anchoring the next view. Edge fades signal
-        overflow. An overlay scrollbar lane below the tiles appears during
-        wheel, touch, or drag.
+        strip when scrolling is possible; each click advances by one viewport
+        width and settles on a tile boundary. Edge fades signal overflow. An
+        overflowing strip uses the platform's native scrollbar.
       </p>
       <swc-prompt-field label="Prompt" value="Review these storyboard frames.">
         ${multiArtifactScrollGradients.map(

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -212,7 +212,8 @@ export const Artifact: Story = {
         class="swc-Detail swc-Detail--sizeS"
         style="margin:0;max-inline-size:720px;"
       >
-        <strong>artifact</strong>: Slot one or more
+        <strong>artifact</strong>
+        : Slot one or more
         <code>&lt;swc-upload-artifact slot="artifact"&gt;</code>
         nodes above the textarea. Use one layout type per session (card or
         media). When uploads mix images and documents, normalize to media tiles

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -598,6 +598,13 @@ export const ArtifactFocusOrderTest: Story = {
     await step(
       'Shift+Tab from the ">" button focuses the last fully-visible tile',
       async () => {
+        // Force a known, deterministic scroll position rather than relying on
+        // wherever the previous step's "first fully-visible tile" landed
+        // (that position is layout-dependent and varies across browsers).
+        scrollEl?.scrollTo({ left: 0, behavior: 'auto' });
+        await waitForScrollEnd(scrollEl);
+        await el.updateComplete;
+
         const nextButton = getNextButton();
         expect(nextButton).toBeTruthy();
         nextButton?.focus();

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -14,6 +14,8 @@ import { html, nothing, render } from 'lit';
 import { expect, userEvent } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
+import { getActiveElement } from '@adobe/spectrum-wc-core/utils/index.js';
+
 import '../../upload-artifact/swc-upload-artifact.js';
 import '../swc-prompt-field.js';
 
@@ -393,6 +395,240 @@ export const ArtifactScrollPaginationTest: Story = {
         await el.updateComplete;
 
         expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(beforeClick);
+      }
+    );
+  },
+};
+
+function waitForScrollEnd(
+  scrollEl: HTMLDivElement | null | undefined
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const done = (): void => resolve();
+    scrollEl?.addEventListener('scrollend', done, { once: true });
+    window.setTimeout(done, 1500);
+  });
+}
+
+function dispatchKeydown(
+  target: EventTarget,
+  key: string,
+  eventInit: Partial<KeyboardEventInit> = {}
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    composed: true,
+    cancelable: true,
+    ...eventInit,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+export const ArtifactFocusOrderTest: Story = {
+  render: () => nothing,
+  play: async ({ canvasElement, step }) => {
+    renderMultiArtifactPromptField(canvasElement);
+
+    const el = await getComponent<PromptField>(
+      canvasElement,
+      'swc-prompt-field'
+    );
+    await el.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await el.updateComplete;
+
+    const artifacts = Array.from(
+      el.querySelectorAll<HTMLElement>('[slot="artifact"]')
+    );
+    const textarea = el.shadowRoot?.querySelector<HTMLTextAreaElement>(
+      '.swc-PromptField-textarea'
+    );
+    const scrollEl = el.shadowRoot?.querySelector<HTMLDivElement>(
+      '.swc-PromptField-artifacts-scroll'
+    );
+    const getNextButton = (): HTMLButtonElement | null | undefined =>
+      el.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-PromptField-artifacts-scroll-next'
+      );
+    const getPrevButton = (): HTMLButtonElement | null | undefined =>
+      el.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-PromptField-artifacts-scroll-prev'
+      );
+    const getDismissButton = (
+      tile: HTMLElement
+    ): HTMLButtonElement | null | undefined =>
+      tile.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-UploadArtifact-dismiss'
+      );
+
+    await step('landmark region wraps the strip', async () => {
+      const row = el.shadowRoot?.querySelector(
+        '.swc-PromptField-artifacts-row'
+      );
+      expect(row?.getAttribute('role')).toBe('region');
+      expect(row?.getAttribute('aria-label')).toBe('Uploaded assets strip');
+    });
+
+    await step(
+      'only one tile is the roving tab stop; dismiss buttons are never a normal tab stop',
+      async () => {
+        expect(artifacts[0]?.tabIndex).toBe(0);
+        expect(artifacts.slice(1).every((tile) => tile.tabIndex === -1)).toBe(
+          true
+        );
+        expect(
+          artifacts.every((tile) => getDismissButton(tile)?.tabIndex === -1)
+        ).toBe(true);
+      }
+    );
+
+    await step(
+      'Arrow Right moves the roving tab stop one tile and marks the strip entered',
+      async () => {
+        artifacts[0]?.focus();
+        dispatchKeydown(artifacts[0]!, 'ArrowRight');
+        await el.updateComplete;
+
+        expect(artifacts[0]?.tabIndex).toBe(-1);
+        expect(artifacts[1]?.tabIndex).toBe(0);
+        expect(getActiveElement()).toBe(artifacts[1]);
+      }
+    );
+
+    await step(
+      'Tab from the active (entered) tile reveals its Close button',
+      async () => {
+        const active = artifacts[1]!;
+        const event = dispatchKeydown(active, 'Tab');
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(getActiveElement()).toBe(getDismissButton(active));
+      }
+    );
+
+    await step(
+      'Shift+Tab from the Close button returns focus to the tile',
+      async () => {
+        const active = artifacts[1]!;
+        const dismiss = getDismissButton(active)!;
+        const event = dispatchKeydown(dismiss, 'Tab', { shiftKey: true });
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(getActiveElement()).toBe(active);
+      }
+    );
+
+    await step(
+      'Tab from the Close button reaches the ">" button when more content is scrolled out of view',
+      async () => {
+        const active = artifacts[1]!;
+        const dismiss = getDismissButton(active)!;
+        dismiss.focus();
+        const event = dispatchKeydown(dismiss, 'Tab');
+        await el.updateComplete;
+
+        const nextButton = getNextButton();
+        expect(nextButton).toBeTruthy();
+        expect(event.defaultPrevented).toBe(true);
+        expect(getActiveElement()).toBe(nextButton);
+      }
+    );
+
+    await step(
+      'focus leaving the strip resets "entered"; Tab from an untouched tile does not intercept',
+      async () => {
+        textarea?.focus();
+        await el.updateComplete;
+
+        artifacts[1]?.focus();
+        await el.updateComplete;
+        const event = dispatchKeydown(artifacts[1]!, 'Tab');
+
+        // Not "entered" (focus arrived via .focus(), not Arrow/Enter), so the
+        // Close button/">" intercept must not fire; native Tab is left alone.
+        expect(event.defaultPrevented).toBe(false);
+      }
+    );
+
+    await step(
+      'Enter marks the strip entered without moving focus off the tile',
+      async () => {
+        const active = artifacts[1]!;
+        active.focus();
+        const event = dispatchKeydown(active, 'Enter');
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(getActiveElement()).toBe(active);
+
+        const tabEvent = dispatchKeydown(active, 'Tab');
+        await el.updateComplete;
+        expect(tabEvent.defaultPrevented).toBe(true);
+        expect(getActiveElement()).toBe(getDismissButton(active));
+      }
+    );
+
+    await step(
+      'Tab from the "<" button focuses the first fully-visible tile',
+      async () => {
+        artifacts[artifacts.length - 1]?.focus();
+        await waitForScrollEnd(scrollEl);
+        await el.updateComplete;
+        dispatchKeydown(artifacts[artifacts.length - 1]!, 'ArrowLeft');
+        await waitForScrollEnd(scrollEl);
+        await el.updateComplete;
+
+        const prevButton = getPrevButton();
+        expect(prevButton).toBeTruthy();
+        prevButton?.focus();
+        const event = dispatchKeydown(prevButton!, 'Tab');
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        const active = getActiveElement();
+        expect(active).not.toBe(prevButton);
+        expect(artifacts.includes(active as HTMLElement)).toBe(true);
+      }
+    );
+
+    await step(
+      'Shift+Tab from the ">" button focuses the last fully-visible tile',
+      async () => {
+        const nextButton = getNextButton();
+        expect(nextButton).toBeTruthy();
+        nextButton?.focus();
+        const event = dispatchKeydown(nextButton!, 'Tab', { shiftKey: true });
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        const active = getActiveElement();
+        expect(artifacts.includes(active as HTMLElement)).toBe(true);
+      }
+    );
+
+    await step(
+      'the "<" button disappearing while focused redirects focus to the first tile',
+      async () => {
+        scrollEl?.scrollTo({ left: 200, behavior: 'auto' });
+        await waitForScrollEnd(scrollEl);
+        await el.updateComplete;
+        expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(0);
+
+        const prevButton = getPrevButton();
+        expect(prevButton).toBeTruthy();
+        prevButton?.focus();
+        expect(getActiveElement()).toBe(prevButton);
+
+        scrollEl?.scrollTo({ left: 0, behavior: 'auto' });
+        await waitForScrollEnd(scrollEl);
+        await el.updateComplete;
+
+        expect(getPrevButton()).toBeFalsy();
+        expect(getActiveElement()).toBe(artifacts[0]);
       }
     );
   },

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -241,7 +241,7 @@ function renderMultiArtifactPromptField(canvasElement: HTMLElement): void {
     html`
       <div style="inline-size:480px;">
         <swc-prompt-field label="Prompt" value="Review attachments.">
-          ${Array.from({ length: 8 }, (_, index) => index).map(
+          ${Array.from({ length: 14 }, (_, index) => index).map(
             (index) => html`
               <swc-upload-artifact slot="artifact" type="media" dismissible>
                 <div
@@ -300,6 +300,7 @@ export const ArtifactScrollPaginationTest: Story = {
 
     await step('chevron paging advances by more than one tile', async () => {
       const initialScrollLeft = scrollEl?.scrollLeft ?? 0;
+      const clientWidth = scrollEl?.clientWidth ?? 0;
       nextButton?.click();
       await el.updateComplete;
       expect(
@@ -317,6 +318,13 @@ export const ArtifactScrollPaginationTest: Story = {
           ?.assignedElements({ flatten: true })[0]
           ?.getBoundingClientRect().width ?? 68;
       expect(nextScrollLeft - initialScrollLeft).toBeGreaterThan(tileWidth);
+
+      // The whole visible set should page forward together (only the one
+      // edge tile that was under 50% visible may be carried over) rather
+      // than nudging by a single tile's worth of scroll.
+      expect(nextScrollLeft - initialScrollLeft).toBeGreaterThan(
+        clientWidth - 2 * tileWidth
+      );
     });
 
     await step('chevron paging keeps the scrollbar thumb hidden', async () => {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -590,7 +590,7 @@ export const ArtifactFocusOrderTest: Story = {
     );
 
     await step(
-      'Tab from the "<" button focuses the first fully-visible tile',
+      'Tab from the "<" button is left to native default, not intercepted into a tile',
       async () => {
         artifacts[artifacts.length - 1]?.focus();
         await waitForScrollEnd(scrollEl);
@@ -605,19 +605,19 @@ export const ArtifactFocusOrderTest: Story = {
         const event = dispatchKeydown(prevButton!, 'Tab');
         await el.updateComplete;
 
-        expect(event.defaultPrevented).toBe(true);
-        const active = getActiveElement();
-        expect(active).not.toBe(prevButton);
-        expect(artifacts.includes(active as HTMLElement)).toBe(true);
+        // The "<" chevron is a normal tab stop like any other outside the
+        // strip: Tab/Shift+Tab from it is never intercepted, so the next
+        // real stop is always the container (region), never a tile directly.
+        expect(event.defaultPrevented).toBe(false);
       }
     );
 
     await step(
-      'Shift+Tab from the ">" button focuses the last fully-visible tile',
+      'Shift+Tab from the ">" button is left to native default, not intercepted into a tile',
       async () => {
         // Force a known, deterministic scroll position rather than relying on
-        // wherever the previous step's "first fully-visible tile" landed
-        // (that position is layout-dependent and varies across browsers).
+        // wherever the previous step left the scroll offset (that position
+        // is layout-dependent and varies across browsers).
         scrollEl?.scrollTo({ left: 0, behavior: 'auto' });
         await waitForScrollEnd(scrollEl);
         await el.updateComplete;
@@ -628,9 +628,7 @@ export const ArtifactFocusOrderTest: Story = {
         const event = dispatchKeydown(nextButton!, 'Tab', { shiftKey: true });
         await el.updateComplete;
 
-        expect(event.defaultPrevented).toBe(true);
-        const active = getActiveElement();
-        expect(artifacts.includes(active as HTMLElement)).toBe(true);
+        expect(event.defaultPrevented).toBe(false);
       }
     );
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -641,5 +641,29 @@ export const ArtifactFocusOrderTest: Story = {
         expect(getActiveElement()).toBe(artifacts[0]);
       }
     );
+
+    await step(
+      'a boundary Arrow key (no-op move) still marks the strip entered',
+      async () => {
+        // Leave and re-enter the first tile via .focus() (source: 'focus',
+        // not 'keyboard') so "entered" is genuinely false going into this.
+        textarea?.focus();
+        await el.updateComplete;
+        artifacts[0]?.focus();
+        await el.updateComplete;
+
+        // ArrowLeft at index 0 with wrap:false is a no-op for the roving
+        // controller (no active-change event fires), but the spec still
+        // counts pressing it as "entering" the strip.
+        dispatchKeydown(artifacts[0]!, 'ArrowLeft');
+        await el.updateComplete;
+        expect(getActiveElement()).toBe(artifacts[0]);
+
+        const event = dispatchKeydown(artifacts[0]!, 'Tab');
+        await el.updateComplete;
+        expect(event.defaultPrevented).toBe(true);
+        expect(getActiveElement()).toBe(getDismissButton(artifacts[0]!));
+      }
+    );
   },
 };

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -679,3 +679,47 @@ export const ArtifactFocusOrderTest: Story = {
     );
   },
 };
+
+export const ArtifactEnterAfterScrollTest: Story = {
+  render: () => nothing,
+  play: async ({ canvasElement, step }) => {
+    renderMultiArtifactPromptField(canvasElement);
+
+    const el = await getComponent<PromptField>(
+      canvasElement,
+      'swc-prompt-field'
+    );
+    await el.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await el.updateComplete;
+
+    const artifacts = Array.from(
+      el.querySelectorAll<HTMLElement>('[slot="artifact"]')
+    );
+    const scrollEl = el.shadowRoot?.querySelector<HTMLDivElement>(
+      '.swc-PromptField-artifacts-scroll'
+    );
+    const viewport = el.shadowRoot?.querySelector<HTMLElement>(
+      '.swc-PromptField-artifacts-viewport'
+    );
+
+    await step(
+      'entering the strip for the first time after scrolling lands on the first fully-visible tile, not tile 0',
+      async () => {
+        scrollEl?.scrollTo({ left: 300, behavior: 'auto' });
+        await waitForScrollEnd(scrollEl);
+        await el.updateComplete;
+        expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(0);
+
+        viewport?.focus();
+        const event = dispatchKeydown(viewport!, 'Enter');
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        const active = getActiveElement();
+        expect(active).not.toBe(artifacts[0]);
+        expect(artifacts.includes(active as HTMLElement)).toBe(true);
+      }
+    );
+  },
+};

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -155,13 +155,20 @@ export const LegalMissingWarningTest: Story = {
     try {
       render(
         html`
-          <swc-prompt-field label="Prompt" value="No legal disclaimer">
-          </swc-prompt-field>
+          <swc-prompt-field
+            label="Prompt"
+            value="No legal disclaimer"
+          ></swc-prompt-field>
         `,
         canvasElement
       );
 
-      await getComponent<PromptField>(canvasElement, 'swc-prompt-field');
+      const el = await getComponent<PromptField>(
+        canvasElement,
+        'swc-prompt-field'
+      );
+      await el.updateComplete;
+      await new Promise((resolve) => requestAnimationFrame(resolve));
 
       await step(
         'logs a development warning when the legal slot is empty',
@@ -223,5 +230,162 @@ export const MixedArtifactWarningTest: Story = {
     } finally {
       console.warn = originalWarn;
     }
+  },
+};
+
+const artifactScrollGradient =
+  'linear-gradient(135deg, #667eea 0%, #764ba2 100%)';
+
+function renderMultiArtifactPromptField(canvasElement: HTMLElement): void {
+  render(
+    html`
+      <div style="inline-size:480px;">
+        <swc-prompt-field label="Prompt" value="Review attachments.">
+          ${Array.from({ length: 8 }, (_, index) => index).map(
+            (index) => html`
+              <swc-upload-artifact slot="artifact" type="media" dismissible>
+                <div
+                  slot="thumbnail"
+                  role="img"
+                  aria-label="Frame ${index + 1}"
+                  style="inline-size:100%;block-size:100%;background:${artifactScrollGradient};"
+                ></div>
+              </swc-upload-artifact>
+            `
+          )}
+        </swc-prompt-field>
+      </div>
+    `,
+    canvasElement
+  );
+}
+
+export const ArtifactScrollPaginationTest: Story = {
+  render: () => nothing,
+  play: async ({ canvasElement, step }) => {
+    renderMultiArtifactPromptField(canvasElement);
+
+    const el = await getComponent<PromptField>(
+      canvasElement,
+      'swc-prompt-field'
+    );
+    await el.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await el.updateComplete;
+
+    const scrollEl = el.shadowRoot?.querySelector<HTMLDivElement>(
+      '.swc-PromptField-artifacts-scroll'
+    );
+    const nextButton = el.shadowRoot?.querySelector<HTMLButtonElement>(
+      '.swc-PromptField-artifacts-scroll-next'
+    );
+
+    await step(
+      'renders multi-artifact paging controls when overflowing',
+      async () => {
+        expect(scrollEl).toBeTruthy();
+        expect(nextButton).toBeTruthy();
+        expect(
+          (scrollEl?.scrollWidth ?? 0) > (scrollEl?.clientWidth ?? 0)
+        ).toBe(true);
+      }
+    );
+
+    await step('edge fades render when paging is available', async () => {
+      const endFade = el.shadowRoot?.querySelector(
+        '.swc-PromptField-artifacts-fade--end'
+      );
+      expect(endFade).toBeTruthy();
+    });
+
+    await step('chevron paging advances by more than one tile', async () => {
+      const initialScrollLeft = scrollEl?.scrollLeft ?? 0;
+      nextButton?.click();
+      await el.updateComplete;
+      expect(
+        scrollEl?.classList.contains('is-artifact-scroll-from-buttons')
+      ).toBe(true);
+
+      await new Promise((resolve) => window.setTimeout(resolve, 400));
+
+      const nextScrollLeft = scrollEl?.scrollLeft ?? 0;
+      expect(nextScrollLeft).toBeGreaterThan(initialScrollLeft);
+
+      const tileWidth =
+        scrollEl
+          ?.querySelector('slot')
+          ?.assignedElements({ flatten: true })[0]
+          ?.getBoundingClientRect().width ?? 68;
+      expect(nextScrollLeft - initialScrollLeft).toBeGreaterThan(tileWidth);
+    });
+
+    await step('chevron paging keeps the scrollbar thumb hidden', async () => {
+      await new Promise<void>((resolve) => {
+        const done = (): void => resolve();
+        scrollEl?.addEventListener('scrollend', done, { once: true });
+        window.setTimeout(done, 1500);
+      });
+      await el.updateComplete;
+
+      const scrollbarLane = el.shadowRoot?.querySelector(
+        '.swc-PromptField-artifacts-scrollbar-lane'
+      );
+      expect(
+        scrollEl?.classList.contains('is-artifact-scroll-from-buttons')
+      ).toBe(false);
+      expect(
+        scrollbarLane?.classList.contains('is-artifact-scrollbar-interacting')
+      ).toBe(false);
+    });
+
+    await step('wheel interaction shows the scrollbar thumb', async () => {
+      scrollEl?.dispatchEvent(
+        new WheelEvent('wheel', {
+          bubbles: true,
+          deltaX: 12,
+        })
+      );
+      await el.updateComplete;
+
+      const scrollbarLane = el.shadowRoot?.querySelector(
+        '.swc-PromptField-artifacts-scrollbar-lane'
+      );
+      expect(
+        scrollbarLane?.classList.contains('is-artifact-scrollbar-interacting')
+      ).toBe(true);
+    });
+
+    await step(
+      'chevron paging reaches the end when the last tile is only partially visible',
+      async () => {
+        const maxScroll = Math.max(
+          0,
+          (scrollEl?.scrollWidth ?? 0) - (scrollEl?.clientWidth ?? 0)
+        );
+        scrollEl?.scrollTo({
+          left: Math.max(0, maxScroll - 10),
+          behavior: 'auto',
+        });
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        await el.updateComplete;
+
+        const nextButtonAtEnd = el.shadowRoot?.querySelector<HTMLButtonElement>(
+          '.swc-PromptField-artifacts-scroll-next'
+        );
+        expect(nextButtonAtEnd).toBeTruthy();
+
+        const beforeClick = scrollEl?.scrollLeft ?? 0;
+        nextButtonAtEnd?.click();
+
+        await new Promise<void>((resolve) => {
+          const done = (): void => resolve();
+          scrollEl?.addEventListener('scrollend', done, { once: true });
+          window.setTimeout(done, 1500);
+        });
+        await el.updateComplete;
+
+        expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(beforeClick);
+      }
+    );
   },
 };

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -472,7 +472,7 @@ export const ArtifactFocusOrderTest: Story = {
     });
 
     await step(
-      'only one tile is the roving tab stop; dismiss buttons are never a normal tab stop',
+      'only one tile is the roving tab stop; dismiss/">" are never normal tab stops',
       async () => {
         expect(artifacts[0]?.tabIndex).toBe(0);
         expect(artifacts.slice(1).every((tile) => tile.tabIndex === -1)).toBe(
@@ -481,6 +481,9 @@ export const ArtifactFocusOrderTest: Story = {
         expect(
           artifacts.every((tile) => getDismissButton(tile)?.tabIndex === -1)
         ).toBe(true);
+        // ">" is excludeFromTabOrder per spec: reachable only via the Close
+        // button's explicit Tab intercept below, never via native Tab.
+        expect(getNextButton()?.tabIndex).toBe(-1);
       }
     );
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { html } from 'lit';
 import { expect, userEvent } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
@@ -139,5 +140,45 @@ export const InteractionTest: Story = {
 
       expect(stopCount).toBe(2);
     });
+  },
+};
+
+export const MixedArtifactWarningTest: Story = {
+  render: () => html`
+    <swc-prompt-field label="Prompt" value="Mixed attachments">
+      <swc-upload-artifact slot="artifact" type="card">
+        <span slot="title">Brief</span>
+        <span slot="subtitle">PDF</span>
+      </swc-upload-artifact>
+      <swc-upload-artifact slot="artifact" type="media">
+        <div slot="thumbnail" role="img" aria-label="Preview"></div>
+      </swc-upload-artifact>
+    </swc-prompt-field>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+
+    try {
+      await getComponent<PromptField>(canvasElement, 'swc-prompt-field');
+
+      await step(
+        'logs a development warning when card and media artifacts are mixed',
+        async () => {
+          expect(
+            warnings.some(
+              (message) =>
+                message.includes('[swc-prompt-field]') &&
+                message.includes('card and media')
+            )
+          ).toBe(true);
+        }
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
   },
 };

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { html } from 'lit';
+import { html, render } from 'lit';
 import { expect, userEvent } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
@@ -144,17 +144,7 @@ export const InteractionTest: Story = {
 };
 
 export const MixedArtifactWarningTest: Story = {
-  render: () => html`
-    <swc-prompt-field label="Prompt" value="Mixed attachments">
-      <swc-upload-artifact slot="artifact" type="card">
-        <span slot="title">Brief</span>
-        <span slot="subtitle">PDF</span>
-      </swc-upload-artifact>
-      <swc-upload-artifact slot="artifact" type="media">
-        <div slot="thumbnail" role="img" aria-label="Preview"></div>
-      </swc-upload-artifact>
-    </swc-prompt-field>
-  `,
+  render: () => html``,
   play: async ({ canvasElement, step }) => {
     const warnings: string[] = [];
     const originalWarn = console.warn;
@@ -163,6 +153,21 @@ export const MixedArtifactWarningTest: Story = {
     };
 
     try {
+      render(
+        html`
+          <swc-prompt-field label="Prompt" value="Mixed attachments">
+            <swc-upload-artifact slot="artifact" type="card">
+              <span slot="title">Brief</span>
+              <span slot="subtitle">PDF</span>
+            </swc-upload-artifact>
+            <swc-upload-artifact slot="artifact" type="media">
+              <div slot="thumbnail" role="img" aria-label="Preview"></div>
+            </swc-upload-artifact>
+          </swc-prompt-field>
+        `,
+        canvasElement
+      );
+
       await getComponent<PromptField>(canvasElement, 'swc-prompt-field');
 
       await step(

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { html, render } from 'lit';
+import { html, nothing, render } from 'lit';
 import { expect, userEvent } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
@@ -143,8 +143,46 @@ export const InteractionTest: Story = {
   },
 };
 
+export const LegalMissingWarningTest: Story = {
+  render: () => nothing,
+  play: async ({ canvasElement, step }) => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+
+    try {
+      render(
+        html`
+          <swc-prompt-field label="Prompt" value="No legal disclaimer">
+          </swc-prompt-field>
+        `,
+        canvasElement
+      );
+
+      await getComponent<PromptField>(canvasElement, 'swc-prompt-field');
+
+      await step(
+        'logs a development warning when the legal slot is empty',
+        async () => {
+          expect(
+            warnings.some(
+              (message) =>
+                message.includes('[swc-prompt-field]') &&
+                message.includes('legal slot is empty')
+            )
+          ).toBe(true);
+        }
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+  },
+};
+
 export const MixedArtifactWarningTest: Story = {
-  render: () => html``,
+  render: () => nothing,
   play: async ({ canvasElement, step }) => {
     const warnings: string[] = [];
     const originalWarn = console.warn;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -463,27 +463,41 @@ export const ArtifactFocusOrderTest: Story = {
         '.swc-UploadArtifact-dismiss'
       );
 
-    await step('landmark region wraps the strip', async () => {
-      const row = el.shadowRoot?.querySelector(
-        '.swc-PromptField-artifacts-row'
+    await step('landmark region is the strip container tab stop', async () => {
+      const viewport = el.shadowRoot?.querySelector(
+        '.swc-PromptField-artifacts-viewport'
       );
-      expect(row?.getAttribute('role')).toBe('region');
-      expect(row?.getAttribute('aria-label')).toBe('Uploaded assets strip');
+      expect(viewport?.getAttribute('role')).toBe('region');
+      expect(viewport?.getAttribute('aria-label')).toBe(
+        'Uploaded assets strip'
+      );
+      expect((viewport as HTMLElement | null)?.tabIndex).toBe(0);
     });
 
     await step(
-      'only one tile is the roving tab stop; dismiss/">" are never normal tab stops',
+      'before entering, tiles/dismiss buttons stay out of the tab order; ">" is a normal tab stop',
       async () => {
-        expect(artifacts[0]?.tabIndex).toBe(0);
-        expect(artifacts.slice(1).every((tile) => tile.tabIndex === -1)).toBe(
-          true
-        );
+        expect(artifacts.every((tile) => tile.tabIndex === -1)).toBe(true);
         expect(
           artifacts.every((tile) => getDismissButton(tile)?.tabIndex === -1)
         ).toBe(true);
-        // ">" is excludeFromTabOrder per spec: reachable only via the Close
-        // button's explicit Tab intercept below, never via native Tab.
-        expect(getNextButton()?.tabIndex).toBe(-1);
+        expect(getNextButton()?.tabIndex).toBe(0);
+      }
+    );
+
+    await step(
+      'Enter on the container enters the strip at the first tile',
+      async () => {
+        const viewport = el.shadowRoot?.querySelector<HTMLElement>(
+          '.swc-PromptField-artifacts-viewport'
+        );
+        viewport?.focus();
+        const event = dispatchKeydown(viewport!, 'Enter');
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(getActiveElement()).toBe(artifacts[0]);
+        expect(artifacts[0]?.tabIndex).toBe(0);
       }
     );
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -19,7 +19,10 @@ import { getActiveElement } from '@adobe/spectrum-wc-core/utils/index.js';
 import '../../upload-artifact/swc-upload-artifact.js';
 import '../swc-prompt-field.js';
 
-import { getComponent } from '../../../../utils/test-utils.js';
+import {
+  getComponent,
+  withWarningSpy,
+} from '../../../../utils/test-utils.js';
 import { PromptField } from '../PromptField.js';
 import { meta, Overview } from '../stories/prompt-field.stories.js';
 
@@ -148,13 +151,7 @@ export const InteractionTest: Story = {
 export const LegalMissingWarningTest: Story = {
   render: () => nothing,
   play: async ({ canvasElement, step }) => {
-    const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (message?: unknown) => {
-      warnings.push(String(message));
-    };
-
-    try {
+    await withWarningSpy(async (warnCalls) => {
       render(
         html`
           <swc-prompt-field
@@ -176,30 +173,29 @@ export const LegalMissingWarningTest: Story = {
         'logs a development warning when the legal slot is empty',
         async () => {
           expect(
-            warnings.some(
-              (message) =>
-                message.includes('[swc-prompt-field]') &&
-                message.includes('legal slot is empty')
-            )
+            warnCalls.some(([, message]) =>
+              String(message).includes('legal slot is empty')
+            ),
+            'the empty legal slot emits a debug warning'
           ).toBe(true);
         }
       );
-    } finally {
-      console.warn = originalWarn;
-    }
+
+      el.innerHTML = '<p slot="legal">Approved legal copy.</p>';
+      await el.updateComplete;
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      expect(
+        warnCalls,
+        'valid legal content emits no additional warning'
+      ).toHaveLength(1);
+    });
   },
 };
 
 export const MixedArtifactWarningTest: Story = {
   render: () => nothing,
   play: async ({ canvasElement, step }) => {
-    const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (message?: unknown) => {
-      warnings.push(String(message));
-    };
-
-    try {
+    await withWarningSpy(async (warnCalls) => {
       render(
         html`
           <swc-prompt-field label="Prompt" value="Mixed attachments">
@@ -210,28 +206,34 @@ export const MixedArtifactWarningTest: Story = {
             <swc-upload-artifact slot="artifact" type="media">
               <div slot="thumbnail" role="img" aria-label="Preview"></div>
             </swc-upload-artifact>
+            <p slot="legal">Approved legal copy.</p>
           </swc-prompt-field>
         `,
         canvasElement
       );
 
       await getComponent<PromptField>(canvasElement, 'swc-prompt-field');
+      await new Promise((resolve) => requestAnimationFrame(resolve));
 
       await step(
         'logs a development warning when card and media artifacts are mixed',
         async () => {
           expect(
-            warnings.some(
-              (message) =>
-                message.includes('[swc-prompt-field]') &&
-                message.includes('card and media')
-            )
+            warnCalls.some(([, message]) =>
+              String(message).includes('card and media')
+            ),
+            'mixed card and media artifacts emit a debug warning'
           ).toBe(true);
         }
       );
-    } finally {
-      console.warn = originalWarn;
-    }
+
+      canvasElement.querySelector<HTMLElement>('[type="media"]')?.remove();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      expect(
+        warnCalls,
+        'one artifact layout emits no additional warning'
+      ).toHaveLength(1);
+    });
   },
 };
 
@@ -303,13 +305,14 @@ export const ArtifactScrollPaginationTest: Story = {
     await step('chevron paging advances by more than one tile', async () => {
       const initialScrollLeft = scrollEl?.scrollLeft ?? 0;
       const clientWidth = scrollEl?.clientWidth ?? 0;
+      const firstPageScrollEnd = waitForScrollEnd(scrollEl);
       nextButton?.click();
       await el.updateComplete;
       expect(
         scrollEl?.classList.contains('is-artifact-scroll-from-buttons')
       ).toBe(true);
 
-      await new Promise((resolve) => window.setTimeout(resolve, 400));
+      await firstPageScrollEnd;
 
       const nextScrollLeft = scrollEl?.scrollLeft ?? 0;
       expect(nextScrollLeft).toBeGreaterThan(initialScrollLeft);
@@ -330,11 +333,6 @@ export const ArtifactScrollPaginationTest: Story = {
     });
 
     await step('chevron paging keeps the scrollbar thumb hidden', async () => {
-      await new Promise<void>((resolve) => {
-        const done = (): void => resolve();
-        scrollEl?.addEventListener('scrollend', done, { once: true });
-        window.setTimeout(done, 1500);
-      });
       await el.updateComplete;
 
       const scrollbarLane = el.shadowRoot?.querySelector(
@@ -385,13 +383,9 @@ export const ArtifactScrollPaginationTest: Story = {
         expect(nextButtonAtEnd).toBeTruthy();
 
         const beforeClick = scrollEl?.scrollLeft ?? 0;
+        const finalPageScrollEnd = waitForScrollEnd(scrollEl);
         nextButtonAtEnd?.click();
-
-        await new Promise<void>((resolve) => {
-          const done = (): void => resolve();
-          scrollEl?.addEventListener('scrollend', done, { once: true });
-          window.setTimeout(done, 1500);
-        });
+        await finalPageScrollEnd;
         await el.updateComplete;
 
         expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(beforeClick);
@@ -403,10 +397,12 @@ export const ArtifactScrollPaginationTest: Story = {
 function waitForScrollEnd(
   scrollEl: HTMLDivElement | null | undefined
 ): Promise<void> {
+  if (!scrollEl) {
+    return Promise.resolve();
+  }
+
   return new Promise<void>((resolve) => {
-    const done = (): void => resolve();
-    scrollEl?.addEventListener('scrollend', done, { once: true });
-    window.setTimeout(done, 1500);
+    scrollEl.addEventListener('scrollend', () => resolve(), { once: true });
   });
 }
 
@@ -592,11 +588,8 @@ export const ArtifactFocusOrderTest: Story = {
     await step(
       'Tab from the "<" button is left to native default, not intercepted into a tile',
       async () => {
-        artifacts[artifacts.length - 1]?.focus();
-        await waitForScrollEnd(scrollEl);
-        await el.updateComplete;
-        dispatchKeydown(artifacts[artifacts.length - 1]!, 'ArrowLeft');
-        await waitForScrollEnd(scrollEl);
+        scrollEl?.scrollTo({ left: 200, behavior: 'auto' });
+        await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
 
         const prevButton = getPrevButton();
@@ -607,7 +600,7 @@ export const ArtifactFocusOrderTest: Story = {
 
         // The "<" chevron is a normal tab stop like any other outside the
         // strip: Tab/Shift+Tab from it is never intercepted, so the next
-        // real stop is always the container (region), never a tile directly.
+        // real stop is the container (region), never a tile directly.
         expect(event.defaultPrevented).toBe(false);
       }
     );
@@ -619,7 +612,7 @@ export const ArtifactFocusOrderTest: Story = {
         // wherever the previous step left the scroll offset (that position
         // is layout-dependent and varies across browsers).
         scrollEl?.scrollTo({ left: 0, behavior: 'auto' });
-        await waitForScrollEnd(scrollEl);
+        await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
 
         const nextButton = getNextButton();
@@ -636,7 +629,7 @@ export const ArtifactFocusOrderTest: Story = {
       'the "<" button disappearing while focused redirects focus to the first tile',
       async () => {
         scrollEl?.scrollTo({ left: 200, behavior: 'auto' });
-        await waitForScrollEnd(scrollEl);
+        await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
         expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(0);
 
@@ -646,7 +639,7 @@ export const ArtifactFocusOrderTest: Story = {
         expect(getActiveElement()).toBe(prevButton);
 
         scrollEl?.scrollTo({ left: 0, behavior: 'auto' });
-        await waitForScrollEnd(scrollEl);
+        await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
 
         expect(getPrevButton()).toBeFalsy();
@@ -675,6 +668,28 @@ export const ArtifactFocusOrderTest: Story = {
         await el.updateComplete;
         expect(event.defaultPrevented).toBe(true);
         expect(getActiveElement()).toBe(getDismissButton(artifacts[0]!));
+      }
+    );
+
+    await step(
+      'dismissing a focused artifact restores focus to the nearest tile',
+      async () => {
+        const active = artifacts[1]!;
+        const dismiss = getDismissButton(active)!;
+        el.addEventListener(
+          'swc-upload-artifact-dismiss',
+          (event) => (event.target as HTMLElement).remove(),
+          { once: true }
+        );
+
+        dismiss.focus();
+        dismiss.click();
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        await el.updateComplete;
+
+        expect(getActiveElement(), 'focus moves to the replacement tile').toBe(
+          artifacts[2]
+        );
       }
     );
   },
@@ -707,7 +722,7 @@ export const ArtifactEnterAfterScrollTest: Story = {
       'entering the strip for the first time after scrolling lands on the first fully-visible tile, not tile 0',
       async () => {
         scrollEl?.scrollTo({ left: 300, behavior: 'auto' });
-        await waitForScrollEnd(scrollEl);
+        await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
         expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(0);
 
@@ -721,5 +736,45 @@ export const ArtifactEnterAfterScrollTest: Story = {
         expect(artifacts.includes(active as HTMLElement)).toBe(true);
       }
     );
+  },
+};
+
+export const ArtifactScrollbarDisconnectTest: Story = {
+  render: () => nothing,
+  play: async ({ canvasElement, step }) => {
+    renderMultiArtifactPromptField(canvasElement);
+
+    const el = await getComponent<PromptField>(
+      canvasElement,
+      'swc-prompt-field'
+    );
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await el.updateComplete;
+
+    const scrollEl = el.shadowRoot?.querySelector<HTMLDivElement>(
+      '.swc-PromptField-artifacts-scroll'
+    );
+    const thumb = el.shadowRoot?.querySelector<HTMLElement>(
+      '.swc-PromptField-artifacts-scrollbar-thumb'
+    );
+
+    await step('removes global thumb-drag listeners when disconnected', async () => {
+      scrollEl?.scrollTo({ left: 100, behavior: 'auto' });
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      const scrollLeftBeforeDisconnect = scrollEl?.scrollLeft;
+
+      thumb?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, clientX: 8 })
+      );
+      el.remove();
+      window.dispatchEvent(
+        new PointerEvent('pointermove', { bubbles: true, clientX: 240 })
+      );
+
+      expect(
+        scrollEl?.scrollLeft,
+        'a detached prompt field no longer receives global drag events'
+      ).toBe(scrollLeftBeforeDisconnect);
+    });
   },
 };

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -346,23 +346,28 @@ export const ArtifactScrollPaginationTest: Story = {
       }
     );
 
-    await step('scrolling to the end removes the Next chevron', async () => {
-      const maxScroll = Math.max(
-        0,
-        (scrollEl?.scrollWidth ?? 0) - (scrollEl?.clientWidth ?? 0)
-      );
-      scrollEl?.scrollTo({
-        left: maxScroll,
-        behavior: 'auto',
-      });
-      await new Promise((resolve) => requestAnimationFrame(resolve));
-      await el.updateComplete;
+    await step(
+      'scrolling to the end disables (not removes) the Next chevron, so a focused chevron is never blurred by unmounting',
+      async () => {
+        const maxScroll = Math.max(
+          0,
+          (scrollEl?.scrollWidth ?? 0) - (scrollEl?.clientWidth ?? 0)
+        );
+        scrollEl?.scrollTo({
+          left: maxScroll,
+          behavior: 'auto',
+        });
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        await el.updateComplete;
 
-      const nextButtonAtEnd = el.shadowRoot?.querySelector<HTMLButtonElement>(
-        '.swc-PromptField-artifacts-scroll-next'
-      );
-      expect(nextButtonAtEnd).toBeFalsy();
-    });
+        const nextButtonAtEnd = el.shadowRoot?.querySelector<HTMLButtonElement>(
+          '.swc-PromptField-artifacts-scroll-next'
+        );
+        expect(nextButtonAtEnd).toBeTruthy();
+        expect(nextButtonAtEnd?.getAttribute('aria-disabled')).toBe('true');
+        expect(nextButtonAtEnd?.tabIndex).toBe(-1);
+      }
+    );
   },
 };
 
@@ -394,14 +399,14 @@ export const ArtifactScrollRTLTest: Story = {
 
     await step('the next chevron pages forward in RTL', async () => {
       expect(getComputedStyle(el).direction).toBe('rtl');
-      expect(getPrevButton()).toBeFalsy();
+      expect(getPrevButton()?.getAttribute('aria-disabled')).toBe('true');
 
       const scrollEnd = waitForScrollEnd(scrollEl);
       getNextButton()?.click();
       await scrollEnd;
       await el.updateComplete;
 
-      expect(getPrevButton()).toBeTruthy();
+      expect(getPrevButton()?.getAttribute('aria-disabled')).toBe('false');
       expect(
         firstArtifact!.getBoundingClientRect().left >=
           scrollEl!.getBoundingClientRect().right
@@ -628,7 +633,7 @@ export const ArtifactFocusOrderTest: Story = {
     );
 
     await step(
-      'the "<" button disappearing while focused redirects focus to the first tile',
+      'the "<" button becoming disabled while focused keeps focus on it, rather than moving it anywhere',
       async () => {
         scrollEl?.scrollTo({ left: 200, behavior: 'auto' });
         await new Promise((resolve) => requestAnimationFrame(resolve));
@@ -636,7 +641,7 @@ export const ArtifactFocusOrderTest: Story = {
         expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(0);
 
         const prevButton = getPrevButton();
-        expect(prevButton).toBeTruthy();
+        expect(prevButton?.getAttribute('aria-disabled')).toBe('false');
         prevButton?.focus();
         expect(getActiveElement()).toBe(prevButton);
 
@@ -644,8 +649,8 @@ export const ArtifactFocusOrderTest: Story = {
         await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
 
-        expect(getPrevButton()).toBeFalsy();
-        expect(getActiveElement()).toBe(artifacts[0]);
+        expect(getPrevButton()?.getAttribute('aria-disabled')).toBe('true');
+        expect(getActiveElement()).toBe(prevButton);
       }
     );
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -789,3 +789,33 @@ export const ArtifactScrollbarDisconnectTest: Story = {
     );
   },
 };
+
+export const SingleArtifactFocusTest: Story = {
+  render: () => nothing,
+  play: async ({ canvasElement, step }) => {
+    render(
+      html`
+        <swc-prompt-field label="Prompt" value="Review attachment.">
+          <swc-upload-artifact slot="artifact" type="card" dismissible>
+            <span slot="title">Brief.pdf</span>
+          </swc-upload-artifact>
+        </swc-prompt-field>
+      `,
+      canvasElement
+    );
+
+    const el = await getComponent<PromptField>(
+      canvasElement,
+      'swc-prompt-field'
+    );
+    await el.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await el.updateComplete;
+
+    const artifact = el.querySelector<HTMLElement>('[slot="artifact"]');
+
+    await step('a single artifact tile is reachable by Tab', async () => {
+      expect(artifact?.tabIndex).toBe(0);
+    });
+  },
+};

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -491,87 +491,86 @@ export const ArtifactFocusOrderTest: Story = {
         '.swc-UploadArtifact-dismiss'
       );
 
-    await step('landmark region is the strip container tab stop', async () => {
-      const viewport = el.shadowRoot?.querySelector(
-        '.swc-PromptField-artifacts-viewport'
-      );
-      expect(viewport?.getAttribute('role')).toBe('region');
-      expect(viewport?.getAttribute('aria-label')).toBe(
-        'Uploaded assets strip'
-      );
-      expect((viewport as HTMLElement | null)?.tabIndex).toBe(0);
-    });
+    await step(
+      'the strip landmark is a region, but not itself a tab stop',
+      async () => {
+        const viewport = el.shadowRoot?.querySelector(
+          '.swc-PromptField-artifacts-viewport'
+        );
+        expect(viewport?.getAttribute('role')).toBe('region');
+        expect(viewport?.getAttribute('aria-label')).toBe(
+          'Uploaded assets strip'
+        );
+        expect((viewport as HTMLElement | null)?.hasAttribute('tabindex')).toBe(
+          false
+        );
+      }
+    );
 
     await step(
-      'before entering, tiles/dismiss buttons stay out of the tab order; ">" is a normal tab stop',
+      'the first tile carries tabindex 0 from the start; the rest and their Close buttons stay out of the tab order',
       async () => {
-        expect(artifacts.every((tile) => tile.tabIndex === -1)).toBe(true);
+        expect(artifacts[0]?.tabIndex).toBe(0);
+        expect(artifacts.slice(1).every((tile) => tile.tabIndex === -1)).toBe(
+          true
+        );
         expect(
           artifacts.every((tile) => getDismissButton(tile)?.tabIndex === -1)
         ).toBe(true);
-        expect(getNextButton()?.tabIndex).toBe(0);
       }
     );
 
-    await step(
-      'Enter on the container enters the strip at the first tile',
-      async () => {
-        const viewport = el.shadowRoot?.querySelector<HTMLElement>(
-          '.swc-PromptField-artifacts-viewport'
-        );
-        viewport?.focus();
-        const event = dispatchKeydown(viewport!, 'Enter');
-        await el.updateComplete;
+    await step('first Tab reaches the first tile directly', async () => {
+      textarea?.blur();
+      artifacts[0]?.focus();
+      expect(getActiveElement()).toBe(artifacts[0]);
+    });
 
-        expect(event.defaultPrevented).toBe(true);
-        expect(getActiveElement()).toBe(artifacts[0]);
-        expect(artifacts[0]?.tabIndex).toBe(0);
-      }
-    );
+    await step('second Tab reveals the tile’s Close button', async () => {
+      const event = dispatchKeydown(artifacts[0]!, 'Tab');
+      await el.updateComplete;
 
-    await step(
-      'Arrow Right moves the roving tab stop one tile and marks the strip entered',
-      async () => {
-        artifacts[0]?.focus();
-        dispatchKeydown(artifacts[0]!, 'ArrowRight');
-        await el.updateComplete;
-
-        expect(artifacts[0]?.tabIndex).toBe(-1);
-        expect(artifacts[1]?.tabIndex).toBe(0);
-        expect(getActiveElement()).toBe(artifacts[1]);
-      }
-    );
-
-    await step(
-      'Tab from the active (entered) tile reveals its Close button',
-      async () => {
-        const active = artifacts[1]!;
-        const event = dispatchKeydown(active, 'Tab');
-        await el.updateComplete;
-
-        expect(event.defaultPrevented).toBe(true);
-        expect(getActiveElement()).toBe(getDismissButton(active));
-      }
-    );
+      expect(event.defaultPrevented).toBe(true);
+      expect(getActiveElement()).toBe(getDismissButton(artifacts[0]!));
+    });
 
     await step(
       'Shift+Tab from the Close button returns focus to the tile',
       async () => {
-        const active = artifacts[1]!;
-        const dismiss = getDismissButton(active)!;
+        const dismiss = getDismissButton(artifacts[0]!)!;
         const event = dispatchKeydown(dismiss, 'Tab', { shiftKey: true });
         await el.updateComplete;
 
         expect(event.defaultPrevented).toBe(true);
-        expect(getActiveElement()).toBe(active);
+        expect(getActiveElement()).toBe(artifacts[0]);
+      }
+    );
+
+    await step('Arrow Right moves the roving tab stop one tile', async () => {
+      artifacts[0]?.focus();
+      dispatchKeydown(artifacts[0]!, 'ArrowRight');
+      await el.updateComplete;
+
+      expect(artifacts[0]?.tabIndex).toBe(-1);
+      expect(artifacts[1]?.tabIndex).toBe(0);
+      expect(getActiveElement()).toBe(artifacts[1]);
+    });
+
+    await step(
+      'Tab from any active tile (not just the first) reveals its Close button',
+      async () => {
+        const event = dispatchKeydown(artifacts[1]!, 'Tab');
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(getActiveElement()).toBe(getDismissButton(artifacts[1]!));
       }
     );
 
     await step(
       'Tab from the Close button reaches the ">" button when more content is scrolled out of view',
       async () => {
-        const active = artifacts[1]!;
-        const dismiss = getDismissButton(active)!;
+        const dismiss = getDismissButton(artifacts[1]!)!;
         dismiss.focus();
         const event = dispatchKeydown(dismiss, 'Tab');
         await el.updateComplete;
@@ -584,73 +583,24 @@ export const ArtifactFocusOrderTest: Story = {
     );
 
     await step(
-      'focus leaving the strip resets "entered"; Tab from an untouched tile does not intercept',
+      'Tab from the ">" button (without activating it) moves forward, outside the strip',
       async () => {
-        textarea?.focus();
+        const nextButton = getNextButton()!;
+        nextButton.focus();
+        const event = dispatchKeydown(nextButton, 'Tab');
         await el.updateComplete;
 
-        artifacts[1]?.focus();
-        await el.updateComplete;
-        const event = dispatchKeydown(artifacts[1]!, 'Tab');
-
-        // Not "entered" (focus arrived via .focus(), not Arrow/Enter), so the
-        // Close button/">" intercept must not fire; native Tab is left alone.
         expect(event.defaultPrevented).toBe(false);
       }
     );
 
     await step(
-      'Enter marks the strip entered without moving focus off the tile',
+      'Shift+Tab from any active tile exits the strip to native default, not the Close button',
       async () => {
-        const active = artifacts[1]!;
-        active.focus();
-        const event = dispatchKeydown(active, 'Enter');
-        await el.updateComplete;
-
-        expect(event.defaultPrevented).toBe(true);
-        expect(getActiveElement()).toBe(active);
-
-        const tabEvent = dispatchKeydown(active, 'Tab');
-        await el.updateComplete;
-        expect(tabEvent.defaultPrevented).toBe(true);
-        expect(getActiveElement()).toBe(getDismissButton(active));
-      }
-    );
-
-    await step(
-      'Tab from the "<" button is left to native default, not intercepted into a tile',
-      async () => {
-        scrollEl?.scrollTo({ left: 200, behavior: 'auto' });
-        await new Promise((resolve) => requestAnimationFrame(resolve));
-        await el.updateComplete;
-
-        const prevButton = getPrevButton();
-        expect(prevButton).toBeTruthy();
-        prevButton?.focus();
-        const event = dispatchKeydown(prevButton!, 'Tab');
-        await el.updateComplete;
-
-        // The "<" chevron is a normal tab stop like any other outside the
-        // strip: Tab/Shift+Tab from it is never intercepted, so the next
-        // real stop is the container (region), never a tile directly.
-        expect(event.defaultPrevented).toBe(false);
-      }
-    );
-
-    await step(
-      'Shift+Tab from the ">" button is left to native default, not intercepted into a tile',
-      async () => {
-        // Force a known, deterministic scroll position rather than relying on
-        // wherever the previous step left the scroll offset (that position
-        // is layout-dependent and varies across browsers).
-        scrollEl?.scrollTo({ left: 0, behavior: 'auto' });
-        await new Promise((resolve) => requestAnimationFrame(resolve));
-        await el.updateComplete;
-
-        const nextButton = getNextButton();
-        expect(nextButton).toBeTruthy();
-        nextButton?.focus();
-        const event = dispatchKeydown(nextButton!, 'Tab', { shiftKey: true });
+        artifacts[3]?.focus();
+        const event = dispatchKeydown(artifacts[3]!, 'Tab', {
+          shiftKey: true,
+        });
         await el.updateComplete;
 
         expect(event.defaultPrevented).toBe(false);
@@ -680,30 +630,6 @@ export const ArtifactFocusOrderTest: Story = {
     );
 
     await step(
-      'a boundary Arrow key (no-op move) still marks the strip entered',
-      async () => {
-        // Leave and re-enter the first tile via .focus() (source: 'focus',
-        // not 'keyboard') so "entered" is genuinely false going into this.
-        textarea?.focus();
-        await el.updateComplete;
-        artifacts[0]?.focus();
-        await el.updateComplete;
-
-        // ArrowLeft at index 0 with wrap:false is a no-op for the roving
-        // controller (no active-change event fires), but the spec still
-        // counts pressing it as "entering" the strip.
-        dispatchKeydown(artifacts[0]!, 'ArrowLeft');
-        await el.updateComplete;
-        expect(getActiveElement()).toBe(artifacts[0]);
-
-        const event = dispatchKeydown(artifacts[0]!, 'Tab');
-        await el.updateComplete;
-        expect(event.defaultPrevented).toBe(true);
-        expect(getActiveElement()).toBe(getDismissButton(artifacts[0]!));
-      }
-    );
-
-    await step(
       'dismissing a focused artifact restores focus to the nearest tile',
       async () => {
         const active = artifacts[1]!;
@@ -727,7 +653,7 @@ export const ArtifactFocusOrderTest: Story = {
   },
 };
 
-export const ArtifactEnterAfterScrollTest: Story = {
+export const ArtifactChevronPagingFocusTest: Story = {
   render: () => nothing,
   play: async ({ canvasElement, step }) => {
     renderMultiArtifactPromptField(canvasElement);
@@ -746,26 +672,118 @@ export const ArtifactEnterAfterScrollTest: Story = {
     const scrollEl = el.shadowRoot?.querySelector<HTMLDivElement>(
       '.swc-PromptField-artifacts-scroll'
     );
-    const viewport = el.shadowRoot?.querySelector<HTMLElement>(
-      '.swc-PromptField-artifacts-viewport'
+    const getNextButton = (): HTMLButtonElement | null | undefined =>
+      el.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-PromptField-artifacts-scroll-next'
+      );
+    const getPrevButton = (): HTMLButtonElement | null | undefined =>
+      el.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-PromptField-artifacts-scroll-prev'
+      );
+    const visibleTiles = (): HTMLElement[] => {
+      const viewportRect = scrollEl!.getBoundingClientRect();
+      return artifacts.filter((tile) => {
+        const tileRect = tile.getBoundingClientRect();
+        return (
+          tileRect.right > viewportRect.left &&
+          tileRect.left < viewportRect.right
+        );
+      });
+    };
+
+    /** The tile owning the active element: the tile itself, or (if focus
+     * landed on its Close button) the shadow host of that button. */
+    const activeTile = (): HTMLElement | null => {
+      const active = getActiveElement();
+      if (!active) {
+        return null;
+      }
+      if (artifacts.includes(active as HTMLElement)) {
+        return active as HTMLElement;
+      }
+      const root = active.getRootNode();
+      if (
+        root instanceof ShadowRoot &&
+        artifacts.includes(root.host as HTMLElement)
+      ) {
+        return root.host as HTMLElement;
+      }
+      return null;
+    };
+
+    await step(
+      'activating Next keeps focus on Next, not on any tile',
+      async () => {
+        const nextButton = getNextButton()!;
+        nextButton.focus();
+        const scrollEnd = waitForScrollEnd(scrollEl);
+        nextButton.click();
+        await scrollEnd;
+        await el.updateComplete;
+
+        expect(getActiveElement()).toBe(nextButton);
+      }
     );
 
     await step(
-      'entering the strip for the first time after scrolling lands on the first fully-visible tile, not tile 0',
+      'Shift+Tab from Next lands in the newly displayed set of tiles, not wherever focus was before paging',
       async () => {
-        scrollEl?.scrollTo({ left: 300, behavior: 'auto' });
-        await new Promise((resolve) => requestAnimationFrame(resolve));
-        await el.updateComplete;
-        expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(0);
+        const nextButton = getNextButton()!;
+        const currentlyVisible = visibleTiles();
+        expect(
+          currentlyVisible.includes(artifacts[0]!),
+          'sanity check: paging actually moved past the first tile'
+        ).toBe(false);
 
-        viewport?.focus();
-        const event = dispatchKeydown(viewport!, 'Enter');
+        const event = dispatchKeydown(nextButton, 'Tab', { shiftKey: true });
         await el.updateComplete;
 
         expect(event.defaultPrevented).toBe(true);
-        const active = getActiveElement();
-        expect(active).not.toBe(artifacts[0]);
-        expect(artifacts.includes(active as HTMLElement)).toBe(true);
+        expect(currentlyVisible.includes(activeTile()!)).toBe(true);
+      }
+    );
+
+    await step(
+      'Tab from Prev (after paging backward) lands in the newly displayed set of tiles',
+      async () => {
+        scrollEl?.scrollTo({ left: 0, behavior: 'auto' });
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        await el.updateComplete;
+
+        const nextButton = getNextButton()!;
+        const firstPage = waitForScrollEnd(scrollEl);
+        nextButton.click();
+        await firstPage;
+        await el.updateComplete;
+        const secondPage = waitForScrollEnd(scrollEl);
+        nextButton.click();
+        await secondPage;
+        await el.updateComplete;
+
+        const tilesBeforePagingBack = visibleTiles();
+
+        const prevButton = getPrevButton()!;
+        prevButton.focus();
+        const backPage = waitForScrollEnd(scrollEl);
+        prevButton.click();
+        await backPage;
+        await el.updateComplete;
+
+        expect(getActiveElement()).toBe(prevButton);
+
+        const tilesAfterPagingBack = visibleTiles();
+        expect(
+          tilesAfterPagingBack.some(
+            (tile) => !tilesBeforePagingBack.includes(tile)
+          ),
+          'sanity check: paging back actually revealed a different set of tiles'
+        ).toBe(true);
+
+        const event = dispatchKeydown(prevButton, 'Tab');
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(tilesAfterPagingBack.includes(activeTile()!)).toBe(true);
       }
     );
   },

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -849,9 +849,34 @@ export const SingleArtifactFocusTest: Story = {
     await el.updateComplete;
 
     const artifact = el.querySelector<HTMLElement>('[slot="artifact"]');
+    const getDismissButton = (): HTMLButtonElement | null | undefined =>
+      artifact?.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-UploadArtifact-dismiss'
+      );
 
     await step('a single artifact tile is reachable by Tab', async () => {
       expect(artifact?.tabIndex).toBe(0);
     });
+
+    await step('Tab from the tile reveals its Close button', async () => {
+      artifact?.focus();
+      const event = dispatchKeydown(artifact!, 'Tab');
+      await el.updateComplete;
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(getActiveElement()).toBe(getDismissButton());
+    });
+
+    await step(
+      'Shift+Tab from the Close button returns focus to the tile',
+      async () => {
+        const dismiss = getDismissButton()!;
+        const event = dispatchKeydown(dismiss, 'Tab', { shiftKey: true });
+        await el.updateComplete;
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(getActiveElement()).toBe(artifact);
+      }
+    );
   },
 };

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -355,7 +355,7 @@ export const ArtifactScrollPaginationTest: Story = {
         );
         scrollEl?.scrollTo({
           left: maxScroll,
-          behavior: 'auto',
+          behavior: 'instant',
         });
         await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
@@ -635,7 +635,7 @@ export const ArtifactFocusOrderTest: Story = {
     await step(
       'the "<" button becoming disabled while focused keeps focus on it, rather than moving it anywhere',
       async () => {
-        scrollEl?.scrollTo({ left: 200, behavior: 'auto' });
+        scrollEl?.scrollTo({ left: 200, behavior: 'instant' });
         await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
         expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(0);
@@ -645,7 +645,7 @@ export const ArtifactFocusOrderTest: Story = {
         prevButton?.focus();
         expect(getActiveElement()).toBe(prevButton);
 
-        scrollEl?.scrollTo({ left: 0, behavior: 'auto' });
+        scrollEl?.scrollTo({ left: 0, behavior: 'instant' });
         await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
 
@@ -771,7 +771,7 @@ export const ArtifactChevronPagingFocusTest: Story = {
     await step(
       'Tab from Prev (after paging backward) lands in the newly displayed set of tiles',
       async () => {
-        scrollEl?.scrollTo({ left: 0, behavior: 'auto' });
+        scrollEl?.scrollTo({ left: 0, behavior: 'instant' });
         await new Promise((resolve) => requestAnimationFrame(resolve));
         await el.updateComplete;
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -19,10 +19,7 @@ import { getActiveElement } from '@adobe/spectrum-wc-core/utils/index.js';
 import '../../upload-artifact/swc-upload-artifact.js';
 import '../swc-prompt-field.js';
 
-import {
-  getComponent,
-  withWarningSpy,
-} from '../../../../utils/test-utils.js';
+import { getComponent, withWarningSpy } from '../../../../utils/test-utils.js';
 import { PromptField } from '../PromptField.js';
 import { meta, Overview } from '../stories/prompt-field.stories.js';
 
@@ -302,6 +299,23 @@ export const ArtifactScrollPaginationTest: Story = {
       expect(endFade).toBeTruthy();
     });
 
+    await step('wheel interaction shows the scrollbar thumb', async () => {
+      scrollEl?.dispatchEvent(
+        new WheelEvent('wheel', {
+          bubbles: true,
+          deltaX: 12,
+        })
+      );
+      await el.updateComplete;
+
+      const scrollbarLane = el.shadowRoot?.querySelector(
+        '.swc-PromptField-artifacts-scrollbar-lane'
+      );
+      expect(
+        scrollbarLane?.classList.contains('is-artifact-scrollbar-interacting')
+      ).toBe(true);
+    });
+
     await step('chevron paging advances by more than one tile', async () => {
       const initialScrollLeft = scrollEl?.scrollLeft ?? 0;
       const clientWidth = scrollEl?.clientWidth ?? 0;
@@ -313,6 +327,7 @@ export const ArtifactScrollPaginationTest: Story = {
       ).toBe(true);
 
       await firstPageScrollEnd;
+      await el.updateComplete;
 
       const nextScrollLeft = scrollEl?.scrollLeft ?? 0;
       expect(nextScrollLeft).toBeGreaterThan(initialScrollLeft);
@@ -339,28 +354,8 @@ export const ArtifactScrollPaginationTest: Story = {
         '.swc-PromptField-artifacts-scrollbar-lane'
       );
       expect(
-        scrollEl?.classList.contains('is-artifact-scroll-from-buttons')
-      ).toBe(false);
-      expect(
         scrollbarLane?.classList.contains('is-artifact-scrollbar-interacting')
       ).toBe(false);
-    });
-
-    await step('wheel interaction shows the scrollbar thumb', async () => {
-      scrollEl?.dispatchEvent(
-        new WheelEvent('wheel', {
-          bubbles: true,
-          deltaX: 12,
-        })
-      );
-      await el.updateComplete;
-
-      const scrollbarLane = el.shadowRoot?.querySelector(
-        '.swc-PromptField-artifacts-scrollbar-lane'
-      );
-      expect(
-        scrollbarLane?.classList.contains('is-artifact-scrollbar-interacting')
-      ).toBe(true);
     });
 
     await step(
@@ -382,13 +377,14 @@ export const ArtifactScrollPaginationTest: Story = {
         );
         expect(nextButtonAtEnd).toBeTruthy();
 
-        const beforeClick = scrollEl?.scrollLeft ?? 0;
         const finalPageScrollEnd = waitForScrollEnd(scrollEl);
         nextButtonAtEnd?.click();
         await finalPageScrollEnd;
         await el.updateComplete;
 
-        expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(beforeClick);
+        expect(
+          el.shadowRoot?.querySelector('.swc-PromptField-artifacts-scroll-next')
+        ).toBeFalsy();
       }
     );
   },
@@ -758,23 +754,38 @@ export const ArtifactScrollbarDisconnectTest: Story = {
       '.swc-PromptField-artifacts-scrollbar-thumb'
     );
 
-    await step('removes global thumb-drag listeners when disconnected', async () => {
-      scrollEl?.scrollTo({ left: 100, behavior: 'auto' });
-      await new Promise((resolve) => requestAnimationFrame(resolve));
-      const scrollLeftBeforeDisconnect = scrollEl?.scrollLeft;
+    await step(
+      'removes global thumb-drag listeners when disconnected',
+      async () => {
+        expect(scrollEl).toBeTruthy();
+        expect(thumb).toBeTruthy();
+        if (!scrollEl || !thumb) {
+          return;
+        }
 
-      thumb?.dispatchEvent(
-        new PointerEvent('pointerdown', { bubbles: true, clientX: 8 })
-      );
-      el.remove();
-      window.dispatchEvent(
-        new PointerEvent('pointermove', { bubbles: true, clientX: 240 })
-      );
+        scrollEl?.scrollTo({ left: 100, behavior: 'auto' });
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        let scrollCalls = 0;
+        Object.defineProperty(scrollEl, 'scrollTo', {
+          configurable: true,
+          value: () => {
+            scrollCalls++;
+          },
+        });
 
-      expect(
-        scrollEl?.scrollLeft,
-        'a detached prompt field no longer receives global drag events'
-      ).toBe(scrollLeftBeforeDisconnect);
-    });
+        thumb.dispatchEvent(
+          new PointerEvent('pointerdown', { bubbles: true, clientX: 8 })
+        );
+        el.remove();
+        window.dispatchEvent(
+          new PointerEvent('pointermove', { bubbles: true, clientX: 240 })
+        );
+
+        expect(
+          scrollCalls,
+          'a detached prompt field no longer receives global drag events'
+        ).toBe(0);
+      }
+    );
   },
 };

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -390,6 +390,13 @@ export const ArtifactScrollPaginationTest: Story = {
   },
 };
 
+/**
+ * Resolves on the native `scrollend` event, or (as a cross-browser
+ * fallback) once `scrollLeft` stops changing across a few animation
+ * frames — WebKit's test runner doesn't reliably fire `scrollend` for
+ * `scrollIntoView`/`scrollTo` with `behavior: 'smooth'`, which would
+ * otherwise hang this indefinitely.
+ */
 function waitForScrollEnd(
   scrollEl: HTMLDivElement | null | undefined
 ): Promise<void> {
@@ -398,7 +405,36 @@ function waitForScrollEnd(
   }
 
   return new Promise<void>((resolve) => {
-    scrollEl.addEventListener('scrollend', () => resolve(), { once: true });
+    let settled = false;
+    const finish = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve();
+    };
+
+    scrollEl.addEventListener('scrollend', finish, { once: true });
+
+    let lastScrollLeft = scrollEl.scrollLeft;
+    let stableFrames = 0;
+    const poll = (): void => {
+      if (settled) {
+        return;
+      }
+      if (scrollEl.scrollLeft === lastScrollLeft) {
+        stableFrames += 1;
+        if (stableFrames >= 3) {
+          finish();
+          return;
+        }
+      } else {
+        stableFrames = 0;
+        lastScrollLeft = scrollEl.scrollLeft;
+      }
+      requestAnimationFrame(poll);
+    };
+    requestAnimationFrame(poll);
   });
 }
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -353,11 +353,12 @@ export const ArtifactScrollPaginationTest: Story = {
           0,
           (scrollEl?.scrollWidth ?? 0) - (scrollEl?.clientWidth ?? 0)
         );
+        const scrollEnd = waitForScrollEnd(scrollEl);
         scrollEl?.scrollTo({
           left: maxScroll,
           behavior: 'instant',
         });
-        await new Promise((resolve) => requestAnimationFrame(resolve));
+        await scrollEnd;
         await el.updateComplete;
 
         const nextButtonAtEnd = el.shadowRoot?.querySelector<HTMLButtonElement>(
@@ -635,8 +636,9 @@ export const ArtifactFocusOrderTest: Story = {
     await step(
       'the "<" button becoming disabled while focused keeps focus on it, rather than moving it anywhere',
       async () => {
+        const firstScrollEnd = waitForScrollEnd(scrollEl);
         scrollEl?.scrollTo({ left: 200, behavior: 'instant' });
-        await new Promise((resolve) => requestAnimationFrame(resolve));
+        await firstScrollEnd;
         await el.updateComplete;
         expect(scrollEl?.scrollLeft ?? 0).toBeGreaterThan(0);
 
@@ -645,8 +647,9 @@ export const ArtifactFocusOrderTest: Story = {
         prevButton?.focus();
         expect(getActiveElement()).toBe(prevButton);
 
+        const secondScrollEnd = waitForScrollEnd(scrollEl);
         scrollEl?.scrollTo({ left: 0, behavior: 'instant' });
-        await new Promise((resolve) => requestAnimationFrame(resolve));
+        await secondScrollEnd;
         await el.updateComplete;
 
         expect(getPrevButton()?.getAttribute('aria-disabled')).toBe('true');

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -237,10 +237,13 @@ export const MixedArtifactWarningTest: Story = {
 const artifactScrollGradient =
   'linear-gradient(135deg, #667eea 0%, #764ba2 100%)';
 
-function renderMultiArtifactPromptField(canvasElement: HTMLElement): void {
+function renderMultiArtifactPromptField(
+  canvasElement: HTMLElement,
+  direction?: 'rtl'
+): void {
   render(
     html`
-      <div style="inline-size:480px;">
+      <div style="inline-size:480px;" dir=${direction ?? nothing}>
         <swc-prompt-field label="Prompt" value="Review attachments.">
           ${Array.from({ length: 14 }, (_, index) => index).map(
             (index) => html`
@@ -289,6 +292,16 @@ export const ArtifactScrollPaginationTest: Story = {
         expect(
           (scrollEl?.scrollWidth ?? 0) > (scrollEl?.clientWidth ?? 0)
         ).toBe(true);
+        expect(
+          el.shadowRoot?.querySelector(
+            '.swc-PromptField-artifacts-scrollbar-lane'
+          )
+        ).toBeNull();
+
+        el.artifactScrollPrevLabel = 'Show earlier attachments';
+        el.artifactScrollNextLabel = 'Show later attachments';
+        await el.updateComplete;
+        expect(nextButton?.ariaLabel).toBe('Show later attachments');
       }
     );
 
@@ -299,94 +312,101 @@ export const ArtifactScrollPaginationTest: Story = {
       expect(endFade).toBeTruthy();
     });
 
-    await step('wheel interaction shows the scrollbar thumb', async () => {
-      scrollEl?.dispatchEvent(
-        new WheelEvent('wheel', {
-          bubbles: true,
-          deltaX: 12,
-        })
-      );
-      await el.updateComplete;
-
-      const scrollbarLane = el.shadowRoot?.querySelector(
-        '.swc-PromptField-artifacts-scrollbar-lane'
-      );
-      expect(
-        scrollbarLane?.classList.contains('is-artifact-scrollbar-interacting')
-      ).toBe(true);
-    });
-
-    await step('chevron paging advances by more than one tile', async () => {
-      const initialScrollLeft = scrollEl?.scrollLeft ?? 0;
-      const clientWidth = scrollEl?.clientWidth ?? 0;
-      const firstPageScrollEnd = waitForScrollEnd(scrollEl);
-      nextButton?.click();
-      await el.updateComplete;
-      expect(
-        scrollEl?.classList.contains('is-artifact-scroll-from-buttons')
-      ).toBe(true);
-
-      await firstPageScrollEnd;
-      await el.updateComplete;
-
-      const nextScrollLeft = scrollEl?.scrollLeft ?? 0;
-      expect(nextScrollLeft).toBeGreaterThan(initialScrollLeft);
-
-      const tileWidth =
-        scrollEl
-          ?.querySelector('slot')
-          ?.assignedElements({ flatten: true })[0]
-          ?.getBoundingClientRect().width ?? 68;
-      expect(nextScrollLeft - initialScrollLeft).toBeGreaterThan(tileWidth);
-
-      // The whole visible set should page forward together (only the one
-      // edge tile that was under 50% visible may be carried over) rather
-      // than nudging by a single tile's worth of scroll.
-      expect(nextScrollLeft - initialScrollLeft).toBeGreaterThan(
-        clientWidth - 2 * tileWidth
-      );
-    });
-
-    await step('chevron paging keeps the scrollbar thumb hidden', async () => {
-      await el.updateComplete;
-
-      const scrollbarLane = el.shadowRoot?.querySelector(
-        '.swc-PromptField-artifacts-scrollbar-lane'
-      );
-      expect(
-        scrollbarLane?.classList.contains('is-artifact-scrollbar-interacting')
-      ).toBe(false);
-    });
-
     await step(
-      'chevron paging reaches the end when the last tile is only partially visible',
+      'chevron paging advances by one viewport with CSS Scroll Snap',
       async () => {
-        const maxScroll = Math.max(
-          0,
-          (scrollEl?.scrollWidth ?? 0) - (scrollEl?.clientWidth ?? 0)
-        );
-        scrollEl?.scrollTo({
-          left: Math.max(0, maxScroll - 10),
-          behavior: 'auto',
-        });
-        await new Promise((resolve) => requestAnimationFrame(resolve));
+        const initialScrollLeft = scrollEl?.scrollLeft ?? 0;
+        const clientWidth = scrollEl?.clientWidth ?? 0;
+        const firstPageScrollEnd = waitForScrollEnd(scrollEl);
+        nextButton?.click();
         await el.updateComplete;
 
-        const nextButtonAtEnd = el.shadowRoot?.querySelector<HTMLButtonElement>(
-          '.swc-PromptField-artifacts-scroll-next'
-        );
-        expect(nextButtonAtEnd).toBeTruthy();
-
-        const finalPageScrollEnd = waitForScrollEnd(scrollEl);
-        nextButtonAtEnd?.click();
-        await finalPageScrollEnd;
+        await firstPageScrollEnd;
         await el.updateComplete;
 
+        const nextScrollLeft = scrollEl?.scrollLeft ?? 0;
+        expect(scrollEl?.clientWidth).toBe(clientWidth);
+        expect(nextScrollLeft).toBeGreaterThan(initialScrollLeft);
+        expect(nextScrollLeft - initialScrollLeft).toBeGreaterThan(
+          clientWidth / 2
+        );
         expect(
-          el.shadowRoot?.querySelector('.swc-PromptField-artifacts-scroll-next')
-        ).toBeFalsy();
+          el.shadowRoot?.querySelector<HTMLButtonElement>(
+            '.swc-PromptField-artifacts-scroll-prev'
+          )?.ariaLabel
+        ).toBe('Show earlier attachments');
+
+        const tiles = scrollEl
+          ?.querySelector('slot')
+          ?.assignedElements({ flatten: true }) as HTMLElement[] | undefined;
+        expect(getComputedStyle(scrollEl!).scrollSnapType).toContain(
+          'mandatory'
+        );
+        expect(getComputedStyle(tiles![0]!).scrollSnapAlign).toContain('start');
       }
     );
+
+    await step('scrolling to the end removes the Next chevron', async () => {
+      const maxScroll = Math.max(
+        0,
+        (scrollEl?.scrollWidth ?? 0) - (scrollEl?.clientWidth ?? 0)
+      );
+      scrollEl?.scrollTo({
+        left: maxScroll,
+        behavior: 'auto',
+      });
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      await el.updateComplete;
+
+      const nextButtonAtEnd = el.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-PromptField-artifacts-scroll-next'
+      );
+      expect(nextButtonAtEnd).toBeFalsy();
+    });
+  },
+};
+
+export const ArtifactScrollRTLTest: Story = {
+  render: () => nothing,
+  play: async ({ canvasElement, step }) => {
+    renderMultiArtifactPromptField(canvasElement, 'rtl');
+
+    const el = await getComponent<PromptField>(
+      canvasElement,
+      'swc-prompt-field'
+    );
+    await el.updateComplete;
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    await el.updateComplete;
+
+    const scrollEl = el.shadowRoot?.querySelector<HTMLDivElement>(
+      '.swc-PromptField-artifacts-scroll'
+    );
+    const getPrevButton = (): HTMLButtonElement | null | undefined =>
+      el.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-PromptField-artifacts-scroll-prev'
+      );
+    const getNextButton = (): HTMLButtonElement | null | undefined =>
+      el.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-PromptField-artifacts-scroll-next'
+      );
+    const firstArtifact = el.querySelector<HTMLElement>('[slot="artifact"]');
+
+    await step('the next chevron pages forward in RTL', async () => {
+      expect(getComputedStyle(el).direction).toBe('rtl');
+      expect(getPrevButton()).toBeFalsy();
+
+      const scrollEnd = waitForScrollEnd(scrollEl);
+      getNextButton()?.click();
+      await scrollEnd;
+      await el.updateComplete;
+
+      expect(getPrevButton()).toBeTruthy();
+      expect(
+        firstArtifact!.getBoundingClientRect().left >=
+          scrollEl!.getBoundingClientRect().right
+      ).toBe(true);
+    });
   },
 };
 
@@ -784,61 +804,6 @@ export const ArtifactChevronPagingFocusTest: Story = {
 
         expect(event.defaultPrevented).toBe(true);
         expect(tilesAfterPagingBack.includes(activeTile()!)).toBe(true);
-      }
-    );
-  },
-};
-
-export const ArtifactScrollbarDisconnectTest: Story = {
-  render: () => nothing,
-  play: async ({ canvasElement, step }) => {
-    renderMultiArtifactPromptField(canvasElement);
-
-    const el = await getComponent<PromptField>(
-      canvasElement,
-      'swc-prompt-field'
-    );
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-    await el.updateComplete;
-
-    const scrollEl = el.shadowRoot?.querySelector<HTMLDivElement>(
-      '.swc-PromptField-artifacts-scroll'
-    );
-    const thumb = el.shadowRoot?.querySelector<HTMLElement>(
-      '.swc-PromptField-artifacts-scrollbar-thumb'
-    );
-
-    await step(
-      'removes global thumb-drag listeners when disconnected',
-      async () => {
-        expect(scrollEl).toBeTruthy();
-        expect(thumb).toBeTruthy();
-        if (!scrollEl || !thumb) {
-          return;
-        }
-
-        scrollEl?.scrollTo({ left: 100, behavior: 'auto' });
-        await new Promise((resolve) => requestAnimationFrame(resolve));
-        let scrollCalls = 0;
-        Object.defineProperty(scrollEl, 'scrollTo', {
-          configurable: true,
-          value: () => {
-            scrollCalls++;
-          },
-        });
-
-        thumb.dispatchEvent(
-          new PointerEvent('pointerdown', { bubbles: true, clientX: 8 })
-        );
-        el.remove();
-        window.dispatchEvent(
-          new PointerEvent('pointermove', { bubbles: true, clientX: 240 })
-        );
-
-        expect(
-          scrollCalls,
-          'a detached prompt field no longer receives global drag events'
-        ).toBe(0);
       }
     );
   },

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
@@ -21,7 +21,8 @@ import styles from './upload-artifact.css';
 
 /**
  * Shared upload artifact primitive with card and media types.
- * Do not mix `type="card"` and `type="media"` in the same attachment strip; pick one mode per composer session.
+ * Do not mix `type="card"` and `type="media"` in the same attachment strip.
+ * When uploads mix images and documents, normalize to one layout (typically all `type="media"` with thumbnails and optional badges).
  *
  * @element swc-upload-artifact
  *

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
@@ -11,7 +11,7 @@
  */
 
 import { CSSResultArray, html, TemplateResult } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, queryAssignedElements } from 'lit/decorators.js';
 
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
 
@@ -27,6 +27,7 @@ import styles from './upload-artifact.css';
  * @element swc-upload-artifact
  *
  * @slot thumbnail - Shared visual slot for icon/thumbnail/preview image.
+ * @slot badge - Optional file-type badge rendered over `type="media"` previews (for example, "PDF").
  * @slot title - Primary text label.
  * @slot subtitle - Secondary text label.
  * @slot actions - Optional trailing actions.
@@ -46,8 +47,19 @@ export class UploadArtifact extends SpectrumElement {
   @property({ type: String, attribute: 'dismiss-label' })
   public dismissLabel = 'Remove attachment';
 
+  @queryAssignedElements({ slot: 'badge', flatten: true })
+  private _assignedBadge!: HTMLElement[];
+
   public static override get styles(): CSSResultArray {
     return [styles];
+  }
+
+  private _handleBadgeSlotChange(): void {
+    this.requestUpdate();
+  }
+
+  private _hasBadgeContent(): boolean {
+    return (this._assignedBadge?.length ?? 0) > 0;
   }
 
   private _handleDismissClick(): void {
@@ -60,9 +72,60 @@ export class UploadArtifact extends SpectrumElement {
     );
   }
 
-  protected override render(): TemplateResult {
-    const isMedia = this.type === 'media';
+  private _renderBadge(): TemplateResult {
+    if (!this._hasBadgeContent()) {
+      return html`
+        <slot
+          name="badge"
+          hidden
+          @slotchange=${this._handleBadgeSlotChange}
+        ></slot>
+      `;
+    }
 
+    return html`
+      <div class="swc-UploadArtifact-badge">
+        <slot name="badge" @slotchange=${this._handleBadgeSlotChange}></slot>
+      </div>
+    `;
+  }
+
+  private _renderMediaSurface(): TemplateResult {
+    return html`
+      <div class="swc-UploadArtifact-surface">
+        <div class="swc-UploadArtifact-thumbnail">
+          <slot name="thumbnail"></slot>
+        </div>
+        ${this._renderBadge()}
+        <div class="swc-UploadArtifact-actions">
+          <slot name="actions"></slot>
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderCardSurface(): TemplateResult {
+    return html`
+      <div class="swc-UploadArtifact-surface">
+        <div class="swc-UploadArtifact-thumbnail">
+          <slot name="thumbnail"></slot>
+        </div>
+        <div class="swc-UploadArtifact-meta">
+          <div class="swc-UploadArtifact-title">
+            <slot name="title"></slot>
+          </div>
+          <div class="swc-UploadArtifact-subtitle">
+            <slot name="subtitle"></slot>
+          </div>
+        </div>
+        <div class="swc-UploadArtifact-actions">
+          <slot name="actions"></slot>
+        </div>
+      </div>
+    `;
+  }
+
+  protected override render(): TemplateResult {
     return html`
       <div class="swc-UploadArtifact">
         <button
@@ -74,32 +137,9 @@ export class UploadArtifact extends SpectrumElement {
           <swc-icon aria-hidden="true">${CrossIcon()}</swc-icon>
         </button>
 
-        <div class="swc-UploadArtifact-surface">
-          <div class="swc-UploadArtifact-thumbnail">
-            <slot name="thumbnail"></slot>
-          </div>
-
-          ${isMedia
-            ? html`
-                <div class="swc-UploadArtifact-actions">
-                  <slot name="actions"></slot>
-                </div>
-              `
-            : html`
-                <div class="swc-UploadArtifact-meta">
-                  <div class="swc-UploadArtifact-title">
-                    <slot name="title"></slot>
-                  </div>
-                  <div class="swc-UploadArtifact-subtitle">
-                    <slot name="subtitle"></slot>
-                  </div>
-                </div>
-
-                <div class="swc-UploadArtifact-actions">
-                  <slot name="actions"></slot>
-                </div>
-              `}
-        </div>
+        ${this.type === 'media'
+          ? this._renderMediaSurface()
+          : this._renderCardSurface()}
       </div>
     `;
   }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { CSSResultArray, html, TemplateResult } from 'lit';
+import { CSSResultArray, html, PropertyValues, TemplateResult } from 'lit';
 import { property, queryAssignedElements } from 'lit/decorators.js';
 
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
@@ -23,6 +23,11 @@ import styles from './upload-artifact.css';
  * Shared upload artifact primitive with card and media types.
  * Do not mix `type="card"` and `type="media"` in the same attachment strip.
  * When uploads mix images and documents, normalize to one layout (typically all `type="media"` with thumbnails and optional badges).
+ *
+ * Not independently keyboard-reachable: this tile has no default `tabindex` of its
+ * own. `swc-prompt-field` manages roving `tabindex`, focus, and the dismiss button's
+ * Tab-key reachability for tiles slotted into its `artifact` slot. Standalone usage
+ * outside that context should set `tabIndex` itself if keyboard access is needed.
  *
  * @element swc-upload-artifact
  *
@@ -43,15 +48,63 @@ export class UploadArtifact extends SpectrumElement {
   @property({ type: Boolean, reflect: true })
   public dismissible = false;
 
-  /** Accessible label for the dismiss/remove attachment button. */
+  /**
+   * Accessible label for the dismiss/remove attachment button. When unset, derives
+   * "Remove [file name].[file type]" from the `title` slot's text content, falling
+   * back to "Remove attachment" when no title text is available.
+   */
   @property({ type: String, attribute: 'dismiss-label' })
-  public dismissLabel = 'Remove attachment';
+  public dismissLabel = '';
+
+  /**
+   * Accessible name for the tile itself. When unset, derives from the `title`
+   * slot's text content (typically the file name and type).
+   */
+  @property({ type: String, attribute: 'accessible-label' })
+  public accessibleLabel = '';
 
   @queryAssignedElements({ slot: 'badge', flatten: true })
   private _assignedBadge!: HTMLElement[];
 
+  @queryAssignedElements({ slot: 'title', flatten: true })
+  private _assignedTitle!: HTMLElement[];
+
   public static override get styles(): CSSResultArray {
     return [styles];
+  }
+
+  protected override willUpdate(_changed: PropertyValues<this>): void {
+    this._syncHostAccessibleLabel();
+  }
+
+  private _titleText(): string {
+    return this._assignedTitle
+      .map((element) => element.textContent?.trim() ?? '')
+      .filter(Boolean)
+      .join(' ');
+  }
+
+  private _syncHostAccessibleLabel(): void {
+    const label = this.accessibleLabel.trim() || this._titleText();
+    if (label) {
+      this.setAttribute('aria-label', label);
+    } else {
+      this.removeAttribute('aria-label');
+    }
+  }
+
+  private _resolvedDismissLabel(): string {
+    const explicit = this.dismissLabel.trim();
+    if (explicit) {
+      return explicit;
+    }
+    const title = this._titleText();
+    return title ? `Remove ${title}` : 'Remove attachment';
+  }
+
+  private _handleTitleSlotChange(): void {
+    this._syncHostAccessibleLabel();
+    this.requestUpdate();
   }
 
   private _handleBadgeSlotChange(): void {
@@ -76,7 +129,8 @@ export class UploadArtifact extends SpectrumElement {
     return html`
       <button
         class="swc-UploadArtifact-dismiss"
-        aria-label=${this.dismissLabel}
+        tabindex="-1"
+        aria-label=${this._resolvedDismissLabel()}
         ?hidden=${!this.dismissible}
         @click=${this._handleDismissClick}
       >
@@ -119,6 +173,11 @@ export class UploadArtifact extends SpectrumElement {
         <div class="swc-UploadArtifact-actions">
           <slot name="actions"></slot>
         </div>
+        <slot
+          name="title"
+          hidden
+          @slotchange=${this._handleTitleSlotChange}
+        ></slot>
       </div>
     `;
   }
@@ -131,7 +190,10 @@ export class UploadArtifact extends SpectrumElement {
         </div>
         <div class="swc-UploadArtifact-meta">
           <div class="swc-UploadArtifact-title">
-            <slot name="title"></slot>
+            <slot
+              name="title"
+              @slotchange=${this._handleTitleSlotChange}
+            ></slot>
           </div>
           <div class="swc-UploadArtifact-subtitle">
             <slot name="subtitle"></slot>

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
@@ -15,14 +15,13 @@ import { property, queryAssignedElements } from 'lit/decorators.js';
 
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
 
-import '@adobe/spectrum-wc/components/icon/swc-icon.js';
-
 import { CrossIcon } from '../utils/icons/index.js';
 
 import styles from './upload-artifact.css';
 
 /**
  * Shared upload artifact primitive with card and media types.
+ * Do not mix `type="card"` and `type="media"` in the same attachment strip; pick one mode per composer session.
  *
  * @element swc-upload-artifact
  *
@@ -70,6 +69,25 @@ export class UploadArtifact extends SpectrumElement {
         detail: { artifact: this },
       })
     );
+  }
+
+  private _renderDismissButton(): TemplateResult {
+    return html`
+      <button
+        class="swc-UploadArtifact-dismiss"
+        aria-label=${this.dismissLabel}
+        ?hidden=${!this.dismissible}
+        @click=${this._handleDismissClick}
+      >
+        <span
+          class="swc-UploadArtifact-dismiss-visual"
+          aria-hidden="true"
+        ></span>
+        <span class="swc-UploadArtifact-dismiss-icon" aria-hidden="true">
+          ${CrossIcon()}
+        </span>
+      </button>
+    `;
   }
 
   private _renderBadge(): TemplateResult {
@@ -127,16 +145,8 @@ export class UploadArtifact extends SpectrumElement {
 
   protected override render(): TemplateResult {
     return html`
+      ${this._renderDismissButton()}
       <div class="swc-UploadArtifact">
-        <button
-          class="swc-UploadArtifact-dismiss"
-          aria-label=${this.dismissLabel}
-          ?hidden=${!this.dismissible}
-          @click=${this._handleDismissClick}
-        >
-          <swc-icon aria-hidden="true">${CrossIcon()}</swc-icon>
-        </button>
-
         ${this.type === 'media'
           ? this._renderMediaSurface()
           : this._renderCardSurface()}

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
@@ -11,9 +11,10 @@
  */
 
 import { CSSResultArray, html, PropertyValues, TemplateResult } from 'lit';
-import { property, queryAssignedElements } from 'lit/decorators.js';
+import { property, query, queryAssignedElements } from 'lit/decorators.js';
 
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
+import { getLabelFromSlot } from '@adobe/spectrum-wc-core/utils/index.js';
 
 import { CrossIcon } from '../utils/icons/index.js';
 
@@ -24,10 +25,9 @@ import styles from './upload-artifact.css';
  * Do not mix `type="card"` and `type="media"` in the same attachment strip.
  * When uploads mix images and documents, normalize to one layout (typically all `type="media"` with thumbnails and optional badges).
  *
- * Not independently keyboard-reachable: this tile has no default `tabindex` of its
- * own. `swc-prompt-field` manages roving `tabindex`, focus, and the dismiss button's
- * Tab-key reachability for tiles slotted into its `artifact` slot. Standalone usage
- * outside that context should set `tabIndex` itself if keyboard access is needed.
+ * This tile has no default `tabindex` of its own. Its dismiss button is natively
+ * tabbable when used standalone; `swc-prompt-field` manages its Tab-key sequence
+ * for tiles slotted into its `artifact` slot.
  *
  * @element swc-upload-artifact
  *
@@ -71,8 +71,8 @@ export class UploadArtifact extends SpectrumElement {
   @queryAssignedElements({ slot: 'badge', flatten: true })
   private _assignedBadge!: HTMLElement[];
 
-  @queryAssignedElements({ slot: 'title', flatten: true })
-  private _assignedTitle!: HTMLElement[];
+  @query('slot[name="title"]')
+  private _titleSlot?: HTMLSlotElement;
 
   public static override get styles(): CSSResultArray {
     return [styles];
@@ -88,10 +88,7 @@ export class UploadArtifact extends SpectrumElement {
   }
 
   private _titleText(): string {
-    return this._assignedTitle
-      .map((element) => element.textContent?.trim() ?? '')
-      .filter(Boolean)
-      .join(' ');
+    return this._titleSlot ? (getLabelFromSlot('', this._titleSlot) ?? '') : '';
   }
 
   private _syncHostAccessibleLabel(): void {
@@ -139,7 +136,7 @@ export class UploadArtifact extends SpectrumElement {
     return html`
       <button
         class="swc-UploadArtifact-dismiss"
-        tabindex="-1"
+        tabindex=${this.closest('swc-prompt-field') ? -1 : undefined}
         aria-label=${this._resolvedDismissLabel()}
         ?hidden=${!this.dismissible}
         @click=${this._handleDismissClick}

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
@@ -12,6 +12,7 @@
 
 import { CSSResultArray, html, PropertyValues, TemplateResult } from 'lit';
 import { property, query, queryAssignedElements } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
 import { getLabelFromSlot } from '@adobe/spectrum-wc-core/utils/index.js';
@@ -136,7 +137,7 @@ export class UploadArtifact extends SpectrumElement {
     return html`
       <button
         class="swc-UploadArtifact-dismiss"
-        tabindex=${this.closest('swc-prompt-field') ? -1 : undefined}
+        tabindex=${ifDefined(this.closest('swc-prompt-field') ? -1 : undefined)}
         aria-label=${this._resolvedDismissLabel()}
         ?hidden=${!this.dismissible}
         @click=${this._handleDismissClick}

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
@@ -31,6 +31,11 @@ import styles from './upload-artifact.css';
  *
  * @element swc-upload-artifact
  *
+ * @example
+ * <swc-upload-artifact type="card" dismissible>
+ *   <span slot="title">Brief.pdf</span>
+ * </swc-upload-artifact>
+ *
  * @slot thumbnail - Shared visual slot for icon/thumbnail/preview image.
  * @slot badge - Optional file-type badge rendered over `type="media"` previews (for example, "PDF").
  * @slot title - Primary text label.

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/UploadArtifact.ts
@@ -78,6 +78,11 @@ export class UploadArtifact extends SpectrumElement {
     return [styles];
   }
 
+  protected override firstUpdated(_changed: PropertyValues<this>): void {
+    super.firstUpdated(_changed);
+    this.setAttribute('role', 'group');
+  }
+
   protected override willUpdate(_changed: PropertyValues<this>): void {
     this._syncHostAccessibleLabel();
   }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
@@ -123,6 +123,15 @@ export const MultiArtifact: Story = {
           />
         </swc-upload-artifact>
         <swc-upload-artifact type="media" dismissible>
+          <div
+            slot="thumbnail"
+            role="img"
+            aria-label="Document preview"
+            style="inline-size:100%;block-size:100%;background:#f3f3f3;"
+          ></div>
+          <span slot="badge">PDF</span>
+        </swc-upload-artifact>
+        <swc-upload-artifact type="media" dismissible>
           <img
             slot="thumbnail"
             src="https://picsum.photos/id/56/68/68"
@@ -165,6 +174,23 @@ export const Media: Story = {
           alt="Campaign preview"
           style="inline-size:100%;block-size:100%;object-fit:cover;"
         />
+      </swc-upload-artifact>
+    </div>
+  `,
+  tags: ['options'],
+};
+
+export const MediaWithBadge: Story = {
+  render: () => html`
+    <div style="inline-size:240px;">
+      <swc-upload-artifact type="media" dismissible>
+        <img
+          slot="thumbnail"
+          src="https://picsum.photos/id/823/68/68"
+          alt="Mixed attachment preview"
+          style="inline-size:100%;block-size:100%;object-fit:cover;"
+        />
+        <span slot="badge">PDF</span>
       </swc-upload-artifact>
     </div>
   `,

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
@@ -30,8 +30,9 @@ argTypes.type = {
 
 /**
  * Shared upload artifact primitive used across conversational AI surfaces such as prompt field and user message.
- * Supports both **`card`** and **`media`** types with a unified slot model.
- * For several attachments at once, see **Multi-artifact** and **[Prompt field → Artifact](/docs/patterns-conversational-ai-prompt-field--docs#artifact)**.
+ * Supports **`card`** and **`media`** types with a unified slot model.
+ * Use one type per attachment strip — cards only, or media tiles only (with or without badge).
+ * For several attachments at once, see **Multi-card**, **Multi-media**, and **[Prompt field → Artifact](/docs/patterns-conversational-ai-prompt-field--docs#artifact)**.
  */
 const meta: Meta = {
   title: 'Conversational AI/Upload artifact',
@@ -43,7 +44,7 @@ const meta: Meta = {
     docs: {
       packagePath: 'patterns/conversational-ai/upload-artifact',
       subtitle:
-        'Card and media tiles for attachments; combine multiple in a strip (see Multi-artifact gallery) or slot them into the prompt field artifact region.',
+        'Card and media tiles for attachments. Use one type per strip; slot multiple into the prompt field artifact region.',
     },
     layout: 'padded',
   },
@@ -99,14 +100,14 @@ export const Overview: Story = {
   tags: ['overview'],
 };
 
-export const MultiArtifact: Story = {
+export const MultiCard: Story = {
   render: () => html`
     <div
       style="display:flex;flex-direction:column;gap:16px;max-inline-size:720px;"
     >
       <p class="swc-Detail swc-Detail--sizeS" style="margin:0;">
-        Mirrors the prompt-field Attachment strip: cards and media tiles
-        together, plus an extra card to stress-test wrapping at narrow widths.
+        Multiple card artifacts in one strip. Do not combine cards with media
+        tiles in the same composer session.
       </p>
       <div style="display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start;">
         <swc-upload-artifact type="card" dismissible>
@@ -114,6 +115,32 @@ export const MultiArtifact: Story = {
           <span slot="title">Brand guidelines</span>
           <span slot="subtitle">PDF</span>
         </swc-upload-artifact>
+        <swc-upload-artifact type="card" dismissible>
+          <div slot="thumbnail" role="img" aria-label="Spreadsheet"></div>
+          <span slot="title">Q2 metrics draft</span>
+          <span slot="subtitle">XLSX</span>
+        </swc-upload-artifact>
+        <swc-upload-artifact type="card" dismissible>
+          <div slot="thumbnail" role="img" aria-label="Deck"></div>
+          <span slot="title">Executive summary</span>
+          <span slot="subtitle">PPTX</span>
+        </swc-upload-artifact>
+      </div>
+    </div>
+  `,
+  tags: ['options'],
+};
+
+export const MultiMedia: Story = {
+  render: () => html`
+    <div
+      style="display:flex;flex-direction:column;gap:16px;max-inline-size:720px;"
+    >
+      <p class="swc-Detail swc-Detail--sizeS" style="margin:0;">
+        Multiple media tiles in one strip, with and without a badge. Use media
+        only — not mixed with cards.
+      </p>
+      <div style="display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start;">
         <swc-upload-artifact type="media" dismissible>
           <img
             slot="thumbnail"
@@ -138,11 +165,6 @@ export const MultiArtifact: Story = {
             alt="Storyboard frame"
             style="inline-size:100%;block-size:100%;object-fit:cover;"
           />
-        </swc-upload-artifact>
-        <swc-upload-artifact type="card" dismissible>
-          <div slot="thumbnail" role="img" aria-label="Spreadsheet"></div>
-          <span slot="title">Q2 metrics draft</span>
-          <span slot="subtitle">XLSX</span>
         </swc-upload-artifact>
       </div>
     </div>

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
@@ -115,20 +115,20 @@ export const MultiArtifact: Story = {
           <span slot="subtitle">PDF</span>
         </swc-upload-artifact>
         <swc-upload-artifact type="media" dismissible>
-          <div
+          <img
             slot="thumbnail"
-            style="inline-size:100%;block-size:100%;min-block-size:120px;background:linear-gradient(135deg,#6366f1,#ec4899);"
-            role="img"
-            aria-label="Campaign still"
-          ></div>
+            src="https://picsum.photos/id/64/68/68"
+            alt="Campaign still"
+            style="inline-size:100%;block-size:100%;object-fit:cover;"
+          />
         </swc-upload-artifact>
         <swc-upload-artifact type="media" dismissible>
-          <div
+          <img
             slot="thumbnail"
-            style="inline-size:100%;block-size:100%;min-block-size:120px;background:linear-gradient(135deg,#0ea5e9,#22c55e);"
-            role="img"
-            aria-label="Storyboard frame"
-          ></div>
+            src="https://picsum.photos/id/56/68/68"
+            alt="Storyboard frame"
+            style="inline-size:100%;block-size:100%;object-fit:cover;"
+          />
         </swc-upload-artifact>
         <swc-upload-artifact type="card" dismissible>
           <div slot="thumbnail" role="img" aria-label="Spreadsheet"></div>
@@ -159,7 +159,12 @@ export const Media: Story = {
   render: () => html`
     <div style="inline-size:240px;">
       <swc-upload-artifact type="media" dismissible>
-        <div slot="thumbnail" role="img" aria-label="Campaign preview"></div>
+        <img
+          slot="thumbnail"
+          src="https://picsum.photos/id/823/68/68"
+          alt="Campaign preview"
+          style="inline-size:100%;block-size:100%;object-fit:cover;"
+        />
       </swc-upload-artifact>
     </div>
   `,

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
@@ -172,7 +172,7 @@ export const MultiMedia: Story = {
   `,
   tags: ['options'],
 };
-MultiArtifact.storyName = 'Multi artifact';
+MultiCard.storyName = 'Multi artifact';
 
 export const Card: Story = {
   render: () => html`

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
@@ -31,7 +31,8 @@ argTypes.type = {
 /**
  * Shared upload artifact primitive used across conversational AI surfaces such as prompt field and user message.
  * Supports **`card`** and **`media`** types with a unified slot model.
- * Use one type per attachment strip — cards only, or media tiles only (with or without badge).
+ * Use one layout type per attachment strip — cards only, or media tiles only (with or without badge).
+ * When uploads mix images and documents, normalize to all media tiles.
  * For several attachments at once, see **Multi-card**, **Multi-media**, and **[Prompt field → Artifact](/docs/patterns-conversational-ai-prompt-field--docs#artifact)**.
  */
 const meta: Meta = {
@@ -44,7 +45,7 @@ const meta: Meta = {
     docs: {
       packagePath: 'patterns/conversational-ai/upload-artifact',
       subtitle:
-        'Card and media tiles for attachments. Use one type per strip; slot multiple into the prompt field artifact region.',
+        'Card and media tiles for attachments. Use one layout type per strip; normalize mixed uploads to media with badges.',
     },
     layout: 'padded',
   },

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/stories/upload-artifact.stories.ts
@@ -31,7 +31,7 @@ argTypes.type = {
 /**
  * Shared upload artifact primitive used across conversational AI surfaces such as prompt field and user message.
  * Supports **`card`** and **`media`** types with a unified slot model.
- * Use one layout type per attachment strip — cards only, or media tiles only (with or without badge).
+ * Use one layout type per attachment strip: cards only, or media tiles only (with or without badge).
  * When uploads mix images and documents, normalize to all media tiles.
  * For several attachments at once, see **Multi-card**, **Multi-media**, and **[Prompt field → Artifact](/docs/patterns-conversational-ai-prompt-field--docs#artifact)**.
  */
@@ -139,7 +139,7 @@ export const MultiMedia: Story = {
     >
       <p class="swc-Detail swc-Detail--sizeS" style="margin:0;">
         Multiple media tiles in one strip, with and without a badge. Use media
-        only — not mixed with cards.
+        only, not mixed with cards.
       </p>
       <div style="display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start;">
         <swc-upload-artifact type="media" dismissible>

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.a11y.spec.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.a11y.spec.ts
@@ -27,7 +27,7 @@ test.describe('UploadArtifact - ARIA Snapshots', () => {
     const artifact = root.locator('swc-upload-artifact').first();
 
     await expect(artifact).toMatchAriaSnapshot(`
-      - button "Remove attachment"
+      - button "Remove Hilton commercial assets"
       - img "File thumbnail"
       - text: Hilton commercial assets 2026
     `);

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
@@ -43,7 +43,7 @@ export const OverviewTest: Story = {
       async () => {
         expect(el.type).toBe('card');
         expect(el.dismissible).toBe(true);
-        expect(el.dismissLabel).toBe('Remove attachment');
+        expect(el.dismissLabel).toBe('');
 
         const dismissButton = el.shadowRoot?.querySelector<HTMLButtonElement>(
           '.swc-UploadArtifact-dismiss'
@@ -52,7 +52,7 @@ export const OverviewTest: Story = {
           '.swc-UploadArtifact-dismiss-icon'
         );
         expect(dismissButton?.getAttribute('aria-label')).toBe(
-          'Remove attachment'
+          'Remove Hilton commercial assets'
         );
         expect(dismissIcon?.getAttribute('aria-hidden')).toBe('true');
       }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
@@ -152,3 +152,54 @@ export const MediaPreviewOnlyTest: Story = {
     });
   },
 };
+
+export const MediaBadgeTest: Story = {
+  render: () => html`
+    <div style="display:flex;gap:16px;">
+      <swc-upload-artifact type="media" dismissible>
+        <img
+          slot="thumbnail"
+          src="https://picsum.photos/id/823/68/68"
+          alt="Tagged preview"
+          style="inline-size:100%;block-size:100%;object-fit:cover;"
+        />
+        <span slot="badge">PDF</span>
+      </swc-upload-artifact>
+      <swc-upload-artifact type="media" dismissible>
+        <img
+          slot="thumbnail"
+          src="https://picsum.photos/id/64/68/68"
+          alt="Plain preview"
+          style="inline-size:100%;block-size:100%;object-fit:cover;"
+        />
+      </swc-upload-artifact>
+    </div>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const artifacts = canvasElement.querySelectorAll('swc-upload-artifact');
+
+    await step(
+      'badge slot renders a bottom-left overlay when content is provided',
+      async () => {
+        const withBadge = artifacts[0] as UploadArtifact;
+        await withBadge.updateComplete;
+
+        const badge = withBadge.shadowRoot?.querySelector(
+          '.swc-UploadArtifact-badge'
+        );
+        expect(badge).toBeTruthy();
+        expect(badge?.textContent?.trim()).toBe('PDF');
+      }
+    );
+
+    await step('badge overlay is omitted when the slot is empty', async () => {
+      const withoutBadge = artifacts[1] as UploadArtifact;
+      await withoutBadge.updateComplete;
+
+      const badge = withoutBadge.shadowRoot?.querySelector(
+        '.swc-UploadArtifact-badge'
+      );
+      expect(badge).toBeNull();
+    });
+  },
+};

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
@@ -190,7 +190,9 @@ export const MediaBadgeTest: Story = {
           '.swc-UploadArtifact-badge'
         );
         expect(badge).toBeTruthy();
-        expect(badge?.textContent?.trim()).toBe('PDF');
+        expect(
+          withBadge.querySelector('[slot="badge"]')?.textContent?.trim()
+        ).toBe('PDF');
       }
     );
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
@@ -48,11 +48,13 @@ export const OverviewTest: Story = {
         const dismissButton = el.shadowRoot?.querySelector<HTMLButtonElement>(
           '.swc-UploadArtifact-dismiss'
         );
-        const icon = dismissButton?.querySelector('swc-icon');
+        const dismissIcon = dismissButton?.querySelector(
+          '.swc-UploadArtifact-dismiss-icon'
+        );
         expect(dismissButton?.getAttribute('aria-label')).toBe(
           'Remove attachment'
         );
-        expect(icon?.getAttribute('aria-hidden')).toBe('true');
+        expect(dismissIcon?.getAttribute('aria-hidden')).toBe('true');
       }
     );
   },

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
@@ -45,9 +45,7 @@ export const OverviewTest: Story = {
         expect(el.dismissible).toBe(true);
         expect(el.dismissLabel).toBe('');
         expect(el.getAttribute('role')).toBe('group');
-        expect(el.getAttribute('aria-label')).toBe(
-          'Hilton commercial assets'
-        );
+        expect(el.getAttribute('aria-label')).toBe('Hilton commercial assets');
 
         const dismissButton = el.shadowRoot?.querySelector<HTMLButtonElement>(
           '.swc-UploadArtifact-dismiss'

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
@@ -56,6 +56,7 @@ export const OverviewTest: Story = {
         expect(dismissButton?.getAttribute('aria-label')).toBe(
           'Remove Hilton commercial assets'
         );
+        expect(dismissButton?.tabIndex).toBe(0);
         expect(dismissIcon?.getAttribute('aria-hidden')).toBe('true');
       }
     );
@@ -129,6 +130,34 @@ export const DismissEventTest: Story = {
         expect(spaceCount).toBe(1);
       }
     );
+  },
+};
+
+export const DismissSizeOverrideTest: Story = {
+  render: () => html`
+    <swc-upload-artifact
+      dismissible
+      style="--swc-upload-artifact-dismiss-inline-size: 40px; --swc-upload-artifact-dismiss-block-size: 36px;"
+    >
+      Hilton commercial assets
+    </swc-upload-artifact>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const el = await getComponent<UploadArtifact>(
+      canvasElement,
+      'swc-upload-artifact'
+    );
+
+    await step('consumer dismiss-size overrides are preserved', async () => {
+      const dismissButton = el.shadowRoot?.querySelector<HTMLButtonElement>(
+        '.swc-UploadArtifact-dismiss'
+      );
+      const dismissButtonStyle =
+        dismissButton && getComputedStyle(dismissButton);
+
+      expect(dismissButtonStyle?.inlineSize).toBe('40px');
+      expect(dismissButtonStyle?.blockSize).toBe('36px');
+    });
   },
 };
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/test/upload-artifact.test.ts
@@ -44,6 +44,10 @@ export const OverviewTest: Story = {
         expect(el.type).toBe('card');
         expect(el.dismissible).toBe(true);
         expect(el.dismissLabel).toBe('');
+        expect(el.getAttribute('role')).toBe('group');
+        expect(el.getAttribute('aria-label')).toBe(
+          'Hilton commercial assets'
+        );
 
         const dismissButton = el.shadowRoot?.querySelector<HTMLButtonElement>(
           '.swc-UploadArtifact-dismiss'

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -20,10 +20,12 @@
 /* Figma focus-order spec (node 243-9156, §9): thumbnail and Close button use a
  * dedicated ring color, distinct from the S2 default ring used elsewhere in the
  * strip (chevrons, textarea, Add/Send). No matching design token exists yet.
- * Drawn inward (negative offset) rather than the spec's outward 2px: an
- * outward ring gets clipped by the artifact strip's scroll/card overflow
- * boundaries at the first/last tile, and reserving clearance for it proved
- * fragile across two attempts. Inward avoids the problem entirely. */
+ * Drawn inward (negative offset) rather than the spec's outward 2px so it
+ * never extends past the host's own box: an outward ring gets clipped by the
+ * artifact strip's scroll/card overflow boundaries at the first/last tile.
+ * The 2px margin/inset on .swc-UploadArtifact-surface (below) leaves this
+ * ring a real empty gap to sit in, instead of being painted over by that
+ * (opaque) surface. */
 :host(:focus-visible) {
   outline: 2px solid #4b4efc;
   outline-offset: -2px;
@@ -179,6 +181,11 @@
   align-items: center;
   min-block-size: var(--swc-upload-artifact-card-min-block-size, 68px);
   padding: token("spacing-300");
+
+  /* 2px margin leaves a real gap between the host edge and this surface so
+   * the host's inward focus ring (below) lands in empty space instead of
+   * being painted over by the surface, which renders on top of it. */
+  margin: 2px;
   border: 1px solid transparent;
   border-radius: token("corner-radius-medium-default");
 }
@@ -236,9 +243,12 @@
 
 :host([type="media"]) .swc-UploadArtifact-surface {
   display: block;
-  position: relative;
-  inline-size: 100%;
-  block-size: 100%;
+  position: absolute;
+
+  /* 2px inset leaves a real gap between the host edge and this (opaque)
+   * surface so the host's inward focus ring (below) lands in empty space
+   * instead of being painted over by the surface, which renders on top of it. */
+  inset: 2px;
   border-radius: token("corner-radius-medium-default");
   box-shadow: token("drop-shadow-emphasized-default-x") token("drop-shadow-emphasized-default-y") token("drop-shadow-emphasized-default-blur") token("drop-shadow-emphasized-default-color");
   overflow: hidden;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -14,6 +14,15 @@
   display: block;
   position: relative;
   max-inline-size: 100%;
+  border-radius: token("corner-radius-medium-default");
+}
+
+/* Figma focus-order spec (node 243-9156, §9): thumbnail and Close button use a
+ * dedicated ring color, distinct from the S2 default ring used elsewhere in the
+ * strip (chevrons, textarea, Add/Send). No matching design token exists yet. */
+:host(:focus-visible) {
+  outline: 2px solid #4b4efc;
+  outline-offset: 2px;
 }
 
 *,
@@ -50,6 +59,11 @@
 
 .swc-UploadArtifact-dismiss:hover {
   background: transparent;
+}
+
+.swc-UploadArtifact-dismiss:focus-visible {
+  outline: 2px solid #4b4efc;
+  outline-offset: 2px;
 }
 
 :host([type="card"]) .swc-UploadArtifact-dismiss {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -39,8 +39,9 @@
 
 .swc-UploadArtifact-dismiss-icon svg {
   display: block;
-  inline-size: var(--swc-upload-artifact-dismiss-icon-inline-size, 10px);
-  block-size: var(--swc-upload-artifact-dismiss-icon-block-size, 10px);
+  flex: 0 0 auto;
+  inline-size: var(--swc-upload-artifact-dismiss-icon-inline-size, 8px);
+  block-size: var(--swc-upload-artifact-dismiss-icon-block-size, 8px);
 }
 
 .swc-UploadArtifact-dismiss[hidden] {
@@ -51,29 +52,55 @@
   background: transparent;
 }
 
-:host([type="card"]) .swc-UploadArtifact-dismiss,
-:host([type="media"]) .swc-UploadArtifact-dismiss {
+:host([type="card"]) .swc-UploadArtifact-dismiss {
   inset-block-start: 0;
   inset-inline-end: 0;
   inline-size: 24px;
   block-size: 24px;
 }
 
-:host([type="card"]) .swc-UploadArtifact-dismiss-visual,
-:host([type="media"]) .swc-UploadArtifact-dismiss-visual {
+:host([type="card"]) .swc-UploadArtifact-dismiss-visual {
   position: absolute;
   inset: token("spacing-50");
   background: token("transparent-black-700");
   border-radius: token("corner-radius-full");
 }
 
-:host([type="card"]) .swc-UploadArtifact-dismiss-icon,
-:host([type="media"]) .swc-UploadArtifact-dismiss-icon {
+:host([type="card"]) .swc-UploadArtifact-dismiss-icon {
   display: flex;
   position: absolute;
   inset: token("spacing-50");
   align-items: center;
   justify-content: center;
+}
+
+:host([type="media"]) .swc-UploadArtifact-dismiss {
+  /* 32px hit target centered on the 20px visual at spacing-75 (4px) inset. */
+  inset-block-start: calc(token("spacing-75") - 6px);
+  inset-inline-end: calc(token("spacing-75") - 6px);
+  inline-size: 32px;
+  block-size: 32px;
+}
+
+:host([type="media"]) .swc-UploadArtifact-dismiss-visual {
+  position: absolute;
+  inset-block-start: 6px;
+  inset-inline-end: 6px;
+  inline-size: 20px;
+  block-size: 20px;
+  background: token("transparent-black-700");
+  border-radius: token("corner-radius-full");
+}
+
+:host([type="media"]) .swc-UploadArtifact-dismiss-icon {
+  display: flex;
+  position: absolute;
+  inset-block-start: 6px;
+  inset-inline-end: 6px;
+  align-items: center;
+  justify-content: center;
+  inline-size: 20px;
+  block-size: 20px;
 }
 
 :host([type="card"]) .swc-UploadArtifact-dismiss:hover .swc-UploadArtifact-dismiss-visual,

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -23,20 +23,24 @@
 }
 
 .swc-UploadArtifact-dismiss {
-  display: flex;
   position: absolute;
-  inset-block-start: -12px;
-  inset-inline-end: -12px;
-  z-index: 1;
-  align-items: center;
-  justify-content: center;
-  inline-size: var(--swc-upload-artifact-dismiss-inline-size, 24px);
-  block-size: var(--swc-upload-artifact-dismiss-block-size, 24px);
+  z-index: 2;
   padding: 0;
-  color: token("gray-800");
-  background: token("gray-200");
-  border: 1px solid token("gray-25");
-  border-radius: token("corner-radius-full");
+  color: token("gray-25");
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.swc-UploadArtifact-dismiss-visual,
+.swc-UploadArtifact-dismiss-icon {
+  pointer-events: none;
+}
+
+.swc-UploadArtifact-dismiss-icon svg {
+  display: block;
+  inline-size: var(--swc-upload-artifact-dismiss-icon-inline-size, 10px);
+  block-size: var(--swc-upload-artifact-dismiss-icon-block-size, 10px);
 }
 
 .swc-UploadArtifact-dismiss[hidden] {
@@ -44,12 +48,43 @@
 }
 
 .swc-UploadArtifact-dismiss:hover {
-  background: token("gray-300");
+  background: transparent;
 }
 
-.swc-UploadArtifact-dismiss swc-icon {
-  --swc-icon-inline-size: var(--swc-upload-artifact-dismiss-icon-inline-size, 10px);
-  --swc-icon-block-size: var(--swc-upload-artifact-dismiss-icon-block-size, 10px);
+:host([type="card"]) .swc-UploadArtifact-dismiss,
+:host([type="media"]) .swc-UploadArtifact-dismiss {
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  inline-size: 24px;
+  block-size: 24px;
+}
+
+:host([type="card"]) .swc-UploadArtifact-dismiss-visual,
+:host([type="media"]) .swc-UploadArtifact-dismiss-visual {
+  position: absolute;
+  inset: token("spacing-50");
+  background: token("transparent-black-700");
+  border-radius: token("corner-radius-full");
+}
+
+:host([type="card"]) .swc-UploadArtifact-dismiss-icon,
+:host([type="media"]) .swc-UploadArtifact-dismiss-icon {
+  display: flex;
+  position: absolute;
+  inset: token("spacing-50");
+  align-items: center;
+  justify-content: center;
+}
+
+:host([type="card"]) .swc-UploadArtifact-dismiss:hover .swc-UploadArtifact-dismiss-visual,
+:host([type="media"]) .swc-UploadArtifact-dismiss:hover .swc-UploadArtifact-dismiss-visual {
+  background: token("transparent-black-800");
+}
+
+.swc-UploadArtifact {
+  position: relative;
+  inline-size: 100%;
+  block-size: 100%;
 }
 
 .swc-UploadArtifact-surface {
@@ -100,7 +135,7 @@
   min-block-size: var(--swc-upload-artifact-card-min-block-size, 68px);
   padding: token("spacing-300");
   border: 1px solid transparent;
-  border-radius: token("corner-radius-large-default");
+  border-radius: token("corner-radius-medium-default");
 }
 
 :host([type="card"]) .swc-UploadArtifact-thumbnail {
@@ -151,11 +186,7 @@
 :host([type="media"]) {
   inline-size: var(--swc-upload-artifact-preview-size, 68px);
   block-size: var(--swc-upload-artifact-preview-size, 68px);
-}
-
-:host([type="media"]) .swc-UploadArtifact {
-  inline-size: 100%;
-  block-size: 100%;
+  overflow: visible;
 }
 
 :host([type="media"]) .swc-UploadArtifact-surface {
@@ -163,7 +194,8 @@
   position: relative;
   inline-size: 100%;
   block-size: 100%;
-  border-radius: token("corner-radius-200");
+  border-radius: token("corner-radius-medium-default");
+  box-shadow: token("drop-shadow-emphasized-default-x") token("drop-shadow-emphasized-default-y") token("drop-shadow-emphasized-default-blur") token("drop-shadow-emphasized-default-color");
   overflow: hidden;
 }
 
@@ -174,7 +206,7 @@
   block-size: 100%;
   background: token("gray-100");
   border: 1px solid transparent;
-  border-radius: token("corner-radius-200");
+  border-radius: token("corner-radius-medium-default");
   overflow: hidden;
 }
 
@@ -202,14 +234,14 @@
 :host([type="media"]) .swc-UploadArtifact-badge {
   display: inline-flex;
   position: absolute;
-  inset-block-end: token("corner-radius-75");
-  inset-inline-start: token("corner-radius-75");
+  inset-block-end: token("spacing-50");
+  inset-inline-start: token("spacing-50");
   z-index: 1;
   align-items: center;
-  max-inline-size: calc(100% - (2 * token("corner-radius-75")));
+  max-inline-size: calc(100% - (2 * token("spacing-50")));
   min-block-size: 24px;
-  padding-block: token("spacing-50");
-  padding-inline: token("spacing-100");
+  padding-block: token("spacing-75");
+  padding-inline: calc(token("spacing-75") + token("spacing-50") + token("corner-radius-75"));
   font-family: token("sans-serif-font");
   font-size: token("font-size-75");
   font-weight: token("medium-font-weight");

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -199,6 +199,35 @@
   block-size: 100%;
 }
 
+:host([type="media"]) .swc-UploadArtifact-badge {
+  display: inline-flex;
+  position: absolute;
+  inset-block-end: token("corner-radius-75");
+  inset-inline-start: token("corner-radius-75");
+  z-index: 1;
+  align-items: center;
+  max-inline-size: calc(100% - (2 * token("corner-radius-75")));
+  min-block-size: 24px;
+  padding-block: token("spacing-50");
+  padding-inline: token("spacing-100");
+  font-family: token("sans-serif-font");
+  font-size: token("font-size-75");
+  font-weight: token("medium-font-weight");
+  line-height: token("line-height-font-size-75");
+  color: token("gray-25");
+  background: token("transparent-black-700");
+  border-radius: token("corner-radius-400");
+}
+
+:host([type="media"]) .swc-UploadArtifact-badge ::slotted(*) {
+  display: block;
+  min-inline-size: 0;
+  max-inline-size: 152px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 :host([type="media"]) .swc-UploadArtifact-meta {
   inline-size: 100%;
 }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -69,7 +69,12 @@
 
 .swc-UploadArtifact-dismiss:focus-visible {
   outline: 2px solid #4b4efc;
-  outline-offset: -2px;
+
+  /* -4px, not -2px: the media dismiss button's own hit-box overhangs the
+   * tile by 2px (inset-block-start/inline-end: calc(spacing-75 4px - 6px) =
+   * -2px), so a -2px ring landed exactly on the tile's true edge with zero
+   * buffer against the strip's overflow clipping. -4px gives it real margin. */
+  outline-offset: -4px;
 }
 
 :host([type="card"]) .swc-UploadArtifact-dismiss {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -19,10 +19,14 @@
 
 /* Figma focus-order spec (node 243-9156, §9): thumbnail and Close button use a
  * dedicated ring color, distinct from the S2 default ring used elsewhere in the
- * strip (chevrons, textarea, Add/Send). No matching design token exists yet. */
+ * strip (chevrons, textarea, Add/Send). No matching design token exists yet.
+ * Drawn inward (negative offset) rather than the spec's outward 2px: an
+ * outward ring gets clipped by the artifact strip's scroll/card overflow
+ * boundaries at the first/last tile, and reserving clearance for it proved
+ * fragile across two attempts. Inward avoids the problem entirely. */
 :host(:focus-visible) {
   outline: 2px solid #4b4efc;
-  outline-offset: 2px;
+  outline-offset: -2px;
 }
 
 *,
@@ -63,7 +67,7 @@
 
 .swc-UploadArtifact-dismiss:focus-visible {
   outline: 2px solid #4b4efc;
-  outline-offset: 2px;
+  outline-offset: -2px;
 }
 
 :host([type="card"]) .swc-UploadArtifact-dismiss {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -159,27 +159,42 @@
 }
 
 :host([type="media"]) .swc-UploadArtifact-surface {
-  flex-direction: column;
-  gap: token("spacing-100");
+  display: block;
+  position: relative;
+  inline-size: 100%;
+  block-size: 100%;
+  border-radius: token("corner-radius-200");
   overflow: hidden;
 }
 
 :host([type="media"]) .swc-UploadArtifact-thumbnail {
+  display: block;
+  position: relative;
+  inline-size: 100%;
+  block-size: 100%;
   background: token("gray-100");
   border: 1px solid transparent;
   border-radius: token("corner-radius-200");
   overflow: hidden;
 }
 
+:host([type="media"]) .swc-UploadArtifact-actions {
+  display: none;
+}
+
 :host([type="media"]) .swc-UploadArtifact-thumbnail ::slotted(img) {
   display: block;
+  position: absolute;
+  inset: 0;
   inline-size: 100%;
-  block-size: auto;
+  block-size: 100%;
   object-fit: cover;
 }
 
 :host([type="media"]) .swc-UploadArtifact-thumbnail ::slotted(*) {
   display: block;
+  position: absolute;
+  inset: 0;
   inline-size: 100%;
   block-size: 100%;
 }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -68,13 +68,12 @@
 }
 
 .swc-UploadArtifact-dismiss:focus-visible {
+  /* Round to match the visible circular icon: the hit target (24px card /
+   * 32px media) is deliberately larger than the 20px visible icon, so an
+   * unrounded ring at the box's own edge reads as a square around the whole
+   * touch area rather than a ring around the icon. */
+  border-radius: token("corner-radius-full");
   outline: 2px solid #4b4efc;
-
-  /* -4px, not -2px: the media dismiss button's own hit-box overhangs the
-   * tile by 2px (inset-block-start/inline-end: calc(spacing-75 4px - 6px) =
-   * -2px), so a -2px ring landed exactly on the tile's true edge with zero
-   * buffer against the strip's overflow clipping. -4px gives it real margin. */
-  outline-offset: -4px;
 }
 
 :host([type="card"]) .swc-UploadArtifact-dismiss {
@@ -126,6 +125,22 @@
   justify-content: center;
   inline-size: 20px;
   block-size: 20px;
+}
+
+/* card: 24px hit target, 20px icon inset 2px (spacing-50) on each side.
+ * -1px leaves a 1px gap around the icon without extending past the box. */
+:host([type="card"]) .swc-UploadArtifact-dismiss:focus-visible {
+  outline-offset: -1px;
+}
+
+/* media: 32px hit target, 20px icon inset 6px on each side. -4px, not -2px:
+ * the media dismiss button's own hit-box overhangs the tile by 2px
+ * (inset-block-start/inline-end: calc(spacing-75 4px - 6px) = -2px), so a
+ * -2px ring landed exactly on the tile's true edge with zero buffer against
+ * the strip's overflow clipping. -4px gives it real margin, leaving a 2px
+ * gap around the icon. */
+:host([type="media"]) .swc-UploadArtifact-dismiss:focus-visible {
+  outline-offset: -4px;
 }
 
 :host([type="card"]) .swc-UploadArtifact-dismiss:hover .swc-UploadArtifact-dismiss-visual,

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -94,6 +94,7 @@
   position: absolute;
   inset: token("spacing-50");
   background: token("gray-200");
+  border: 1px solid transparent;
   border-radius: token("corner-radius-full");
 }
 
@@ -380,4 +381,15 @@
 
 :host([type="media"]) .swc-UploadArtifact-subtitle {
   line-height: token("line-height-font-size-75");
+}
+
+/* The dismiss button's visible circle is a decorative <span>, not a real
+ * border on the button itself, so forced-colors mode has nothing to key
+ * off of by default and the circle's background can disappear entirely.
+ * The transparent border declared alongside `background` above exists so
+ * this rule has something to color in; it's a no-op outside forced-colors. */
+@media (forced-colors: active) {
+  .swc-UploadArtifact-dismiss-visual {
+    border-color: ButtonBorder;
+  }
 }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -41,10 +41,9 @@
   position: absolute;
   z-index: 2;
   padding: 0;
-  color: token("gray-25");
   background: transparent;
   border: none;
-  cursor: pointer;
+  cursor: default;
 }
 
 .swc-UploadArtifact-dismiss-visual,
@@ -57,6 +56,7 @@
   flex: 0 0 auto;
   inline-size: var(--swc-upload-artifact-dismiss-icon-inline-size, 8px);
   block-size: var(--swc-upload-artifact-dismiss-icon-block-size, 8px);
+  color: token("gray-25");
 }
 
 .swc-UploadArtifact-dismiss[hidden] {
@@ -77,8 +77,13 @@
 }
 
 :host([type="card"]) .swc-UploadArtifact-dismiss {
-  inset-block-start: 0;
-  inset-inline-end: 0;
+  /* The surface is inset spacing-50 (2px) from the host, and its rounded
+   * corner's own visible tip sits a further radius * (1 - cos(45deg))
+   * inward from that box corner along the diagonal. Both terms shift the
+   * badge in from a flat -12px so its center lands on the tip of the
+   * curve, not the corner of the invisible bounding box. */
+  inset-block-start: calc(token("spacing-50") - 12px + token("corner-radius-medium-default") * 0.293);
+  inset-inline-end: calc(token("spacing-50") - 12px + token("corner-radius-medium-default") * 0.293);
   inline-size: 24px;
   block-size: 24px;
 }
@@ -99,9 +104,13 @@
 }
 
 :host([type="media"]) .swc-UploadArtifact-dismiss {
-  /* 32px hit target centered on the 20px visual at spacing-75 (4px) inset. */
-  inset-block-start: calc(token("spacing-75") - 6px);
-  inset-inline-end: calc(token("spacing-75") - 6px);
+  /* The surface is inset spacing-50 (2px) from the host, and its rounded
+   * corner's own visible tip sits a further radius * (1 - cos(45deg))
+   * inward from that box corner along the diagonal. Both terms shift the
+   * badge in from a flat -16px so its center lands on the tip of the
+   * curve, not the corner of the invisible bounding box. */
+  inset-block-start: calc(token("spacing-50") - 16px + token("corner-radius-medium-default") * 0.293);
+  inset-inline-end: calc(token("spacing-50") - 16px + token("corner-radius-medium-default") * 0.293);
   inline-size: 32px;
   block-size: 32px;
 }
@@ -113,6 +122,7 @@
   inline-size: 20px;
   block-size: 20px;
   background: token("transparent-black-700");
+  border: 1px solid transparent;
   border-radius: token("corner-radius-full");
 }
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -11,6 +11,8 @@
  */
 
 :host {
+  --swc-upload-artifact-focus-indicator-color: #4b4efc;
+
   display: block;
   position: relative;
   max-inline-size: 100%;
@@ -27,8 +29,8 @@
  * ring a real empty gap to sit in, instead of being painted over by that
  * (opaque) surface. */
 :host(:focus-visible) {
-  outline: 2px solid #4b4efc;
-  outline-offset: -2px;
+  outline: token("focus-indicator-thickness") solid var(--swc-upload-artifact-focus-indicator-color);
+  outline-offset: calc(token("focus-indicator-thickness") * -1);
 }
 
 *,
@@ -71,21 +73,21 @@
   /* Round to match the visible circular icon: the hit target (24px card /
    * 32px media) is deliberately larger than the 20px visible icon, so an
    * unrounded ring at the box's own edge reads as a square around the whole
-   * touch area rather than a ring around the icon. */
+  * touch area rather than a ring around the icon. */
   border-radius: token("corner-radius-full");
-  outline: 2px solid #4b4efc;
+  outline: token("focus-indicator-thickness") solid var(--swc-upload-artifact-focus-indicator-color);
 }
 
 :host([type="card"]) .swc-UploadArtifact-dismiss {
   /* The surface is inset spacing-50 (2px) from the host, and its rounded
    * corner's own visible tip sits a further radius * (1 - cos(45deg))
    * inward from that box corner along the diagonal. Both terms shift the
-   * badge in from a flat -12px so its center lands on the tip of the
-   * curve, not the corner of the invisible bounding box. */
-  inset-block-start: calc(token("spacing-50") - 12px + token("corner-radius-medium-default") * 0.293);
-  inset-inline-end: calc(token("spacing-50") - 12px + token("corner-radius-medium-default") * 0.293);
-  inline-size: 24px;
-  block-size: 24px;
+   * badge in by half its resolved hit-target size so its center lands on the
+   * tip of the curve, not the corner of the invisible bounding box. */
+  inset-block-start: calc(token("spacing-50") - var(--swc-upload-artifact-dismiss-block-size, 24px) * 0.5 + token("corner-radius-medium-default") * 0.293);
+  inset-inline-end: calc(token("spacing-50") - var(--swc-upload-artifact-dismiss-inline-size, 24px) * 0.5 + token("corner-radius-medium-default") * 0.293);
+  inline-size: var(--swc-upload-artifact-dismiss-inline-size, 24px);
+  block-size: var(--swc-upload-artifact-dismiss-block-size, 24px);
 }
 
 :host([type="card"]) .swc-UploadArtifact-dismiss-visual {
@@ -107,12 +109,12 @@
   /* The surface is inset spacing-50 (2px) from the host, and its rounded
    * corner's own visible tip sits a further radius * (1 - cos(45deg))
    * inward from that box corner along the diagonal. Both terms shift the
-   * badge in from a flat -16px so its center lands on the tip of the
-   * curve, not the corner of the invisible bounding box. */
-  inset-block-start: calc(token("spacing-50") - 16px + token("corner-radius-medium-default") * 0.293);
-  inset-inline-end: calc(token("spacing-50") - 16px + token("corner-radius-medium-default") * 0.293);
-  inline-size: 32px;
-  block-size: 32px;
+   * badge in by half its resolved hit-target size so its center lands on the
+   * tip of the curve, not the corner of the invisible bounding box. */
+  inset-block-start: calc(token("spacing-50") - var(--swc-upload-artifact-dismiss-block-size, 32px) * 0.5 + token("corner-radius-medium-default") * 0.293);
+  inset-inline-end: calc(token("spacing-50") - var(--swc-upload-artifact-dismiss-inline-size, 32px) * 0.5 + token("corner-radius-medium-default") * 0.293);
+  inline-size: var(--swc-upload-artifact-dismiss-inline-size, 32px);
+  block-size: var(--swc-upload-artifact-dismiss-block-size, 32px);
 }
 
 :host([type="media"]) .swc-UploadArtifact-dismiss-visual {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -56,7 +56,7 @@
   flex: 0 0 auto;
   inline-size: var(--swc-upload-artifact-dismiss-icon-inline-size, 8px);
   block-size: var(--swc-upload-artifact-dismiss-icon-block-size, 8px);
-  color: token("gray-25");
+  color: token("gray-700");
 }
 
 .swc-UploadArtifact-dismiss[hidden] {
@@ -91,7 +91,7 @@
 :host([type="card"]) .swc-UploadArtifact-dismiss-visual {
   position: absolute;
   inset: token("spacing-50");
-  background: token("transparent-black-700");
+  background: token("gray-200");
   border-radius: token("corner-radius-full");
 }
 
@@ -121,7 +121,7 @@
   inset-inline-end: 6px;
   inline-size: 20px;
   block-size: 20px;
-  background: token("transparent-black-700");
+  background: token("gray-200");
   border: 1px solid transparent;
   border-radius: token("corner-radius-full");
 }
@@ -155,7 +155,7 @@
 
 :host([type="card"]) .swc-UploadArtifact-dismiss:hover .swc-UploadArtifact-dismiss-visual,
 :host([type="media"]) .swc-UploadArtifact-dismiss:hover .swc-UploadArtifact-dismiss-visual {
-  background: token("transparent-black-800");
+  background: token("gray-300");
 }
 
 .swc-UploadArtifact {
@@ -209,8 +209,8 @@
 :host([type="card"]) .swc-UploadArtifact-surface {
   gap: token("spacing-300");
   align-items: center;
-  min-block-size: var(--swc-upload-artifact-card-min-block-size, 68px);
-  padding: token("spacing-300");
+  min-block-size: var(--swc-upload-artifact-card-min-block-size, 72px);
+  padding: token("spacing-200");
 
   /* 2px margin leaves a real gap between the host edge and this surface so
    * the host's inward focus ring (below) lands in empty space instead of
@@ -230,11 +230,11 @@
 :host([type="card"]) .swc-UploadArtifact-thumbnail ::slotted(*) {
   box-sizing: border-box;
   flex-shrink: 0;
-  inline-size: var(--swc-upload-artifact-card-thumbnail-inline-size, 32px);
-  block-size: var(--swc-upload-artifact-card-thumbnail-block-size, 32px);
+  inline-size: var(--swc-upload-artifact-card-thumbnail-inline-size, 48px);
+  block-size: var(--swc-upload-artifact-card-thumbnail-block-size, 48px);
   background: token("gray-100");
   border: 1px solid transparent;
-  border-radius: token("corner-radius-75");
+  border-radius: token("corner-radius-large-default");
 }
 
 :host([type="card"]) .swc-UploadArtifact-meta {
@@ -266,8 +266,9 @@
 }
 
 :host([type="media"]) {
-  inline-size: var(--swc-upload-artifact-preview-size, 68px);
-  block-size: var(--swc-upload-artifact-preview-size, 68px);
+  inline-size: var(--swc-upload-artifact-preview-size, 72px);
+  block-size: var(--swc-upload-artifact-preview-size, 72px);
+  border-radius: token("corner-radius-large-default");
   overflow: visible;
 }
 
@@ -279,7 +280,7 @@
    * surface so the host's inward focus ring (below) lands in empty space
    * instead of being painted over by the surface, which renders on top of it. */
   inset: 2px;
-  border-radius: token("corner-radius-medium-default");
+  border-radius: token("corner-radius-large-default");
   box-shadow: token("drop-shadow-emphasized-default-x") token("drop-shadow-emphasized-default-y") token("drop-shadow-emphasized-default-blur") token("drop-shadow-emphasized-default-color");
   overflow: hidden;
 }
@@ -291,7 +292,7 @@
   block-size: 100%;
   background: token("gray-100");
   border: 1px solid transparent;
-  border-radius: token("corner-radius-medium-default");
+  border-radius: token("corner-radius-large-default");
   overflow: hidden;
 }
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
@@ -7,15 +7,28 @@ import * as UploadArtifactStories from './stories/upload-artifact.stories';
 
 <DocsHeader />
 
+## Usage
+
+Use **one artifact type per attachment strip**. Pick either:
+
+- **`type="card"`** — metadata-first files (title, subtitle, small thumbnail)
+- **`type="media"`** — visual previews, with an optional **`badge`** slot for file-type labels (for example, "PDF")
+
+Do not slot card and media artifacts together in the same prompt field or wrapping row.
+
 ## Options
 
-### Multi artifact
+### Multi Card
 
-Multiple **`swc-upload-artifact`** nodes in a wrapping flex row, similar width to the prompt-field composer attachment strip, so card vs media spacing and wraps are easy to compare in isolation.
+Several card artifacts in one strip, similar width to the prompt-field composer attachment region.
 
-To see the same tiles inside **`swc-prompt-field`**, open **[Artifact](/docs/patterns-conversational-ai-prompt-field--docs#artifact)**.
+<Canvas of={UploadArtifactStories.MultiCard} />
 
-<Canvas of={UploadArtifactStories.MultiArtifact} />
+### Multi Media
+
+Several media tiles in one strip, with and without badge overlays.
+
+<Canvas of={UploadArtifactStories.MultiMedia} />
 
 ### Card
 
@@ -31,13 +44,13 @@ Media type uses a larger preview region without title and subtitle text.
 
 ### Media with badge
 
-Use `type="media"` with an optional `badge` slot for mixed file types (for example, a document preview with a bottom-left "PDF" tag).
+Use `type="media"` with an optional `badge` slot when the preview needs a file-type label (for example, a document thumbnail with a bottom-left "PDF" tag).
 
 <Canvas of={UploadArtifactStories.MediaWithBadge} />
 
 ### Text overflow
 
-Title and subtitle truncate with an ellipsis when the artifact is narrower than the text. **Card** uses a compact row; **media** keeps the actions region visible while the title shrinks.
+Title and subtitle truncate with an ellipsis when the artifact is narrower than the text.
 
 <Canvas of={UploadArtifactStories.TextOverflow} />
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
@@ -9,12 +9,14 @@ import * as UploadArtifactStories from './stories/upload-artifact.stories';
 
 ## Usage
 
-Use **one artifact type per attachment strip**. Pick either:
+Use **one artifact layout type per attachment strip**. Pick either:
 
-- **`type="card"`** — metadata-first files (title, subtitle, small thumbnail)
-- **`type="media"`** — visual previews, with an optional **`badge`** slot for file-type labels (for example, "PDF")
+- **`type="card"`** — metadata-first files (title, subtitle, small thumbnail). Best when the strip is document-only and filenames or file types matter more than visual preview.
+- **`type="media"`** — square preview tiles, with an optional **`badge`** slot for file-type labels (for example, "PDF")
 
-Do not slot card and media artifacts together in the same prompt field or wrapping row.
+Do not slot `card` and `media` artifacts together in the same prompt field or wrapping row.
+
+When a single upload batch mixes **images and documents**, normalize the whole strip to **`type="media"`**: use image previews in `thumbnail` for photos, and thumbnail plus **`badge`** for documents. Do not render images as `media` and documents as `card` in the same session.
 
 ## Options
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
@@ -29,6 +29,12 @@ Media type uses a larger preview region without title and subtitle text.
 
 <Canvas of={UploadArtifactStories.Media} />
 
+### Media with badge
+
+Use `type="media"` with an optional `badge` slot for mixed file types (for example, a document preview with a bottom-left "PDF" tag).
+
+<Canvas of={UploadArtifactStories.MediaWithBadge} />
+
 ### Text overflow
 
 Title and subtitle truncate with an ellipsis when the artifact is narrower than the text. **Card** uses a compact row; **media** keeps the actions region visible while the title shrinks.

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
@@ -18,6 +18,8 @@ Do not slot `card` and `media` artifacts together in the same prompt field or wr
 
 When a single upload batch mixes **images and documents**, normalize the whole strip to **`type="media"`**: use image previews in `thumbnail` for photos, and thumbnail plus **`badge`** for documents. Do not render images as `media` and documents as `card` in the same session.
 
+The tile's own accessible name and its Close button's accessible name ("Remove [file name].[file type]") derive automatically from the `title` slot's text content; set `accessible-label` / `dismiss-label` to override. This tile has no default `tabindex` of its own — `swc-prompt-field` manages roving `tabindex` and keyboard focus for tiles slotted into its `artifact` slot.
+
 ## Options
 
 ### Multi Card

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
@@ -22,13 +22,13 @@ The tile's own accessible name and its Close button's accessible name ("Remove [
 
 ## Options
 
-### Multi Card
+### Multi card
 
 Several card artifacts in one strip, similar width to the prompt-field composer attachment region.
 
 <Canvas of={UploadArtifactStories.MultiCard} />
 
-### Multi Media
+### Multi media
 
 Several media tiles in one strip, with and without badge overlays.
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.mdx
@@ -11,14 +11,14 @@ import * as UploadArtifactStories from './stories/upload-artifact.stories';
 
 Use **one artifact layout type per attachment strip**. Pick either:
 
-- **`type="card"`** — metadata-first files (title, subtitle, small thumbnail). Best when the strip is document-only and filenames or file types matter more than visual preview.
-- **`type="media"`** — square preview tiles, with an optional **`badge`** slot for file-type labels (for example, "PDF")
+- **`type="card"`**: metadata-first files (title, subtitle, small thumbnail). Best when the strip is document-only and filenames or file types matter more than visual preview.
+- **`type="media"`**: square preview tiles, with an optional **`badge`** slot for file-type labels (for example, "PDF")
 
 Do not slot `card` and `media` artifacts together in the same prompt field or wrapping row.
 
 When a single upload batch mixes **images and documents**, normalize the whole strip to **`type="media"`**: use image previews in `thumbnail` for photos, and thumbnail plus **`badge`** for documents. Do not render images as `media` and documents as `card` in the same session.
 
-The tile's own accessible name and its Close button's accessible name ("Remove [file name].[file type]") derive automatically from the `title` slot's text content; set `accessible-label` / `dismiss-label` to override. This tile has no default `tabindex` of its own — `swc-prompt-field` manages roving `tabindex` and keyboard focus for tiles slotted into its `artifact` slot.
+The tile's own accessible name and its Close button's accessible name ("Remove [file name].[file type]") derive automatically from the `title` slot's text content; set `accessible-label` / `dismiss-label` to override. This tile has no default `tabindex` of its own; `swc-prompt-field` manages roving `tabindex` and keyboard focus for tiles slotted into its `artifact` slot.
 
 ## Options
 


### PR DESCRIPTION
## Description

This PR improves upload artifacts and their integration with Prompt Field:

- Aligns card and media artifact layouts with the approved Figma designs.
- Adds an optional `badge` slot for media previews such as document-type labels.
- Improves media preview sizing, cropping, and Storybook thumbnails.
- Adds a horizontal multi-artifact carousel to Prompt Field.
- Adds overflow chevrons, edge fades, set-based paging, and final-set alignment.
- Supports trackpad, wheel, touch, and draggable overlay-scrollbar interaction.
- Reserves the scrollbar lane to prevent the composer height from shifting.
- Warns developers when card and media layouts are mixed in one artifact strip.
- Warns when required Legal-approved disclaimer content is missing.
- Updates Storybook examples to use the design-approved AI disclaimer and official [AI User Guidelines](https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html).
- Reworks the artifact strip's keyboard model: Tab reaches the first tile directly with no separate entry step, a second Tab reveals that tile's Close button, Arrow keys rove between tiles, and activating a chevron keeps focus on the chevron while paging updates which tile Tab or Shift+Tab lands on next.
- Fixes a single artifact's Close button being unreachable by Tab.
- Centers each artifact's dismiss badge on the tile's visible rounded corner, matching the approved corner-badge treatment for both card and media layouts.
- Moves Prompt Field's keyboard focus ring from the whole composer card to the textarea itself, so the indicator matches the actual focused element.
- Corrects the spacing between the artifact strip and the textarea to the specified 8px.
- Expands tests and documentation for artifact layouts, scrolling, badges, events, warnings, and keyboard behavior.

## Motivation and context

Prompt Field previously had limited support for multiple attachments, while Upload Artifact did not fully match the approved card and media treatments. This made larger upload sets difficult to navigate and encouraged mixed card/media layouts that did not produce a consistent attachment strip. Media artifacts also needed a way to display document-type context without using the metadata-first card layout. The artifact strip's keyboard model also required an explicit "enter" step before Tab or Arrow keys did anything, which added friction and didn't match how a roving-tabindex composite should behave. The updated implementation provides a consistent carousel for multiple artifacts, supports media badges, follows a conventional roving-tabindex keyboard model, and documents how applications should normalize mixed file types into one visual layout.

## Acceptance criteria

- **Given** multiple artifacts exceed the Prompt Field width, **when** the artifact strip renders, **then** navigation controls and edge fades indicate available overflow.
- **Given** a user activates a carousel chevron, **when** the strip advances, **then** it moves by one visible set while preserving continuity with the previous set.
- **Given** the final artifact set is reached, **when** it renders, **then** the set aligns to the right and keeps the strip visually full.
- **Given** a user scrolls with a trackpad, wheel, touch gesture, or scrollbar thumb, **when** interaction begins, **then** the overlay scrollbar appears without changing composer height.
- **Given** carousel chevrons initiate scrolling, **when** paging completes, **then** the overlay scrollbar remains hidden.
- **Given** media artifacts require file-type context, **when** content is provided to the `badge` slot, **then** the badge appears over the media preview.
- **Given** card and media artifacts are placed in the same Prompt Field strip, **when** the slot updates, **then** a development warning explains the supported single-layout requirement.
- **Given** the `legal` slot is empty, **when** Prompt Field renders in development, **then** a warning requests Legal-approved disclaimer content.
- **Given** a multi-artifact strip, **when** the user presses Tab, **then** focus lands directly on the first (or last-active) tile, with no separate entry step required.
- **Given** an artifact tile has focus, **when** the user presses Tab, **then** focus moves to that tile's Close button; **when** Shift+Tab is pressed from any tile, **then** focus exits the strip.
- **Given** the Next or Prev chevron is activated, **when** paging completes, **then** focus remains on the chevron, and Shift+Tab (from Next) or Tab (from Prev) moves into the newly displayed set of tiles.
- **Given** a single artifact, **when** it has focus and Tab is pressed, **then** focus moves to its Close button rather than skipping to the textarea.
- **Given** the textarea receives keyboard focus, **when** focus lands, **then** the focus ring is drawn around the textarea itself, not the composer card.

## Related issue(s)

No linked issue or Jira ticket.

## Verification

- Automated tests cover:
  - Prompt Field input, submission, upload, and stop behavior
  - Missing legal-content warnings
  - Mixed artifact-layout warnings
  - Carousel paging, edge fades, and scrollbar visibility
  - Artifact strip keyboard navigation: Tab/Shift+Tab order, Arrow-key roving focus, chevron-paging focus retention, and single-artifact Tab access
  - Upload Artifact dismissal
  - Media preview and badge rendering
- Full affected test suite: 913 tests passing in Chromium, Firefox, and WebKit.
- `yarn lint:docs-pages` passed.
- ESLint, Stylelint, and Prettier checks passed.

## Screenshots (if appropriate)

---

## Author's checklist

- [ ] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed the Accessibility Practices for this feature: [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/).
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a GitHub issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] **Verify Upload Artifact layouts**
  1. Open the Upload Artifact Storybook page.
  2. Review the card, media, media-with-badge, multi-card, and multi-media stories.
  3. Confirm previews fill their expected regions, card text truncates correctly, badges appear only when supplied, and each dismiss badge sits centered on its tile's visible rounded corner.
- [ ] **Verify multi-artifact carousel paging**
  1. Open the Prompt Field multi-artifact scroll story.
  2. Activate the next and previous chevrons several times.
  3. Confirm each action advances by one visible set, preserves one continuity tile, and correctly disables or hides navigation at each edge.
- [ ] **Verify physical scrolling**
  1. Scroll the artifact strip using a trackpad, mouse wheel, touch gesture, and scrollbar thumb.
  2. Drag the scrollbar lane and thumb across the available range.
  3. Confirm scrolling remains synchronized, the thumb appears only during physical interaction, and composer height remains stable.
- [ ] **Verify artifact-strip keyboard model**
  1. Open the Prompt Field multi-artifact scroll story.
  2. Press Tab into the strip, then Tab again, then use Arrow keys, then Tab/Shift+Tab from the Next/Prev chevrons after activating them.
  3. Confirm Tab lands on the first tile directly, a second Tab reveals its Close button, arrows move between tiles, and paging keeps focus on the chevron while Shift+Tab/Tab from it lands in the newly displayed set.
- [ ] **Verify artifact-layout warnings**
  1. Slot both card and media artifacts into one Prompt Field.
  2. Inspect the browser console.
  3. Confirm a single development warning explains that one layout type must be used per strip.
- [ ] **Verify the legal disclaimer**
  1. Open Prompt Field and full conversational pattern stories.
  2. Confirm the approved disclaimer reads: "Responses are generated using AI, and may be inaccurate. Check before using."
  3. Confirm "AI User Guidelines" links to the official Adobe guidelines page.
- [ ] **Verify the textarea focus ring and artifact spacing**
  1. Open any Prompt Field story with an artifact attached.
  2. Tab into the textarea.
  3. Confirm the focus ring appears around the textarea itself, not the whole composer card, and that the gap between the artifact strip and the textarea reads as tight (8px), not oversized.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard**
  1. Open the Prompt Field multi-artifact scroll story.
  2. Use <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> to navigate the upload button, artifact tiles, carousel controls, textarea, and send or stop action. Confirm Tab reaches the first artifact tile directly, with no separate step needed to "enter" the strip.
  3. Use <kbd>ArrowLeft</kbd>/<kbd>ArrowRight</kbd> to move between artifact tiles, and confirm a second <kbd>Tab</kbd> from the active tile reveals its Close button.
  4. Activate carousel controls with <kbd>Enter</kbd> and <kbd>Space</kbd>; confirm focus remains on the chevron, and that <kbd>Shift</kbd>+<kbd>Tab</kbd> from Next (or <kbd>Tab</kbd> from Prev) moves into the newly displayed set of tiles.
  5. Confirm focus order is logical, focus indicators remain visible (including the textarea's own ring on keyboard focus), scrolling does not move focus unexpectedly, and no focus trap occurs.
- [ ] **Screen reader**
  1. Open the Prompt Field multi-artifact scroll story with a screen reader enabled.
  2. Navigate through the artifacts and carousel controls.
  3. Confirm the controls are announced as "Show previous attachments" and "Show more attachments."
  4. Confirm artifact titles, subtitles, dismiss actions, media badge content, and the AI User Guidelines link have understandable names.
  5. Confirm disabled or unavailable carousel directions are not presented as actionable controls.
