### PR TITLE
fix(illustrated-message): center actions slot content

### DIFF
--- a/.changeset/fix-illustrated-message-actions-slot-alignment.md
+++ b/.changeset/fix-illustrated-message-actions-slot-alignment.md
@@ -1,0 +1,7 @@
+---
+'@adobe/spectrum-wc': patch
+---
+
+**fix(illustrated-message):** Fixed the `actions` slot content alignment in `<swc-illustrated-message>`.
+
+The `.swc-IllustratedMessage-content` flex container was missing `align-items: center`, causing slotted actions (e.g. a `<swc-button>` or `<swc-button-group>`) to stretch to the container width instead of centering horizontally.

--- a/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
@@ -57,12 +57,10 @@ export class IllustratedMessage extends IllustratedMessageBase {
           <div class="swc-IllustratedMessage-description">
             <slot name="description"></slot>
           </div>
-          <div class="swc-IllustratedMessage-actions">
-            <slot
-              name="actions"
-              @slotchange=${this.handleActionsSlotChange}
-            ></slot>
-          </div>
+          <slot
+            name="actions"
+            @slotchange=${this.handleActionsSlotChange}
+          ></slot>
         </div>
       </div>
     `;

--- a/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/IllustratedMessage.ts
@@ -57,10 +57,12 @@ export class IllustratedMessage extends IllustratedMessageBase {
           <div class="swc-IllustratedMessage-description">
             <slot name="description"></slot>
           </div>
-          <slot
-            name="actions"
-            @slotchange=${this.handleActionsSlotChange}
-          ></slot>
+          <div class="swc-IllustratedMessage-actions">
+            <slot
+              name="actions"
+              @slotchange=${this.handleActionsSlotChange}
+            ></slot>
+          </div>
         </div>
       </div>
     `;

--- a/2nd-gen/packages/swc/components/illustrated-message/illustrated-message.css
+++ b/2nd-gen/packages/swc/components/illustrated-message/illustrated-message.css
@@ -44,6 +44,7 @@
   display: flex;
   flex-direction: column;
   gap: token("spacing-75");
+  align-items: center;
   text-align: center;
 }
 
@@ -138,9 +139,7 @@ slot[name="heading"] {
   color: inherit !important;
 }
 
-:host(:has([slot="actions"])) .swc-IllustratedMessage-actions {
-  display: flex;
-  justify-content: center;
+:host(:has([slot="actions"])) slot[name="actions"] {
   margin-block-start: token("spacing-300");
 }
 

--- a/2nd-gen/packages/swc/components/illustrated-message/illustrated-message.css
+++ b/2nd-gen/packages/swc/components/illustrated-message/illustrated-message.css
@@ -138,7 +138,9 @@ slot[name="heading"] {
   color: inherit !important;
 }
 
-:host(:has([slot="actions"])) slot[name="actions"] {
+:host(:has([slot="actions"])) .swc-IllustratedMessage-actions {
+  display: flex;
+  justify-content: center;
   margin-block-start: token("spacing-300");
 }
 


### PR DESCRIPTION
Description

Wraps the slot[name="actions"] in a .swc-IllustratedMessage-actions div with display: flex; justify-content: center so that buttons and button groups placed in the actions slot are horizontally centered, consistent with the illustration, heading, and description above them.

Motivation and context

When PR #6454 added slot="actions" support to swc-illustrated-message, the slot was placed as a direct child of .swc-IllustratedMessage-content (a flex column). That container uses text-align: center for inline text but has no align-items: center, so block-level slotted content defaulted to left-aligned. The fix follows the existing wrapper pattern already used for .swc-IllustratedMessage-description.

Related issue(s)

- fixes SWC-2312

Screenshots (if appropriate)

Before/after of the Actions story at size l showing centered button.

Author's checklist

- [x] I have read the CONTRIBUTING and PULL_REQUESTS documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: Aria Practices
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include patch, minor, or major features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

Manual review test cases

- [ ] Actions slot single button is centered
  a. Open the Illustrated Message Actions story in Storybook
  b. Confirm the "Browse files" button is horizontally centered below the heading and description at sizes s, m, and l
- [ ] Actions slot button group is centered
  a. On the same story, scroll to the "No results found" instance with two buttons
  b. Confirm the button group is horizontally centered as a unit, with both buttons still laid out in a row
- [ ] No regression to heading or description alignment
  a. Confirm the heading and description text remain centered across all sizes

Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

Accessibility testing checklist

- [x] Keyboard (required — document steps below)
  a. Open the Illustrated Message Actions story in Storybook
  b. Press <kbd>Tab</kbd> to move focus into the component
  c. Confirm focus lands on the "Browse files" button and the focus indicator is visible
  d. On the button-group instance, confirm <kbd>Tab</kbd> moves between "Clear filters" and "Browse all" in order with no trapped focus
- [x] Screen reader (required — document steps below)
  a. Open the Illustrated Message Actions story with VoiceOver or NVDA
  b. Navigate into the component and confirm the heading, description, and button label are each announced correctly
  c. Confirm no duplicate or unexpected announcements from the wrapper div (it has no role or label and should be transparent to the accessibility tree)