### PR TITLE
docs: minor fixes

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -86,7 +86,7 @@ These two rules share the same glob (`2nd-gen/**/stories/**`) and work as a pair
 - **stories-format**: File structure and technical conventions
   - Visual separators, meta configuration, required tags, layout parameters
   - `render` vs `args` patterns, `flexLayout` usage
-  - Static color three-story pattern, image asset conventions
+  - Static color single-story pattern, image asset conventions
 
 #### Component README
 

--- a/.ai/rules/stories-documentation.md
+++ b/.ai/rules/stories-documentation.md
@@ -226,7 +226,7 @@ const allLabels = { ...semanticLabels, ...colorLabels };
 1. **JSDoc description above meta**: Provides the main description of what the component does and when to use it. This description:
    - Is displayed as the primary documentation for the Overview story
    - Can include markdown formatting and links to other components
-   - Should reference other components using Storybook paths: `[Badge](../?path=/docs/badge--readme)`
+   - Should reference other components using Storybook paths: `[Badge](../?path=/docs/components-badge--docs)`
    - Should provide fuller context than the subtitle
 
 2. **`parameters.docs.subtitle`**: Provides a brief summary displayed as the subtitle. This subtitle:
@@ -241,7 +241,7 @@ const allLabels = { ...semanticLabels, ...colorLabels };
 /**
  * A badge is a non-interactive visual label that displays a status, category, or attribute.
  * Badges can be used to highlight important information or to categorize items. For interactive
- * labels, see [Button](../?path=/docs/button--readme).
+ * labels, see [Button](../?path=/docs/components-button--docs).
  */
 const meta: Meta = {
   title: 'Badge',
@@ -902,7 +902,7 @@ After verifying accuracy:
 When referencing other components — whether in the meta-level JSDoc, the meta `parameters.docs.subtitle`, or anywhere in the per-unit MDX:
 
 - **Use Storybook paths**: Link to the component's docs page using relative paths
-- **Format**: `[ComponentName](../?path=/docs/components-component-name--docs)` (or `--readme` if that's the convention in your area)
+- **Format**: `[ComponentName](../?path=/docs/components-component-name--docs)`
 - **Component name format**: Use kebab-case in the path (e.g., `action-button`, `progress-circle`)
 - **Subtitle exception**: `parameters.docs.subtitle` is plain text and cannot include links.
 

--- a/.ai/rules/stories-documentation.md
+++ b/.ai/rules/stories-documentation.md
@@ -130,7 +130,7 @@ If a single-story section's rendered name _differs_ from the `## Section` headin
 
 ### Untagged stories do not appear
 
-Stories without any section tag (`anatomy`, `options`, `states`, `behaviors`, `a11y`, `upcoming`, `usage`, `appendix`, `full-pattern`, `api`) are not surfaced on the Docs page (subject to the global `'!autodocs'` / `'!dev'` exclusion in `preview.ts`). Do not author a `<Canvas of={...}>` for an untagged story in MDX; that would surface content production does not render.
+Stories without any section tag (`anatomy`, `options`, `states`, `behaviors`, `a11y`, `upcoming`, `appendix`, `full-pattern`, `api`) are not surfaced on the Docs page (subject to the global `'!autodocs'` / `'!dev'` exclusion in `preview.ts`). Do not author a `<Canvas of={...}>` for an untagged story in MDX; that would surface content production does not render.
 
 ### Self-check with `yarn lint:docs-pages`
 

--- a/.ai/rules/stories-documentation.md
+++ b/.ai/rules/stories-documentation.md
@@ -335,17 +335,22 @@ export const Anatomy: Story = {
 
 **Pattern for sizes**:
 
+```mdx
+### Sizes
+
+Component-names come in [X] sizes to fit various contexts:
+
+- **Small (`s`)**: Used for inline indicators or space-constrained areas
+- **Medium (`m`)**: Default size, used for typical use cases
+- **Large (`l`)**: Used for prominent displays or primary content areas
+- **Extra-large (`xl`)**: Maximum visibility (if applicable)
+
+All sizes shown below for comparison.
+
+<Canvas of={Stories.Sizes} />
+```
+
 ```typescript
-/**
- * Component-names come in [X] sizes to fit various contexts:
- *
- * - **Small (`s`)**: Used for inline indicators or space-constrained areas
- * - **Medium (`m`)**: Default size, used for typical use cases
- * - **Large (`l`)**: Used for prominent displays or primary content areas
- * - **Extra-large (`xl`)**: Maximum visibility (if applicable)
- *
- * All sizes shown below for comparison.
- */
 export const Sizes: Story = {
   render: (args) => html`
     ${template({ ...args, size: 's', label: 'Small' })}
@@ -361,19 +366,24 @@ export const Sizes: Story = {
 
 **Pattern for semantic variants**:
 
+```mdx
+### Semantic variants
+
+Semantic variants provide meaning through color:
+
+- **`accent`**: New, beta, prototype, draft
+- **`informative`**: Active, in use, live, published
+- **`neutral`**: Archived, deleted, paused, draft, not started, ended
+- **`positive`**: Approved, complete, success, new, purchased, licensed
+- **`notice`**: Needs approval, pending, scheduled
+- **`negative`**: Error, alert, rejected, failed
+
+All semantic variants shown below for comparison.
+
+<Canvas of={Stories.SemanticVariants} />
+```
+
 ```typescript
-/**
- * Semantic variants provide meaning through color:
- *
- * - **`accent`**: New, beta, prototype, draft
- * - **`informative`**: Active, in use, live, published
- * - **`neutral`**: Archived, deleted, paused, draft, not started, ended
- * - **`positive`**: Approved, complete, success, new, purchased, licensed
- * - **`notice`**: Needs approval, pending, scheduled
- * - **`negative`**: Error, alert, rejected, failed
- *
- * All semantic variants shown below for comparison.
- */
 export const SemanticVariants: Story = {
   render: (args) => html`
     ${template({ ...args, variant: 'positive', label: 'Positive' })}
@@ -387,6 +397,7 @@ export const SemanticVariants: Story = {
     flexLayout: 'row-wrap',
   },
 };
+SemanticVariants.storyName = 'Semantic variants';
 ```
 
 **Pattern for static color**: sourced from Spectrum's static color usage guidance (e.g. [Button](https://spectrum.adobe.com/page/button/#Static-color)). The component's color pins to the chosen value regardless of the active theme, and the choice of value depends on the background it sits over.
@@ -426,19 +437,24 @@ export const StaticColors: Story = {
 
 **Consolidation rule**: Combine all states into a **single States story** when possible (or minimal stories when states are complex).
 
-**Pattern**:
+**Pattern** (single States story; section heading and story name match — collapse to one heading, no `### States`; see "Single-story sections"):
+
+```mdx
+## States
+
+Components can exist in various states:
+
+- **Default**: Normal, interactive state
+- **Selected**: Item has been chosen or activated
+- **Disabled**: Functionality exists but is not available
+- **Error**: Validation failure or error condition
+
+All states shown below for comparison.
+
+<Canvas of={Stories.States} />
+```
 
 ```typescript
-/**
- * Components can exist in various states:
- *
- * - **Default**: Normal, interactive state
- * - **Selected**: Item has been chosen or activated
- * - **Disabled**: Functionality exists but is not available
- * - **Error**: Validation failure or error condition
- *
- * All states shown below for comparison.
- */
 export const States: Story = {
   render: (args) => html`
     ${template({ ...args, label: 'Default' })}
@@ -453,13 +469,18 @@ export const States: Story = {
 };
 ```
 
-**Pattern for complex states** (when animation or interaction is critical):
+**Pattern for complex states** (when animation or interaction is critical — states no longer combine into one story, so each gets its own per-story `### Title`):
+
+```mdx
+### Indeterminate
+
+The indeterminate state shows an animated loading indicator when progress is unknown or cannot be determined.
+The animation automatically loops until the state changes.
+
+<Canvas of={Stories.Indeterminate} />
+```
 
 ```typescript
-/**
- * The indeterminate state shows an animated loading indicator when progress is unknown or cannot be determined.
- * The animation automatically loops until the state changes.
- */
 export const Indeterminate: Story = {
   tags: ['states'],
   args: {
@@ -469,15 +490,13 @@ export const Indeterminate: Story = {
 };
 ```
 
-**Disabled state template**:
+**Disabled state note** (fold into the `## States` prose above, or use verbatim if Disabled needs its own `### Disabled` story):
 
-```typescript
-/**
- * A component in a disabled state shows that [functionality] exists, but is not available in that circumstance.
- * This can be used to maintain layout continuity and communicate that [functionality] may become available later.
- *
- * **ARIA support**: When disabled, the component automatically sets `aria-disabled="true"`.
- */
+```mdx
+A component in a disabled state shows that [functionality] exists, but is not available in that circumstance.
+This can be used to maintain layout continuity and communicate that [functionality] may become available later.
+
+**ARIA support**: When disabled, the component automatically sets `aria-disabled="true"`.
 ```
 
 ### Behaviors
@@ -488,18 +507,16 @@ export const Indeterminate: Story = {
 
 **Pattern for automatic behaviors**:
 
+```mdx
+### Text wrapping
+
+Long text content automatically wraps to multiple lines to fit the available space.
+When space is constrained, text truncates with an ellipsis (...).
+
+<Canvas of={Stories.TextWrapping} />
+```
+
 ```typescript
-/**
- * ### Text handling
- *
- * Long text content automatically wraps to multiple lines to fit the available space.
- * When space is constrained, text truncates with an ellipsis (...).
- *
- * ### Focus management
- *
- * When opened, focus is automatically trapped within the component.
- * When closed, focus returns to the triggering element.
- */
 export const TextWrapping: Story = {
   render: (args) => html`
     ${template({ 'default-slot': 'Short text' })}
@@ -513,60 +530,67 @@ export const TextWrapping: Story = {
     flexLayout: 'row-wrap',
   },
 };
+TextWrapping.storyName = 'Text wrapping';
 ```
 
 **Pattern for methods**:
 
-````typescript
-/**
- * ### Methods
- *
- * The component exposes the following public methods:
- *
- * - **open()**: Opens the component programmatically
- * - **close()**: Closes the component programmatically
- * - **toggle()**: Toggles between open and closed states
- * - **reset()**: Resets the component to its initial state
- *
- * Example usage:
- *
- * ```javascript
- * const component = document.querySelector('swc-component-name');
- * component.open();
- * ```
- */
+````mdx
+### Methods
+
+The component exposes the following public methods:
+
+- **open()**: Opens the component programmatically
+- **close()**: Closes the component programmatically
+- **toggle()**: Toggles between open and closed states
+- **reset()**: Resets the component to its initial state
+
+Example usage:
+
+```javascript
+const component = document.querySelector('swc-component-name');
+component.open();
+```
+
+<Canvas of={Stories.Methods} />
+````
+
+```typescript
 export const Methods: Story = {
   tags: ['behaviors'],
   // ... implementation
 };
-````
+```
 
 **Pattern for events**:
 
-````typescript
-/**
- * ### Events
- *
- * The component dispatches the following custom events:
- *
- * - **change**: Fired when the value changes (bubbles: true, composed: true)
- * - **input**: Fired during user input (bubbles: true, composed: true)
- * - **swc-opened**: Fired when the component opens (bubbles: true, composed: true)
- * - **swc-closed**: Fired when the component closes (bubbles: true, composed: true)
- *
- * Example event listener:
- *
- * ```javascript
- * component.addEventListener('change', (event) => {
- *     console.log('Value changed:', event.target.value);
- * });
- * ```
- */
+````mdx
+### Events
+
+The component dispatches the following custom events:
+
+- **change**: Fired when the value changes (bubbles: true, composed: true)
+- **input**: Fired during user input (bubbles: true, composed: true)
+- **swc-opened**: Fired when the component opens (bubbles: true, composed: true)
+- **swc-closed**: Fired when the component closes (bubbles: true, composed: true)
+
+Example event listener:
+
+```javascript
+component.addEventListener('change', (event) => {
+    console.log('Value changed:', event.target.value);
+});
+```
+
+<Canvas of={Stories.Events} />
+````
+
+```typescript
 export const Events: Story = {
   tags: ['behaviors'],
   // ... implementation
 };
-````
+```
 
 ### Accessibility
 
@@ -576,42 +600,45 @@ export const Events: Story = {
 
 **Pattern**:
 
+```mdx
+### Features
+
+The `<swc-component-name>` element implements several accessibility features:
+
+#### Keyboard navigation
+
+- <kbd>Tab</kbd>: Moves focus to/from the component
+- <kbd>Space</kbd> or <kbd>Enter</kbd>: Activates the component
+- <kbd>Arrow keys</kbd>: Navigate between items
+- <kbd>Escape</kbd>: Closes the component (if applicable)
+
+#### ARIA implementation
+
+1. **ARIA role**: Automatically sets `role="progressbar"` (or appropriate role)
+2. **Labeling**: Uses the `label` attribute as `aria-label`
+3. **States**:
+    - Sets `aria-valuenow` with current progress value
+    - Sets `aria-disabled="true"` when disabled
+4. **Status communication**: Screen readers announce value changes
+
+#### Visual accessibility
+
+- Progress is shown visually through multiple cues, not relying solely on color
+- High contrast mode is supported with appropriate color overrides
+- Static color variants ensure sufficient contrast on different backgrounds
+
+### Best practices
+
+- Always provide a descriptive `label` that explains what the component represents
+- Use meaningful, specific labels (e.g., "Uploading document" instead of "Loading")
+- Ensure sufficient color contrast between the component and its background
+- Use semantic variants when status has specific meaning
+- Test with screen readers to verify announcements are clear
+
+<Canvas of={Stories.Accessibility} />
+```
+
 ```typescript
-/**
- * ### Features
- *
- * The `<swc-component-name>` element implements several accessibility features:
- *
- * #### Keyboard navigation
- *
- * - <kbd>Tab</kbd>: Moves focus to/from the component
- * - <kbd>Space</kbd> or <kbd>Enter</kbd>: Activates the component
- * - <kbd>Arrow keys</kbd>: Navigate between items
- * - <kbd>Escape</kbd>: Closes the component (if applicable)
- *
- * #### ARIA implementation
- *
- * 1. **ARIA role**: Automatically sets `role="progressbar"` (or appropriate role)
- * 2. **Labeling**: Uses the `label` attribute as `aria-label`
- * 3. **States**:
- *     - Sets `aria-valuenow` with current progress value
- *     - Sets `aria-disabled="true"` when disabled
- * 4. **Status communication**: Screen readers announce value changes
- *
- * #### Visual accessibility
- *
- * - Progress is shown visually through multiple cues, not relying solely on color
- * - High contrast mode is supported with appropriate color overrides
- * - Static color variants ensure sufficient contrast on different backgrounds
- *
- * ### Best practices
- *
- * - Always provide a descriptive `label` that explains what the component represents
- * - Use meaningful, specific labels (e.g., "Uploading document" instead of "Loading")
- * - Ensure sufficient color contrast between the component and its background
- * - Use semantic variants when status has specific meaning
- * - Test with screen readers to verify announcements are clear
- */
 export const Accessibility: Story = {
   tags: ['a11y'],
   args: {

--- a/.ai/rules/stories-documentation.md
+++ b/.ai/rules/stories-documentation.md
@@ -106,19 +106,19 @@ import * as Stories from './stories/<unit>.stories';
 
 ### Per-story title rules
 
-Per-story `### Title` headings (in sections with `hideTitle=false`: Options, States, Behaviors, Full pattern) must match the story's rendered name exactly:
+Per-story `### Title` headings (in sections with `hideTitle=false`: Options, States, Behaviors, Full pattern) must match the story's rendered name exactly, and that rendered name must be sentence case (see "Documentation style" below):
 
 - If the story has an explicit `<Story>.storyName = '...'` override, use that exact string.
-- Otherwise, use Storybook's PascalCase → Title Case conversion of the export name (each word capitalized).
+- Otherwise, use the export name as rendered by Storybook. This only produces a valid title for single-word exports, where the default rendering is already sentence case (`Sizes` → `Sizes`). For multi-word exports, Storybook's default PascalCase → Title Case conversion capitalizes every word, which is **not** sentence case — add a `.storyName` override (see stories-format.md's story-naming pattern) so the rendered title is sentence case.
 
 Examples:
 
 | Export name                                                       | Rendered title          |
 | ----------------------------------------------------------------- | ----------------------- |
 | `Sizes`                                                           | `Sizes`                 |
-| `TextWrapping`                                                    | `Text Wrapping`         |
-| `InActionButton`                                                  | `In Action Button`      |
-| `ActivationModes`                                                 | `Activation Modes`      |
+| `TextWrapping` with `.storyName = 'Text wrapping'`                | `Text wrapping`         |
+| `InActionButton` with `.storyName = 'In action button'`           | `In action button`      |
+| `ActivationModes` with `.storyName = 'Activation modes'`          | `Activation modes`      |
 | `SemanticVariants` with `.storyName = 'Semantic variants'`        | `Semantic variants`     |
 | `NonSemanticVariants` with `.storyName = 'Non-semantic variants'` | `Non-semantic variants` |
 
@@ -955,7 +955,7 @@ When creating or updating documentation:
 - [ ] `<DocsHeader />` at the top, `<DocsFooter />` at the bottom
 - [ ] Sections appear in the canonical order (Anatomy → Usage → Options → States → Behaviors → Accessibility → Full pattern → Upcoming features → API → Appendix → Feedback) — skip sections that do not apply
 - [ ] Every section-tagged story is referenced via `<Canvas of={Stories.StoryName} />`
-- [ ] Per-story `### Title` headings match Storybook's rendered story names (PascalCase → Title Case, or explicit `storyName`)
+- [ ] Per-story `### Title` headings match Storybook's rendered story names and are sentence case (single-word exports render as-is; multi-word exports need an explicit `.storyName` override — see "Per-story title rules")
 - [ ] No `<Canvas>` references to untagged stories
 - [ ] Controllers: hand-authored `## API` section ahead of `<DocsFooter />`; `meta.tags` contains `'controller'` so `<ApiTable />` is omitted
 - [ ] Anatomy: parts listed as a flat, unordered list with no `###`/`####` subsections (components and patterns)

--- a/.ai/rules/stories-documentation.md
+++ b/.ai/rules/stories-documentation.md
@@ -578,7 +578,7 @@ Example event listener:
 
 ```javascript
 component.addEventListener('change', (event) => {
-    console.log('Value changed:', event.target.value);
+  console.log('Value changed:', event.target.value);
 });
 ```
 
@@ -617,8 +617,8 @@ The `<swc-component-name>` element implements several accessibility features:
 1. **ARIA role**: Automatically sets `role="progressbar"` (or appropriate role)
 2. **Labeling**: Uses the `label` attribute as `aria-label`
 3. **States**:
-    - Sets `aria-valuenow` with current progress value
-    - Sets `aria-disabled="true"` when disabled
+   - Sets `aria-valuenow` with current progress value
+   - Sets `aria-disabled="true"` when disabled
 4. **Status communication**: Screen readers announce value changes
 
 #### Visual accessibility

--- a/.ai/rules/stories-documentation.md
+++ b/.ai/rules/stories-documentation.md
@@ -53,9 +53,7 @@ import * as Stories from './stories/<unit>.stories';
 
 ## States
 
-### States
-
-...prose...
+...prose (single-story section whose story name matches the heading — no `### States`; see "Single-story sections")...
 
 <Canvas of={Stories.States} />
 

--- a/.ai/rules/stories-format.md
+++ b/.ai/rules/stories-format.md
@@ -173,7 +173,7 @@ See `.ai/rules/stories-documentation.md` for full per-section authoring patterns
  * This description is displayed in the Overview story. It should provide context about
  * what the component does and when to use it. If referencing other components, link to
  * their Storybook paths using relative URLs (e.g., `<swc-badge>` becomes
- * `[Badge](../?path=/docs/badge--overview)`).
+ * `[Badge](../?path=/docs/components-badge--docs)`).
  */
 const meta: Meta = {
   title: 'Component name',
@@ -198,7 +198,7 @@ const meta: Meta = {
 - **JSDoc description above meta**: Displayed in the Overview story. Can include markdown links to other components.
 - **`parameters.docs.subtitle`**: Displayed as the subtitle in the Overview story. Cannot include links (plain text only).
 - **Avoid repetition**: The subtitle and JSDoc description should complement each other, not duplicate content. The subtitle is a brief summary; the JSDoc provides fuller context.
-- **Component links**: When referencing other components in the JSDoc description, use relative Storybook paths: `[ComponentName](../?path=/docs/component-name--overview)`
+- **Component links**: When referencing other components in the JSDoc description, use relative Storybook paths: `[ComponentName](../?path=/docs/components-component-name--docs)`
 
 ### Internal attributes: exclude from the Storybook helper round-trip
 
@@ -563,7 +563,7 @@ Do **not** add JSDoc comments above any individual `export const Foo: Story = ..
 /**
  * A `<swc-badge>` is a non-interactive visual label that displays a status,
  * category, or attribute. For interactive labels, see
- * [Button](../?path=/docs/button--docs).
+ * [Button](../?path=/docs/components-button--docs).
  */
 const meta: Meta = {
   title: 'Badge',

--- a/.ai/rules/stories-format.md
+++ b/.ai/rules/stories-format.md
@@ -408,9 +408,9 @@ Document every attribute/property not covered in Anatomy, States, or Behaviors. 
 | `Sizes`                   | All size variants                                 |
 | `SemanticVariants`        | Positive, informative, negative, notice, neutral  |
 | `NonSemanticVariants`     | Color-coded categories (seafoam, indigo, etc.)    |
-| `StaticColors`            | Static color pattern (see below)                  |
 | `Quiet/Subtle/Emphasized` | Quiet, subtle, emphasized variants                |
 | `Outline`                 | Outline variants                                  |
+| `StaticColors`            | Static color pattern (see below)                  |
 | `Positioning`             | Positioning modifiers (fixed, absolute, relative) |
 
 ```typescript
@@ -698,7 +698,7 @@ See `asset.stories.ts` for complete examples.
 - [ ] States: consolidated states, `['states']` tag, `flexLayout: 'row-wrap'` (if applicable)
 - [ ] Behaviors: `['behaviors']` tag (if applicable)
 - [ ] Accessibility: `['a11y']` tag (prose lives in MDX)
-- [ ] Static colors: three-story or combined-story pattern with `staticColorsDemo` (if applicable)
+- [ ] Static colors: single `StaticColors` story (flat or div-wrapped shape) with `staticColorsDemo` (if applicable)
 - [ ] No story-level JSDoc comments above any `export const`
 - [ ] No `section-order` parameter on any story
 - [ ] No `description-only` tag on any story

--- a/.ai/rules/stories-format.md
+++ b/.ai/rules/stories-format.md
@@ -222,14 +222,13 @@ argTypes['internal-attribute'] = {
 
 These rules apply to every `title` field in meta objects and every `<Meta title="..." />` in MDX files.
 
-- **Component names are proper nouns — keep their title case.** `'Action Button'`, `'Illustrated Message'`, `'Color Loupe'`. Each word in the component name is capitalised.
-- **Everything else uses sentence case.** Page labels, section names, and group names that are not component names: `'Pattern overview'`, `'Migration guide'`.
+- **Use sentence case — including component names**, matching Spectrum's own docs (e.g. [Action bar](https://spectrum.adobe.com/page/action-bar/), [Color loupe](https://spectrum.adobe.com/page/color-loupe/)). Capitalize only the first word plus any proper nouns/acronyms: `'Action button'`, `'Illustrated message'`, `'Color loupe'`. Page labels, section names, and group names follow the same rule: `'Pattern overview'`, `'Migration guide'`.
 - **No filename as label.** Never use a bare filename (`README`, `CHANGELOG`) as a Storybook title or page name. Use a descriptive label: `'Pattern overview'`, `'Migration guide'`.
-- **Flatten single-component groups.** If a Storybook group contains only one component, do not nest it. Use a flat title (`'Color Loupe'`) rather than a group path (`'Color Components/Color Loupe'`).
+- **Flatten single-component groups.** If a Storybook group contains only one component, do not nest it. Use a flat title (`'Color loupe'`) rather than a group path (`'Color components/Color loupe'`).
 
 | ❌ Don't                         | ✅ Do                                  |
 | -------------------------------- | -------------------------------------- |
-| `'Color Components/Color Loupe'` | `'Color Loupe'` (flattened)            |
+| `'Color components/Color loupe'` | `'Color loupe'` (flattened)            |
 | `'Conversational AI/README'`     | `'Conversational AI/Pattern overview'` |
 | `'Badge/Migration Guide'`        | `'Badge/Migration guide'`              |
 | `'Pattern Overview'`             | `'Pattern overview'`                   |

--- a/.ai/skills/consumer-migration-guide/SKILL.md
+++ b/.ai/skills/consumer-migration-guide/SKILL.md
@@ -67,7 +67,7 @@ Verify claims against the real implementation and docs before writing:
 
 - **Migration plan:** `CONTRIBUTOR-DOCS/03_project-planning/03_components/[component]/migration-plan.md` — primary source for what breaking changes to cover (see Step 0 above)
 - **Spectrum 1 docs and source:** `1st-gen/packages/[component-name]/README.md`, public element files such as `sp-*.ts`, stories, and tests when needed
-- **Spectrum 2 docs and source:** `2nd-gen/packages/swc/components/[component-name]/src/`, stories, tests, and any package README or docs that describe the public API
+- **Spectrum 2 docs and source:** `2nd-gen/packages/swc/components/[component-name]/`, stories, tests, and any package README or docs that describe the public API
 - **Related migration docs:** the component's `rendering-and-styling-migration-analysis.md` and `accessibility-migration-analysis.md` when present
 
 ### Important

--- a/.ai/skills/consumer-migration-guide/SKILL.md
+++ b/.ai/skills/consumer-migration-guide/SKILL.md
@@ -95,7 +95,7 @@ The guide must be **short, direct, and consumer-focused**. Optimize for scannabi
 - Attributes, properties, and their values
 - Slots and slot names
 - Events
-- Supported CSS custom properties (`--mod-*` and documented theming hooks)
+- Supported CSS custom properties (`--swc-*` and documented theming hooks)
 - Accessibility expectations that affect the consumer's markup (e.g. `aria-label` on icon-only variants)
 - Behavior changes the consumer can observe (focus, wrapping, positioning)
 

--- a/.ai/skills/consumer-migration-guide/references/consumer-migration-guide-prompt.md
+++ b/.ai/skills/consumer-migration-guide/references/consumer-migration-guide-prompt.md
@@ -66,7 +66,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 # [Component name] migration guide
 ```
 
-- Use title case for `[Component name]` — component names are proper nouns (for example `Badge`, `Action Button`).
+- Use sentence case for `[Component name]` (for example `Badge`, `Action button`).
 - Do **not** prefix `<Meta title>` with `Components/` — `titlePrefix` supplies it.
 - Use sentence case for all other headings.
 - Prefer tables, bullets, and fenced code blocks over prose.

--- a/.ai/skills/consumer-migration-guide/references/consumer-migration-guide-prompt.md
+++ b/.ai/skills/consumer-migration-guide/references/consumer-migration-guide-prompt.md
@@ -20,7 +20,7 @@ Keep the guide **short, direct, and scannable**. A consumer should be able to co
 - Attributes, properties, and accepted values
 - Slots and content-rendering properties
 - Events
-- Supported CSS custom properties (documented `--mod-*` and other public theming hooks)
+- Supported CSS custom properties (documented `--swc-*` and other public theming hooks)
 - Accessibility changes that affect consumer markup (e.g. where to place `aria-label`, when to hide decorative icons)
 - Observable behavior changes (focus, wrapping, positioning)
 
@@ -143,7 +143,7 @@ Cover only:
 - Include this JSX comment immediately above the table so future passes can replace the hand-written descriptions with the canonical copy once it lands:
 
   ```mdx
-  {/* @todo Replace the Description column with the `@cssproperty` JSDoc descriptions from `<swc-[component]>`'s CEM entry once they are added in a follow-up PR. */}
+  {/* @todo Replace the Description column with the `@cssprop` JSDoc descriptions from `<swc-[component]>`'s CEM entry once they are added in a follow-up PR. */}
   ```
 
 - **Required amber "breaking change" callout at the top** (immediately after the section intro sentence, before the property list) **if** the Spectrum 1 component used a different custom-property prefix (e.g. `--mod-*`) and Spectrum 2 does not. Tells consumers their Spectrum 1 overrides won't apply. Template:

--- a/.ai/skills/consumer-migration-guide/references/consumer-migration-guide-prompt.md
+++ b/.ai/skills/consumer-migration-guide/references/consumer-migration-guide-prompt.md
@@ -42,7 +42,7 @@ In "Update your code", present **numbered steps in the order the consumer perfor
 Before writing, verify claims against:
 
 - `1st-gen/packages/[component-name]/README.md` and public element files (`sp-*.ts`)
-- `2nd-gen/packages/swc/components/[component-name]/src/`, stories, and tests
+- `2nd-gen/packages/swc/components/[component-name]/`, stories, and tests
 
 If a claim is not confirmed by source, omit it.
 

--- a/.ai/skills/migration-conformance/SKILL.md
+++ b/.ai/skills/migration-conformance/SKILL.md
@@ -70,8 +70,8 @@ That rule is the authoritative source for what to check in each domain and which
 |            | `2nd-gen/packages/swc/components/[component]/[Component].ts`                 |
 |            | Any mixins, controllers, or directives added for this component              |
 | CSS        | `2nd-gen/packages/swc/components/[component]/[component].css`                |
-| Tests      | `2nd-gen/packages/swc/components/[component]/[component].test.ts`            |
-|            | `2nd-gen/packages/swc/components/[component]/[component].a11y.spec.ts`       |
+| Tests      | `2nd-gen/packages/swc/components/[component]/test/[component].test.ts`       |
+|            | `2nd-gen/packages/swc/components/[component]/test/[component].a11y.spec.ts`  |
 |            | Play functions within the stories file                                       |
 | Stories    | `2nd-gen/packages/swc/components/[component]/stories/[component].stories.ts` |
 

--- a/2nd-gen/packages/swc/components/button-group/stories/button-group.stories.ts
+++ b/2nd-gen/packages/swc/components/button-group/stories/button-group.stories.ts
@@ -70,7 +70,7 @@ argTypes.disabled = {
 /**
  * A button group clusters related actions together, providing consistent spacing,
  * sizing, and orientation. It propagates `size` and `disabled` state to its slotted
- * [Button](../?path=/docs/components-button--overview) children and exposes `role="group"` for
+ * [Button](../?path=/docs/components-button--docs) children and exposes `role="group"` for
  * accessibility.
  *
  * Use button group when you have two or more related button actions that belong

--- a/2nd-gen/packages/swc/components/close-button/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/close-button/migration-guide.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Close Button/Migration guide" />
+<Meta title="Close button/Migration guide" />
 
 # Close button migration guide
 

--- a/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
+++ b/2nd-gen/packages/swc/components/close-button/stories/close-button.stories.ts
@@ -58,7 +58,7 @@ args['accessible-label'] = 'Close';
  * [Button](../?path=/docs/components-button--docs).
  */
 const meta: Meta = {
-  title: 'Close Button',
+  title: 'Close button',
   component: 'swc-close-button',
   args,
   argTypes,

--- a/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
+++ b/2nd-gen/packages/swc/components/close-button/test/close-button.test.ts
@@ -34,7 +34,7 @@ import meta, {
 
 export default {
   ...meta,
-  title: 'Close Button/Tests',
+  title: 'Close button/Tests',
   parameters: {
     ...meta.parameters,
     docs: { disable: true, page: null },

--- a/2nd-gen/packages/swc/components/dropzone/stories/dropzone.stories.ts
+++ b/2nd-gen/packages/swc/components/dropzone/stories/dropzone.stories.ts
@@ -60,7 +60,7 @@ argTypes['filled-content-slot'] = {
  * a required browse button or link that opens the OS file picker for keyboard users.
  */
 const meta: Meta = {
-  title: 'Drop Zone',
+  title: 'Drop zone',
   component: 'swc-dropzone',
   args,
   argTypes,

--- a/2nd-gen/packages/swc/components/progress-bar/migration-guide.mdx
+++ b/2nd-gen/packages/swc/components/progress-bar/migration-guide.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Progress Bar/Migration guide" />
+<Meta title="Progress bar/Migration guide" />
 
 # Progress bar migration guide
 

--- a/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
+++ b/2nd-gen/packages/swc/components/progress-bar/stories/progress-bar.stories.ts
@@ -78,7 +78,7 @@ argTypes.value = {
  * values use [Meter](../?path=/docs/components-meter--docs).
  */
 const meta: Meta = {
-  title: 'Progress Bar',
+  title: 'Progress bar',
   component: 'swc-progress-bar',
   parameters: {
     docs: {

--- a/2nd-gen/packages/swc/components/progress-bar/test/progress-bar.test.ts
+++ b/2nd-gen/packages/swc/components/progress-bar/test/progress-bar.test.ts
@@ -29,7 +29,7 @@ import { Indeterminate, Overview } from '../stories/progress-bar.stories.js';
 // This file defines dev-only test stories that reuse the main story metadata.
 export default {
   ...meta,
-  title: 'Progress Bar/Tests',
+  title: 'Progress bar/Tests',
   parameters: {
     ...meta.parameters,
     docs: { disable: true, page: null },

--- a/scripts/validate-docs-pages.js
+++ b/scripts/validate-docs-pages.js
@@ -33,6 +33,10 @@
  *    only; patterns and controllers have not been audited for this yet).
  *    Only the first word, acronyms, and known proper-noun phrases may start
  *    with a capital letter.
+ * 6. **Sentence-case stories meta `title`** (component and internal genres
+ *    only) — the `title` in the stories module is the docs-page and sidebar
+ *    label; each `/`-separated segment must be sentence case. Not rendered as
+ *    a markdown heading, so Check 5 does not cover it.
  *
  * Usage (standalone):
  *   yarn lint:docs-pages
@@ -429,6 +433,50 @@ function parseStoryTags(storiesPath) {
   return stories;
 }
 
+/**
+ * Extract the `title` string from a stories module's `const meta` object.
+ *
+ * The `title` becomes the Storybook sidebar node and the docs-page heading
+ * (component MDX uses `<Meta of={Stories} />`, so the page title is derived
+ * from this field, not from any markdown heading). Returns `null` when no
+ * meta `title` is found.
+ */
+function extractStoriesTitle(storiesPath) {
+  const content = fs.readFileSync(storiesPath, 'utf8');
+
+  // Locate the `const meta ... = {` object and brace-match its body so we
+  // only read the meta-level `title`, not a `title` nested elsewhere.
+  const metaMatch = content.match(/const\s+meta\b[^=]*=\s*\{/);
+  if (!metaMatch) {
+    return null;
+  }
+  const openIdx = content.indexOf('{', metaMatch.index);
+  if (openIdx === -1) {
+    return null;
+  }
+  let depth = 0;
+  let closeIdx = -1;
+  for (let i = openIdx; i < content.length; i++) {
+    const ch = content[i];
+    if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        closeIdx = i;
+        break;
+      }
+    }
+  }
+  if (closeIdx === -1) {
+    return null;
+  }
+
+  const body = content.slice(openIdx, closeIdx + 1);
+  const titleMatch = body.match(/\btitle:\s*(['"])(.+?)\1/);
+  return titleMatch ? titleMatch[2] : null;
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 //   Per-file check
 // ────────────────────────────────────────────────────────────────────────────
@@ -548,6 +596,25 @@ function checkMdx(absPath) {
         errors.push(
           `${relPath}: story \`${name}\` is tagged \`${sectionTag}\` in ${path.relative(repoRoot, storiesPath)} but has no <Canvas of={${importInfo.binding}.${name}} /> reference in the MDX`
         );
+      }
+    }
+  }
+
+  // Check 6: Sentence-case stories meta `title` (component and internal
+  // genres only, matching Check 5's scope). The title is the sidebar node and
+  // docs-page label; it is not a markdown heading, so Check 5 misses it. Each
+  // `/`-separated segment is its own label and must be sentence case.
+  if (rules.genre === 'component' || rules.genre === 'internal') {
+    const title = extractStoriesTitle(storiesPath);
+    if (title) {
+      for (const segment of title.split('/')) {
+        const label = segment.trim();
+        if (label && !isSentenceCase(label)) {
+          errors.push(
+            `${path.relative(repoRoot, storiesPath)}: meta title segment "${label}" is not sentence case (capitalize only the first word, acronyms, and known proper nouns; component names are sentence case, e.g. 'Action button')`
+          );
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Documentation-conformance fixes to the `.ai` authoring rules, plus a lint check that enforces one of them in CI.

### 1. Fix the `## States` template so it matches its own prose rule

The section template showed `## States` immediately followed by `### States`, contradicting the "Single-story sections" prose rule, which says a single-story section whose story name matches the `## Section` heading must **omit** the `### Title` subheading and author prose directly under the section heading — explicitly calling `## States` → `### States` "redundant; collapse it to one heading" (compliant examples: `button.mdx`, `color-handle.mdx`). Collapsed the States example so the illustration agrees with the rule it documents.

### 2. Sentence-case two sidebar titles that slipped into Title Case

`stories-documentation.md` requires "Use sentence case for all headings and descriptions," and the sidebar convention across components is sentence case (`Action button`, `Progress circle`, `Status light`, …). Two exceptions had landed on main:

- `Close Button` → `Close button`
- `Progress Bar` → `Progress bar`

Each is corrected in three places so the whole sidebar subtree stays consistent under one nav node: the stories meta `title`, the migration-guide `<Meta title>`, and the test story `title` (which shares the nav prefix).

### 3. Resolve the component-name casing contradiction (sentence case)

`stories-format.md`'s "Title naming conventions" said component names keep **Title Case** (`'Action Button'`, `'Color Loupe'`), while its own checklist, `stories-documentation.md`, the `consumer-migration-guide` SKILL.md, the sentence-case heading lint (its allowlist is `'Action button'`), and the shipped meta titles (`'Action button'`, `'Color loupe'`) all use **sentence case**. Aligned the two outliers to sentence case, citing Spectrum's own docs ([Action bar](https://spectrum.adobe.com/page/action-bar/), [Color loupe](https://spectrum.adobe.com/page/color-loupe/)):

- `stories-format.md` — component names use sentence case; fixed the `Color loupe` example and the flatten-group table row.
- `consumer-migration-guide/references/consumer-migration-guide-prompt.md` — sentence case, matching its own SKILL.md (removes an in-skill self-contradiction).

No new rule was added — the "Title naming conventions" section already scopes to every meta `title` and `<Meta title>`.

### 4. Enforce sentence-case meta titles in CI (new lint check)

The sentence-case lint (`scripts/validate-docs-pages.js`, Check 5) only validates `###`/`####` markdown headings — so a Title-Case stories meta `title`, which renders the Storybook **sidebar node and docs-page label**, was never enforced (e.g. `title: 'Infield Button'` passes CI). Added **Check 6**: extract the `const meta` `title` and validate each `/`-separated segment with the existing `isSentenceCase()`, scoped to component/internal genres to match Check 5.

Verified: 0 of the 23 existing component titles are flagged (CI stays green), and the check catches Title-Case titles (`'Infield Button'`, `'Close Button'`) while passing acronym/multi-segment forms (`'Conversational AI/Pattern overview'`, `'Progress bar/Tests'`).

> Note: this closes the enforcement gap for component/internal meta titles. `<Meta title>` strings in migration-guide MDX and pattern/controller titles are still out of scope (a possible follow-up).

### 5. Sentence-case the per-story `### Title` rule and examples

`stories-documentation.md`'s per-story title rule told authors to use Storybook's PascalCase → Title Case conversion for multi-word story exports (`TextWrapping` → `Text Wrapping`), directly contradicting this file's own sentence-case rule and the sentence-case heading lint (Check 5), which rejects any `###`/`####` heading that isn't sentence case. A heading authored exactly as the rule instructed would fail CI. Reworded the rule and updated the example table so multi-word exports use a `.storyName` override that renders sentence case (`Text wrapping`, `In action button`, `Activation modes`), matching the pattern `stories-format.md` already used, and updated the authoring checklist to match.

### 6. Rewrite Section-patterns examples to MDX prose, drop story-level JSDoc

The Options/States/Behaviors/Accessibility "Section patterns" examples in `stories-documentation.md` showed prose as JSDoc directly above `export const`, contradicting this same file's "prose lives in per-unit MDX, not in JSDoc above story exports" rule (and `stories-format.md`'s "story-level JSDoc is not authored"). The earlier Anatomy example already modeled the correct pattern (MDX prose + bare export); these had drifted from it. Rewrote each example to show MDX prose under the appropriate `##`/`###` heading followed by a bare (no-JSDoc) export, added `storyName` overrides for multi-word exports, and collapsed the States pattern per the "Single-story sections" rule.

### 7. Fix `--mod-*` vs `--swc-*` and `@cssproperty` vs `@cssprop` in consumer-migration-guide

The "Include" bullet in `consumer-migration-guide`'s `SKILL.md` and prompt reference told authors to document `--mod-*` custom properties, contradicting the same skill's own rule and mandated breaking-change callout — both say Spectrum 1 `--mod-*` properties don't apply and the real prefix is `--swc-*`. Fixed both Include bullets to say `--swc-*`. Also fixed a JSX `@todo` comment template referencing a `@cssproperty` JSDoc tag; the actual tag used throughout the 2nd-gen source is `@cssprop`.

### 8. Fix component-path conventions in migration-conformance and consumer-migration-guide

`migration-conformance/SKILL.md`'s file-scope table pointed at test files directly under the component root (`[component].test.ts`), but every migrated component keeps tests in a `test/` subdirectory — a conformance pass keyed on the wrong path reviews nothing. Added the missing `test/` segment. Separately, `consumer-migration-guide`'s `SKILL.md` and prompt both pointed at a `src/` subdirectory under the 2nd-gen component path that doesn't exist (2nd-gen components are flat); the same prompt file's own "Source precedence" section already used the correct flat path three lines below. Dropped `/src/` from both.

### 9. Align static-colors story count and Options order to actual components

`stories-format.md`'s checklist and `.ai/README.md` described a "three-story or combined-story pattern" for static colors, contradicting `stories-format.md`'s own "Static color pattern" section a few lines above (single `StaticColors` story) and every real component. Verified: all 8 components with a static-color option (action-button, button, close-button, divider, link, meter, progress-bar, progress-circle) export a single `StaticColors` story; none use separate `Static*` stories. Aligned both to "single story."

Separately, `stories-format.md`'s canonical Options order put `StaticColors` 4th (right after the variant stories), while `stories-documentation.md` put it 6th (after Quiet/Outline, before Positioning). Verified against every component's rendered MDX: static colors consistently renders last in Options, after Quiet/Outline/other modifiers, in all 8 components checked. Reordered `stories-format.md`'s table to match.

### 10. Remove the deprecated `usage` tag from the section-tag list

`stories-format.md` explicitly marks the `'usage'` story tag as deprecated ("Use the `'usage'` tag for new units (deprecated)"), and it's absent from `validate-story-tags.js`'s `ALLOWED_TAGS` — tagging a story `usage` today fails `yarn lint:ai` as an unknown tag. `stories-documentation.md` still listed it alongside the live section tags, implying it was valid. Removed it.

> Note: a related gap (`appendix`/`full-pattern`/`api` are documented section tags not yet in `ALLOWED_TAGS`) is deferred — 0 of 23 in-scope component stories currently use those tags, so there's no active breakage; it's a fix-when-hit item, not addressed here.

### 11. Align docs-page link slug to `components-<name>--docs` everywhere

`stories-format.md` and `stories-documentation.md` showed four different conventions for linking to a component's docs page: `--overview`, `--docs` (missing the `components-` prefix), `--readme`, and `components-<name>--docs`. Grepped every real cross-component link in `2nd-gen/packages/swc/components` (12 instances): 11 already use `components-<name>--docs`, one stray `--overview`. That confirms `components-<name>--docs` is the actual, working convention (Storybook's docs-page id from the "Components/Name" title plus the `--docs` viewMode suffix); `--overview` and `--readme` don't correspond to any real Storybook route and would produce broken links if followed as written.

Fixed the stale examples in both rule files, dropped the "(or `--readme` if that's the convention in your area)" hedge now that there's one confirmed canonical form, and fixed the one real stray link this surfaced: `button-group.stories.ts` referenced `components-button--overview` instead of `components-button--docs`.

## Motivation and context

The rules were internally contradictory (title vs sentence case across three files) and the one that mattered most for AI-generated pages — the meta `title` — wasn't enforced anywhere. These changes make the authoring rules consistent with the code and add CI enforcement so the sidebar/docs-page label can't regress to Title Case. Items 5-8 came out of a broader `.ai/`-scope contradiction audit and fix the same class of issue (rule vs. example, rule vs. lint, rule vs. sibling rule) surfaced elsewhere in the authoring docs.

## Related issue(s)

- SWC-2460

## Author's checklist

- [ ] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## How has this been tested?

- Rule/skill edits are documentation-only.
- The new lint check was verified against all existing component titles (0 false positives) and a set of positive/negative edge cases; it fails CI on a Title-Case meta title and passes sentence-case + acronym/multi-segment titles.
- Items 5-8 are prose/example edits verified against the actual file and directory structure (e.g. confirmed `test/` subdirectory usage against `badge/test/*.ts`, confirmed the flat 2nd-gen component layout against `badge/Badge.ts`) — no lint or build changes.
- Item 9 was verified by grepping every 2nd-gen component with a static-color option (8 components) for their actual story export names and rendered MDX Options order, confirming both docs now match the codebase — no lint or build changes.
- Item 11 was verified by grepping every real `path=/docs/...` cross-component link under `2nd-gen/packages/swc/components` (12 instances) to confirm `components-<name>--docs` is the dominant, working form before aligning the docs and fixing the one stray link — no lint or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


