### PR TITLE
ci(vrt): add skip_vrt label to short-circuit the required Chromatic check

### DIFF
--- a/.github/workflows/chromatic-vrt.yml
+++ b/.github/workflows/chromatic-vrt.yml
@@ -31,7 +31,11 @@ jobs:
     name: Chromatic
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || contains(github.event.pull_request.labels.*.name, 'run_vrt') }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || contains(github.event.pull_request.labels.*.name, 'run_vrt') || contains(github.event.pull_request.labels.*.name, 'skip_vrt') }}
+    env:
+      # Skip the build but let Chromatic mark "UI Tests"/"UI Review" as passing.
+      # True for workflow_call opt-out, or a PR labeled skip_vrt (unless run_vrt wins).
+      SKIP_VRT: ${{ inputs.skip || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip_vrt') && !contains(github.event.pull_request.labels.*.name, 'run_vrt')) }}
     outputs:
       storybook-url: ${{ steps.chromatic.outputs.storybookUrl != 'undefined' && steps.chromatic.outputs.storybookUrl || '' }}
 
@@ -42,9 +46,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Job and Install Dependencies
+        if: ${{ env.SKIP_VRT != 'true' }}
         uses: ./.github/actions/setup-job
 
       - name: Generate Custom Elements Manifest
+        if: ${{ env.SKIP_VRT != 'true' }}
         working-directory: 2nd-gen/packages/swc
         run: yarn analyze
 
@@ -55,4 +61,4 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_TOKEN }}
           workingDir: 2nd-gen/packages/swc
           autoAcceptChanges: 'main'
-          skip: ${{ inputs.skip }}
+          skip: ${{ env.SKIP_VRT }}


### PR DESCRIPTION
## Description

The **UI Tests (Chromatic)** check is required on PRs. The `chromatic` job in `chromatic-vrt.yml` was gated by the `run_vrt` label. Without that label the entire job was skipped, so `chromaui/action` never ran and Chromatic never posted the required status — leaving PRs that don't touch components (docs, workflow changes) blocked with a permanently pending check.

This adds a `skip_vrt` label that runs the job in **skip mode**. Chromatic's own `skip` input marks `UI Tests` / `UI Review` as passing without running a build (per [Chromatic docs](https://www.chromatic.com/docs/github-actions/)):

> "Sometimes you might want to skip running a build for a certain branch but still have Chromatic mark the latest commit on that branch as 'passed'. Otherwise, pull requests could be blocked due to required checks that remain pending."

The `Setup Job` and `Generate Custom Elements Manifest` steps are skipped in this mode, so a `skip_vrt` PR only checks out and posts the status.

## Behavior

| PR labels | Job runs | Chromatic build | UI Tests check |
| --- | --- | --- | --- |
| `run_vrt` | yes | yes | real result |
| `skip_vrt` | yes (skip mode) | no | green, no build |
| both | yes | yes (`run_vrt` wins) | real result |
| neither | no | no | pending (must label) |

The existing `workflow_call` `inputs.skip` opt-out is preserved.

## Motivation and context

Docs-only and CI-only PRs are known-safe for VRT but were blocked by the required Chromatic check. `skip_vrt` gives an explicit, auditable green escape hatch without weakening coverage on component PRs.

## Related issue(s)

- fixes [N/A]

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have included updated documentation if my change required it.

> CI-only change (GitHub Actions workflow); no package code, no changeset. This PR is labeled `skip_vrt` to exercise the new path — the `UI Tests (Chromatic)` check should report green without a Chromatic build.