### PR TITLE
[DO-NOT-MERGE] ci(docs): stage 2nd-gen docs on merge, gate prod publish behind #gen2-publish

### DIFF
--- a/.github/workflows/publish-2ndgen-docs.yml
+++ b/.github/workflows/publish-2ndgen-docs.yml
@@ -77,7 +77,7 @@ jobs:
       # production path (docs/) maps to spectrum-web-components.adobe.com and is
       # published only on a manual run or a commit whose message contains
       # `#gen2-publish`, so the public site stays in sync with releases. The
-      # keyword deliberately avoids the substring `#publish`, which the 1st-gen
+      # keyword deliberately avoids the substring `#publish`, which the Gen1
       # publish-docs-site workflow matches on.
       - name: Deploy to staging
         run: |

--- a/.github/workflows/publish-2ndgen-docs.yml
+++ b/.github/workflows/publish-2ndgen-docs.yml
@@ -73,11 +73,28 @@ jobs:
       - name: Setup AzCopy
         uses: ./.github/actions/setup-azcopy
 
-      - name: Deploy to Azure Blob Storage
+      # Every merge to main deploys to the staging path (docs-staging/). The
+      # production path (docs/) maps to spectrum-web-components.adobe.com and is
+      # published only on a manual run or a commit whose message contains
+      # `#gen2-publish`, so the public site stays in sync with releases. The
+      # keyword deliberately avoids the substring `#publish`, which the 1st-gen
+      # publish-docs-site workflow matches on.
+      - name: Deploy to staging
+        run: |
+          echo "Deploying 2nd-gen docs to docs-staging/"
+          azcopy sync "2nd-gen/packages/swc/storybook-static/" \
+            "https://swcpreviews.blob.core.windows.net/\$web/docs-staging/" \
+            --recursive \
+            --delete-destination=true \
+            --from-to LocalBlob
+          echo "Deployed to https://swcpreviews.z13.web.core.windows.net/docs-staging/"
+
+      - name: Deploy to production
         # spectrum-web-components.adobe.com maps to the /docs path in the storage
         # container, so deploying to $web/docs/ IS the domain root. The generated
         # .well-known/agent-skills/ directory inside storybook-static/ is therefore
         # served at the expected discovery URL without a separate upload step.
+        if: github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '#gen2-publish')
         run: |
           echo "Deploying 2nd-gen docs to docs/"
           azcopy sync "2nd-gen/packages/swc/storybook-static/" \

--- a/2nd-gen/packages/swc/.storybook/preview.ts
+++ b/2nd-gen/packages/swc/.storybook/preview.ts
@@ -336,7 +336,6 @@ const preview = {
               [
                 'Accordion',
                 ['Accessibility migration analysis', 'Migration plan'],
-                'Action bar',
                 'Action button',
                 [
                   'Accessibility migration analysis',

--- a/CONTRIBUTOR-DOCS/01_contributor-guides/06_releasing-swc.md
+++ b/CONTRIBUTOR-DOCS/01_contributor-guides/06_releasing-swc.md
@@ -22,6 +22,8 @@
 - [Approving the publish job](#approving-the-publish-job)
 - [Verifying the release](#verifying-the-release)
 - [Publishing the documentation site](#publishing-the-documentation-site)
+    - [1st-gen documentation site](#1st-gen-documentation-site)
+    - [2nd-gen documentation site](#2nd-gen-documentation-site)
 - [Troubleshooting](#troubleshooting)
 
 </details>
@@ -182,7 +184,9 @@ After the workflow completes, verify the following:
 
 ## Publishing the documentation site
 
-The documentation site publishes automatically on any push to `main` whose commit message contains `#publish`, `docs:`, or `docs(`. This happens automatically as part of every production release (the version commit uses `#publish`).
+### 1st-gen documentation site
+
+The 1st-gen documentation site publishes automatically on any push to `main` whose commit message contains `#publish`, `docs:`, or `docs(`. This happens automatically as part of every production release (the version commit uses `#publish`).
 
 To publish the docs site manually:
 
@@ -194,6 +198,29 @@ To publish the docs site manually:
 
 ```bash
 gh workflow run publish-docs-site.yml --ref main
+```
+
+### 2nd-gen documentation site
+
+The 2nd-gen docs site (the Storybook served at `spectrum-web-components.adobe.com`) uses a two-target flow so the public site stays in sync with releases while a staging copy always tracks `main`:
+
+| Target | URL | When it deploys |
+| --- | --- | --- |
+| Staging | `https://swcpreviews.z13.web.core.windows.net/docs-staging/` | Every push to `main` that touches non-1st-gen files |
+| Production | `spectrum-web-components.adobe.com` (`docs/` path) | Manual run, or a push to `main` whose commit message contains `#gen2-publish` |
+
+> **Note:** the production keyword is `#gen2-publish`, not `#publish`. It deliberately avoids the `#publish` substring so publishing the 2nd-gen site does not also trigger the 1st-gen documentation site above.
+
+To publish the 2nd-gen production site manually:
+
+**From GitHub:**
+1. Navigate to **Actions → Publish 2nd-Gen Documentation**.
+2. Click **Run workflow**, select `main`, and click **Run workflow**.
+
+**From the terminal** (requires [GitHub CLI](https://cli.github.com)):
+
+```bash
+gh workflow run publish-2ndgen-docs.yml --ref main
 ```
 
 ---

--- a/CONTRIBUTOR-DOCS/01_contributor-guides/06_releasing-swc.md
+++ b/CONTRIBUTOR-DOCS/01_contributor-guides/06_releasing-swc.md
@@ -22,8 +22,8 @@
 - [Approving the publish job](#approving-the-publish-job)
 - [Verifying the release](#verifying-the-release)
 - [Publishing the documentation site](#publishing-the-documentation-site)
-    - [1st-gen documentation site](#1st-gen-documentation-site)
-    - [2nd-gen documentation site](#2nd-gen-documentation-site)
+    - [Gen1 documentation site](#gen1-documentation-site)
+    - [Gen2 documentation site](#gen2-documentation-site)
 - [Troubleshooting](#troubleshooting)
 
 </details>
@@ -184,9 +184,9 @@ After the workflow completes, verify the following:
 
 ## Publishing the documentation site
 
-### 1st-gen documentation site
+### Gen1 documentation site
 
-The 1st-gen documentation site publishes automatically on any push to `main` whose commit message contains `#publish`, `docs:`, or `docs(`. This happens automatically as part of every production release (the version commit uses `#publish`).
+The Gen1 documentation site publishes automatically on any push to `main` whose commit message contains `#publish`, `docs:`, or `docs(`. This happens automatically as part of every production release (the version commit uses `#publish`).
 
 To publish the docs site manually:
 
@@ -200,18 +200,18 @@ To publish the docs site manually:
 gh workflow run publish-docs-site.yml --ref main
 ```
 
-### 2nd-gen documentation site
+### Gen2 documentation site
 
-The 2nd-gen docs site (the Storybook served at `spectrum-web-components.adobe.com`) uses a two-target flow so the public site stays in sync with releases while a staging copy always tracks `main`:
+The Gen2 docs site (the Storybook served at `spectrum-web-components.adobe.com`) uses a two-target flow so the public site stays in sync with releases while a staging copy always tracks `main`:
 
 | Target | URL | When it deploys |
 | --- | --- | --- |
-| Staging | `https://swcpreviews.z13.web.core.windows.net/docs-staging/` | Every push to `main` that touches non-1st-gen files |
+| Staging | `https://swcpreviews.z13.web.core.windows.net/docs-staging/` | Every push to `main` that touches non-Gen1 files |
 | Production | `spectrum-web-components.adobe.com` (`docs/` path) | Manual run, or a push to `main` whose commit message contains `#gen2-publish` |
 
-> **Note:** the production keyword is `#gen2-publish`, not `#publish`. It deliberately avoids the `#publish` substring so publishing the 2nd-gen site does not also trigger the 1st-gen documentation site above.
+> **Note:** the production keyword is `#gen2-publish`, not `#publish`. It deliberately avoids the `#publish` substring so publishing the Gen2 site does not also trigger the Gen1 documentation site above.
 
-To publish the 2nd-gen production site manually:
+To publish the Gen2 production site manually:
 
 **From GitHub:**
 1. Navigate to **Actions → Publish 2nd-Gen Documentation**.


### PR DESCRIPTION
> [!WARNING]
> Do not merge before we release / announce our beta publicly.

## Description

Splits the 2nd-gen documentation deploy into two targets so the public site can stay in sync with releases instead of updating on every merge:

- **Staging** — every push to `main` (non-1st-gen changes) syncs to `$web/docs-staging/` (`https://swcpreviews.z13.web.core.windows.net/docs-staging/`). This preserves the always-latest environment we have today.
- **Production** — `$web/docs/` (mapped to `spectrum-web-components.adobe.com`) now deploys only on a manual `workflow_dispatch` **or** a push to `main` whose commit message contains `#gen2-publish`.

The keyword is `#gen2-publish` rather than `#publish` on purpose: the 1st-gen `publish-docs-site.yml` matches on the `#publish` substring, so a shared keyword would couple the two sites. `#gen2-publish` does not contain `#publish`, keeping them independent.

## Motivation and context

We're moving into pre-release/beta publishing and want the public 2nd-gen docs site to update in sync with announced releases, not on every merge. Staging keeps tracking `main` for day-to-day validation.

## Related issue(s)

- fixes [N/A]

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

### Manual review test cases

- [ ] _Staging deploys on merge_
  1. Merge a non-1st-gen change to `main`.
  2. Confirm **Publish 2nd-Gen Documentation** runs the "Deploy to staging" step and skips "Deploy to production".
  3. Verify `https://swcpreviews.z13.web.core.windows.net/docs-staging/` reflects the change.

- [ ] _Production deploys on keyword_
  1. Merge a change to `main` with `#gen2-publish` in the commit message (or run the workflow manually).
  2. Confirm both "Deploy to staging" and "Deploy to production" run.
  3. Verify `spectrum-web-components.adobe.com` reflects the change.

- [ ] _No cross-trigger with 1st-gen_
  1. Confirm a `#gen2-publish` commit does not trigger **Publish Documentation Site** (1st-gen).

## Accessibility testing checklist

CI/documentation-deploy change only; no component or runtime UI is modified.

- [ ] **Keyboard** (required — document steps below)
  1. N/A — no focusable UI is added or changed by this workflow/docs update.

- [ ] **Screen reader** (required — document steps below)
  1. N/A — no roles, names, or announcements are affected by this workflow/docs update.