### PR TITLE
chore(workflow): make changeset grep tolerant of no matches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,8 +49,8 @@ jobs:
             HAS_1ST_GEN=false
             for file in .changeset/*.md; do
               if [ "$(basename "$file")" != "README.md" ]; then
-                PACKAGES=$(grep -oP "@spectrum-web-components/[a-z-]+" "$file")
-                NON_CORE=$(echo "$PACKAGES" | grep -v "^@spectrum-web-components/core$")
+                PACKAGES=$(grep -oP "@spectrum-web-components/[a-z-]+" "$file" || true)
+                NON_CORE=$(echo "$PACKAGES" | grep -v "^@spectrum-web-components/core$" || true)
                 if [ -n "$NON_CORE" ]; then
                   HAS_1ST_GEN=true
                   break


### PR DESCRIPTION
## Description

The `publish.yml` workflow runs under `bash -e`. In the **Check for changesets** step, when a changeset file contains no `@spectrum-web-components/` mention, `grep -oP` exits with status 1, which under `-e` aborts the step and fails the job. Logs show `Found N changesets` immediately followed by a non-zero exit.

This guards the `grep` calls with `|| true` so a no-match result yields a zero exit and the loop continues, correctly detecting whether any non-core (1st-gen) package is referenced.

## Motivation and context

The publish job was failing on changesets that don't list package names.

https://github.com/adobe/spectrum-web-components/actions/runs/28891039549/job/85703536379

## Related issue(s)

- fixes [N/A]

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature.
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

> CI-only change (GitHub Actions workflow); no package code affected, so no changeset. Verified locally by running the loop under `bash -e` with a package-free changeset — the step no longer aborts.

