### PR TITLE
fix(swc): style API table typography and render markdown in descriptions

### DIFF
--- a/2nd-gen/packages/swc/.storybook/blocks/ApiTable.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/ApiTable.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { HeaderMdx, useOf } from '@storybook/addon-docs/blocks';
+import { HeaderMdx, Markdown, useOf } from '@storybook/addon-docs/blocks';
 import type {
   Attribute,
   ClassField,
@@ -91,6 +91,24 @@ function sectionId(baseId: string, tagName?: string): string {
   return tagName ? `${baseId}-${tagName}` : baseId;
 }
 
+/** Renders a CEM description as inline markdown (code spans, links, bold, etc). */
+function Description({ text }: { text?: string }) {
+  if (!text) return null;
+  return (
+    <Markdown
+      className="swc-Typography--prose"
+      options={{
+        forceInline: true,
+        overrides: {
+          code: { props: { className: 'swc-Code swc-Code--sizeS' } },
+        },
+      }}
+    >
+      {text}
+    </Markdown>
+  );
+}
+
 function getArgTypeForMember(
   argTypes: Record<string, ArgType>,
   propName: string,
@@ -144,7 +162,10 @@ function PropertiesTable({
         Properties
       </HeaderMdx>
       <div style={scrollStyle}>
-        <table style={tableStyle}>
+        <table
+          style={tableStyle}
+          className="swc-ApiTable swc-Body swc-Body--sizeM"
+        >
           <thead>
             <tr>
               <th>Property</th>
@@ -171,14 +192,21 @@ function PropertiesTable({
               return (
                 <tr key={prop.name}>
                   <td>
-                    <code>{prop.name}</code>
+                    <code className="swc-Code swc-Code--sizeS">
+                      {prop.name}
+                    </code>
                   </td>
                   <td>
                     {attr ? (
                       <>
-                        <code>{attr.name}</code>
+                        <code className="swc-Code swc-Code--sizeS">
+                          {attr.name}
+                        </code>
                         {prop.reflects && (
-                          <small style={{ opacity: '0.8', marginLeft: 4 }}>
+                          <small
+                            className="swc-Detail swc-Detail--sizeS"
+                            style={{ opacity: '0.8', marginLeft: 4 }}
+                          >
                             (reflects)
                           </small>
                         )}
@@ -187,11 +215,25 @@ function PropertiesTable({
                       '-'
                     )}
                   </td>
-                  <td>{typeName && <code>{typeName}</code>}</td>
                   <td>
-                    {prop.default != null ? <code>{prop.default}</code> : '-'}
+                    {typeName && (
+                      <code className="swc-Code swc-Code--sizeS">
+                        {typeName}
+                      </code>
+                    )}
                   </td>
-                  <td>{prop.description ?? ''}</td>
+                  <td>
+                    {prop.default != null ? (
+                      <code className="swc-Code swc-Code--sizeS">
+                        {prop.default}
+                      </code>
+                    ) : (
+                      '-'
+                    )}
+                  </td>
+                  <td>
+                    <Description text={prop.description} />
+                  </td>
                 </tr>
               );
             })}
@@ -218,7 +260,10 @@ function SlotsTable({
         Slots
       </HeaderMdx>
       <div style={scrollStyle}>
-        <table style={tableStyle}>
+        <table
+          style={tableStyle}
+          className="swc-ApiTable swc-Body swc-Body--sizeM"
+        >
           <thead>
             <tr>
               <th>Name</th>
@@ -229,9 +274,13 @@ function SlotsTable({
             {slots.map((slot) => (
               <tr key={slot.name || 'default'}>
                 <td>
-                  <code>{slot.name || '(default)'}</code>
+                  <code className="swc-Code swc-Code--sizeS">
+                    {slot.name || '(default)'}
+                  </code>
                 </td>
-                <td>{slot.description ?? ''}</td>
+                <td>
+                  <Description text={slot.description} />
+                </td>
               </tr>
             ))}
           </tbody>
@@ -258,7 +307,10 @@ function EventsTable({
         Events
       </HeaderMdx>
       <div style={scrollStyle}>
-        <table style={tableStyle}>
+        <table
+          style={tableStyle}
+          className="swc-ApiTable swc-Body swc-Body--sizeM"
+        >
           <thead>
             <tr>
               <th>Name</th>
@@ -269,9 +321,11 @@ function EventsTable({
             {events.map((event) => (
               <tr key={event.name}>
                 <td>
-                  <code>{event.name}</code>
+                  <code className="swc-Code swc-Code--sizeS">{event.name}</code>
                 </td>
-                <td>{event.description ?? ''}</td>
+                <td>
+                  <Description text={event.description} />
+                </td>
               </tr>
             ))}
           </tbody>
@@ -300,7 +354,10 @@ function CssPropsTable({
         CSS Custom Properties
       </HeaderMdx>
       <div style={scrollStyle}>
-        <table style={tableStyle}>
+        <table
+          style={tableStyle}
+          className="swc-ApiTable swc-Body swc-Body--sizeM"
+        >
           <thead>
             <tr>
               <th>Name</th>
@@ -312,12 +369,20 @@ function CssPropsTable({
             {cssProps.map((prop) => (
               <tr key={prop.name}>
                 <td>
-                  <code>{prop.name}</code>
+                  <code className="swc-Code swc-Code--sizeS">{prop.name}</code>
                 </td>
                 <td>
-                  {prop.default != null ? <code>{prop.default}</code> : '-'}
+                  {prop.default != null ? (
+                    <code className="swc-Code swc-Code--sizeS">
+                      {prop.default}
+                    </code>
+                  ) : (
+                    '-'
+                  )}
                 </td>
-                <td>{prop.description ?? ''}</td>
+                <td>
+                  <Description text={prop.description} />
+                </td>
               </tr>
             ))}
           </tbody>
@@ -343,7 +408,10 @@ function CssPartsTable({
         CSS Parts
       </HeaderMdx>
       <div style={scrollStyle}>
-        <table style={tableStyle}>
+        <table
+          style={tableStyle}
+          className="swc-ApiTable swc-Body swc-Body--sizeM"
+        >
           <thead>
             <tr>
               <th>Name</th>
@@ -354,9 +422,11 @@ function CssPartsTable({
             {cssParts.map((part) => (
               <tr key={part.name}>
                 <td>
-                  <code>{part.name}</code>
+                  <code className="swc-Code swc-Code--sizeS">{part.name}</code>
                 </td>
-                <td>{part.description ?? ''}</td>
+                <td>
+                  <Description text={part.description} />
+                </td>
               </tr>
             ))}
           </tbody>
@@ -394,12 +464,16 @@ export function ApiTable({
 
   const cem = window.__STORYBOOK_CUSTOM_ELEMENTS_MANIFEST__;
   if (!cem || !tagName) {
-    return <p>No API data available.</p>;
+    return <p className="swc-Body swc-Body--sizeM">No API data available.</p>;
   }
 
   const component = findComponent(cem, tagName);
   if (!component) {
-    return <p>Component &ldquo;{tagName}&rdquo; not found in manifest.</p>;
+    return (
+      <p className="swc-Body swc-Body--sizeM">
+        Component &ldquo;{tagName}&rdquo; not found in manifest.
+      </p>
+    );
   }
 
   const members = component.members ?? [];

--- a/2nd-gen/packages/swc/.storybook/blocks/ApiTable.tsx
+++ b/2nd-gen/packages/swc/.storybook/blocks/ApiTable.tsx
@@ -205,7 +205,7 @@ function PropertiesTable({
                         {prop.reflects && (
                           <small
                             className="swc-Detail swc-Detail--sizeS"
-                            style={{ opacity: '0.8', marginLeft: 4 }}
+                            style={{ marginLeft: 4 }}
                           >
                             (reflects)
                           </small>

--- a/2nd-gen/packages/swc/.storybook/preview-head.html
+++ b/2nd-gen/packages/swc/.storybook/preview-head.html
@@ -160,7 +160,7 @@
       line-height: unset;
     }
 
-    table,
+    table:not(.swc-ApiTable),
     input,
     select,
     textarea,
@@ -170,7 +170,7 @@
       font-size: 0.875rem !important;
     }
 
-    table code {
+    table:not(.swc-ApiTable) code {
       font-size: 0.75rem !important;
     }
 


### PR DESCRIPTION
## Description

Before: 
<img width="599" height="124" alt="Screenshot 2026-07-17 at 16 15 03" src="https://github.com/user-attachments/assets/34c7cec0-074c-4619-8386-f8eea949a530" />
(https://spectrum-web-components.adobe.com/?path=/docs/components-tabs--docs#api)


After:
<img width="554" height="103" alt="Screenshot 2026-07-17 at 16 18 24" src="https://github.com/user-attachments/assets/a1a19e2a-c6f6-47bc-a7ae-75e312d08d1e" />
(https://swcpreviews.z13.web.core.windows.net/pr-6524/docs/gen2-storybook-prod/?path=/docs/components-tabs--docs#api)


The Storybook `ApiTable` block (used on every 2nd-gen component/pattern/controller docs page) rendered its Properties/Slots/Events/CSS Custom Properties/CSS Parts tables at the docs-wide default table font size, and rendered CEM `description` text as raw strings, so markdown syntax (code spans, links, bold) authored in JSDoc never rendered, and none of the design system's own typography classes were applied.

This PR:

- Adds `swc-Body`/`swc-Body--sizeM` to each API table (bumping from 14px to 16px) and scopes the docs-wide generic `table` font-size override in `preview-head.html` to exclude these tables (`table:not(.swc-ApiTable)`).
- Adds `swc-Code`/`swc-Code--sizeS` to every `<code>` cell (property/attribute/slot/event/CSS name and default value).
- Adds `swc-Detail`/`swc-Detail--sizeS` to the `(reflects)` annotation, and `swc-Body`/`swc-Body--sizeM` to the empty/error-state fallback messages.
- Renders `description` fields through Storybook's `Markdown` block (`forceInline: true`) instead of interpolating the raw string, so markdown authored in CEM descriptions (code spans, links, bold) now renders.
- Configures `Markdown`'s `overrides` so emitted `<code>` spans get `swc-Code`/`swc-Code--sizeS`, and wraps output in `swc-Typography--prose` so links inherit the design system's prose link colors/hover/focus states.

## Motivation and context

The API reference tables are the primary technical reference on every component's docs page. They were both harder to read (undersized text, inconsistent with the rest of the docs page) and silently dropped any markdown formatting authored in component JSDoc (e.g. `` `code` `` references or links to related components), rendering it as literal asterisks/backticks instead.

## Related issue(s)

- fixes https://github.com/adobe/spectrum-web-components/pull/6495#discussion_r3589478897

## Screenshots (if appropriate)

N/A — text/typography only change, verify visually in Storybook docs for any component (e.g. Badge, Button) under the API section.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _API table renders at increased size and description markdown renders_
  1. Run Storybook (`yarn storybook`, in `2nd-gen/packages/swc`) and open any migrated component's docs page (e.g. Badge)
  2. Scroll to the API section (Properties/Slots/Events/CSS Custom Properties/CSS Parts tables)
  3. Expect table text visibly larger than before (16px body / 14px code) and, for any property/slot with a JSDoc description containing `` `code` `` or a markdown link, expect it to render as an actual `<code>` span or `<a>` link rather than literal backticks/brackets

- [ ] _No regression to other docs tables_
  1. Open any docs page and inspect a non-API table (e.g. an argTypes Controls table or a Storybook-native table)
  2. Expect font size unchanged (still the smaller docs-wide default), since the override now only excludes `.swc-ApiTable`

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  - Not applicable: this change only affects static, non-interactive reference tables and prose text (font size, typography classes, and markdown rendering of description text). No focusable elements are added, removed, or reordered. Confirm no regressions in keyboard navigation through the surrounding docs page (Tab order into/out of the API section unchanged).

- [ ] **Screen reader** (required — document steps below)
  1. Open a component's docs page in Storybook and navigate to the API section with a screen reader active (e.g. VoiceOver)
  2. Read through a Properties table row where the description contains a markdown link (e.g. cross-references to another component)
  3. Expect the link to be announced as a link with its accessible name (not read as literal `[text](url)` markdown), and expect table structure (row/column headers, cell content) to be announced correctly and unchanged from before this change