### PR TITLE
test(infield-button): add complete test suites for Phase 6

### DIFF
--- a/2nd-gen/packages/swc/components/infield-button/test/infield-button.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/infield-button/test/infield-button.a11y.spec.ts
@@ -159,28 +159,6 @@ test.describe('Infield Button - Keyboard Interactions', () => {
       'Tab does not focus swc-infield-button — component is pointer-only'
     ).not.toBe('swc-infield-button');
   });
-
-  test('inner button should not be in tab order — tabindex="-1"', async ({
-    page,
-  }) => {
-    await gotoStory(
-      page,
-      'components-infield-button--overview',
-      'swc-infield-button'
-    );
-    // Verify that pressing Tab does not land on any infield button component.
-    await page.keyboard.press('Tab');
-    const isInfieldFocused = await page.evaluate(() => {
-      const active = document.activeElement;
-      return (
-        active instanceof HTMLElement &&
-        active.tagName.toLowerCase() === 'swc-infield-button'
-      );
-    });
-    expect(isInfieldFocused, 'swc-infield-button is not in the tab order').toBe(
-      false
-    );
-  });
 });
 
 test.describe('Infield Button - Pointer Interactions', () => {

--- a/2nd-gen/packages/swc/components/infield-button/test/infield-button.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/infield-button/test/infield-button.a11y.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { gotoStory } from '../../../utils/a11y-helpers.js';
+
+/**
+ * Accessibility tests for Infield Button component (2nd generation).
+ *
+ * ARIA snapshot tests validate the accessibility tree structure.
+ * aXe WCAG compliance and color contrast validation are run via
+ * test-storybook (see .storybook/test-runner.ts). Both are included
+ * in the `test:a11y` command.
+ */
+
+test.describe('Infield Button - ARIA Snapshots', () => {
+  test('should have correct accessibility tree for default button', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-infield-button--overview',
+      'swc-infield-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Open picker"
+    `);
+  });
+
+  test('should handle anatomy — all four icon-only affordances', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-infield-button--anatomy',
+      'swc-infield-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Open picker"
+      - button "Clear"
+      - button "Increment"
+      - button "Decrement"
+    `);
+  });
+
+  test('should handle all four sizes with correct accessible names', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-infield-button--sizes',
+      'swc-infield-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Small open picker"
+      - button "Medium open picker"
+      - button "Large open picker"
+      - button "Extra-large open picker"
+    `);
+  });
+
+  test('should handle quiet variant — same role, no ARIA change', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-infield-button--quiet',
+      'swc-infield-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Open picker (default)"
+      - button "Open picker (quiet)"
+    `);
+  });
+
+  test('should handle disabled state with native disabled attribute', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-infield-button--states',
+      'swc-infield-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Open picker"
+      - button "Open picker (disabled)" [disabled]
+      - button "Open picker (quiet)"
+      - button "Open picker (quiet disabled)" [disabled]
+    `);
+  });
+
+  test('should have correct accessibility tree for accessibility story', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-infield-button--accessibility',
+      'swc-infield-button'
+    );
+    await expect(root).toMatchAriaSnapshot(`
+      - button "Open picker"
+    `);
+  });
+
+  test('should have no role attribute on the host element', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-infield-button--overview',
+      'swc-infield-button'
+    );
+    const host = root.locator('swc-infield-button').first();
+    await expect(host).not.toHaveAttribute('role');
+  });
+
+  test('inner button should have tabindex="-1" — not in tab order', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-infield-button--overview',
+      'swc-infield-button'
+    );
+    const host = root.locator('swc-infield-button').first();
+    const internalButton = host.locator('button').first();
+    await expect(internalButton).toHaveAttribute('tabindex', '-1');
+  });
+});
+
+test.describe('Infield Button - Keyboard Interactions', () => {
+  test('should NOT receive focus via Tab — button is pointer-only', async ({
+    page,
+  }) => {
+    await gotoStory(
+      page,
+      'components-infield-button--overview',
+      'swc-infield-button'
+    );
+    // Press Tab: infield buttons are removed from the tab order; no button
+    // should receive keyboard focus.
+    await page.keyboard.press('Tab');
+    const focused = await page.evaluate(() => {
+      const active = document.activeElement;
+      return active?.tagName.toLowerCase() ?? '';
+    });
+    expect(
+      focused,
+      'Tab does not focus swc-infield-button — component is pointer-only'
+    ).not.toBe('swc-infield-button');
+  });
+
+  test('inner button should not be in tab order — tabindex="-1"', async ({
+    page,
+  }) => {
+    await gotoStory(
+      page,
+      'components-infield-button--overview',
+      'swc-infield-button'
+    );
+    // Verify that pressing Tab does not land on any infield button component.
+    await page.keyboard.press('Tab');
+    const isInfieldFocused = await page.evaluate(() => {
+      const active = document.activeElement;
+      return (
+        active instanceof HTMLElement &&
+        active.tagName.toLowerCase() === 'swc-infield-button'
+      );
+    });
+    expect(isInfieldFocused, 'swc-infield-button is not in the tab order').toBe(
+      false
+    );
+  });
+});
+
+test.describe('Infield Button - Pointer Interactions', () => {
+  test('should fire click event when clicked while enabled', async ({
+    page,
+  }) => {
+    await gotoStory(
+      page,
+      'components-infield-button--overview',
+      'swc-infield-button'
+    );
+    await page.evaluate(() => {
+      const el = document.querySelector('swc-infield-button')!;
+      (el as any).__clickCount = 0;
+      el.addEventListener('click', () => {
+        (el as any).__clickCount++;
+      });
+    });
+
+    await page.locator('swc-infield-button').first().click();
+
+    const count = await page.evaluate(
+      () => (document.querySelector('swc-infield-button') as any).__clickCount
+    );
+    expect(count, 'click event fires when button is enabled').toBe(1);
+  });
+
+  test('should not fire click event when clicked while disabled', async ({
+    page,
+  }) => {
+    const root = await gotoStory(
+      page,
+      'components-infield-button--states',
+      'swc-infield-button'
+    );
+    // The disabled button is the second in the States story.
+    const disabledButton = root.locator('swc-infield-button[disabled]').first();
+
+    await page.evaluate(() => {
+      const el = document.querySelector('swc-infield-button[disabled]')!;
+      (el as any).__clickCount = 0;
+      el.addEventListener('click', () => {
+        (el as any).__clickCount++;
+      });
+    });
+
+    // Playwright click on a disabled element still dispatches the event at
+    // the browser level — handleClick on the host suppresses it.
+    await disabledButton.click({ force: true });
+
+    const count = await page.evaluate(() => {
+      const el = document.querySelector('swc-infield-button[disabled]') as any;
+      return el.__clickCount;
+    });
+    expect(count, 'click is suppressed while disabled').toBe(0);
+  });
+});

--- a/2nd-gen/packages/swc/components/infield-button/test/infield-button.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/infield-button/test/infield-button.a11y.spec.ts
@@ -33,11 +33,12 @@ test.describe('Infield Button - ARIA Snapshots', () => {
       'swc-infield-button'
     );
     await expect(root).toMatchAriaSnapshot(`
-      - button "Open picker"
+      - textbox "Country"
+      - button "Open country picker"
     `);
   });
 
-  test('should handle anatomy — all four icon-only affordances', async ({
+  test('should handle anatomy — three real field use cases', async ({
     page,
   }) => {
     const root = await gotoStory(
@@ -46,10 +47,13 @@ test.describe('Infield Button - ARIA Snapshots', () => {
       'swc-infield-button'
     );
     await expect(root).toMatchAriaSnapshot(`
-      - button "Open picker"
-      - button "Clear"
-      - button "Increment"
-      - button "Decrement"
+      - textbox "Country"
+      - button "Open country picker"
+      - searchbox "Keyword"
+      - button "Clear keyword search"
+      - spinbutton "Quantity"
+      - button "Decrement quantity"
+      - button "Increment quantity"
     `);
   });
 
@@ -108,7 +112,13 @@ test.describe('Infield Button - ARIA Snapshots', () => {
       'swc-infield-button'
     );
     await expect(root).toMatchAriaSnapshot(`
-      - button "Open picker"
+      - textbox "Country"
+      - button "Open country picker"
+      - searchbox "Keyword"
+      - button "Clear keyword search"
+      - spinbutton "Quantity"
+      - button "Decrement quantity"
+      - button "Increment quantity"
     `);
   });
 
@@ -147,17 +157,22 @@ test.describe('Infield Button - Keyboard Interactions', () => {
       'components-infield-button--overview',
       'swc-infield-button'
     );
-    // Press Tab: infield buttons are removed from the tab order; no button
-    // should receive keyboard focus.
-    await page.keyboard.press('Tab');
-    const focused = await page.evaluate(() => {
-      const active = document.activeElement;
-      return active?.tagName.toLowerCase() ?? '';
-    });
-    expect(
-      focused,
-      'Tab does not focus swc-infield-button — component is pointer-only'
-    ).not.toBe('swc-infield-button');
+    // Tab through the entire story; swc-infield-button must never be the
+    // active element (the native <input> may receive focus, which is correct).
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('Tab');
+      const focused = await page.evaluate(() => {
+        const active = document.activeElement;
+        return active?.tagName.toLowerCase() ?? '';
+      });
+      if (focused === 'swc-infield-button') {
+        expect(
+          focused,
+          'Tab must not land on swc-infield-button — component is pointer-only'
+        ).not.toBe('swc-infield-button');
+        break;
+      }
+    }
   });
 });
 

--- a/2nd-gen/packages/swc/components/infield-button/test/infield-button.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/infield-button/test/infield-button.a11y.spec.ts
@@ -51,8 +51,8 @@ test.describe('Infield Button - ARIA Snapshots', () => {
       - button "Open country picker"
       - searchbox "Keyword"
       - button "Clear keyword search"
-      - spinbutton "Quantity"
       - button "Decrement quantity"
+      - spinbutton "Quantity"
       - button "Increment quantity"
     `);
   });
@@ -116,8 +116,8 @@ test.describe('Infield Button - ARIA Snapshots', () => {
       - button "Open country picker"
       - searchbox "Keyword"
       - button "Clear keyword search"
-      - spinbutton "Quantity"
       - button "Decrement quantity"
+      - spinbutton "Quantity"
       - button "Increment quantity"
     `);
   });

--- a/2nd-gen/packages/swc/components/infield-button/test/infield-button.test.ts
+++ b/2nd-gen/packages/swc/components/infield-button/test/infield-button.test.ts
@@ -25,7 +25,6 @@ import {
   withWarningSpy,
 } from '../../../utils/test-utils.js';
 import meta, {
-  Accessibility,
   Anatomy,
   Overview,
   Quiet,
@@ -470,7 +469,22 @@ export const FocusDelegationTest: Story = {
 };
 
 export const AccessibilityTest: Story = {
-  ...Accessibility,
+  // Standalone render so this test story is independent of the docs Accessibility
+  // story's field-context layout. The accessible-label value must be stable across
+  // refactors to the docs story.
+  render: () => html`
+    <swc-infield-button accessible-label="Open picker">
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 10 10"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M5 7.376 1.281 3.656l.875-.875L5 5.625l2.844-2.844.875.875Z" />
+      </svg>
+    </swc-infield-button>
+  `,
   play: async ({ canvasElement, step }) => {
     const button = await getComponent<InfieldButton>(
       canvasElement,

--- a/2nd-gen/packages/swc/components/infield-button/test/infield-button.test.ts
+++ b/2nd-gen/packages/swc/components/infield-button/test/infield-button.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import { InfieldButton } from '@adobe/spectrum-wc/infield-button';
+import { INFIELD_BUTTON_VALID_SIZES } from '@adobe/spectrum-wc-core/components/infield-button';
+
+import '@adobe/spectrum-wc/components/infield-button/swc-infield-button.js';
+
+import {
+  getComponent,
+  getComponents,
+  withWarningSpy,
+} from '../../../utils/test-utils.js';
+import meta, {
+  Accessibility,
+  Anatomy,
+  Overview,
+  Quiet,
+  Sizes,
+  States,
+} from '../stories/infield-button.stories.js';
+
+export default {
+  ...meta,
+  title: 'Infield Button/Tests',
+  parameters: {
+    ...meta.parameters,
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+// Shared inline chevron SVG used in tests that need a slotted icon.
+const chevronSvg = `<svg slot="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" aria-hidden="true" focusable="false"><path d="M5 7.376 1.281 3.656l.875-.875L5 5.625l2.844-2.844.875.875Z"/></svg>`;
+
+// ──────────────────────────────────────────────────────────────
+// SECTION 1: Defaults
+// ──────────────────────────────────────────────────────────────
+
+export const OverviewTest: Story = {
+  ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const button = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+
+    await step('renders expected default property values', async () => {
+      expect(button.quiet, 'quiet defaults to false').toBe(false);
+      expect(button.disabled, 'disabled defaults to false').toBe(false);
+      expect(button.size, 'size is set to m from Overview story').toBe('m');
+    });
+
+    await step(
+      'renders internal <button> as semantic control in shadow root',
+      async () => {
+        const internalButton = button.renderRoot.querySelector('button');
+        expect(
+          internalButton,
+          'internal <button> exists in shadow root'
+        ).toBeTruthy();
+      }
+    );
+
+    await step(
+      'sets type="button" on inner button to prevent form submission',
+      async () => {
+        const internalButton = button.renderRoot.querySelector('button');
+        expect(
+          internalButton?.getAttribute('type'),
+          'inner button has type="button"'
+        ).toBe('button');
+      }
+    );
+
+    await step(
+      'sets tabindex="-1" on inner button — button is pointer-only, not in tab order',
+      async () => {
+        const internalButton = button.renderRoot.querySelector('button');
+        expect(
+          internalButton?.getAttribute('tabindex'),
+          'inner button has tabindex="-1"'
+        ).toBe('-1');
+      }
+    );
+
+    await step('excludes role attribute from host element', async () => {
+      expect(
+        button.getAttribute('role'),
+        'host has no role attribute'
+      ).toBeNull();
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// SECTION 2: Properties / Attributes
+// ──────────────────────────────────────────────────────────────
+
+export const PropertyMutationTest: Story = {
+  ...Overview,
+  play: async ({ canvasElement, step }) => {
+    const button = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+
+    await step(
+      'reflects each valid size to attribute after mutation',
+      async () => {
+        for (const size of INFIELD_BUTTON_VALID_SIZES) {
+          button.size = size;
+          await button.updateComplete;
+          expect(
+            button.getAttribute('size'),
+            `size="${size}" reflects after mutation`
+          ).toBe(size);
+          expect(button.size, `size property equals "${size}"`).toBe(size);
+        }
+      }
+    );
+
+    await step(
+      'reflects quiet to and from attribute after mutation',
+      async () => {
+        button.quiet = true;
+        await button.updateComplete;
+        expect(
+          button.hasAttribute('quiet'),
+          'quiet=true adds attribute to host'
+        ).toBe(true);
+
+        button.quiet = false;
+        await button.updateComplete;
+        expect(
+          button.hasAttribute('quiet'),
+          'quiet=false removes attribute from host'
+        ).toBe(false);
+      }
+    );
+
+    await step(
+      'reflects disabled to and from attribute after mutation',
+      async () => {
+        button.disabled = true;
+        await button.updateComplete;
+        expect(
+          button.hasAttribute('disabled'),
+          'disabled=true adds attribute to host'
+        ).toBe(true);
+
+        button.disabled = false;
+        await button.updateComplete;
+        expect(
+          button.hasAttribute('disabled'),
+          'disabled=false removes attribute from host'
+        ).toBe(false);
+      }
+    );
+  },
+};
+
+export const AccessibleLabelTest: Story = {
+  render: () => html`
+    <swc-infield-button>
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 10 10"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M5 7.376 1.281 3.656l.875-.875L5 5.625l2.844-2.844.875.875Z" />
+      </svg>
+    </swc-infield-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const button = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+    const internalButton = button.renderRoot.querySelector('button');
+
+    await step(
+      'omits aria-label from internal button when accessible-label is not set',
+      async () => {
+        expect(
+          internalButton?.getAttribute('aria-label'),
+          'no aria-label without accessibleLabel'
+        ).toBeNull();
+      }
+    );
+
+    await step(
+      'forwards accessible-label as aria-label on internal button after mutation',
+      async () => {
+        button.accessibleLabel = 'Clear search';
+        await button.updateComplete;
+        expect(
+          internalButton?.getAttribute('aria-label'),
+          'aria-label matches new accessibleLabel'
+        ).toBe('Clear search');
+      }
+    );
+
+    await step(
+      'clears aria-label from internal button when accessible-label is removed',
+      async () => {
+        button.accessibleLabel = undefined;
+        await button.updateComplete;
+        expect(
+          internalButton?.getAttribute('aria-label'),
+          'aria-label removed after clearing accessibleLabel'
+        ).toBeNull();
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// SECTION 3: Slots
+// ──────────────────────────────────────────────────────────────
+
+export const AnatomyTest: Story = {
+  ...Anatomy,
+  play: async ({ canvasElement, step }) => {
+    const buttons = await getComponents<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+
+    await step('renders all four Anatomy buttons', async () => {
+      expect(buttons.length, 'four Anatomy buttons are rendered').toBe(4);
+    });
+
+    await step('each Anatomy button has a slotted icon element', async () => {
+      for (const btn of buttons) {
+        const slottedIcon = btn.querySelector('[slot="icon"]');
+        expect(
+          slottedIcon,
+          `${btn.getAttribute('accessible-label') ?? 'button'} has a slotted icon`
+        ).toBeTruthy();
+      }
+    });
+
+    await step(
+      'each Anatomy button has an aria-label on its inner button',
+      async () => {
+        for (const btn of buttons) {
+          await btn.updateComplete;
+          const internalButton = btn.renderRoot.querySelector('button');
+          expect(
+            internalButton?.getAttribute('aria-label'),
+            `${btn.getAttribute('accessible-label') ?? 'button'} inner button has aria-label`
+          ).toBeTruthy();
+        }
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// SECTION 4: Variants / States
+// ──────────────────────────────────────────────────────────────
+
+export const SizesTest: Story = {
+  ...Sizes,
+  play: async ({ canvasElement, step }) => {
+    await step('renders all valid sizes', async () => {
+      for (const size of INFIELD_BUTTON_VALID_SIZES) {
+        const button = canvasElement.querySelector(
+          `swc-infield-button[size="${size}"]`
+        ) as InfieldButton;
+        await button.updateComplete;
+        expect(button.size, `size="${size}" is reflected`).toBe(size);
+      }
+    });
+  },
+};
+
+export const QuietTest: Story = {
+  ...Quiet,
+  play: async ({ canvasElement, step }) => {
+    await step(
+      'renders default and quiet variants with correct quiet attribute state',
+      async () => {
+        const buttons = await getComponents<InfieldButton>(
+          canvasElement,
+          'swc-infield-button'
+        );
+        const [defaultButton, quietButton] = buttons;
+
+        expect(defaultButton.quiet, 'default button quiet is false').toBe(
+          false
+        );
+        expect(
+          defaultButton.hasAttribute('quiet'),
+          'default button has no quiet attribute'
+        ).toBe(false);
+
+        expect(quietButton.quiet, 'quiet button quiet is true').toBe(true);
+        expect(
+          quietButton.hasAttribute('quiet'),
+          'quiet button has quiet attribute'
+        ).toBe(true);
+      }
+    );
+  },
+};
+
+export const StatesTest: Story = {
+  ...States,
+  play: async ({ canvasElement, step }) => {
+    const defaultButton = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button:not([disabled]):not([quiet])'
+    );
+    const disabledButton = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button[disabled]:not([quiet])'
+    );
+
+    await step(
+      'verifies default button is neither disabled nor quiet',
+      async () => {
+        expect(defaultButton.disabled, 'default button disabled is false').toBe(
+          false
+        );
+        expect(defaultButton.quiet, 'default button quiet is false').toBe(
+          false
+        );
+        const internalButton = defaultButton.renderRoot.querySelector('button');
+        expect(
+          internalButton?.hasAttribute('disabled'),
+          'default inner button has no native disabled'
+        ).toBe(false);
+      }
+    );
+
+    await step(
+      'verifies disabled button uses native disabled on internal button',
+      async () => {
+        expect(disabledButton.disabled, 'disabled prop is true').toBe(true);
+        const internalButton =
+          disabledButton.renderRoot.querySelector('button');
+        expect(
+          internalButton?.hasAttribute('disabled'),
+          'native disabled is set on internal button'
+        ).toBe(true);
+        expect(
+          internalButton?.getAttribute('aria-disabled'),
+          'disabled does not add aria-disabled'
+        ).toBeNull();
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// SECTION 5: Behaviors
+// ──────────────────────────────────────────────────────────────
+
+export const DisabledBehaviorTest: Story = {
+  render: () => html`
+    <swc-infield-button
+      disabled
+      accessible-label="Clear"
+      .innerHTML=${chevronSvg}
+    ></swc-infield-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const button = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+
+    await step('suppresses click events while disabled', async () => {
+      let clickCount = 0;
+      const listener = () => {
+        clickCount++;
+      };
+      button.addEventListener('click', listener);
+      button.click();
+      await button.updateComplete;
+      button.removeEventListener('click', listener);
+      expect(clickCount, 'click is suppressed while disabled').toBe(0);
+    });
+  },
+};
+
+export const ClickBehaviorTest: Story = {
+  render: () => html`
+    <swc-infield-button accessible-label="Clear">
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 10 10"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M5 7.376 1.281 3.656l.875-.875L5 5.625l2.844-2.844.875.875Z" />
+      </svg>
+    </swc-infield-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const button = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+
+    await step('allows click events when not disabled', async () => {
+      let clickCount = 0;
+      const listener = () => {
+        clickCount++;
+      };
+      button.addEventListener('click', listener);
+      button.click();
+      await button.updateComplete;
+      button.removeEventListener('click', listener);
+      expect(clickCount, 'click fires normally when enabled').toBe(1);
+    });
+  },
+};
+
+export const FocusDelegationTest: Story = {
+  render: () => html`
+    <swc-infield-button accessible-label="Clear">
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 10 10"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M5 7.376 1.281 3.656l.875-.875L5 5.625l2.844-2.844.875.875Z" />
+      </svg>
+    </swc-infield-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const button = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+
+    await step(
+      'does not delegate focus to inner button — infield buttons are pointer-only',
+      async () => {
+        button.focus();
+        const activeElement = (button.renderRoot as ShadowRoot).activeElement;
+        expect(
+          activeElement,
+          'delegatesFocus=false means inner button is not focused via host.focus()'
+        ).toBeNull();
+      }
+    );
+  },
+};
+
+export const AccessibilityTest: Story = {
+  ...Accessibility,
+  play: async ({ canvasElement, step }) => {
+    const button = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+
+    await step(
+      'forwards accessible-label as aria-label on internal button',
+      async () => {
+        const internalButton = button.renderRoot.querySelector('button');
+        expect(
+          internalButton?.getAttribute('aria-label'),
+          'accessible-label is forwarded to internal button as aria-label'
+        ).toBe('Open picker');
+      }
+    );
+
+    await step(
+      'internal button has no aria-pressed or aria-expanded',
+      async () => {
+        const internalButton = button.renderRoot.querySelector('button');
+        expect(
+          internalButton?.getAttribute('aria-pressed'),
+          'no aria-pressed on infield button'
+        ).toBeNull();
+        expect(
+          internalButton?.getAttribute('aria-expanded'),
+          'no aria-expanded on infield button by default'
+        ).toBeNull();
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// SECTION 6: Dev mode warnings
+// ──────────────────────────────────────────────────────────────
+
+export const IconOnlyMissingLabelWarningTest: Story = {
+  render: () => html`
+    <swc-infield-button>
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 10 10"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M5 7.376 1.281 3.656l.875-.875L5 5.625l2.844-2.844.875.875Z" />
+      </svg>
+    </swc-infield-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const button = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+
+    await step('warns when icon-only button is missing accessible-label', () =>
+      withWarningSpy(async (warnCalls) => {
+        button.requestUpdate();
+        await button.updateComplete;
+
+        expect(
+          warnCalls.length,
+          'warning emitted for icon-only button without accessible-label'
+        ).toBeGreaterThan(0);
+        expect(
+          String(warnCalls[0]?.[1] || ''),
+          'warning message mentions accessible-label'
+        ).toContain('accessible-label');
+      })
+    );
+  },
+};
+
+export const IconOnlyWithLabelNoWarningTest: Story = {
+  render: () => html`
+    <swc-infield-button accessible-label="Open picker">
+      <svg
+        slot="icon"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 10 10"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M5 7.376 1.281 3.656l.875-.875L5 5.625l2.844-2.844.875.875Z" />
+      </svg>
+    </swc-infield-button>
+  `,
+  play: async ({ canvasElement, step }) => {
+    const button = await getComponent<InfieldButton>(
+      canvasElement,
+      'swc-infield-button'
+    );
+
+    await step(
+      'emits no warnings when icon-only button has an accessible-label',
+      () =>
+        withWarningSpy(async (warnCalls) => {
+          button.requestUpdate();
+          await button.updateComplete;
+
+          expect(
+            warnCalls.length,
+            'no warning emitted when accessible-label is present'
+          ).toBe(0);
+        })
+    );
+  },
+};

--- a/2nd-gen/packages/swc/components/infield-button/test/infield-button.test.ts
+++ b/2nd-gen/packages/swc/components/infield-button/test/infield-button.test.ts
@@ -281,10 +281,10 @@ export const SizesTest: Story = {
   play: async ({ canvasElement, step }) => {
     await step('renders all valid sizes', async () => {
       for (const size of INFIELD_BUTTON_VALID_SIZES) {
-        const button = canvasElement.querySelector(
+        const button = await getComponent<InfieldButton>(
+          canvasElement,
           `swc-infield-button[size="${size}"]`
-        ) as InfieldButton;
-        await button.updateComplete;
+        );
         expect(button.size, `size="${size}" is reflected`).toBe(size);
       }
     });


### PR DESCRIPTION
## Description

Adds the Phase 6 test suite for the 2nd-gen `swc-infield-button` component. This PR contains only test and story files; the component implementation ships in the Phase 5 PR and must be merged into `swc-2105/infield-button` before this branch is rebased.

**Files added:**

- `stories/infield-button.stories.ts` — Storybook stories with the Quiet story updated to render both default and quiet variants side-by-side for test comparison
- `test/infield-button.test.ts` — 13 Storybook/Vitest play-function stories covering: defaults, property reflection (size, quiet, disabled, accessible-label), anatomy slots, sizes, quiet variant, states, click suppression, focus delegation, and dev-mode warnings
- `test/infield-button.a11y.spec.ts` — Playwright ARIA snapshot tests for all 6 stories plus keyboard (Tab does not focus the button) and pointer interaction tests (click fires when enabled, suppressed when disabled)

## Motivation and context

Phase 6 of the infield-button 2nd-gen migration. Establishes automated coverage for the full `InfieldButton` API surface so regressions can be caught during future refactors and dependency bumps.

**Depends on:** Phase 5 PR must merge into `swc-2105/infield-button` before this branch can be rebased and run independently.

## Related issue(s)

- SWC-2105

## Screenshots (if appropriate)

N/A — test-only PR.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

> **Note:** This PR depends on the Phase 5 implementation. Run these steps after Phase 5 merges into `swc-2105/infield-button` and this branch is rebased on top.

- [ ] **Vitest play functions pass**
  1. From `2nd-gen/packages/swc/`, run `yarn vitest --project storybook infield-button`
  2. Expect all 13 test stories to pass: `OverviewTest`, `PropertyMutationTest`, `AccessibleLabelTest`, `AnatomyTest`, `SizesTest`, `QuietTest`, `StatesTest`, `DisabledBehaviorTest`, `ClickBehaviorTest`, `FocusDelegationTest`, `AccessibilityTest`, `IconOnlyMissingLabelWarningTest`, `IconOnlyWithLabelNoWarningTest`

- [ ] **Playwright a11y spec passes**
  1. From `2nd-gen/packages/swc/`, run `yarn playwright test infield-button.a11y.spec.ts`
  2. Expect all tests in three groups to pass: ARIA Snapshots (8 tests), Keyboard Interactions (2 tests), Pointer Interactions (2 tests)

- [ ] **Storybook stories render correctly**
  1. Run `yarn storybook` from `2nd-gen/packages/swc/`
  2. Navigate to **Infield Button** in the sidebar
  3. Verify Overview shows a single medium button with chevron icon
  4. Verify Anatomy shows four icon affordances: Open picker, Clear, Increment, Decrement
  5. Verify Sizes shows all four sizes (s, m, l, xl)
  6. Verify Quiet shows default and quiet variants side-by-side
  7. Verify States shows default, disabled, quiet, and quiet-disabled
  8. Verify Accessibility shows a labeled button ("Open picker")

- [ ] **No regressions in Action Button**
  1. Run `yarn vitest --project storybook action-button`
  2. Expect all action-button tests to still pass (shared `ButtonBase` logic)

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

**Required:** Complete each applicable item and document your testing steps.

- [x] **Keyboard** (infield buttons are pointer-only; Tab must not focus them)
  1. Run Storybook and navigate to **Infield Button > Overview**
  2. Press <kbd>Tab</kbd> once
  3. Expect: focus does not land on `swc-infield-button` — the component is intentionally excluded from the tab order (`tabindex="-1"` on the inner button, `delegatesFocus: false` on the shadow root). Keyboard activation is the responsibility of the parent field.

- [x] **Screen reader** (button role and accessible name must be announced)
  1. Run Storybook and navigate to **Infield Button > Accessibility**
  2. Enable VoiceOver (macOS) or NVDA (Windows) and move focus to the `swc-infield-button` element
  3. Expect: screen reader announces "Open picker, button" — role `button` and the `accessible-label` value are correctly forwarded via `aria-label` on the inner `<button>` element
  4. Navigate to **Infield Button > States** and locate the disabled button
  5. Expect: screen reader announces the button as dimmed/unavailable — the native `disabled` attribute on the inner `<button>` provides the state without requiring `aria-disabled`