### PR TITLE
fix(build): resolve icon build script issues

### DIFF
--- a/1st-gen/packages/icons-ui/bin/build.js
+++ b/1st-gen/packages/icons-ui/bin/build.js
@@ -21,7 +21,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const rootDir = path.join(__dirname, '../../../');
+const rootDir = path.join(__dirname, '../../../').replace(/\\/g, '/');
 
 const disclaimer = `
 /*

--- a/1st-gen/packages/icons-ui/bin/build.js
+++ b/1st-gen/packages/icons-ui/bin/build.js
@@ -83,7 +83,7 @@ const defaultIconImport = `import { DefaultIcon as AlternateIcon } from '../Defa
 
 async function buildIcons(icons, tag, iconsNameList) {
     console.log('Building icons for', { icons, tag, iconsNameList });
-    icons.forEach((i) => {
+    for (const i of icons) {
         const svg = fs.readFileSync(i, 'utf-8');
         let id = path
             .basename(i, '.svg')
@@ -124,7 +124,7 @@ async function buildIcons(icons, tag, iconsNameList) {
         );
 
         if (!Number.isNaN(Number(ComponentName[0]))) {
-            return;
+            continue;
         }
 
         $('*').each((index, el) => {
@@ -179,22 +179,19 @@ async function buildIcons(icons, tag, iconsNameList) {
         }
     `;
 
-        prettier
-            .format(iconLiteral, {
-                printWidth: 100,
-                tabWidth: 2,
-                useTabs: false,
-                semi: true,
-                singleQuote: true,
-                trailingComma: 'all',
-                bracketSpacing: true,
-                jsxBracketSameLine: false,
-                arrowParens: 'avoid',
-                parser: 'typescript',
-            })
-            .then((icon) => {
-                fs.writeFileSync(location, icon, 'utf-8');
-            });
+        const icon = await prettier.format(iconLiteral, {
+            printWidth: 100,
+            tabWidth: 2,
+            useTabs: false,
+            semi: true,
+            singleQuote: true,
+            trailingComma: 'all',
+            bracketSpacing: true,
+            jsxBracketSameLine: false,
+            arrowParens: 'avoid',
+            parser: 'typescript',
+        });
+        fs.writeFileSync(location, icon, 'utf-8');
 
         const exportString = `export {${ComponentName}Icon} from './${tag}/${id}.js';\r\n`;
         fs.appendFileSync(
@@ -250,33 +247,23 @@ async function buildIcons(icons, tag, iconsNameList) {
         }
         `;
 
-        prettier
-            .format(iconElement, {
-                printWidth: 100,
-                tabWidth: 2,
-                useTabs: false,
-                semi: true,
-                singleQuote: true,
-                trailingComma: 'all',
-                bracketSpacing: true,
-                jsxBracketSameLine: false,
-                arrowParens: 'avoid',
-                parser: 'typescript',
-            })
-            .then((iconElementFile) => {
-                fs.writeFileSync(
-                    path.join(
-                        rootDir,
-                        'packages',
-                        'icons-ui',
-                        'src',
-                        'elements',
-                        `Icon${id}.ts`
-                    ),
-                    iconElementFile,
-                    'utf-8'
-                );
-            });
+        const iconElementFile = await prettier.format(iconElement, {
+            printWidth: 100,
+            tabWidth: 2,
+            useTabs: false,
+            semi: true,
+            singleQuote: true,
+            trailingComma: 'all',
+            bracketSpacing: true,
+            jsxBracketSameLine: false,
+            arrowParens: 'avoid',
+            parser: 'typescript',
+        });
+        fs.writeFileSync(
+            path.join(rootDir, 'packages', 'icons-ui', 'src', 'elements', `Icon${id}.ts`),
+            iconElementFile,
+            'utf-8'
+        );
 
         const iconRegistration = `
         ${disclaimer}
@@ -293,32 +280,23 @@ async function buildIcons(icons, tag, iconsNameList) {
         }
         `;
 
-        prettier
-            .format(iconRegistration, {
-                printWidth: 100,
-                tabWidth: 2,
-                useTabs: false,
-                semi: true,
-                singleQuote: true,
-                trailingComma: 'all',
-                bracketSpacing: true,
-                jsxBracketSameLine: false,
-                arrowParens: 'avoid',
-                parser: 'typescript',
-            })
-            .then((iconRegistrationFile) => {
-                fs.writeFileSync(
-                    path.join(
-                        rootDir,
-                        'packages',
-                        'icons-ui',
-                        'icons',
-                        `${iconElementName}.ts`
-                    ),
-                    iconRegistrationFile,
-                    'utf-8'
-                );
-            });
+        const iconRegistrationFile = await prettier.format(iconRegistration, {
+            printWidth: 100,
+            tabWidth: 2,
+            useTabs: false,
+            semi: true,
+            singleQuote: true,
+            trailingComma: 'all',
+            bracketSpacing: true,
+            jsxBracketSameLine: false,
+            arrowParens: 'avoid',
+            parser: 'typescript',
+        });
+        fs.writeFileSync(
+            path.join(rootDir, 'packages', 'icons-ui', 'icons', `${iconElementName}.ts`),
+            iconRegistrationFile,
+            'utf-8'
+        );
 
         const importStatement = `\r\nimport '@spectrum-web-components/icons-ui/icons/${iconElementName}.js';`;
         const metadata = `{name: '${Case.sentence(
@@ -326,7 +304,7 @@ async function buildIcons(icons, tag, iconsNameList) {
         )}', tag: '<${iconElementName}>', story: (size: string): TemplateResult => html\`<${iconElementName} size=\$\{size\}></${iconElementName}>\`},\r\n`;
         manifestImports += importStatement;
         manifestListings += metadata;
-    });
+    }
 }
 
 const iconsV1 = (

--- a/1st-gen/packages/icons-workflow/bin/build.js
+++ b/1st-gen/packages/icons-workflow/bin/build.js
@@ -50,8 +50,8 @@ const S2IconsPackagePath = path.dirname(
   )
 );
 
-const S1IconsDir = path.join(S1IconsPackagePath, 'dist/18');
-const S2IconsDir = path.join(S2IconsPackagePath, 'dist/assets/svg');
+const S1IconsDir = path.join(S1IconsPackagePath, 'dist/18').replace(/\\/g, '/');
+const S2IconsDir = path.join(S2IconsPackagePath, 'dist/assets/svg').replace(/\\/g, '/');
 const keepColors = '';
 
 const ensureDirectoryExists = (dirPath) => {

--- a/1st-gen/packages/icons-workflow/bin/build.js
+++ b/1st-gen/packages/icons-workflow/bin/build.js
@@ -116,7 +116,7 @@ export const getComponentName = (i) => {
 };
 
 async function buildIcons(icons, tag, iconsNameList) {
-  icons.forEach((i) => {
+  for (const i of icons) {
     const svg = fs.readFileSync(i, 'utf-8');
     let id = path
       .basename(i, '.svg')
@@ -146,7 +146,7 @@ async function buildIcons(icons, tag, iconsNameList) {
     );
 
     if (!Number.isNaN(Number(ComponentName[0]))) {
-      return;
+      continue;
     }
 
     $('*').each((index, el) => {
@@ -201,22 +201,19 @@ async function buildIcons(icons, tag, iconsNameList) {
         }
     `;
 
-    prettier
-      .format(iconLiteral, {
-        printWidth: 100,
-        tabWidth: 2,
-        useTabs: false,
-        semi: true,
-        singleQuote: true,
-        trailingComma: 'all',
-        bracketSpacing: true,
-        jsxBracketSameLine: false,
-        arrowParens: 'avoid',
-        parser: 'typescript',
-      })
-      .then((icon) => {
-        fs.writeFileSync(location, icon, 'utf-8');
-      });
+    const icon = await prettier.format(iconLiteral, {
+      printWidth: 100,
+      tabWidth: 2,
+      useTabs: false,
+      semi: true,
+      singleQuote: true,
+      trailingComma: 'all',
+      bracketSpacing: true,
+      jsxBracketSameLine: false,
+      arrowParens: 'avoid',
+      parser: 'typescript',
+    });
+    fs.writeFileSync(location, icon, 'utf-8');
 
     const exportString = `export {${ComponentName}Icon} from './${tag}/${id}.js';\r\n`;
     fs.appendFileSync(
@@ -276,33 +273,23 @@ async function buildIcons(icons, tag, iconsNameList) {
         }
         `;
 
-    prettier
-      .format(iconElement, {
-        printWidth: 100,
-        tabWidth: 2,
-        useTabs: false,
-        semi: true,
-        singleQuote: true,
-        trailingComma: 'all',
-        bracketSpacing: true,
-        jsxBracketSameLine: false,
-        arrowParens: 'avoid',
-        parser: 'typescript',
-      })
-      .then((iconElementFile) => {
-        fs.writeFileSync(
-          path.join(
-            rootDir,
-            'packages',
-            'icons-workflow',
-            'src',
-            'elements',
-            `Icon${id}.ts`
-          ),
-          iconElementFile,
-          'utf-8'
-        );
-      });
+    const iconElementFile = await prettier.format(iconElement, {
+      printWidth: 100,
+      tabWidth: 2,
+      useTabs: false,
+      semi: true,
+      singleQuote: true,
+      trailingComma: 'all',
+      bracketSpacing: true,
+      jsxBracketSameLine: false,
+      arrowParens: 'avoid',
+      parser: 'typescript',
+    });
+    fs.writeFileSync(
+      path.join(rootDir, 'packages', 'icons-workflow', 'src', 'elements', `Icon${id}.ts`),
+      iconElementFile,
+      'utf-8'
+    );
 
     const iconRegistration = `
         ${disclaimer}
@@ -319,32 +306,23 @@ async function buildIcons(icons, tag, iconsNameList) {
         }
         `;
 
-    prettier
-      .format(iconRegistration, {
-        printWidth: 100,
-        tabWidth: 2,
-        useTabs: false,
-        semi: true,
-        singleQuote: true,
-        trailingComma: 'all',
-        bracketSpacing: true,
-        jsxBracketSameLine: false,
-        arrowParens: 'avoid',
-        parser: 'typescript',
-      })
-      .then((iconRegistrationFile) => {
-        fs.writeFileSync(
-          path.join(
-            rootDir,
-            'packages',
-            'icons-workflow',
-            'icons',
-            `${iconElementName}.ts`
-          ),
-          iconRegistrationFile,
-          'utf-8'
-        );
-      });
+    const iconRegistrationFile = await prettier.format(iconRegistration, {
+      printWidth: 100,
+      tabWidth: 2,
+      useTabs: false,
+      semi: true,
+      singleQuote: true,
+      trailingComma: 'all',
+      bracketSpacing: true,
+      jsxBracketSameLine: false,
+      arrowParens: 'avoid',
+      parser: 'typescript',
+    });
+    fs.writeFileSync(
+      path.join(rootDir, 'packages', 'icons-workflow', 'icons', `${iconElementName}.ts`),
+      iconRegistrationFile,
+      'utf-8'
+    );
 
     const importStatement = `\r\nimport '@spectrum-web-components/icons-workflow/icons/${iconElementName}.js';`;
     const metadata = `{name: '${Case.sentence(
@@ -352,7 +330,7 @@ async function buildIcons(icons, tag, iconsNameList) {
     )}', tag: '<${iconElementName}>', story: (size: string): TemplateResult => html\`<${iconElementName} size=\$\{size\}></${iconElementName}>\`},\r\n`;
     manifestImports += importStatement;
     manifestListings += metadata;
-  });
+  }
 }
 
 const iconsV1 = (await fg(`${S1IconsDir}/**.svg`)).sort();

--- a/1st-gen/test/visual/create.js
+++ b/1st-gen/test/visual/create.js
@@ -58,10 +58,14 @@ regressVisuals('${name}', stories as unknown as TestsType);
 }
 async function main() {
   try {
-    const filesToDelete = await fg('**/*-vrt.ts');
+    const filesToDelete = await fg('**/*-vrt.ts', {
+      ignore: ['**/node_modules/**'],
+    });
     await rimraf(filesToDelete);
   } catch (error) {
-    console.warn(`Failed to delete test files: ${JSON.stringify(error)}`);
+    console.warn(
+      `Failed to delete test files: ${error instanceof Error ? error.message : String(error)}`
+    );
     process.exit(1);
   }
   await createTest('packages');

--- a/1st-gen/test/visual/create.js
+++ b/1st-gen/test/visual/create.js
@@ -58,15 +58,10 @@ regressVisuals('${name}', stories as unknown as TestsType);
 }
 async function main() {
   try {
-    await rimraf('**/*-vrt.ts');
+    const filesToDelete = await fg('**/*-vrt.ts');
+    await rimraf(filesToDelete);
   } catch (error) {
-    if (window.__swc?.DEBUG) {
-      window.__swc.warn(
-        undefined,
-        `Failed to delete test files: ${JSON.stringify(error)}`,
-        { issues: [error instanceof Error ? error.message : 'Unknown error'] }
-      );
-    }
+    console.warn(`Failed to delete test files: ${JSON.stringify(error)}`);
     process.exit(1);
   }
   await createTest('packages');


### PR DESCRIPTION
## Description

- **`1st-gen/test/visual/create.js`**: Fixed two issues in the VRT test-creation script. First, `rimraf('**/*-vrt.ts')` was passing a glob pattern directly to rimraf, which fails on Windows with `EINVAL` because `*` is an illegal path character — fixed by pre-expanding the glob with `fast-glob` (already imported) and passing the resolved file list to rimraf. Second, the error catch block referenced `window.__swc?.DEBUG`, but `window` does not exist in a Node.js process — replaced with `console.warn`.
- **`1st-gen/packages/icons-ui/bin/build.js`**: Added `.replace(/\\/g, '/')` to `rootDir` so `fast-glob` receives forward-slash paths on Windows. Also fixed three fire-and-forget `prettier.format().then()` calls — promises were not awaited, so icon TypeScript files could silently fail to write before the process exited. Converted `forEach` to `for...of` to enable `await`, and updated the numeric-name guard from `return` to `continue` (semantically equivalent to the original `forEach` + `return` behavior).
- **`1st-gen/packages/icons-workflow/bin/build.js`**: Same async fixes as `icons-ui`. The path-separator fix is applied to `S1IconsDir` and `S2IconsDir` (the variables actually passed to `fast-glob` in this script, unlike `icons-ui` where it was `rootDir`).

## Motivation and context

On Windows, `path.join` produces backslash-separated paths. `fast-glob` only understands forward slashes, so glob patterns containing backslashes match nothing. The icon build scripts passed these Windows paths directly to `fast-glob`, resulting in 0 icon files being generated and downstream TypeScript errors across the entire 1st-gen build. These errors only surface on Windows because `path.join` on macOS already returns forward slashes.

The `prettier.format().then(fs.writeFileSync)` pattern is a separate latent bug — the promises were never awaited, so file writes could be skipped if the process exited before the microtask queue drained. On macOS this worked by coincidence; on Windows the timing differed.

The `window` reference in `create.js` is a copy-paste error from browser code into a Node.js script. It would crash on any platform if the `rimraf` call ever threw.

## Related issue(s)

- N/A — discovered during Windows developer environment setup; no existing issue.

## Screenshots (if appropriate)

N/A — build tooling fix; no UI changes.

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/) <!-- Not applicable — build tooling only; no interactive component code changed. -->
- [ ] I have added automated tests to cover my changes. <!-- Not applicable — these are one-shot build scripts; there is no test harness for them. -->
- [ ] I have included a well-written changeset if my change needs to be published. <!-- Not applicable — no publishable package changed; these are internal build scripts. -->
- [ ] I have included updated documentation if my change required it. <!-- Not applicable — no public API or contributor workflow changed. -->

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

> **Context for Mac reviewers:** The `.replace(/\\/g, '/')` calls are a no-op on macOS — `path.join` already returns forward slashes, so the replace matches nothing. The `for...of` + `await` rewrite is strictly more correct async code; it previously worked on macOS by coincidence of process lifetime. The `return` → `continue` change is semantically identical to the original `forEach` + `return` behavior. None of these changes alter the generated output on macOS.

- [ ] _1st-gen build produces the correct output_
  1. From the repo root, delete any cached wireit output:
     - Mac/Linux: `rm -rf 1st-gen/.wireit`
     - Windows: `Remove-Item -Recurse -Force 1st-gen/.wireit`
  2. Delete any previously generated icon files to ensure a clean slate (on Windows, these may have been generated on another platform and committed or copied in):
     - Mac/Linux: `rm -rf 1st-gen/packages/icons-ui/src/icons 1st-gen/packages/icons-ui/src/icons-s2 1st-gen/packages/icons-workflow/src/icons 1st-gen/packages/icons-workflow/src/icons-s2`
     - Windows: `Remove-Item -Recurse -Force 1st-gen/packages/icons-ui/src/icons, 1st-gen/packages/icons-ui/src/icons-s2, 1st-gen/packages/icons-workflow/src/icons, 1st-gen/packages/icons-workflow/src/icons-s2`
  3. Run `yarn build:1st-gen`
  4. Confirm `1st-gen/packages/icons-ui/src/icons/` contains TypeScript files (expect ~49)
  5. Confirm `1st-gen/packages/icons-workflow/src/icons/` contains TypeScript files (expect ~905)
  6. Confirm the build completes without TypeScript errors (`test:create` runs as part of this step; a passing build confirms the `create.js` fix is working)

- [ ] _2nd-gen Storybook starts successfully_
  1. After a successful `yarn build:1st-gen`, `cd 2nd-gen && yarn start`
  2. Confirm Storybook opens on port 6006 without esbuild errors about missing `.css.js` or icon files

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** — not applicable; no interactive component code changed.
- [ ] **Screen reader** — not applicable; no interactive component code changed.
