### PR TITLE
fix(1st-gen): run storybook npm script from start instead of bare CLI

### DIFF
--- a/1st-gen/package.json
+++ b/1st-gen/package.json
@@ -55,7 +55,7 @@
     "pretest:bench": "yarn build:tests && test -f test/benchmark/cli.js ||:",
     "pretest:visual": "yarn build && yarn build",
     "process-icons": "wireit",
-    "start": "storybook",
+    "start": "yarn storybook",
     "storybook": "wireit",
     "storybook:build": "NODE_ENV=production storybook build -o projects/documentation/dist/storybook -c storybook",
     "storybook:quick": "run-p build:watch storybook:run",


### PR DESCRIPTION
## Description

`yarn start` in `1st-gen/package.json` ran the `storybook` command directly instead of delegating to the `storybook` npm script. Changed it to `yarn storybook` so it invokes the properly wired script.

## Motivation and context

Running `yarn start` from the repo root failed with `ERROR: "start:1st-gen" exited with 1`. The `start` script was set to the literal command `storybook`, which invokes the Storybook CLI binary directly with no subcommand. With no subcommand, the CLI just prints usage help and exits 1, instead of launching a dev server.

The `storybook` npm script in the same file is wired through `wireit` to `storybook dev -p 8080 -c storybook`, along with its `prestorybook` and `build:watch` dependencies. `start` needs to run that script rather than invoke the bare CLI, so it should call `yarn storybook`, not `storybook`.

This regressed in #6489, which changed `"start": "run-p dev:core storybook"` to `"start": "storybook"` while removing the retired `dev:core` script, but replaced `run-p dev:core storybook` with the bare CLI command instead of just dropping `dev:core` from the `run-p` call.

## Related issue(s)

- No related issue

## Screenshots (if appropriate)

N/A (build tooling fix, no visual changes)

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _`yarn start` launches the 1st-gen Storybook dev server_
  1. From the repo root, run `yarn start`
  2. Wait for the build/watch tasks to complete
  3. Expect Storybook to start serving on `http://localhost:8080` instead of the process printing CLI usage help and exiting with code 1

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)

  No focusable UI is added or changed by this fix; it only corrects a build script. Confirm no regressions in the Storybook dev server's own keyboard navigation once it loads.

- [ ] **Screen reader** (required — document steps below)

  No DOM, roles, or labels are added or changed by this fix. Confirm no regressions in the Storybook dev server UI once it loads.