### PR TITLE
fix(popover): reset stuck trigger-press flag on drag-off release

### DIFF
--- a/.changeset/fix-popover-trigger-pointer-active-stuck.md
+++ b/.changeset/fix-popover-trigger-pointer-active-stuck.md
@@ -1,0 +1,8 @@
+---
+'@spectrum-web-components/core': patch
+'@adobe/spectrum-wc': patch
+---
+
+**fix(popover):** Fixed `swc-popover` staying dismissed on the next unrelated outside click after a trigger press was dragged off and released elsewhere.
+
+A `pointerdown` on the trigger followed by a drag off the trigger and a release elsewhere never dispatches a `click`, so the internal reopen-guard flag was left stuck `true`, misattributing the next unrelated outside light-dismiss to that stale press and swallowing the following legitimate trigger click.

--- a/2nd-gen/packages/core/components/popover/Popover.base.ts
+++ b/2nd-gen/packages/core/components/popover/Popover.base.ts
@@ -275,6 +275,9 @@ export abstract class PopoverBase extends SpectrumElement {
    */
   private _triggerPointerActive = false;
 
+  /** Cancels the pending press-end listeners armed in `_onTriggerPressStart`. */
+  private _pressEndAbort: AbortController | null = null;
+
   /**
    * Set when the trigger press light-dismissed an open popover (an `'outside'`
    * close observed while `_triggerPointerActive`), so the trailing `click` of
@@ -504,6 +507,35 @@ export abstract class PopoverBase extends SpectrumElement {
   // already recorded (`_onTriggerClick` clears it per gesture).
   private _onTriggerPressStart = (): void => {
     this._triggerPointerActive = true;
+    // Catches a press that ends without a click (drag off the trigger, or a
+    // cancelled gesture), which would otherwise leave the flag stuck true.
+    this._pressEndAbort = new AbortController();
+    const { signal } = this._pressEndAbort;
+    document.addEventListener('pointerup', this._onTriggerPressEnd, {
+      capture: true,
+      once: true,
+      signal,
+    });
+    document.addEventListener('pointercancel', this._onTriggerPressEnd, {
+      capture: true,
+      once: true,
+      signal,
+    });
+  };
+
+  private _onTriggerPressEnd = (event: PointerEvent): void => {
+    this._pressEndAbort?.abort();
+    // A same-target pointerup still gets its own click, which resets the flag
+    // itself; resetting it here too would race that click's read of
+    // `_dismissedByTriggerPress`. pointercancel never gets a click, so it
+    // always resets.
+    if (
+      event.type === 'pointerup' &&
+      event.composedPath().includes(this._clickTrigger as EventTarget)
+    ) {
+      return;
+    }
+    this._triggerPointerActive = false;
   };
 
   // If the press light-dismissed the popover (recorded in `_onBeforeToggle`),

--- a/2nd-gen/packages/swc/components/popover/Popover.ts
+++ b/2nd-gen/packages/swc/components/popover/Popover.ts
@@ -27,7 +27,7 @@ import styles from './popover.css';
  * and the shadow-DOM element getters the base reads.
  *
  * @element swc-popover
- * @since 2.0.0
+ * @since 2.0.0-beta.2
  *
  * @slot - Popover content.
  *

--- a/2nd-gen/packages/swc/components/popover/test/popover.test.ts
+++ b/2nd-gen/packages/swc/components/popover/test/popover.test.ts
@@ -100,6 +100,45 @@ export const ClickToggleTest: Story = {
 };
 
 // ──────────────────────────────────────────────────────────────
+// TEST: A press dragged off the trigger does not stick the reopen guard
+// ──────────────────────────────────────────────────────────────
+
+// A `pointerdown` on the trigger with the matching `pointerup` landing
+// elsewhere (drag-off) never dispatches `click` on the trigger, so it must
+// not leave the trigger's internal press-tracking stuck. A subsequent normal
+// click cycle must still open and close as usual.
+export const PressDragOffTest: Story = {
+  render: () => html`
+    <button id="drag-off-trigger">Trigger</button>
+    <swc-popover for="drag-off-trigger">Popover content</swc-popover>
+  `,
+  play: async ({ canvasElement }) => {
+    const popover = await getComponent<Popover>(canvasElement, 'swc-popover');
+    const trigger = canvasElement.querySelector(
+      '#drag-off-trigger'
+    ) as HTMLButtonElement;
+    await popover.updateComplete;
+
+    trigger.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, composed: true })
+    );
+    document.body.dispatchEvent(
+      new PointerEvent('pointerup', { bubbles: true, composed: true })
+    );
+
+    await userEvent.click(trigger);
+    await popover.updateComplete;
+    expect(popover.open, 'opens after a drag-off then a normal click').toBe(
+      true
+    );
+
+    await userEvent.click(trigger);
+    await popover.updateComplete;
+    expect(popover.open, 'closes on the following normal click').toBe(false);
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
 // TEST: A programmatic close does not suppress a reopen click
 // ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Description

A trigger press dragged off and released elsewhere never dispatches a `click`, leaving the internal reopen-guard flag stuck `true` and swallowing the next legitimate trigger click.

## Motivation and context

Found while manually testing trigger press/drag interactions on the gen2 popover.

## Related issue(s)

- fixes N/A (found during manual testing, no tracked issue)

## Fix

Arms a transient, document-level `pointerup`/`pointercancel` listener at press-start that resets the flag only when the release lands outside the trigger, or the gesture is cancelled. A same-target release still gets its own `click`, which already resets the flag, so this can't race the native-dismiss path a normal click-to-close depends on.

Also bumps popover's `@since` to `2.0.0-beta.2` to catch up with the rest of 2nd-gen (#6503).

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Drag-off then a normal click still opens/closes_
  1. Storybook: `Popover/Tests` → `Press Drag Off Test`
  2. Confirm the follow-up open then close both toggle normally

- [ ] _Plain click-to-toggle unaffected_
  1. Storybook: `Popover/Tests` → `Click Toggle Test`
  2. Click the trigger, then click it again; confirm open then close

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard**
  1. No focus/keyboard-path changes; fix is scoped to pointer/touch press tracking.
  2. Verify Enter/Space to open and Escape to close still work.
  3. Expect no regression.

- [ ] **Screen reader**
  1. Open and close the popover via its trigger with a screen reader running.
  2. Verify `aria-expanded` still announces correctly on open and close.
  3. Expect no change in announced state or timing.