### PR TITLE
fix(tabs): correct selection indicator position in RTL

### DIFF
--- a/.changeset/fix-tabs-rtl-selection-indicator.md
+++ b/.changeset/fix-tabs-rtl-selection-indicator.md
@@ -5,4 +5,4 @@
 
 **fix(tabs):** Fixed the `<swc-tabs>` selection indicator rendering in the wrong horizontal position in right-to-left (RTL) layouts.
 
-The indicator's resting position is set via the logical property `inset-inline-start: 0`, which resolves to `right: 0` in RTL, but the JS that positions it always measured and translated it from the container's left edge regardless of direction. The offset calculation now branches on `getComputedStyle(this).direction`, and `transform-origin` flips to `right center` in RTL to match the indicator's anchor point.
+The indicator's resting position is set via the logical property `inset-inline-start: 0`, which resolves to `right: 0` in RTL, but the JS that positions it always measured and translated it from the container's left edge regardless of direction. The offset calculation now branches on `getComputedStyle(this).direction`, and `transform-origin` flips to `right center` in RTL to match the indicator's anchor point. The indicator also recalculates when the writing direction changes at runtime, such as an ancestor's `dir` attribute flipping after the tabs have already rendered.

--- a/.changeset/fix-tabs-rtl-selection-indicator.md
+++ b/.changeset/fix-tabs-rtl-selection-indicator.md
@@ -1,0 +1,8 @@
+---
+'@adobe/spectrum-wc': patch
+'@spectrum-web-components/core': patch
+---
+
+**fix(tabs):** Fixed the `<swc-tabs>` selection indicator rendering in the wrong horizontal position in right-to-left (RTL) layouts.
+
+The indicator's resting position is set via the logical property `inset-inline-start: 0`, which resolves to `right: 0` in RTL, but the JS that positions it always measured and translated it from the container's left edge regardless of direction. The offset calculation now branches on `getComputedStyle(this).direction`, and `transform-origin` flips to `right center` in RTL to match the indicator's anchor point.

--- a/2nd-gen/packages/core/components/tabs/Tabs.base.ts
+++ b/2nd-gen/packages/core/components/tabs/Tabs.base.ts
@@ -562,9 +562,12 @@ export abstract class TabsBase extends SpectrumElement {
     const listRect = tablist.getBoundingClientRect();
 
     if (this._direction === 'horizontal') {
-      const left = tabRect.left - listRect.left;
+      const isRtl = getComputedStyle(this).direction === 'rtl';
+      const offset = isRtl
+        ? tabRect.right - listRect.right
+        : tabRect.left - listRect.left;
       const scale = tabRect.width / TabsBase.INDICATOR_BASE_SIZE;
-      this.selectionIndicatorStyle = `transform: translateX(${left}px) scaleX(${scale})`;
+      this.selectionIndicatorStyle = `transform: translateX(${offset}px) scaleX(${scale})`;
     } else {
       const top = tabRect.top - listRect.top;
       const scale = tabRect.height / TabsBase.INDICATOR_BASE_SIZE;

--- a/2nd-gen/packages/core/components/tabs/Tabs.base.ts
+++ b/2nd-gen/packages/core/components/tabs/Tabs.base.ts
@@ -562,7 +562,7 @@ export abstract class TabsBase extends SpectrumElement {
     const listRect = tablist.getBoundingClientRect();
 
     if (this._direction === 'horizontal') {
-      const isRtl = this.dir === 'rtl';
+      const isRtl = getComputedStyle(this).direction === 'rtl';
       const offset = isRtl
         ? tabRect.right - listRect.right
         : tabRect.left - listRect.left;
@@ -582,6 +582,19 @@ export abstract class TabsBase extends SpectrumElement {
 
   /** @internal */
   private _resizeObserver?: ResizeObserver;
+
+  /**
+   * @internal
+   *
+   * Watches for `dir` attribute changes so the indicator recalculates
+   * when writing direction flips at runtime. `getComputedStyle` in
+   * `updateSelectionIndicator` resolves inherited direction correctly,
+   * but nothing else observes it: a `dir` flip on the document root or
+   * an ancestor doesn't resize this element, so the `ResizeObserver`
+   * below won't catch it. Mirrors the `dir`-watching pattern in
+   * `placement-controller.ts`.
+   */
+  private _directionObserver?: MutationObserver;
 
   // ───────────────────────────────────
   //     LIFECYCLE
@@ -649,6 +662,20 @@ export abstract class TabsBase extends SpectrumElement {
       this.updateSelectionIndicator();
     });
     this._resizeObserver.observe(this);
+
+    this._directionObserver = new MutationObserver(() => {
+      this.updateSelectionIndicator();
+    });
+    const observeDir = (node: Element | null | undefined) => {
+      if (node) {
+        this._directionObserver?.observe(node, {
+          attributes: true,
+          attributeFilter: ['dir'],
+        });
+      }
+    };
+    observeDir(this.ownerDocument.documentElement);
+    observeDir(this.closest('[dir]'));
   }
 
   public override disconnectedCallback(): void {
@@ -661,6 +688,8 @@ export abstract class TabsBase extends SpectrumElement {
     }
     this._resizeObserver?.disconnect();
     this._resizeObserver = undefined;
+    this._directionObserver?.disconnect();
+    this._directionObserver = undefined;
     super.disconnectedCallback();
   }
 

--- a/2nd-gen/packages/core/components/tabs/Tabs.base.ts
+++ b/2nd-gen/packages/core/components/tabs/Tabs.base.ts
@@ -562,7 +562,7 @@ export abstract class TabsBase extends SpectrumElement {
     const listRect = tablist.getBoundingClientRect();
 
     if (this._direction === 'horizontal') {
-      const isRtl = getComputedStyle(this).direction === 'rtl';
+      const isRtl = this.dir === 'rtl';
       const offset = isRtl
         ? tabRect.right - listRect.right
         : tabRect.left - listRect.left;

--- a/2nd-gen/packages/swc/components/tabs/tabs.css
+++ b/2nd-gen/packages/swc/components/tabs/tabs.css
@@ -108,6 +108,13 @@
   --swc-tabs-indicator-color: token("disabled-border-color");
 }
 
+/* ── RTL ───────────────────────────────────────────────── */
+
+:host([direction="horizontal"]:dir(rtl)) .selection-indicator,
+:host(:not([direction]):dir(rtl)) .selection-indicator {
+  transform-origin: right center;
+}
+
 /* ── High contrast ─────────────────────────────────────── */
 
 @media (forced-colors: active) {

--- a/2nd-gen/packages/swc/components/tabs/test/tabs.test.ts
+++ b/2nd-gen/packages/swc/components/tabs/test/tabs.test.ts
@@ -1190,6 +1190,53 @@ export const SelectionIndicatorTest: Story = {
   },
 };
 
+export const SelectionIndicatorDirectionChangeTest: Story = {
+  render: () => html`
+    <div id="direction-wrapper" dir="ltr">
+      <swc-tabs selected="2" accessible-label="Direction change indicator test">
+        <swc-tab tab-id="1">Tab 1</swc-tab>
+        <swc-tab tab-id="2">Tab 2</swc-tab>
+        <swc-tab-panel tab-id="1"><p>Panel 1</p></swc-tab-panel>
+        <swc-tab-panel tab-id="2"><p>Panel 2</p></swc-tab-panel>
+      </swc-tabs>
+    </div>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const tabs = await getComponent<Tabs>(canvasElement, 'swc-tabs');
+    const wrapper = canvasElement.querySelector(
+      '#direction-wrapper'
+    ) as HTMLElement;
+
+    await step(
+      'indicator recalculates when an ancestor dir attribute flips at runtime',
+      async () => {
+        await tabs.updateComplete;
+        await new Promise((r) => requestAnimationFrame(r));
+        await tabs.updateComplete;
+
+        const indicator = tabs.shadowRoot?.querySelector(
+          '.selection-indicator'
+        ) as HTMLElement;
+        const styleBefore = indicator.getAttribute('style') || '';
+
+        wrapper.setAttribute('dir', 'rtl');
+
+        await tabs.updateComplete;
+        await new Promise((r) => requestAnimationFrame(r));
+        await tabs.updateComplete;
+
+        const styleAfter = indicator.getAttribute('style') || '';
+        expect(
+          styleBefore !== styleAfter,
+          'indicator style changed after an ancestor dir attribute flips to rtl'
+        ).toBe(true);
+
+        wrapper.removeAttribute('dir');
+      }
+    );
+  },
+};
+
 // ──────────────────────────────────────────────────────────────
 // TEST: Variants / States
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

`<swc-tabs>`'s animated selection indicator was rendering in the wrong horizontal position when the tab list is rendered in a right-to-left (RTL) context (`dir="rtl"` or an RTL-inheriting ancestor).

**Root cause:** the indicator's resting position is set in CSS via the logical property `inset-inline-start: 0`, which resolves to `right: 0` in RTL. However, `updateSelectionIndicator()` in `Tabs.base.ts` always computed the `translateX` offset as the distance from the container's **left** edge (`tabRect.left - listRect.left`), regardless of direction. In RTL, the indicator's anchor point (right edge) and the JS offset (measured from the left) disagreed, so the indicator was translated to the wrong spot instead of aligning under the selected tab.

**Fix:**
- `Tabs.base.ts`: detect the current writing direction via `getComputedStyle(this).direction === 'rtl'` (the same pattern already used by `placement-controller.ts`, `Tooltip.base.ts`, and `focusgroup-navigation-controller.ts`), and compute the offset from the container's right edge (`tabRect.right - listRect.right`) when RTL.
- `tabs.css`: added a `:dir(rtl)` override so `transform-origin` flips to `right center`, matching the indicator's RTL-anchored resting position (mirrors the existing `:dir(rtl)` pattern in `accordion-item.css`).

Vertical tabs are unaffected, since block-axis layout doesn't change with `dir`.

## Motivation and context

The horizontal selection indicator misalignment is visible on the `components-tabs-vrt--permutations` Storybook story and breaks the visual affordance for which tab is selected in any RTL locale.

## Related issue(s)

No related issue filed.

## Screenshots (if appropriate)

N/A — see the `components-tabs-vrt--permutations` Storybook story (RTL permutation) before/after this change for a visual comparison.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Selection indicator aligns with the selected tab in RTL_
  1. Open https://swcpreviews.z13.web.core.windows.net/pr-6466/docs/second-gen-storybook/?path=/story/components-tabs--playground&globals=textDirection:rtl
  2. Select each tab in turn
  3. Expect the indicator bar to sit directly under/beside the currently selected tab, with no gap or overlap, matching its LTR counterpart mirrored

- [ ] _No regression in LTR or vertical orientation_
  1. Open the default (LTR) https://swcpreviews.z13.web.core.windows.net/pr-6466/docs/second-gen-storybook/?path=/story/components-tabs--playground&globals=textDirection:ltr
  2. Select each tab in turn
  3. Expect the indicator to continue tracking the selected tab exactly as before this change

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  The selection indicator is a non-interactive, presentational element (`role="presentation"`, `pointer-events: none`) that is not part of the focus order. This change only affects its visual transform in RTL; it does not alter tab list keyboard navigation (Arrow keys, Home/End, Enter/Space).
  1. Go to any `<swc-tabs>` story with `dir="rtl"` applied
  2. Tab into the tab list and use Arrow Left/Right (already RTL-aware via `getNavigationDelta`) to move between tabs
  3. Expect focus and selection behavior to be unchanged; only the indicator's visual position should differ from before this fix

- [ ] **Screen reader** (required — document steps below)
  The selection indicator carries no accessible name, role, or state (`role="presentation"`) and is not announced. This is a purely visual fix with no screen reader-observable behavior.
  1. Go to any `<swc-tabs>` story with `dir="rtl"` applied
  2. Navigate through tabs with a screen reader active (e.g. VoiceOver)
  3. Expect tab name, selected state (`aria-selected`), and panel announcements to be unchanged before and after this fix