### PR TITLE
fix(color-loupe): add adaptive white-first border for WCAG 1.4.11

### DIFF
--- a/.changeset/color-loupe-adaptive-border.md
+++ b/.changeset/color-loupe-adaptive-border.md
@@ -5,4 +5,4 @@
 
 **fix(color-loupe):** Added an adaptive white-first inner border to `<swc-color-loupe>` so its chrome meets WCAG 1.4.11 non-text contrast (≥3:1) across the color spectrum.
 
-The inner border's opacity now escalates above its default floor only when the white outer halo can't itself carry 3:1 contrast against the loupe's color. The outer border, shape, and sizing are unchanged, and there is no public API change. This supersedes the prior practical-limits exception recorded in SWC-1193, matching the adaptive dual-border approach already shipped for `<swc-color-handle>`.
+The inner border's opacity now escalates above its default floor only when the white outer halo can't itself carry 3:1 contrast against the loupe's color. The outer border, shape, and sizing are unchanged, and there is no public API change. This supersedes the prior practical-limits exception, matching the adaptive dual-border approach already shipped for `<swc-color-handle>`.

--- a/.changeset/color-loupe-adaptive-border.md
+++ b/.changeset/color-loupe-adaptive-border.md
@@ -1,0 +1,8 @@
+---
+'@adobe/spectrum-wc-core': patch
+'@adobe/spectrum-wc': patch
+---
+
+**fix(color-loupe):** Added an adaptive white-first inner border to `<swc-color-loupe>` so its chrome meets WCAG 1.4.11 non-text contrast (≥3:1) across the color spectrum.
+
+The inner border's opacity now escalates above its default floor only when the white outer halo can't itself carry 3:1 contrast against the loupe's color. The outer border, shape, and sizing are unchanged, and there is no public API change. This supersedes the prior practical-limits exception recorded in SWC-1193, matching the adaptive dual-border approach already shipped for `<swc-color-handle>`.

--- a/2nd-gen/packages/core/components/color-loupe/ColorLoupe.base.ts
+++ b/2nd-gen/packages/core/components/color-loupe/ColorLoupe.base.ts
@@ -12,7 +12,14 @@
 
 import { property } from 'lit/decorators.js';
 
+import { computeBorderAlpha } from '@adobe/spectrum-wc-core/components/color-handle';
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
+
+/**
+ * Minimum inner-border opacity (matches the existing `transparent-black-200`
+ * token) so the default look on mid/dark colors is unchanged (SWC-2295).
+ */
+export const COLOR_LOUPE_ALPHA_FLOOR = 0.12;
 
 /**
  * A visual magnifier that shows the currently picked color, including
@@ -45,4 +52,21 @@ export abstract class ColorLoupeBase extends SpectrumElement {
    */
   @property({ type: String })
   public color = 'rgba(255, 0, 0, 0.5)';
+
+  // ──────────────────────────
+  //     ADAPTIVE CONTRAST
+  // ──────────────────────────
+
+  /**
+   * The adaptive inner-border opacity for the current `color`, derived by the
+   * white-first strategy (shared with `<swc-color-handle>`) so the loupe
+   * chrome meets WCAG 1.4.11 (≥3:1) across the color spectrum. The white
+   * outer border is unchanged; the rendering layer applies this value to the
+   * inner border only.
+   *
+   * @internal
+   */
+  protected get borderAlpha(): number {
+    return computeBorderAlpha(this.color, { floor: COLOR_LOUPE_ALPHA_FLOOR });
+  }
 }

--- a/2nd-gen/packages/core/components/color-loupe/ColorLoupe.base.ts
+++ b/2nd-gen/packages/core/components/color-loupe/ColorLoupe.base.ts
@@ -17,7 +17,7 @@ import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
 
 /**
  * Minimum inner-border opacity (matches the existing `transparent-black-200`
- * token) so the default look on mid/dark colors is unchanged (SWC-2295).
+ * token) so the default look on mid/dark colors is unchanged.
  */
 export const COLOR_LOUPE_ALPHA_FLOOR = 0.12;
 

--- a/2nd-gen/packages/swc/components/color-loupe/ColorLoupe.ts
+++ b/2nd-gen/packages/swc/components/color-loupe/ColorLoupe.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { CSSResultArray, html, TemplateResult } from 'lit';
+import { CSSResultArray, html, PropertyValues, TemplateResult } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { ColorLoupeBase } from '@adobe/spectrum-wc-core/components/color-loupe';
@@ -37,6 +37,17 @@ export class ColorLoupe extends ColorLoupeBase {
 
   public static override get styles(): CSSResultArray {
     return [opacityCheckerboardStyles, styles];
+  }
+
+  protected override updated(changed: PropertyValues): void {
+    super.updated(changed);
+    if (changed.has('color')) {
+      // Apply the core white-first contrast decision to the inner border.
+      this.style.setProperty(
+        '--_swc-color-loupe-border-alpha',
+        String(this.borderAlpha)
+      );
+    }
   }
 
   protected override render(): TemplateResult {

--- a/2nd-gen/packages/swc/components/color-loupe/color-loupe.css
+++ b/2nd-gen/packages/swc/components/color-loupe/color-loupe.css
@@ -11,11 +11,11 @@
  */
 
 /* The inner-border opacity is set adaptively by the component (white-first
-   contrast, SWC-2295); the floor here matches the existing
-   `transparent-black-200` token and is the fallback before the component
-   computes a value. The outer border stays the fixed white halo: the loupe
-   stays visible if either the inner dark border or the white outer border
-   meets 3:1 against the underlying color. */
+   contrast); the floor here matches the existing `transparent-black-200`
+   token and is the fallback before the component computes a value. The outer
+   border stays the fixed white halo: the loupe stays visible if either the
+   inner dark border or the white outer border meets 3:1 against the
+   underlying color. */
 :host {
   --_swc-color-loupe-width: token("color-loupe-width");
   --_swc-color-loupe-border-alpha: 0.12;

--- a/2nd-gen/packages/swc/components/color-loupe/color-loupe.css
+++ b/2nd-gen/packages/swc/components/color-loupe/color-loupe.css
@@ -10,8 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
+/* The inner-border opacity is set adaptively by the component (white-first
+   contrast, SWC-2295); the floor here matches the existing
+   `transparent-black-200` token and is the fallback before the component
+   computes a value. The outer border stays the fixed white halo: the loupe
+   stays visible if either the inner dark border or the white outer border
+   meets 3:1 against the underlying color. */
 :host {
   --_swc-color-loupe-width: token("color-loupe-width");
+  --_swc-color-loupe-border-alpha: 0.12;
 
   display: block;
   position: absolute;
@@ -64,10 +71,11 @@
   block-size: inherit;
 }
 
-/* Inner border: thin stroke separating color fill from the loupe edge */
+/* Inner border: thin stroke separating color fill from the loupe edge. Alpha
+   is adaptive (see the `:host` comment above); the color itself stays black. */
 .swc-ColorLoupe-innerBorder {
   fill: none;
-  stroke: token("color-loupe-inner-border");
+  stroke: rgb(0 0 0 / var(--_swc-color-loupe-border-alpha));
   stroke-width: token("color-loupe-inner-border-width");
 }
 

--- a/2nd-gen/packages/swc/components/color-loupe/color-loupe.mdx
+++ b/2nd-gen/packages/swc/components/color-loupe/color-loupe.mdx
@@ -58,6 +58,14 @@ The loupe animates its visibility with CSS transitions: `opacity` over 125 ms an
 
 <Canvas of={ColorLoupeStories.ParentDrivenVisibility} />
 
+### Adaptive contrast
+
+The loupe keeps its chrome at 3:1 non-text contrast (WCAG 1.4.11) across the color spectrum using a white-first adaptive border. The chrome is an inner dark border and a fixed white outer border; the loupe stays visible if either the inner border or the white outer border meets 3:1 against the underlying color.
+
+The inner-border opacity is computed from the current `color`: it holds a floor of 12% whenever the white outer border already carries 3:1, and climbs only where white cannot. The surrounding color is approximated by the loupe's own `color`, which is accurate on smooth gradients and approximate at steep or saturated edges.
+
+<Canvas of={ColorLoupeStories.AdaptiveContrast} />
+
 ## Accessibility
 
 ### Features
@@ -81,5 +89,9 @@ The loupe does not represent a standalone accessible control. Accessibility sema
 - Avoid conveying meaning through the loupe color alone; pair color selection with text labels or other indicators as appropriate
 
 <Canvas of={ColorLoupeStories.Accessibility} />
+
+## Upcoming features
+
+- **Exact surrounding-color contrast**: sampling the true adjacent gradient color (rather than the loupe's own color) so the adaptive border is precise at steep gradient edges
 
 <DocsFooter />

--- a/2nd-gen/packages/swc/components/color-loupe/stories/color-loupe.stories.ts
+++ b/2nd-gen/packages/swc/components/color-loupe/stories/color-loupe.stories.ts
@@ -220,6 +220,30 @@ export const ParentDrivenVisibility: Story = {
 };
 ParentDrivenVisibility.storyName = 'Parent-driven visibility';
 
+export const AdaptiveContrast: Story = {
+  render: (args) => html`
+    ${labeledLoupe('White', {
+      ...args,
+      open: true,
+      color: 'rgb(255, 255, 255)',
+    })}
+    ${labeledLoupe('Yellow', {
+      ...args,
+      open: true,
+      color: 'rgb(255, 235, 0)',
+    })}
+    ${labeledLoupe('Mid gray', {
+      ...args,
+      open: true,
+      color: 'rgb(120, 120, 120)',
+    })}
+    ${labeledLoupe('Black', { ...args, open: true, color: 'rgb(0, 0, 0)' })}
+  `,
+  tags: ['behaviors'],
+  parameters: { flexLayout: 'row-wrap' },
+};
+AdaptiveContrast.storyName = 'Adaptive contrast';
+
 // ────────────────────────────────
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────

--- a/2nd-gen/packages/swc/components/color-loupe/test/color-loupe.test.ts
+++ b/2nd-gen/packages/swc/components/color-loupe/test/color-loupe.test.ts
@@ -14,6 +14,8 @@ import { expect } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
 import { ColorLoupe } from '@adobe/spectrum-wc/color-loupe';
+import { computeBorderAlpha } from '@adobe/spectrum-wc-core/components/color-handle';
+import { COLOR_LOUPE_ALPHA_FLOOR } from '@adobe/spectrum-wc-core/components/color-loupe';
 
 import '@adobe/spectrum-wc/color-loupe';
 
@@ -66,6 +68,15 @@ export const OverviewTest: Story = {
       expect(
         fill.style.getPropertyValue('--swc-color-loupe-picked-color')
       ).toContain('0, 128, 255');
+    });
+
+    await step('sets the adaptive inner-border opacity variable', async () => {
+      const alpha = loupe.style.getPropertyValue(
+        '--_swc-color-loupe-border-alpha'
+      );
+      expect(alpha).not.toBe('');
+      expect(Number.isNaN(Number(alpha))).toBe(false);
+      expect(Number(alpha)).toBeGreaterThanOrEqual(COLOR_LOUPE_ALPHA_FLOOR);
     });
   },
 };
@@ -200,5 +211,36 @@ export const ParentDrivenVisibilityTest: Story = {
       expect(btn.getAttribute('aria-expanded')).toBe('false');
       expect(btn.textContent?.trim()).toBe('Show loupe');
     });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: adaptive contrast helper, loupe's own floor (pure logic, no DOM)
+// ──────────────────────────────────────────────────────────────
+
+export const ContrastHelperTest: Story = {
+  render: () => html`
+    <div></div>
+  `,
+  play: async ({ step }) => {
+    await step(
+      'white-first keeps the loupe floor when white already carries 3:1',
+      async () => {
+        // Black background: white outer border has maximal contrast, so the
+        // inner border stays at the loupe's own (lower) floor.
+        expect(
+          computeBorderAlpha('black', { floor: COLOR_LOUPE_ALPHA_FLOOR })
+        ).toBe(COLOR_LOUPE_ALPHA_FLOOR);
+      }
+    );
+
+    await step(
+      'escalates alpha above the loupe floor for light colors white cannot carry',
+      async () => {
+        expect(
+          computeBorderAlpha('tomato', { floor: COLOR_LOUPE_ALPHA_FLOOR })
+        ).toBeGreaterThan(COLOR_LOUPE_ALPHA_FLOOR);
+      }
+    );
   },
 };


### PR DESCRIPTION
## Description

Adds an adaptive white-first inner border to `<swc-color-loupe>`, mirroring the adaptive dual-border treatment already shipped for `<swc-color-handle>`.

The inner border's opacity is computed from the loupe's current `color`: it holds a floor of 12% (matching the existing `transparent-black-200` token, so the default look on mid/dark colors is unchanged) and climbs only when the white outer halo can't itself carry ≥3:1 contrast against that color. The white outer halo, loupe shape, and sizing are all unchanged. No public API change.

## Motivation and context

`<swc-color-loupe>` chrome could fall below the WCAG 2.2 SC 1.4.11 non-text contrast threshold (3:1) against saturated or light colors. This was previously accepted as a practical-limits exception. The adaptive dual-border approach (spec: RSP-2021, SDS-16402) resolves that gap and was already implemented for `<swc-color-handle>`; this PR brings the same treatment to the loupe's inner border, superseding the prior exception.

## Related issue(s)

- Jira: SWC-2295

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Adaptive border strengthens only where needed_
  1. Go to Storybook → `Color Loupe` → `Docs` → **Behaviors → Adaptive contrast**
  2. Compare the loupe's inner border across the White, Yellow, Mid gray, and Black swatches
  3. Expect the border to stay at its soft default on mid/dark colors and visibly strengthen on white/yellow, where the white outer halo alone can't carry 3:1

- [ ] _No regression to outer halo, shape, or sizing_
  1. Go to Storybook → `Color Loupe` → `Docs` → **Anatomy** and **Options → Colors**
  2. Confirm the teardrop shape, size, and white outer border are unchanged from before this PR

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  - Not applicable: `<swc-color-loupe>` is a non-interactive, visual-only primitive with no host role, no `tabindex`, and no keyboard interaction of its own (accessibility semantics are owned by the parent color-selection component). Confirm no keyboard regressions in the parent components that anchor a loupe (`swc-color-area`, `swc-color-slider`, `swc-color-wheel`, `swc-color-handle`).

- [ ] **Screen reader** (required — document steps below)
  1. Go to Storybook → `Color Loupe` → `Docs` → **Accessibility**
  2. Inspect the rendered DOM/accessibility tree for `<swc-color-loupe>`
  3. Expect: no `role`, `aria-label`, or `aria-labelledby` on the host; the internal `<svg>` remains `aria-hidden="true"`; run aXe on the composite Storybook stories and confirm no WCAG 1.4.11 non-text contrast violations are newly introduced
