### PR TITLE
chore: regenerate stale version.ts files

### DIFF
--- a/1st-gen/tools/base/src/version.ts
+++ b/1st-gen/tools/base/src/version.ts
@@ -17,9 +17,9 @@
 /**
  * The version of the 1st-gen Spectrum Web Components library.
  */
-export const version = '1.12.1';
+export const version = '1.12.2';
 
 /**
  * The version of the core base package.
  */
-export const coreVersion = '0.1.0';
+export const coreVersion = '0.3.0';

--- a/2nd-gen/packages/core/element/version.ts
+++ b/2nd-gen/packages/core/element/version.ts
@@ -17,9 +17,9 @@
 /**
  * The version of the 2nd-gen Spectrum Web Components library.
  */
-export const version = '0.1.0';
+export const version = '0.3.0';
 
 /**
  * The version of the core base package.
  */
-export const coreVersion = '0.1.0';
+export const coreVersion = '0.3.0';


### PR DESCRIPTION
## Description

Regenerates `1st-gen/tools/base/src/version.ts` and `2nd-gen/packages/core/element/version.ts` via `scripts/generate-versions.js`, since both had drifted from their source `package.json` versions:

- `1st-gen/tools/base`: `1.12.1` → `1.12.2` (and `coreVersion` `0.1.0` → `0.3.0`)
- `2nd-gen/packages/core`: `0.1.0` → `0.3.0` (both `version` and `coreVersion`)

## Motivation and context

These files are auto-generated (marked `DO NOT EDIT`) but had gone stale relative to their `package.json` versions. Regenerating keeps the exported `version`/`coreVersion` constants accurate for consumers.

## Related issue(s)

- N/A — routine sync, no linked issue.

## Author's checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md) and [PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md) documents.
- [ ] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Accessibility testing checklist

- [ ] **Keyboard**: No user-facing or interactive changes; these are generated constants with no DOM/keyboard surface.
- [ ] **Screen reader**: No user-facing or interactive changes; no roles, labels, or announcements are affected.