### PR TITLE
fix(ci): commit release changes before rebasing onto main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Commit and push changes
         if: steps.extract-tag.outputs.tag == 'latest'
         run: |
-          git pull --rebase origin main
+          git pull --rebase --autostash origin main
           git add .
           git commit --no-verify -m "chore: release packages #publish" || echo "No changes to commit"
           git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -297,9 +297,9 @@ jobs:
       - name: Commit and push changes
         if: steps.extract-tag.outputs.tag == 'latest'
         run: |
-          git pull --rebase --autostash origin main
           git add .
           git commit --no-verify -m "chore: release packages #publish" || echo "No changes to commit"
+          git pull --rebase origin main
           git push
 
       - name: Create git tag


### PR DESCRIPTION
## Summary
- The "Version packages" step (`yarn changeset version`) leaves the working tree dirty before the later "Commit and push changes" step runs `git pull --rebase origin main`. If `main` has moved at all since checkout, that rebase aborts on unstaged changes (`cannot pull with rebase: you have unstaged changes`), and the whole version bump is discarded without anything being committed — this is exactly what happened in the run that #6470/#6471 recovered from manually.
- Commit the release changes locally first, then rebase that commit onto whatever's new on `main`, then push. The working tree is never dirty when `pull --rebase` runs, so there's nothing to abort on.

## Test plan
- [ ] CI passes on this PR
- [ ] Next scheduled release run completes the "Commit and push changes" step without manual recovery