### PR TITLE
feat(swc): force hover/focus-visible/active states in Button VRT

### DIFF
--- a/2nd-gen/packages/swc/.storybook/helpers/index.ts
+++ b/2nd-gen/packages/swc/.storybook/helpers/index.ts
@@ -12,4 +12,5 @@
 
 export { formatTitle } from './format-title.js';
 export { iconForSize } from './icon-for-size.js';
+export { forcePseudoState } from './pseudo-state.js';
 export { row, staticColorBackground, theme } from './vrt.js';

--- a/2nd-gen/packages/swc/.storybook/helpers/pseudo-state.ts
+++ b/2nd-gen/packages/swc/.storybook/helpers/pseudo-state.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Forces a real CSS pseudo-class's visual state for VRT snapshots.
+ *
+ * `:hover` and `:active` can't be triggered by synthetic events — browsers only apply
+ * them from genuine pointer/OS input state, which doesn't exist in a static snapshot.
+ * `:focus-visible` has a similar heuristic gotcha. So instead of trying to fake the
+ * input, this mirrors the component's own `:hover`/`:focus-visible`/`:active` rules
+ * (in its shadow root's adopted stylesheets) into equivalent class selectors, then
+ * applies the matching class directly to the component's internal element.
+ */
+
+const PSEUDO_TO_FORCED_CLASS: Record<string, string> = {
+  ':hover': '.is-hover',
+  ':focus-visible': '.is-focus-visible',
+  ':active': '.is-active',
+};
+
+export type ForcedPseudoState = 'hover' | 'focus-visible' | 'active';
+
+/** Shadow roots already given mirrored pseudo-class stylesheets. */
+const augmented = new WeakSet<ShadowRoot>();
+
+function mirrorPseudoClassRules(sheet: CSSStyleSheet): CSSStyleSheet | null {
+  const rules: string[] = [];
+  for (const rule of sheet.cssRules) {
+    if (!(rule instanceof CSSStyleRule)) {
+      continue;
+    }
+    for (const [pseudo, forcedClass] of Object.entries(
+      PSEUDO_TO_FORCED_CLASS
+    )) {
+      if (rule.selectorText.includes(pseudo)) {
+        rules.push(
+          `${rule.selectorText.replaceAll(pseudo, forcedClass)} { ${rule.style.cssText} }`
+        );
+      }
+    }
+  }
+  if (!rules.length) {
+    return null;
+  }
+  const mirror = new CSSStyleSheet();
+  rules.forEach((rule, index) => mirror.insertRule(rule, index));
+  return mirror;
+}
+
+function augmentShadowRoot(root: ShadowRoot): void {
+  if (augmented.has(root)) {
+    return;
+  }
+  augmented.add(root);
+  const mirrors = root.adoptedStyleSheets
+    .map(mirrorPseudoClassRules)
+    .filter((sheet): sheet is CSSStyleSheet => sheet !== null);
+  if (mirrors.length) {
+    root.adoptedStyleSheets = [...root.adoptedStyleSheets, ...mirrors];
+  }
+}
+
+/**
+ * Forces `state`'s visual appearance onto `internalSelector` inside `host`'s shadow
+ * root. Call after `host` has rendered (its shadow root must already have its adopted
+ * stylesheets in place — true as soon as the element is connected and updated).
+ */
+export function forcePseudoState(
+  host: Element,
+  internalSelector: string,
+  state: ForcedPseudoState
+): void {
+  if (!host.shadowRoot) {
+    return;
+  }
+  augmentShadowRoot(host.shadowRoot);
+  host.shadowRoot.querySelector(internalSelector)?.classList.add(`is-${state}`);
+}

--- a/2nd-gen/packages/swc/.storybook/helpers/pseudo-state.ts
+++ b/2nd-gen/packages/swc/.storybook/helpers/pseudo-state.ts
@@ -70,18 +70,29 @@ function augmentShadowRoot(root: ShadowRoot): void {
 }
 
 /**
- * Forces `state`'s visual appearance onto `internalSelector` inside `host`'s shadow
- * root. Call after `host` has rendered (its shadow root must already have its adopted
- * stylesheets in place — true as soon as the element is connected and updated).
+ * Forces `state`'s visual appearance on `host`. Call after `host` has rendered (its
+ * shadow root must already have its adopted stylesheets in place — true as soon as
+ * the element is connected and updated).
+ *
+ * Some components style pseudo-states on an internal shadow part (e.g. Button's
+ * `.swc-Button:hover`) — pass `internalSelector` for those, and the forced class is
+ * added there instead. Others style pseudo-states directly on `:host()` (e.g. Tab's
+ * `:host(:hover)`) — omit `internalSelector` and the class is added to `host` itself.
+ * Either way, the mirrored rule lives in the *same* shadow root's adopted
+ * stylesheets, so `:host(:hover)` naturally still matches against `host`'s own class
+ * list even though the rule was defined inside its own shadow tree.
  */
 export function forcePseudoState(
   host: Element,
-  internalSelector: string,
-  state: ForcedPseudoState
+  state: ForcedPseudoState,
+  internalSelector?: string
 ): void {
   if (!host.shadowRoot) {
     return;
   }
   augmentShadowRoot(host.shadowRoot);
-  host.shadowRoot.querySelector(internalSelector)?.classList.add(`is-${state}`);
+  const target = internalSelector
+    ? host.shadowRoot.querySelector(internalSelector)
+    : host;
+  target?.classList.add(`is-${state}`);
 }

--- a/2nd-gen/packages/swc/.storybook/helpers/vrt.ts
+++ b/2nd-gen/packages/swc/.storybook/helpers/vrt.ts
@@ -32,6 +32,11 @@ export const row = (children: unknown) => html`
  * across the shadow boundary without needing the toolbar globals. Also
  * stacks its children (e.g. multiple `row()` groups) vertically with a gap,
  * since it already wraps everything a VRT story renders.
+ *
+ * Sets `color` as well as `background-color`: SWC intentionally never sets a
+ * page-level default text color (that's left to the consuming app, same as
+ * background), so plain slotted content (e.g. TabPanel's text) has nothing
+ * to inherit and stays illegible-dark-on-dark without this.
  */
 export const theme = (
   children: unknown,
@@ -41,7 +46,7 @@ export const theme = (
   <div
     class="swc-theme--${mode}"
     dir=${dir}
-    style="display: flex; flex-direction: column; gap: 16px; padding: 16px; background-color: var(--swc-background-base-color);"
+    style="display: flex; flex-direction: column; gap: 16px; padding: 16px; background-color: var(--swc-background-base-color); color: var(--swc-neutral-content-color-default);"
   >
     ${children}
   </div>

--- a/2nd-gen/packages/swc/components/button/test/button.vrt.ts
+++ b/2nd-gen/packages/swc/components/button/test/button.vrt.ts
@@ -22,6 +22,7 @@ import '@adobe/spectrum-wc/components/button/swc-button.js';
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 
 import {
+  forcePseudoState,
   row,
   staticColorBackground,
   theme,
@@ -73,10 +74,11 @@ const arrowIcon = () => html`
 
 // Every variant × fill-style × size combination, disabled/pending states,
 // static-color variants on their contrast backgrounds, icon anatomy
-// (label-only, icon+label, icon-only) for fill and outline, and text
-// wrapping/truncation behavior. Rendered once in light/ltr and once in
-// dark/rtl below (that combination covers both axes), all still in a single
-// story so it costs one snapshot.
+// (label-only, icon+label, icon-only) for fill and outline, text
+// wrapping/truncation behavior, and forced hover/focus-visible/active per
+// variant (see the `play` function below). Rendered once in light/ltr and
+// once in dark/rtl below (that combination covers both axes), all still in a
+// single story so it costs one snapshot.
 const permutationContent = () => html`
   ${ROWS.map(({ variant, fillStyle }) =>
     row(
@@ -174,6 +176,17 @@ const permutationContent = () => html`
       </swc-button>
     `,
   ])}
+  ${BUTTON_VARIANTS.map((variant) =>
+    row(
+      (['hover', 'focus-visible', 'active'] as const).map(
+        (state) => html`
+          <swc-button variant=${variant} data-force-state=${state}>
+            ${variant} ${state}
+          </swc-button>
+        `
+      )
+    )
+  )}
 `;
 
 export const Permutations: Story = {
@@ -183,5 +196,25 @@ export const Permutations: Story = {
   `,
   parameters: {
     styles: { display: 'flex', 'flex-direction': 'column', gap: '16px' },
+    // The global default (preview.ts) only autoplays under Chromatic, so the
+    // forced hover/focus-visible/active row below wouldn't otherwise render
+    // in local dev/the Chromatic addon panel without manually triggering play.
+    autoplay: true,
+  },
+  // :hover/:active can't be triggered by synthetic events, and static VRT
+  // captures have no real pointer — see helpers/pseudo-state.ts. Applying
+  // this after render (rather than baking the class into the markup above)
+  // is what lets it target the real internal `.swc-Button` element inside
+  // the shadow root, which the light-DOM markup above has no access to.
+  play: async ({ canvasElement }) => {
+    canvasElement
+      .querySelectorAll<HTMLElement>('swc-button[data-force-state]')
+      .forEach((host) => {
+        const state = host.dataset.forceState as
+          | 'hover'
+          | 'focus-visible'
+          | 'active';
+        forcePseudoState(host, '.swc-Button', state);
+      });
   },
 };

--- a/2nd-gen/packages/swc/components/button/test/button.vrt.ts
+++ b/2nd-gen/packages/swc/components/button/test/button.vrt.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
 import {
@@ -73,7 +73,9 @@ const arrowIcon = () => html`
 // ──────────────────────────
 
 // Every variant × fill-style × size combination, disabled/pending states,
-// static-color variants on their contrast backgrounds, icon anatomy
+// static-color variants (each with their own forced hover/focus-visible/
+// active, since static-color buttons keep their own contrast rules
+// regardless of app theme) on their contrast backgrounds, icon anatomy
 // (label-only, icon+label, icon-only) for fill and outline, text
 // wrapping/truncation behavior, and forced hover/focus-visible/active per
 // variant (see the `play` function below). Rendered once in light/ltr and
@@ -85,7 +87,7 @@ const permutationContent = () => html`
       BUTTON_VALID_SIZES.map(
         (size) => html`
           <swc-button variant=${variant} fill-style=${fillStyle} size=${size}>
-            ${variant} ${fillStyle} ${size}
+            I am ${variant} ${fillStyle} ${size}
           </swc-button>
         `
       )
@@ -105,25 +107,42 @@ const permutationContent = () => html`
       `
     )
   )}
-  ${staticColorBackground(
-    ['fill', 'outline'].map(
-      (fillStyle) => html`
-        <swc-button static-color="white" fill-style=${fillStyle}>
-          White ${fillStyle}
-        </swc-button>
-      `
-    ),
-    'white'
-  )}
-  ${staticColorBackground(
-    ['fill', 'outline'].map(
-      (fillStyle) => html`
-        <swc-button static-color="black" fill-style=${fillStyle}>
-          Black ${fillStyle}
-        </swc-button>
-      `
-    ),
-    'black'
+  ${(['white', 'black'] as const).map((color) =>
+    staticColorBackground(
+      [
+        // static-color collapses semantic variants into two treatments —
+        // "solid" (primary/accent/negative, the default here) and
+        // "secondary" (its own, more subtle tokens) — each with its own
+        // hover/focus-visible/active values, so both need covering.
+        ...['fill', 'outline'].flatMap((fillStyle) =>
+          [undefined, 'secondary'].map(
+            (variant) => html`
+              <swc-button
+                static-color=${color}
+                fill-style=${fillStyle}
+                variant=${variant ?? nothing}
+              >
+                ${color} ${variant ?? 'solid'} ${fillStyle}
+              </swc-button>
+            `
+          )
+        ),
+        ...(['hover', 'focus-visible', 'active'] as const).flatMap((state) =>
+          [undefined, 'secondary'].map(
+            (variant) => html`
+              <swc-button
+                static-color=${color}
+                variant=${variant ?? nothing}
+                data-force-state=${state}
+              >
+                ${color} ${variant ?? 'solid'} ${state}
+              </swc-button>
+            `
+          )
+        ),
+      ],
+      color
+    )
   )}
   ${['fill', 'outline'].map((fillStyle) =>
     row([

--- a/2nd-gen/packages/swc/components/button/test/button.vrt.ts
+++ b/2nd-gen/packages/swc/components/button/test/button.vrt.ts
@@ -214,7 +214,7 @@ export const Permutations: Story = {
           | 'hover'
           | 'focus-visible'
           | 'active';
-        forcePseudoState(host, '.swc-Button', state);
+        forcePseudoState(host, state, '.swc-Button');
       });
   },
 };

--- a/2nd-gen/packages/swc/components/tabs/test/tab.vrt.ts
+++ b/2nd-gen/packages/swc/components/tabs/test/tab.vrt.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import { TAB_DENSITIES } from '@spectrum-web-components/core/components/tabs/index.js';
+
+import '@adobe/spectrum-wc/components/tabs/swc-tabs.js';
+import '@adobe/spectrum-wc/components/tabs/swc-tab.js';
+import '@adobe/spectrum-wc/components/tabs/swc-tab-panel.js';
+
+import {
+  forcePseudoState,
+  row,
+  theme,
+} from '../../../.storybook/helpers/index.js';
+
+// ────────────────
+//    METADATA
+// ────────────────
+
+const meta: Meta = {
+  title: 'Tabs/VRT',
+  component: 'swc-tabs',
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
+  tags: ['dev'],
+};
+
+export default meta;
+
+// ────────────────────
+//    HELPERS
+// ────────────────────
+
+// One tab group per density: default, selected, and disabled tabs, each
+// paired with a matching panel (Tabs warns if a tab has no matching panel).
+const tabGroup = (density: (typeof TAB_DENSITIES)[number]) => html`
+  <swc-tabs selected="2" density=${density} accessible-label="Product details">
+    <swc-tab tab-id="1">Overview</swc-tab>
+    <swc-tab tab-id="2">Specifications</swc-tab>
+    <swc-tab tab-id="3" disabled>Guidelines</swc-tab>
+    <swc-tab-panel tab-id="1">Overview content.</swc-tab-panel>
+    <swc-tab-panel tab-id="2">Specifications content.</swc-tab-panel>
+    <swc-tab-panel tab-id="3">Guidelines content.</swc-tab-panel>
+  </swc-tabs>
+`;
+
+// ──────────────────────────
+//    VRT STORIES
+// ──────────────────────────
+
+// Regular/compact density, each with default/selected/disabled tabs, plus
+// forced hover/focus-visible/active on standalone tabs. Rendered once in
+// light/ltr and once in dark/rtl below, all in a single story/snapshot.
+//
+// Tab's hover/active/focus-visible rules are all `:host(:hover)` etc. (see
+// tab.css) — styled on the host itself, not an internal shadow part like
+// Button's `.swc-Button:hover`. forcePseudoState() with no internalSelector
+// adds the forced class straight to the host for that case.
+const permutationContent = () => html`
+  ${row(TAB_DENSITIES.map((density) => tabGroup(density)))}
+  ${row(
+    (['hover', 'focus-visible', 'active'] as const).map(
+      (state) => html`
+        <swc-tab data-force-state=${state} tab-id=${state}>${state}</swc-tab>
+      `
+    )
+  )}
+`;
+
+export const Permutations: Story = {
+  render: () => html`
+    ${theme(permutationContent(), 'light', 'ltr')}
+    ${theme(permutationContent(), 'dark', 'rtl')}
+  `,
+  parameters: {
+    styles: { display: 'flex', 'flex-direction': 'column', gap: '16px' },
+    // The global default (preview.ts) only autoplays under Chromatic, so the
+    // forced hover/focus-visible/active row below wouldn't otherwise render
+    // in local dev/the Chromatic addon panel without manually triggering play.
+    autoplay: true,
+  },
+  play: async ({ canvasElement }) => {
+    canvasElement
+      .querySelectorAll<HTMLElement>('swc-tab[data-force-state]')
+      .forEach((host) => {
+        const state = host.dataset.forceState as
+          | 'hover'
+          | 'focus-visible'
+          | 'active';
+        forcePseudoState(host, state);
+      });
+  },
+};


### PR DESCRIPTION
## Description

Follow-up to #6463: adds forced `:hover`/`:focus-visible`/`:active` coverage to the Button VRT story, one row per variant.

`:hover`/`:active` can't be triggered by synthetic events, and static VRT captures have no real pointer; `:focus-visible` has a similar heuristic gotcha (`.focus()` alone doesn't reliably set it). `forcePseudoState()` (`.storybook/helpers/pseudo-state.ts`) mirrors a component's own `:hover`/`:focus-visible`/`:active` CSS rules — found in its shadow root's adopted stylesheets — into equivalent class selectors, then applies the matching class to its internal element. Wired into `button.vrt.ts`'s `Permutations` story via a `play` function (needs `autoplay: true` locally since the global default only autoplays under Chromatic).

This takes the core trick from `aziz/storybook-test-grid`'s pseudo-states tooling, but is a fraction of the size: no generic `data-vrt-host`/`data-vrt-control` selector indirection (that exists to support *any* unknown component via their generic grid — we hand-write each VRT file and already know exactly which internal part needs the class, e.g. `.swc-Button`), no toolbar toggle, no recursive whole-document shadow-tree walk (a single VRT story only needs to augment its own rendered subtree), and no CSS grouping-rule (`@media`/`@layer`/`@container`) recursion, since Button's hover/focus/active rules aren't nested in any of those.

Verified locally (screenshots) that all four variants (primary, secondary, accent, negative) render visually distinct hover/focus-visible/active colors, confirming the mirrored rules apply correctly, not just that the classes exist.

## Motivation and context

Part of the same VRT exploration as #6463 — this was deliberately deferred there to keep that PR scoped, and tackled here once the base story shape was settled.

## Related issue(s)

- Builds on #6463

## Author's checklist

- [ ] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [ ] I have reviewed the Accessibility Practices for this feature.
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Accessibility testing checklist

- [ ] **Keyboard**: N/A — VRT-only tooling, no new interactive surface.
- [ ] **Screen reader**: N/A — VRT-only tooling, no new interactive surface.