### PR TITLE
fix(storybook): correct brand logo link to overview docs page

### DIFF
--- a/2nd-gen/packages/swc/.storybook/manager.tsx
+++ b/2nd-gen/packages/swc/.storybook/manager.tsx
@@ -56,7 +56,7 @@ addons.setConfig({
     base: 'light',
 
     brandTitle: 'Adobe | Spectrum Web Components',
-    brandUrl: '?path=/docs/about-swc-overview--readme', // TODO: Add the correct URL once we are publishing 2nd-gen
+    brandUrl: '?path=/docs/learn-about-swc-overview--docs',
     brandImage: logo,
     brandTarget: '_self',
 


### PR DESCRIPTION
Storybook brand logo linked to a non-existent `about-swc-overview--readme` page. Point it at `learn-about-swc-overview--docs`.