### PR TITLE
docs: hide Stories code blocks by default

### DIFF
--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -187,7 +187,8 @@ const preview = {
       canvas: {
         withToolbar: true,
         layout: 'centered',
-        sourceState: 'shown',
+        // Individual stories can override this with parameters.docs.canvas.sourceState.
+        sourceState: 'hidden',
       },
       source: {
         excludeDecorators: true,


### PR DESCRIPTION
## Description

So... much... cleaner? https://swcpreviews.z13.web.core.windows.net/pr-6481/docs/gen2-storybook-prod/?path=/docs/components-button--docs

Hide gen2 Storybook docs canvas source blocks by default by changing the global `parameters.docs.canvas.sourceState` default to `hidden`.

Individual stories can still override the default with `parameters.docs.canvas.sourceState` when a story needs its source shown or omitted.

## Motivation and context

The rendered examples should be the first thing readers see in gen2 docs. Hiding source by default keeps docs pages easier to scan while preserving the source toolbar for readers who want to expand the code.

## Related issue(s)

- N/A

## Screenshots (if appropriate)

N/A

---

## Author's checklist

- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Storybook docs hide source by default
  1. Run the gen2 Storybook locally.
  2. Open a component docs page with a Canvas story.
  3. Expect the source block to be hidden until expanded from the canvas toolbar.

- [ ] Story-level overrides still work
  1. Open a story that sets `parameters.docs.canvas.sourceState` explicitly.
  2. Compare the rendered docs canvas source state with that override.
  3. Expect the story-level setting to take precedence over the global hidden default.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

**Required:** Complete each applicable item and document your testing steps (replace the placeholders with your component-specific instructions).

- [ ] **Keyboard** (required — document steps below) — _What to test for:_ Focus order is logical; <kbd>Tab</kbd> reaches the component and all interactive descendants; <kbd>Enter</kbd>/<kbd>Space</kbd> activate where appropriate; arrow keys work for tabs, menus, sliders, etc.; no focus traps; <kbd>Escape</kbd> dismisses when applicable; focus indicator is visible.
  1. Run the gen2 Storybook locally.
  2. Navigate to a docs Canvas toolbar using the keyboard.
  3. Expect the source toggle to remain keyboard accessible and expand the hidden source when activated.

- [ ] **Screen reader** (required — document steps below) — _What to test for:_ Role and name are announced correctly; state changes (e.g. expanded, selected) are announced; labels and relationships are clear; no unnecessary or duplicate announcements.
  1. Run the gen2 Storybook locally with a screen reader.
  2. Navigate to a docs Canvas toolbar and source toggle.
  3. Expect the existing Storybook control semantics to remain available; this change does not alter component semantics.