### PR TITLE
docs: minor fixes

### DIFF
--- a/.ai/rules/stories-documentation.md
+++ b/.ai/rules/stories-documentation.md
@@ -53,9 +53,7 @@ import * as Stories from './stories/<unit>.stories';
 
 ## States
 
-### States
-
-...prose...
+...prose (single-story section whose story name matches the heading — no `### States`; see "Single-story sections")...
 
 <Canvas of={Stories.States} />
 

--- a/2nd-gen/packages/swc/components/close-button/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/close-button/migration-guide.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Close Button/Migration guide" />
+<Meta title="Close button/Migration guide" />
 
 # Close button migration guide
 

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -58,7 +58,7 @@ args['accessible-label'] = 'Close';
  * [Button](../?path=/docs/components-button--docs).
  */
 const meta: Meta = {
-  title: 'Close Button',
+  title: 'Close button',
   component: 'swc-close-button',
   args,
   argTypes,

--- a/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
@@ -34,7 +34,7 @@ import meta, {
 
 export default {
   ...meta,
-  title: 'Close Button/Tests',
+  title: 'Close button/Tests',
   parameters: {
     ...meta.parameters,
     docs: { disable: true, page: null },

--- a/2nd-gen/packages/swc/components/progress-bar/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/progress-bar/migration-guide.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Progress Bar/Migration guide" />
+<Meta title="Progress bar/Migration guide" />
 
 # Progress bar migration guide
 

--- a/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
@@ -78,7 +78,7 @@ argTypes.value = {
  * values use [Meter](../?path=/docs/components-meter--docs).
  */
 const meta: Meta = {
-  title: 'Progress Bar',
+  title: 'Progress bar',
   component: 'swc-progress-bar',
   parameters: {
     docs: {

--- a/2nd-gen/packages/swc/components/progress-bar/test/progress-bar.test.ts
+++ b/2nd-gen/packages/swc/components/progress-bar/test/progress-bar.test.ts
@@ -29,7 +29,7 @@ import { Indeterminate, Overview } from '../stories/progress-bar.stories.js';
 // This file defines dev-only test stories that reuse the main story metadata.
 export default {
   ...meta,
-  title: 'Progress Bar/Tests',
+  title: 'Progress bar/Tests',
   parameters: {
     ...meta.parameters,
     docs: { disable: true, page: null },


### PR DESCRIPTION
## Description

Two small documentation-conformance fixes against `stories-documentation.md`.

### 1. Fix the `## States` template so it matches its own prose rule

The section template showed `## States` immediately followed by `### States`, contradicting the "Single-story sections" prose rule, which says a single-story section whose story name matches the `## Section` heading must **omit** the `### Title` subheading and author prose directly under the section heading — explicitly calling `## States` → `### States` "redundant; collapse it to one heading" (compliant examples: `button.mdx`, `color-handle.mdx`). Collapsed the States example so the illustration agrees with the rule it documents.

### 2. Sentence-case two sidebar titles that slipped into Title Case

`stories-documentation.md` requires "Use sentence case for all headings and descriptions," and the sidebar convention across components is sentence case (`Action button`, `Progress circle`, `Status light`, …). Two exceptions had landed on main:

- `Close Button` → `Close button`
- `Progress Bar` → `Progress bar`

Each is corrected in three places so the whole sidebar subtree stays consistent under one nav node: the stories meta `title`, the migration-guide `<Meta title>`, and the test story `title` (which shares the nav prefix).

## Motivation and context

The contradictory States template was actively misleading — authoring against it reproduced the exact redundant heading the prose forbids, and reviewing against it produced false "this is fine" reads. The two Title Case titles render inconsistently in the Storybook sidebar next to their sentence-case peers.

## Related issue(s)

- N/A

## Author's checklist

- [ ] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## How has this been tested?

- Documentation/authoring-rule and Storybook nav-title changes only; no runtime/component behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)