### PR TITLE
Phase 5: progress-bar full fidelity 

### DIFF
--- a/2nd-gen/packages/swc/components/progress-bar/progress-bar.css
+++ b/2nd-gen/packages/swc/components/progress-bar/progress-bar.css
@@ -11,11 +11,68 @@
  */
 
 /*
- * Progress-bar-specific styles. Shared structural rules (bar/track/fill,
- * sizes, side-label layout, static colors, forced-colors) live in
- * `swc/stylesheets/_lit-styles/linear-progress-base.css` and consume
- * `--swc-linear-progress-*` custom properties. This file adds only the
- * indeterminate fill animation (keyframes, duration, reduced-motion
- * fallback) — see Q2 in the migration plan; exact values to be lifted
- * from spectrum-css spectrum-two progressbar/index.css during Styling phase.
+ * Shared structural rules (bar/track/fill, sizes, side-label layout, static
+ * colors, forced-colors) live in `linear-progress-base.css` and are composed
+ * into the component's `styles` array in `ProgressBar.ts`. This file adds only
+ * the indeterminate fill animation (keyframes, duration, reduced-motion
+ * fallback) and the necessary fill-state resets.
  */
+
+/*
+ * The fill size for the indeterminate animation (70%) is sourced from the
+ * Spectrum animation token `--system-progress-bar-fill-size-indeterminate`.
+ * There is no dedicated 2nd-gen token for this value, so it is hardcoded
+ * here. The translateX end-keyframe uses calc(100% / 0.7) ≈ 142.857% so
+ * the fill's left edge aligns with the track's right edge, ensuring the
+ * fill exits fully off-screen.
+ */
+:host([indeterminate]) .swc-LinearProgress-fill {
+  inline-size: 70%;
+  min-inline-size: 0; /* reset the 3% determinate visibility floor */
+  transition: none; /* drop the determinate inline-size sweep */
+  animation: indeterminate-loop-ltr token("animation-duration-2000") token("animation-ease-in-out") infinite;
+  will-change: transform;
+
+  &:dir(rtl) {
+    animation-name: indeterminate-loop-rtl;
+  }
+}
+
+@keyframes indeterminate-loop-ltr {
+  from {
+    /* matches React: translate(calc(fillWidth * -1)) — fill starts partially off screen left */
+    transform: translateX(-70%);
+  }
+
+  to {
+    /* fill left edge at track right edge — fully off screen right;
+     * fill is 70% of track, so trackWidth = fillWidth / 0.7 = calc(100% / 0.7) */
+    transform: translateX(calc(100% / 0.7));
+  }
+}
+
+@keyframes indeterminate-loop-rtl {
+  from {
+    /* matches React: translate(trackWidth) — fill starts fully off screen right */
+    transform: translateX(calc(100% / 0.7));
+  }
+
+  to {
+    /* matches React: translate(calc(trackWidth * -1)) — fill ends fully off screen left */
+    transform: translateX(calc(-100% / 0.7));
+  }
+}
+
+/* Media queries sorted to the bottom per style guide. */
+
+/*
+ * Honor `prefers-reduced-motion` (WCAG 2.3.3 / 2.2.2): suppress the looping
+ * animation and render a static partial fill so the indeterminate busy state
+ * remains visually perceivable without motion.
+ */
+@media (prefers-reduced-motion: reduce) {
+  :host([indeterminate]) .swc-LinearProgress-fill {
+    inline-size: 50%; /* static fallback fill — conveys partial/busy state */
+    animation: none;
+  }
+}

--- a/2nd-gen/packages/swc/components/progress-bar/progress-bar.css
+++ b/2nd-gen/packages/swc/components/progress-bar/progress-bar.css
@@ -10,25 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-/*
- * Shared structural rules (bar/track/fill, sizes, side-label layout, static
- * colors, forced-colors) live in `linear-progress-base.css` and are composed
- * into the component's `styles` array in `ProgressBar.ts`. This file adds only
- * the indeterminate fill animation (keyframes, duration, reduced-motion
- * fallback) and the necessary fill-state resets.
- */
+/* Structural rules live in `linear-progress-base.css`; this file adds only the indeterminate animation.
+ * The fill spans the full track width and scaleX(0.7) gives it its visual size, matching React S2. */
 
-/*
- * The fill size for the indeterminate animation (70%) is sourced from the
- * Spectrum animation token `--system-progress-bar-fill-size-indeterminate`.
- * There is no dedicated 2nd-gen token for this value, so it is hardcoded
- * here. The translateX end-keyframe uses calc(100% / 0.7) ≈ 142.857% so
- * the fill's left edge aligns with the track's right edge, ensuring the
- * fill exits fully off-screen.
- */
 :host([indeterminate]) .swc-LinearProgress-fill {
-  inline-size: 70%;
+  inline-size: 100%;
   min-inline-size: 0; /* reset the 3% determinate visibility floor */
+  transform-origin: left;
   transition: none; /* drop the determinate inline-size sweep */
   animation: indeterminate-loop-ltr token("animation-duration-2000") token("animation-ease-in-out") infinite;
   will-change: transform;
@@ -40,39 +28,28 @@
 
 @keyframes indeterminate-loop-ltr {
   from {
-    /* matches React: translate(calc(fillWidth * -1)) — fill starts partially off screen left */
-    transform: translateX(-70%);
+    transform: translateX(-70%) scaleX(0.7);
   }
 
   to {
-    /* fill left edge at track right edge — fully off screen right;
-     * fill is 70% of track, so trackWidth = fillWidth / 0.7 = calc(100% / 0.7) */
-    transform: translateX(calc(100% / 0.7));
+    transform: translateX(100%) scaleX(0.7);
   }
 }
 
 @keyframes indeterminate-loop-rtl {
   from {
-    /* matches React: translate(trackWidth) — fill starts fully off screen right */
-    transform: translateX(calc(100% / 0.7));
+    transform: translateX(100%) scaleX(0.7);
   }
 
   to {
-    /* matches React: translate(calc(trackWidth * -1)) — fill ends fully off screen left */
-    transform: translateX(calc(-100% / 0.7));
+    transform: translateX(-70%) scaleX(0.7);
   }
 }
 
-/* Media queries sorted to the bottom per style guide. */
-
-/*
- * Honor `prefers-reduced-motion` (WCAG 2.3.3 / 2.2.2): suppress the looping
- * animation and render a static partial fill so the indeterminate busy state
- * remains visually perceivable without motion.
- */
+/* Slow rather than stop (WCAG 2.3.3): a static fill loses the indeterminate meaning. */
 @media (prefers-reduced-motion: reduce) {
   :host([indeterminate]) .swc-LinearProgress-fill {
-    inline-size: 50%; /* static fallback fill — conveys partial/busy state */
-    animation: none;
+    animation-duration: 15s;
+    animation-timing-function: linear;
   }
 }

--- a/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
@@ -83,6 +83,7 @@ const meta: Meta = {
     docs: {
       subtitle: `Non-focusable, read-only bar that shows task progress or an indeterminate loading state.`,
     },
+    styles: { 'min-inline-size': '250px' },
   },
   args,
   argTypes,
@@ -164,7 +165,12 @@ export const Anatomy: Story = {
   `,
   tags: ['anatomy'],
   parameters: {
-    styles: { gap: 'var(--swc-spacing-300)', margin: '0 auto' },
+    styles: {
+      display: 'flex',
+      'flex-direction': 'column',
+      gap: 'var(--swc-spacing-200)',
+      margin: '0 auto',
+    },
   },
   args: {
     size: 'm',
@@ -188,7 +194,12 @@ export const Sizes: Story = {
   `,
   tags: ['options'],
   parameters: {
-    styles: { gap: 'var(--swc-spacing-300)', margin: '0 auto' },
+    styles: {
+      display: 'flex',
+      'flex-direction': 'column',
+      gap: 'var(--swc-spacing-200)',
+      margin: '0 auto',
+    },
   },
   args: { value: 50 },
 };
@@ -205,7 +216,9 @@ export const LabelPosition: Story = {
   `,
   parameters: {
     styles: {
-      gap: 'var(--swc-spacing-300)',
+      display: 'flex',
+      'flex-direction': 'column',
+      gap: '20px',
       margin: '0 auto',
     },
   },
@@ -246,7 +259,12 @@ export const Values: Story = {
   `,
   tags: ['states'],
   parameters: {
-    styles: { gap: 'var(--swc-spacing-300)', margin: '0 auto' },
+    styles: {
+      display: 'flex',
+      'flex-direction': 'column',
+      gap: 'var(--swc-spacing-200)',
+      margin: '0 auto',
+    },
   },
   args: { size: 'm' },
 };

--- a/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
@@ -1,0 +1,334 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+
+import {
+  LINEAR_PROGRESS_LABEL_POSITIONS,
+  LINEAR_PROGRESS_STATIC_COLORS,
+  LINEAR_PROGRESS_VALID_SIZES,
+  type LinearProgressLabelPosition,
+  type LinearProgressSize,
+  type LinearProgressStaticColor,
+} from '@spectrum-web-components/core/mixins/index.js';
+
+import '@adobe/spectrum-wc/components/progress-bar/swc-progress-bar.js';
+
+// ────────────────
+//    METADATA
+// ────────────────
+
+const { args, argTypes, template } = getStorybookHelpers('swc-progress-bar');
+
+argTypes.size = {
+  ...argTypes.size,
+  control: { type: 'select' },
+  options: LINEAR_PROGRESS_VALID_SIZES,
+  table: {
+    ...argTypes.size?.table,
+    category: 'attributes',
+    defaultValue: { summary: 'm' },
+  },
+};
+
+argTypes['label-position'] = {
+  ...argTypes['label-position'],
+  control: { type: 'inline-radio' },
+  options: LINEAR_PROGRESS_LABEL_POSITIONS,
+  table: {
+    ...argTypes['label-position']?.table,
+    defaultValue: { summary: 'top' },
+  },
+};
+
+argTypes['static-color'] = {
+  ...argTypes['static-color'],
+  control: { type: 'select' },
+  options: [undefined, ...LINEAR_PROGRESS_STATIC_COLORS],
+};
+
+argTypes.value = {
+  ...argTypes.value,
+  control: { type: 'number', min: 0, max: 100, step: 1 },
+  table: {
+    ...argTypes.value?.table,
+    defaultValue: { summary: '0' },
+  },
+};
+
+/**
+ * A `<swc-progress-bar>` is a non-focusable, read-only bar that shows task
+ * progress (0–100, or a custom range). When completion time is unknown, set
+ * `indeterminate` to show a looping fill animation instead of a value. The
+ * WAI-ARIA `progressbar` role and all `aria-value*` attributes live on the
+ * internal shadow wrapper; the host carries no ARIA role. For scalar
+ * measurements (storage used, survey completion), prefer
+ * [Meter](../?path=/docs/meter--overview).
+ */
+const meta: Meta = {
+  title: 'Progress Bar',
+  component: 'swc-progress-bar',
+  parameters: {
+    docs: {
+      subtitle: `Non-focusable, read-only bar that shows task progress or an indeterminate loading state.`,
+    },
+  },
+  args,
+  argTypes,
+  render: (args) => template(args),
+  tags: ['migrated'],
+};
+
+export default meta;
+
+// ────────────────────
+//    HELPERS
+// ────────────────────
+
+const sizeLabels = {
+  s: 'Small',
+  m: 'Medium',
+  l: 'Large',
+  xl: 'Extra-large',
+} as const satisfies Record<LinearProgressSize, string>;
+
+const labelPositionLabels = {
+  top: 'Top label',
+  side: 'Side label',
+} as const satisfies Record<LinearProgressLabelPosition, string>;
+
+const staticColorLabels = {
+  white: 'Static white',
+  black: 'Static black',
+} as const satisfies Record<LinearProgressStaticColor, string>;
+
+// ────────────────────
+//    PLAYGROUND STORY
+// ────────────────────
+
+export const Playground: Story = {
+  tags: ['dev'],
+  args: {
+    size: 'm',
+    value: 60,
+    'label-slot': 'Uploading file',
+  },
+};
+
+// ──────────────────────────────
+//    OVERVIEW STORY
+// ──────────────────────────────
+
+export const Overview: Story = {
+  tags: ['overview'],
+  args: {
+    size: 'm',
+    value: 75,
+    'label-slot': 'Uploading file',
+    'description-slot': 'Step 3 of 4 complete',
+  },
+};
+
+// ──────────────────────────
+//    ANATOMY STORIES
+// ──────────────────────────
+
+export const Anatomy: Story = {
+  render: (args) => html`
+    ${template({ ...args, 'label-slot': 'Label only' })}
+    ${template({
+      ...args,
+      'label-slot': 'Label and description',
+      'description-slot': 'Additional context below the bar',
+    })}
+    ${template({
+      ...args,
+      'accessible-label': 'Screen-reader-only label',
+    })}
+    ${template({
+      ...args,
+      'label-slot': 'Custom value text',
+      'value-label': '3 of 4 steps',
+    })}
+  `,
+  tags: ['anatomy'],
+  parameters: {
+    styles: { gap: 'var(--swc-spacing-300)', margin: '0 auto' },
+  },
+  args: {
+    size: 'm',
+    value: 40,
+  },
+};
+
+// ──────────────────────────
+//    OPTIONS STORIES
+// ──────────────────────────
+
+export const Sizes: Story = {
+  render: (args) => html`
+    ${LINEAR_PROGRESS_VALID_SIZES.map((size) =>
+      template({
+        ...args,
+        size,
+        'label-slot': sizeLabels[size],
+      })
+    )}
+  `,
+  tags: ['options'],
+  parameters: {
+    styles: { gap: 'var(--swc-spacing-300)', margin: '0 auto' },
+  },
+  args: { value: 50 },
+};
+
+export const LabelPosition: Story = {
+  render: (args) => html`
+    ${LINEAR_PROGRESS_LABEL_POSITIONS.map((labelPosition) =>
+      template({
+        ...args,
+        'label-position': labelPosition,
+        'label-slot': labelPositionLabels[labelPosition],
+      })
+    )}
+  `,
+  parameters: {
+    styles: {
+      gap: 'var(--swc-spacing-300)',
+      margin: '0 auto',
+    },
+  },
+  tags: ['options'],
+  args: { value: 50 },
+};
+LabelPosition.storyName = 'Label position';
+
+export const StaticColors: Story = {
+  render: (args) => html`
+    ${LINEAR_PROGRESS_STATIC_COLORS.map((staticColor) =>
+      template({
+        ...args,
+        'static-color': staticColor,
+        'label-slot': staticColorLabels[staticColor],
+      })
+    )}
+  `,
+  parameters: { staticColorsDemo: true },
+  tags: ['options', '!test'],
+  args: { value: 50 },
+};
+StaticColors.storyName = 'Static colors';
+
+// ──────────────────────────
+//    STATES STORIES
+// ──────────────────────────
+
+// The value stories exercise the CSS-visible range edges (0 %, midpoint, 100 %)
+// so the fill / track contrast can be verified at the boundaries (WCAG 1.4.11).
+export const Values: Story = {
+  render: (args) => html`
+    ${template({ ...args, value: 0, 'label-slot': '0 %' })}
+    ${template({ ...args, value: 25, 'label-slot': '25 %' })}
+    ${template({ ...args, value: 50, 'label-slot': '50 %' })}
+    ${template({ ...args, value: 75, 'label-slot': '75 %' })}
+    ${template({ ...args, value: 100, 'label-slot': '100 %' })}
+  `,
+  tags: ['states'],
+  parameters: {
+    styles: { gap: 'var(--swc-spacing-300)', margin: '0 auto' },
+  },
+  args: { size: 'm' },
+};
+
+// Indeterminate suppresses all aria-value* attributes and the visible
+// value text, and runs the sliding fill animation.
+export const Indeterminate: Story = {
+  tags: ['states'],
+  args: {
+    indeterminate: true,
+    'accessible-label': 'Loading content',
+  },
+};
+
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+// Custom min / max range. Arbitrary numeric ranges are supported; the
+// rendered fill and aria-valuetext use the sanitized range.
+export const CustomRange: Story = {
+  render: (args) => html`
+    ${template({
+      ...args,
+      'min-value': 0,
+      'max-value': 10,
+      value: 3,
+      'label-slot': 'Steps completed',
+      'value-label': '3 of 10',
+    })}
+  `,
+  tags: ['behaviors'],
+  args: { size: 'm' },
+};
+CustomRange.storyName = 'Custom range';
+
+// `value-label` overrides the auto-formatted percentage in both the
+// rendered value cell and aria-valuetext.
+export const ValueLabel: Story = {
+  render: (args) => html`
+    ${template({
+      ...args,
+      value: 2,
+      'max-value': 5,
+      'label-slot': 'Files uploaded',
+      'value-label': '2 of 5',
+    })}
+  `,
+  tags: ['behaviors'],
+  args: { size: 'm' },
+};
+ValueLabel.storyName = 'Value label';
+
+// `formatOptions` is a JS-only property (no attribute). It accepts any
+// `Intl.NumberFormatOptions`; the default style is percent.
+export const FormatOptions: Story = {
+  render: (args) => html`
+    ${template({
+      ...args,
+      value: 42,
+      'max-value': 100,
+      'label-slot': 'Amount processed',
+      formatOptions: { style: 'decimal', maximumFractionDigits: 0 },
+    })}
+  `,
+  tags: ['behaviors'],
+  args: { size: 'm' },
+};
+FormatOptions.storyName = 'Format options';
+
+// ────────────────────────────────
+//    ACCESSIBILITY STORIES
+// ────────────────────────────────
+
+// TODO (Phase 7): add accessibility prose to progress-bar.mdx § Accessibility
+export const Accessibility: Story = {
+  tags: ['a11y'],
+  args: {
+    size: 'm',
+    value: 2,
+    'max-value': 5,
+    'label-slot': 'Files uploaded',
+    'description-slot': 'Upload will complete shortly',
+  },
+};

--- a/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
@@ -67,15 +67,6 @@ argTypes.value = {
   },
 };
 
-/**
- * A `<swc-progress-bar>` is a non-focusable, read-only bar that shows task
- * progress (0–100, or a custom range). When completion time is unknown, set
- * `indeterminate` to show a looping fill animation instead of a value. The
- * WAI-ARIA `progressbar` role and all `aria-value*` attributes live on the
- * internal shadow wrapper; the host carries no ARIA role. For scalar
- * measurements (storage used, survey completion), prefer
- * [Meter](../?path=/docs/meter--overview).
- */
 const meta: Meta = {
   title: 'Progress Bar',
   component: 'swc-progress-bar',

--- a/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
@@ -118,7 +118,7 @@ const staticColorLabels = {
 // ────────────────────
 
 export const Playground: Story = {
-  tags: ['dev'],
+  tags: ['autodocs', 'dev'],
   args: {
     size: 'm',
     value: 60,


### PR DESCRIPTION


## Description

Updates the `<swc-progress-bar>` indeterminate animation to match React S2's implementation, adds a `prefers-reduced-motion` treatment, and improves Storybook story layout and spacing for ease of review.


## Motivation and context

This branch implements the full-fidelity visual pass for `<swc-progress-bar>` as part of the Phase 5 (styling) migration. 

## Related issue(s)

- SWC-1775

## Screenshots (if appropriate)

Reduced motion ui: 

https://github.com/user-attachments/assets/2867c4af-736d-4b6b-a13d-65d2174008a1



---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Indeterminate animation matches React S2
  1. Open the Progress Bar Storybook page and navigate to the Indeterminate story
  2. Observe the fill animation — it should slide smoothly from left to right (LTR) using a fill that is visually ~70% of the track width
  3. Expect: animation matches the React S2 `<ProgressBar isIndeterminate>` visual output at the same speed (1 s, ease-in-out)

- [ ] Reduced motion slows rather than stops
  1. In your OS accessibility settings, enable "Reduce motion" (macOS: System Settings → Accessibility → Display → Reduce Motion)
  2. Open the Indeterminate story in Storybook
  3. Expect: the fill animation continues looping but at a noticeably slower pace (15 s, linear), rather than freezing or reverting to a static fill

- [ ] RTL animation is mirrored
  1. In Storybook, set the story to RTL direction
  2. Open the Indeterminate story
  3. Expect: the fill slides from right to left

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

**Required:** Complete each applicable item and document your testing steps.

- [ ] **Keyboard** (required — document steps below)
  `<swc-progress-bar>` is a non-interactive, read-only component with no focusable parts. Keyboard testing should confirm no regressions in surrounding interactive elements.
  1. Open the Progress Bar Storybook Accessibility story
  2. Tab through the page
  3. Expect: the progress bar is skipped entirely; focus moves to the next interactive element without being trapped

- [ ] **Screen reader** (required — document steps below)
  1. Open the Progress Bar Storybook Accessibility story with VoiceOver (macOS) or NVDA (Windows) active
  2. Navigate to the progress bar element using the screen reader's element browser
  3. Expect: role announced as "progress indicator"; label announced from the `label` slot content; current value announced as a percentage (e.g. "40%") for determinate, no value announced for indeterminate
