### PR TITLE
chore(typography): override CJK font family for code blocks

### DIFF
--- a/2nd-gen/packages/swc/stylesheets/typography.css
+++ b/2nd-gen/packages/swc/stylesheets/typography.css
@@ -489,7 +489,7 @@
   ========================= */
 .swc-Code {
   margin-block: var(--swc-monospace-margin-top, 0) var(--swc-monospace-margin-bottom, 0);
-  font-family: var(--swc-monospace-font-family, token("code-font"));
+  font-family: var(--swc-monospace-font-family, token("code-font")) !important;
   font-size: var(--swc-monospace-font-size, token("code-size-m"));
   font-weight: var(--swc-monospace-font-weight, token("regular-font-weight"));
   line-height: var(--swc-monospace-line-height, token("line-height-font-size-200"));

--- a/2nd-gen/packages/tools/swc-tokens/src/typography.js
+++ b/2nd-gen/packages/tools/swc-tokens/src/typography.js
@@ -57,6 +57,9 @@ const VARIANT_CONFIG = {
     // Prevent clash with code design tokens by using "monospace" as cp base
     cpBaseSuffix: 'monospace',
     supportsCjkSizeAdjustment: false,
+    // Code should always render in the code font, even in CJK languages, where
+    // per-locale font-family rules otherwise win via their own `!important`.
+    forceFontFamilyImportant: true,
   },
 };
 
@@ -686,7 +689,9 @@ export async function generateTypographyCssString(options = {}) {
       }),
       pickValidDecls({
         color: `var(--${cpBase}-font-color, ${colorRef})`,
-        'font-family': `var(--${cpBase}-font-family, token("${defaultFont}"))`,
+        'font-family': `var(--${cpBase}-font-family, token("${defaultFont}"))${
+          cfg.forceFontFamilyImportant ? ' !important' : ''
+        }`,
         'font-weight': sansWeightRef
           ? `var(--${cpBase}-font-weight, ${sansWeightRef})`
           : `var(--${cpBase}-font-weight, token("regular-font-weight"))`,


### PR DESCRIPTION
## Description

Scopes an `!important` override to the `code` typography variant's `font-family` declaration so `.swc-Code` always renders with `source-code-pro`, even when the element sits inside a CJK (`zh`, `ja`, `ko`) language context.

- `2nd-gen/packages/tools/swc-tokens/src/typography.js`: adds a `forceFontFamilyImportant: true` flag to `VARIANT_CONFIG.code`, and appends `!important` to the generated `font-family` declaration only when that flag is set. No other variant (`heading`, `title`, `body`, `detail`) is affected.
- `2nd-gen/packages/swc/stylesheets/typography.css`: regenerated via `yarn stylesheet:typography`, then run through `stylelint --fix` and `prettier --write` (matching the repo's pre-commit formatting) so the diff is limited to the single `.swc-Code` `font-family` line.

## Motivation and context

Follow-up to SWC-1574. The generated per-locale font rules (`:lang(zh)`, `:lang(ja)`, `:lang(ko)`, etc.) already use `!important` and match a `<code>` element directly whenever it carries or inherits that `lang`. Since `.swc-Code`'s own `font-family` declaration had no `!important`, the locale rule always won regardless of selector specificity or source order, and code samples silently fell back to the CJK font instead of `source-code-pro`.

Adding `!important` to every variant's `font-family` was considered and rejected: `heading`/`title`/`body`/`detail` *intentionally* pick up the CJK locale font today (that's the desired behavior for prose), and a blanket `!important` would have broken that. The fix is scoped to `code` only via a new per-variant config flag.

## Related issue(s)

- fixes SWC-2309

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/) _(N/A — visual `font-family` only, no ARIA/semantic changes)_
- [ ] I have added automated tests to cover my changes. _(no automated test added; verified manually via Storybook computed styles — see test plan below)_
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it. _(N/A — internal token generator, no public API or docs changes)_

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Code font-family wins over CJK locale font in every CJK language_
  1. Go to Storybook → `Typography` → `Code Variant`
  2. Set the `lang` control to `zh`, then `ja`, then `ko`
  3. Expect the code sample's computed `font-family` to remain
     `source-code-pro, "Source Code Pro", Monaco, monospace` in all three
     cases (confirmed via `getComputedStyle` during development)

- [ ] _Other variants still receive the CJK locale font (no regression)_
  1. Go to Storybook → `Typography` → `Heading Variant` (repeat for `Title Variant`, `Body Variant`, `Detail Variant`)
  2. Set the `lang` control to `zh`, `ja`, and `ko`
  3. Expect the computed `font-family` to switch to the corresponding CJK
     font-family token (e.g. `adobe-clean-han-traditional` for `zh`), not
     `source-code-pro`

- [ ] _Non-CJK code rendering is unchanged_
  1. Go to Storybook → `Typography` → `Code Variant`
  2. Leave `lang` unset (default `en`)
  3. Expect the code sample's computed `font-family` to remain
     `source-code-pro, "Source Code Pro", Monaco, monospace`

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

**Required:** Complete each applicable item and document your testing steps.

- [ ] **Keyboard** (required — document steps below)
  1. `.swc-Code` and the other typography variants render static text (`<code>`, `<p>`, `<h1>`–`<h4>`) with no interactive or focusable parts — this change only affects the `font-family` CSS declaration.
  2. Tab through the `ProseContainer` and `LinkList` Typography stories (the only stories with focusable content, i.e. `<a>` links) and confirm focus order and behavior are unchanged.

- [ ] **Screen reader** (required — document steps below)
  1. Go to Storybook → `Typography` → `Code Variant`, with a screen reader (VoiceOver or NVDA) enabled.
  2. Set the `lang` control to `zh`, `ja`, and `ko` in turn, and navigate to the code sample text.
  3. Expect the text content to be announced as plain text with no role or structural change; only the rendered font changes, not the semantics or `lang` attribute handling.
