### PR TITLE
feat(card): add collection slot support to swc-card

### DIFF
--- a/2nd-gen/packages/core/components/card/Card.base.ts
+++ b/2nd-gen/packages/core/components/card/Card.base.ts
@@ -44,6 +44,21 @@ import {
  * @slot description - Supporting description text
  * @slot footer - Optional footer content
  * @slot - Additional body content
+ *
+ * @cssprop --swc-card-base-max-inline-size - Maximum inline size of the card. Defaults to 280px, overridden per size.
+ * @cssprop --swc-card-base-border-radius - Corner radius of the card. Defaults to the extra-large corner-radius token, overridden per size.
+ * @cssprop --swc-card-base-box-shadow - Box shadow (elevation) of the card. Defaults to the emphasized drop-shadow token; overridden by the tertiary variant, selectable focus, and title-as-link/selectable hover.
+ * @cssprop --swc-card-base-background-color - Background color of the card. Defaults to the layer-2 background token; overridden by the secondary, tertiary, and quiet variants.
+ * @cssprop --swc-card-base-preview-aspect-ratio - Aspect ratio of the preview slot. Defaults to 3/2.
+ * @cssprop --swc-card-base-title-font-size - Font size of the title slot. Defaults to the medium font-size token, overridden per size.
+ * @cssprop --swc-card-base-title-line-height - Line height of the title slot. Defaults to the medium line-height token, overridden per size.
+ * @cssprop --swc-card-base-description-font-size - Font size of the description slot and default slot content. Defaults to a smaller font-size token, overridden per size.
+ * @cssprop --swc-card-base-action-component-height - Height used to vertically balance slotted actions content. Defaults to the smallest component-height token, overridden per size.
+ * @cssprop --swc-card-base-content-header-gap - Column gap between the title and actions slots. Defaults to the medium base-gap token, overridden per size.
+ * @cssprop --swc-card-base-content-padding - Padding of the content region. Defaults to the medium container-padding token; overridden by density.
+ * @cssprop --swc-card-base-content-padding-regular - Content padding used at the default (regular) density, per size.
+ * @cssprop --swc-card-base-content-padding-compact - Content padding used at compact density, per size.
+ * @cssprop --swc-card-base-content-padding-spacious - Content padding used at spacious density, per size.
  */
 export abstract class CardBase extends SizedMixin(SpectrumElement, {
   validSizes: CARD_VALID_SIZES,

--- a/2nd-gen/packages/swc/components/card/Card.ts
+++ b/2nd-gen/packages/swc/components/card/Card.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { CSSResultArray, TemplateResult } from 'lit';
+import { CSSResultArray, html, TemplateResult } from 'lit';
 
 import { CardBase } from '@adobe/spectrum-wc-core/components/card';
 
@@ -40,20 +40,10 @@ import styles from './card.css';
  *   </swc-action-button>
  * </swc-card>
  *
- * @cssprop --swc-card-base-max-inline-size - Maximum inline size of the card. Defaults to 280px, overridden per size.
- * @cssprop --swc-card-base-border-radius - Corner radius of the card. Defaults to the extra-large corner-radius token, overridden per size.
- * @cssprop --swc-card-base-box-shadow - Box shadow (elevation) of the card. Defaults to the emphasized drop-shadow token; overridden by the tertiary variant, selectable focus, and title-as-link/selectable hover.
- * @cssprop --swc-card-base-background-color - Background color of the card. Defaults to the layer-2 background token; overridden by the secondary, tertiary, and quiet variants.
- * @cssprop --swc-card-base-preview-aspect-ratio - Aspect ratio of the preview slot. Defaults to 3/2.
- * @cssprop --swc-card-base-title-font-size - Font size of the title slot. Defaults to the medium font-size token, overridden per size.
- * @cssprop --swc-card-base-title-line-height - Line height of the title slot. Defaults to the medium line-height token, overridden per size.
- * @cssprop --swc-card-base-description-font-size - Font size of the description slot and default slot content. Defaults to a smaller font-size token, overridden per size.
- * @cssprop --swc-card-base-action-component-height - Height used to vertically balance slotted actions content. Defaults to the smallest component-height token, overridden per size.
- * @cssprop --swc-card-base-content-header-gap - Column gap between the title and actions slots. Defaults to the medium base-gap token, overridden per size.
- * @cssprop --swc-card-base-content-padding - Padding of the content region. Defaults to the medium container-padding token; overridden by density.
- * @cssprop --swc-card-base-content-padding-regular - Content padding used at the default (regular) density, per size.
- * @cssprop --swc-card-base-content-padding-compact - Content padding used at compact density, per size.
- * @cssprop --swc-card-base-content-padding-spacious - Content padding used at spacious density, per size.
+ * @slot collection - Optional collection images. Assign each image to the slot.
+ *
+ * @cssprop --swc-card-collection-item-aspect-ratio - Aspect ratio of each collection image. Defaults to 1 (square).
+ * @cssprop --swc-card-collection-gap - Gap between collection images, and between the preview and the collection row. Defaults to a small group-gap token, overridden at size="xs".
  */
 export class Card extends CardBase {
   // ──────────────────────────────
@@ -65,6 +55,11 @@ export class Card extends CardBase {
   }
 
   protected override render(): TemplateResult {
-    return renderCardTemplate({ cardClass: 'Card' });
+    return renderCardTemplate({
+      cardClass: 'Card',
+      renderCollection: () => html`
+        <div class="swc-Card-collection"><slot name="collection"></slot></div>
+      `,
+    });
   }
 }

--- a/2nd-gen/packages/swc/components/card/Card.ts
+++ b/2nd-gen/packages/swc/components/card/Card.ts
@@ -43,7 +43,7 @@ import styles from './card.css';
  * @slot collection - Optional collection images. Assign each image to the slot.
  *
  * @cssprop --swc-card-collection-item-aspect-ratio - Aspect ratio of each collection image. Defaults to 1 (square).
- * @cssprop --swc-card-collection-gap - Gap between collection images, and between the preview and the collection row. Defaults to a small group-gap token, overridden at size="xs".
+ * @cssprop --swc-card-collection-gap - Gap between collection images, and between the preview and the collection row. Defaults to a extra-small group-gap token, overridden at size="xs".
  */
 export class Card extends CardBase {
   // ──────────────────────────────

--- a/2nd-gen/packages/swc/components/card/card.css
+++ b/2nd-gen/packages/swc/components/card/card.css
@@ -13,6 +13,7 @@
 .swc-Card {
   --_swc-card-collection-item-aspect-ratio: var(--swc-card-collection-item-aspect-ratio, 1);
   --_swc-card-collection-gap: var(--swc-card-collection-gap, token("group-gap-extra-small"));
+  --_swc-card-collection-columns: repeat(3, 1fr);
 }
 
 .swc-Card-media {
@@ -29,7 +30,7 @@
 .swc-Card-collection {
   display: none;
   grid-area: collection;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: var(--_swc-card-collection-columns);
   margin-block-start: var(--_swc-card-collection-gap);
   column-gap: var(--_swc-card-collection-gap);
 }
@@ -83,20 +84,20 @@
 }
 
 :host([size="xs"]:has([slot="preview"]):has([slot="collection"])) .swc-Card {
-  --_swc-card-media-layout: xs;
+  --_swc-card-media-layout: 3col;
 }
 
 /* Chromium :host(:has()) support */
 @scope (:host([size="xs"])) {
   :scope:has([slot="preview"]):has([slot="collection"]) .swc-Card {
-    --_swc-card-media-layout: xs;
+    --_swc-card-media-layout: 3col;
   }
 }
 
-@container style(--_swc-card-media-layout: xs) {
+@container style(--_swc-card-media-layout: 3col) {
   .swc-Card-media {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: var(--_swc-card-collection-columns);
     column-gap: var(--_swc-card-collection-gap);
   }
 

--- a/2nd-gen/packages/swc/components/card/card.css
+++ b/2nd-gen/packages/swc/components/card/card.css
@@ -9,3 +9,110 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+
+.swc-Card {
+  --_swc-card-collection-item-aspect-ratio: var(--swc-card-collection-item-aspect-ratio, 1);
+  --_swc-card-collection-gap: var(--swc-card-collection-gap, token("group-gap-extra-small"));
+}
+
+.swc-Card-media {
+  grid-template-areas:
+    "preview"
+    "collection";
+  grid-template-rows: repeat(2, auto);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   COLLECTION SLOT
+   ───────────────────────────────────────────────────────────────────────────── */
+
+.swc-Card-collection {
+  display: none;
+  grid-area: collection;
+  grid-template-columns: repeat(3, 1fr);
+  margin-block-start: var(--_swc-card-collection-gap);
+  column-gap: var(--_swc-card-collection-gap);
+}
+
+:host(:has([slot="collection"])) .swc-Card-collection {
+  display: grid;
+}
+
+/* Chromium :host(:has()) support */
+@scope {
+  :scope:has([slot="collection"]) .swc-Card-collection {
+    display: grid;
+  }
+}
+
+::slotted([slot="collection"]) {
+  inline-size: 100%;
+  aspect-ratio: var(--_swc-card-collection-item-aspect-ratio);
+  object-fit: cover;
+}
+
+/* Hide collection items after the 3rd one */
+::slotted(:nth-child(n + 4 of [slot="collection"])) {
+  display: none;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   COLLECTION WITHOUT PREVIEW
+   ───────────────────────────────────────────────────────────────────────────── */
+
+:host(:has([slot="collection"]):not(:has([slot="preview"]))) .swc-Card-collection {
+  margin-block-start: 0;
+}
+
+/* Chromium :host(:has()) support */
+@scope {
+  :scope:has([slot="collection"]):not(:has([slot="preview"])) .swc-Card-collection {
+    margin-block-start: 0;
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   SIZE=XS
+   For the extra-small size, if both the preview and collection slots are filled,
+   move the preview item into the first position of the collection row and 
+   hide overflow.
+   ───────────────────────────────────────────────────────────────────────────── */
+
+:host([size="xs"]) {
+  --swc-card-collection-gap: token("group-gap-compact");
+}
+
+:host([size="xs"]:has([slot="preview"]):has([slot="collection"])) .swc-Card {
+  --_swc-card-media-layout: xs;
+}
+
+/* Chromium :host(:has()) support */
+@scope (:host([size="xs"])) {
+  :scope:has([slot="preview"]):has([slot="collection"]) .swc-Card {
+    --_swc-card-media-layout: xs;
+  }
+}
+
+@container style(--_swc-card-media-layout: xs) {
+  .swc-Card-media {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    column-gap: var(--_swc-card-collection-gap);
+  }
+
+  .swc-Card-collection {
+    grid-template-columns: subgrid;
+    grid-row: -1 / 1;
+    grid-column: 2 / -1;
+    margin-block-start: 0;
+  }
+
+  ::slotted([slot="preview"]) {
+    --swc-card-base-preview-aspect-ratio: var(--_swc-card-collection-item-aspect-ratio);
+  }
+
+  /* Hide collection items after the 2nd one */
+  ::slotted(:nth-child(n + 3 of [slot="collection"])) {
+    display: none;
+  }
+}

--- a/2nd-gen/packages/swc/components/card/stories/card.stories.ts
+++ b/2nd-gen/packages/swc/components/card/stories/card.stories.ts
@@ -101,12 +101,12 @@ const densityLabels = {
   spacious: 'Spacious',
 } as const satisfies Record<CardDensity, string>;
 
-const previewImage = html`
-  <img slot="preview" src="./images/card-preview.jpg" alt="" />
+const mediaImage = (slot = 'preview') => html`
+  <img slot=${slot} src="./images/card-preview.jpg" alt="" />
 `;
 
 const basicSlots = html`
-  ${previewImage}
+  ${mediaImage()}
   <span slot="title">Card title</span>
   <span slot="description">Supporting description text.</span>
 `;
@@ -156,8 +156,35 @@ export const Anatomy: Story = {
     ${template(
       args,
       html`
-        ${previewImage}
-        <span slot="title">Full anatomy</span>
+        ${mediaImage()} ${mediaImage('collection')} ${mediaImage('collection')}
+        ${mediaImage('collection')}
+        <span slot="title">Collection slots filled</span>
+        <p slot="description">Supporting description text.</p>
+        <swc-action-button slot="actions" quiet accessible-label="More actions">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            viewBox="0 0 20 18"
+            slot="icon"
+          >
+            <circle cx="10" cy="10" r="1.5" />
+            <path d="M10 8.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3" />
+            <circle cx="4" cy="10" r="1.5" />
+            <circle cx="4" cy="10" r="1.5" />
+            <circle cx="16" cy="10" r="1.5" />
+            <circle cx="16" cy="10" r="1.5" />
+          </svg>
+        </swc-action-button>
+        <swc-status-light slot="footer" variant="positive" size="s">
+          Published
+        </swc-status-light>
+      `
+    )}
+    ${template(
+      args,
+      html`
+        ${mediaImage()}
+        <span slot="title">Preview only</span>
         <p slot="description">Supporting description text.</p>
         <swc-action-button slot="actions" quiet accessible-label="More actions">
           <svg
@@ -181,7 +208,7 @@ export const Anatomy: Story = {
     )}
   `,
   tags: ['anatomy'],
-  parameters: { flexLayout: 'column-center' },
+  parameters: { flexLayout: 'row-wrap' },
 };
 
 // ──────────────────────────
@@ -194,7 +221,7 @@ export const Sizes: Story = {
       template(
         { ...args, size },
         html`
-          ${previewImage}
+          ${mediaImage()}
           <span slot="title">${sizeLabels[size]}</span>
           <span slot="description">Supporting description text.</span>
         `
@@ -211,7 +238,7 @@ export const Variants: Story = {
       template(
         { ...args, variant },
         html`
-          ${previewImage}
+          ${mediaImage()}
           <span slot="title">${variantLabels[variant]}</span>
           <span slot="description">Supporting description text.</span>
         `
@@ -228,11 +255,57 @@ export const Density: Story = {
       template(
         { ...args, density },
         html`
-          ${previewImage}
+          ${mediaImage()}
           <span slot="title">${densityLabels[density]}</span>
           <span slot="description">Supporting description text.</span>
         `
       )
+    )}
+  `,
+  tags: ['options'],
+  parameters: { flexLayout: 'column-center' },
+};
+
+export const WithCollection: Story = {
+  render: (args) => html`
+    ${template(
+      { ...args, size: 'xs' },
+      html`
+        ${mediaImage()} ${mediaImage('collection')} ${mediaImage('collection')}
+        ${mediaImage('collection')}
+        <span slot="title">Extra Small</span>
+        <span slot="description">
+          Preview slot placed in first row position.
+        </span>
+      `
+    )}
+    ${template(
+      { ...args, size: 'm' },
+      html`
+        ${mediaImage()} ${mediaImage('collection')} ${mediaImage('collection')}
+        ${mediaImage('collection')}
+        <span slot="title">Filled Collection Card</span>
+        <span slot="description">Preview and collection slots are full.</span>
+      `
+    )}
+    ${template(
+      { ...args, size: 'm' },
+      html`
+        ${mediaImage()} ${mediaImage('collection')} ${mediaImage('collection')}
+        <span slot="title">Partial Collection Card</span>
+        <span slot="description">Only two collection slots filled.</span>
+      `
+    )}
+    ${template(
+      { ...args, size: 'm' },
+      html`
+        ${mediaImage('collection')} ${mediaImage('collection')}
+        ${mediaImage('collection')}
+        <span slot="title">Collection With No Preview</span>
+        <span slot="description">
+          No preview slot content, only collection items.
+        </span>
+      `
     )}
   `,
   tags: ['options'],
@@ -248,7 +321,7 @@ export const TitleAsLink: Story = {
     ${template(
       { ...args, 'title-as-link': true },
       html`
-        ${previewImage}
+        ${mediaImage()}
         <a slot="title" href="#">Linked card title</a>
         <span slot="description">
           Clicking anywhere on the card activates this link.

--- a/2nd-gen/packages/swc/stylesheets/_lit-styles/card-template.css
+++ b/2nd-gen/packages/swc/stylesheets/_lit-styles/card-template.css
@@ -149,10 +149,6 @@
   display: none;
 }
 
-::slotted([slot="content"]) {
-  grid-area: content;
-}
-
 ::slotted([slot="footer"]) {
   grid-area: footer;
 }

--- a/2nd-gen/packages/swc/stylesheets/_lit-styles/card-template.css
+++ b/2nd-gen/packages/swc/stylesheets/_lit-styles/card-template.css
@@ -56,7 +56,7 @@
     "media"
     "content"
     "footer";
-  grid-template-rows: auto auto 1fr auto;
+  grid-template-rows: auto 1fr auto;
   align-items: start;
   font-size: var(--_swc-card-base-title-font-size);
   line-height: var(--_swc-card-base-title-line-height);
@@ -86,10 +86,8 @@
 .swc-CardBase-media {
   display: grid;
   grid-area: media;
-  grid-template-areas:
-    "preview"
-    "collection";
-  grid-template-rows: auto auto;
+  grid-template-areas: "preview";
+  grid-template-rows: auto;
   border-radius: var(--_swc-card-base-border-radius) var(--_swc-card-base-border-radius) 0 0;
   overflow: hidden;
   pointer-events: none;
@@ -146,8 +144,9 @@
   object-fit: cover;
 }
 
-::slotted([slot="collection"]) {
-  grid-area: collection;
+/* Hide preview items after the first one */
+::slotted(:nth-child(n + 2 of [slot="preview"])) {
+  display: none;
 }
 
 ::slotted([slot="content"]) {

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/card/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/card/migration-plan.md
@@ -50,7 +50,7 @@
 - **Clickable card, no `href` on Card:** the consumer supplies their own link in the `title` slot; `title-as-link` extends its hit area, `selectable` independently makes the card focusable and dispatches a click event. Both are implemented and tested on `CardBase`.
 - **Labeling (avatar/thumbnail vs. title) is consumer documentation, not code** — Card doesn't validate or bridge accessible names that consumers already fully control.
 - **Styling:** CSS Grid for the shared structural layout; `size`/`density` resolve through `container-padding` tokens for content/footer padding. Region and intra-region spacing (title-to-description, media-to-content) relies on padding plus a blanket `margin-block: 0` reset on slotted content, not a gap-token scale.
-- **Tested:** `CardBase` has 20 passing behavior/dev-warning tests against test-only fixtures, plus 8 automated per-story smoke tests from `swc-card`'s own stories file (render-only; no explicit `play` functions yet). `swc-card` itself has no dedicated test file — it's still in the Styling pass, ahead of Testing.
+- **Tested:** `CardBase` has 20 passing behavior/dev-warning tests against test-only fixtures, plus 9 automated per-story smoke tests from `swc-card`'s own stories file (render-only; no explicit `play` functions yet). `swc-card` itself has no dedicated test file — it's still in the Styling pass, ahead of Testing.
 - **Still open:** five items (see [Blockers](#blockers-and-open-questions)) — naming, deferred design questions, and unresolved product-card scoping, none blocking.
 
 
@@ -100,8 +100,8 @@ React's card implementation is simplified to four patterns, mixed with consumer-
 Three concrete SWC components, all extending the already-built `CardBase`:
 
 - **`swc-card`** — regular, collection, and gallery layouts, all driven purely by slot presence, with no explicit layout attribute:
-  - **Collection** — populating the `collection` slot displays it; leaving it empty hides it, the same simple presence rule as any other optional slot.
-  - **Gallery** — triggered by a populated `preview` slot *and* the absence of **all** of `title`, `description`, `actions`, the default slot, and `footer`. That combination signals the image/asset is the card's only content, so it fills the available space. Any other combination renders the regular layout.
+  - **Collection** — populating the `collection` slot displays it; leaving it empty hides it, the same simple presence rule as any other optional slot. Implemented in `card.css`: up to 3 square-aspect images in a row below `preview`, extras beyond the 3rd hidden via `:nth-child(n + 4 of [slot="collection"])`. `preview` and `collection` are independently optional in either direction — a card can render `collection` alone with no `preview`, or vice versa. **`size="xs"` special case:** when both `preview` and `collection` are populated at `xs`, the preview image moves into the first position of the collection row (sharing its square aspect ratio) instead of stacking above it, and only 2 collection images show instead of 3 — implemented via a `--_swc-card-media-layout` custom property read through a CSS `@container style()` query, set conditionally via `:host([size="xs"]):has([slot="preview"]):has([slot="collection"])`.
+  - **Gallery** — triggered by a populated `preview` slot *and* the absence of **all** of `title`, `description`, `actions`, the default slot, and `footer`. That combination signals the image/asset is the card's only content, so it fills the available space. Any other combination renders the regular layout. Not yet implemented — tracked as its own follow-up ticket.
   Phase 1 handles basic `<img>` content and "cover" fit behavior directly. Once the 2nd-gen `Asset` component ships, documentation updates to recommend it in place of plain `<img>`; no dedicated `swc-asset-card` is planned.
 - **`swc-user-card`** — adds an `avatar` glyph slot; optional preview image, aspect ratio `3/1`.
 - **`swc-product-card`** — adds a `thumbnail` glyph slot (expects a logo); optional preview image, aspect ratio `5/1`; footer content alignment forced to `end`.
@@ -153,7 +153,7 @@ Shared slots from `renderCardTemplate()`: `preview`, `title`, `actions`, `descri
 
 | Component | Glyph slot | Preview aspect ratio | Notes |
 |---|---|---|---|
-| `swc-card` | none | `3/2` default, `1:1` gallery | Enables the `collection` slot: 1–3 images, square aspect ratio, shown when populated and hidden otherwise. Gallery is triggered by a populated `preview` slot plus the absence of **all** of `title`/`description`/`actions`/default/`footer` — the image becomes the only content and fills the available space. `preview` and `collection` are independently optional — a card can render `collection` alone with no larger `preview` image. Current `renderCardTemplate()` already tolerates this (an empty `<slot name="preview">` simply renders nothing); the swc-card styling phase needs to verify the media wrapper's sizing/aspect-ratio rules degrade correctly when only one of the two is populated, rather than assuming both. |
+| `swc-card` | none | `3/2` default, `1:1` collection/gallery | **Collection implemented** (`card.css`): 1–3 square-aspect images below `preview`, shown when populated and hidden otherwise (extras past the 3rd hidden via `:nth-child(n + 4 of [slot="collection"])`); `preview` and `collection` are independently optional in either direction, verified via the `WithCollection` story's four combinations (xs preview+3 collection, m preview+3 collection, m preview+2 collection, m collection-only/no-preview). **Gallery not yet implemented** — triggered by a populated `preview` slot plus the absence of **all** of `title`/`description`/`actions`/default/`footer` — the image becomes the only content and fills the available space; tracked as its own follow-up ticket. |
 | `swc-user-card` | `avatar` | `3/1` (optional) | |
 | `swc-product-card` | `thumbnail` | `5/1` (optional) | Footer content forced to `end` alignment. |
 
@@ -295,7 +295,8 @@ Both branches (`titleAsLink`'s proxy-click and `selectable`'s event dispatch) ru
 | Stretched-link CSS trick (A11y-3) | The rule now exists in `card-template.css` (`:host([title-as-link]) ::slotted(a[slot="title"])::before`, using `::before`), but verifying it properly needs coordinate-based clicking (e.g. clicking an empty corner of the rendered card) rather than DOM event dispatch | Playwright-level or manual browser verification |
 | Native modifier-click/middle-click/right-click-"open in new tab" across the *extended* surface | Tests intentionally use `event.preventDefault()` on the test anchor to avoid triggering real navigation inside the test run — this confirms the click-proxy fires, not that a real click-through would fully succeed, and modifier/button state can't be verified via `.click()` at all (see A11y-3) | Real browser/manual verification; likely also needs a Playwright-level test, not a `.click()`-based one |
 | "Elevate nested interactive targets" CSS stacking (A11y-3) | The rule now exists (`:host([title-as-link]) ::slotted(*:not([slot="title"])) { position: relative; z-index: 1; }`), but needs the same coordinate-based click verification as the stretched-link trick, with real actions-slot content styled alongside it | Playwright-level or manual browser verification |
-| Collection (1–3 images, square) and gallery (content area omitted) layout behavior | `swc-card`-specific; not yet implemented in `card-template.css` — deferred to its own follow-up ticket per the epic breakdown | Collection/gallery follow-up tickets |
+| Collection layout visual verification | Implemented in `card.css` and demonstrated across 4 combinations in the `WithCollection` story, but only visually — no automated test asserts the rendered grid/overflow behavior (e.g. that a 4th+ image is actually hidden, or that the `xs` merged preview+collection layout renders correctly) | `swc-card` Testing phase |
+| Gallery (content area omitted) layout behavior | `swc-card`-specific; not yet implemented — tracked as its own follow-up ticket | Gallery follow-up ticket |
 | Per-component `VARIANTS` override (e.g. `swc-user-card`/`swc-product-card` excluding `quiet`) | Only the base's full variant set is tested; no concrete class exists yet to override the static | Each per-component ticket |
 | Aspect ratios (3/1, 5/1) and footer `end`-alignment override | `swc-user-card`/`swc-product-card`-specific CSS, neither of which exists yet. `swc-card`'s own default `3/2` preview aspect ratio is implemented (`--swc-card-base-preview-aspect-ratio`) but still untested through a real component | Each per-component ticket |
 | A11y-1/A11y-2 consumer-documentation guidance | Prose guidance for consumers, not `CardBase` behavior — nothing to assert against | N/A (documentation task, not a test) |
@@ -319,7 +320,8 @@ Both branches (`titleAsLink`'s proxy-click and `selectable`'s event dispatch) ru
 - **`swc-card`** — in progress:
   - [x] Setup: `Card.ts`, `swc-card.ts`, `index.ts`, `card.css` placeholder, stories file scaffolded
   - [x] Shared `card-template.css` implemented: base structure, size/density/visual variants, title-as-link CSS mechanisms, actions-slot support gating, forced-colors override
-  - [ ] Styling: in progress — collection/gallery layout still outstanding
+  - [x] Collection layout implemented in `card.css` (own-component styles), including the `size="xs"` merged preview+collection layout
+  - [ ] Styling: in progress — gallery layout still outstanding
   - [ ] Accessibility, Testing, Documentation, Review: not started
 - **`swc-user-card`** — not started
 - **`swc-product-card`** — not started


### PR DESCRIPTION
## Description

Implements the `collection` slot for `swc-card` — one of the three layout modes described in the card family plan (regular/collection/gallery). See the migration plan updates for a summary of implementation changes.

- `card.css`: `collection` slot layout — up to 3 square-aspect images displayed below `preview`, hidden via `:nth-child(n + 4 of [slot="collection"])` beyond the 3rd; `preview` and `collection` are independently optional in either direction
- `size="xs"` special case: when both `preview` and `collection` are populated, the preview image merges into the first position of the collection row (sharing its square aspect ratio) instead of stacking above it, and the visible cap drops to 2 images instead of 3 — implemented via a `--_swc-card-media-layout` custom property read through a CSS `@container style()` query
- Shared `card-template.css` adjusted to make room for this: the generic two-row `preview`/`collection` grid was removed from `.swc-CardBase-media` (collection is `swc-card`-specific, not shared with `swc-user-card`/`swc-product-card`), and a defensive rule was added to hide extra `preview` slot content beyond the first item
- `Card.ts`: added `@slot collection` and two new `@cssprop` tags (`--swc-card-collection-item-aspect-ratio`, `--swc-card-collection-gap`); wired `renderCollection` into `render()`
- New `WithCollection` Storybook story demonstrating four combinations: `xs` preview+3 collection (merged row), `m` preview+3 collection, `m` preview+2 collection, `m` collection-only (no preview)
- `Anatomy` story updated to show a collection-filled card alongside a preview-only card

## Motivation and context

Collection was split out from the base `swc-card` structure/API/styling PR (SWC-2361) into its own ticket to keep that PR reviewable, per the card family epic breakdown.

## Related issue(s)

- Jira: SWC-2362
- Builds on SWC-2361 (`swc-card` structure/API/styling)

## Screenshots

See the "With collection" stories for full visual coverage.

<img width="291" height="405" alt="image" src="https://github.com/user-attachments/assets/eba09af3-ba6c-48d9-8556-aa5d760005ad" />

## Manual review test cases

- [x] _Collection slot combinations_
  1. Go to the `With Collection` story
  2. Confirm each of the four demoed combinations renders correctly: `xs` preview+3 collection (merged row, 2 visible), `m` preview+3 collection, `m` preview+2 collection, `m` collection-only (no preview)
  3. Add a 4th+ collection image via Controls and confirm extras beyond the 3rd (2nd at `xs`) are hidden, not overflowing
    - Insert the following in the "collection" slot control one or more times with no space in-between for correct visual render: `<img slot="collection" src="./images/card-preview.jpg" alt="" />`
  4. Populate the collection slot and remove the image from the preview slot and validate correct appearance of the collection row with no extra margin
  5. Validate correct outline when `selectable` is true and the card receives keyboard focus

- [x] _Preview/collection independence_
  1. Go to the `Anatomy` story
  2. Confirm the collection-filled card and the preview-only card both render correctly with no missing or misplaced content
  3. Confirm no regression to cards with neither slot populated (e.g. `Sizes`/`Variants`/`Density` stories)

- [x] _Multiple preview items (defensive rule)_
  1. Slot two `<img slot="preview">` elements on a card
     - Insert the following in the "preview" slot control one or more times with no space in-between for correct visual render: `<img slot="preview" src="./images/card-preview.jpg" alt="" />`
  3. Expect only the first to render; the second should not appear or overflow

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [x] **Keyboard** (required — document steps below)
  1. Go to the `With Collection` story
  2. Confirm collection images are non-interactive and introduce no new tab stops
  6. Confirm no keyboard behavior regresses for existing `actions`/`title-as-link`/`selectable` focus flows on a card that also has collection content

- [x] **Screen reader** (required — document steps below)
  1. With VoiceOver or NVDA, navigate to a card with collection images
  2. Confirm each visible collection `<img>` announces its `alt` text (or is skipped if decorative, matching preview-slot guidance)
  3. Confirm collection images hidden past the visible cap (3, or 2 at `xs`) are not exposed to the accessibility tree
