### PR TITLE
fix(menu, slider): use package imports for divider/handle registration

### DIFF
--- a/.changeset/fix-menu-slider-registration-import.md
+++ b/.changeset/fix-menu-slider-registration-import.md
@@ -1,0 +1,8 @@
+---
+'@spectrum-web-components/menu': patch
+'@spectrum-web-components/slider': patch
+---
+
+**fix(menu, slider):** Use package imports for `sp-menu-divider` and `sp-slider-handle` registration instead of relative imports.
+
+In build systems that alias `@spectrum-web-components/*` packages (for example UXP wrappers), a relative side-effect import can resolve to a different module instance than the package export consumers use, causing `NotSupportedError: Failed to execute 'define' on 'CustomElementRegistry'` from duplicate custom element registration. This applies the same fix as #3225 (already applied to `MenuGroup`, `DialogBase`, `DialogWrapper`, and `Table`) to `Menu` and `Slider`.

--- a/1st-gen/packages/menu/src/Menu.ts
+++ b/1st-gen/packages/menu/src/Menu.ts
@@ -28,7 +28,9 @@ import type { Overlay } from '@spectrum-web-components/overlay';
 import { RovingTabindexController } from '@spectrum-web-components/reactive-controllers/src/RovingTabindex.js';
 
 import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow500.js';
-import '../sp-menu-divider.js';
+// Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@spectrum-web-components/menu/sp-menu-divider.js';
 
 import menuStyles from './menu.css.js';
 import type {

--- a/1st-gen/packages/slider/sp-slider.ts
+++ b/1st-gen/packages/slider/sp-slider.ts
@@ -11,7 +11,8 @@
  */
 import { defineElement } from '@spectrum-web-components/base/src/define-element.js';
 
-import './sp-slider-handle.js'; // codify sp-slider's implicit dependency on sp-slider-handle
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@spectrum-web-components/slider/sp-slider-handle.js';
 
 import { Slider } from './src/Slider.js';
 


### PR DESCRIPTION
## Description

`Menu.ts` and `sp-slider.ts` register `sp-menu-divider` and `sp-slider-handle` via relative side-effect imports. In build systems that alias `@spectrum-web-components/*` packages (for example UXP wrappers), that relative path can resolve to a different module instance than the package export consumers use, causing duplicate custom element registration.

This applies the same fix as #3225 (already applied to `MenuGroup`, `DialogBase`, `DialogWrapper`, and `Table`) to `Menu` and `Slider`.

## Motivation and context

Related to #6420, opened by @Govind-gupta75. CI does not currently run against community contributions, so this re-creates that PR on an internal branch to get CI coverage. Credit for the original fix goes to @Govind-gupta75 (see the `Co-authored-by` trailer on the commit). #6420 will be closed manually in favor of this PR.

## Related issue(s)

- References #6420

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Accessibility testing checklist

- [ ] **Keyboard** — no behavioral change; import path only, no DOM/keyboard-affecting change.
- [ ] **Screen reader** — no behavioral change; import path only, no DOM/ARIA-affecting change.