### PR TITLE
chore(accordion): add vrt tests

### DIFF
--- a/2nd-gen/packages/swc/components/accordion/test/vrt/accordion-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/accordion/test/vrt/accordion-custom-properties.vrt.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '@adobe/spectrum-wc/components/accordion/swc-accordion.js';
+import '@adobe/spectrum-wc/components/accordion/swc-accordion-item.js';
+
+import type {
+  CustomPropertyCase,
+  ForcedPseudoState,
+} from '../../../../.storybook/helpers/index.js';
+import {
+  coveredCustomProperties,
+  customPropertyRows,
+  forcePseudoStates,
+  theme,
+  verifyCustomPropertyCoverage,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import customElementsManifest from '../../../../dist/custom-elements.json';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Accordion/Accordion VRT',
+  component: 'swc-accordion',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+// swc-accordion and swc-accordion-item are two separate custom-elements-
+// manifest declarations, each with its own `cssProperties` list (Accordion:
+// 1, AccordionItem: 9). `tabs` (Tabs + Tab) has the identical two-declaration
+// shape and will need this same pattern once it gets VRT coverage: one
+// case list + render function per declaration, folded into a single story,
+// with the shared `play` function below calling `verifyCustomPropertyCoverage`
+// once per declaration.
+
+const forceAccordionItemStates = forcePseudoStates(
+  'swc-accordion-item[data-force-state]',
+  '.swc-AccordionItem-header'
+);
+
+// ────────────────────────────────
+//    swc-accordion CUSTOM PROPERTIES
+// ────────────────────────────────
+
+type AccordionPropertyCase =
+  CustomPropertyCase<'--swc-accordion-min-inline-size'>;
+
+const ACCORDION_PROPERTY_CASES: readonly AccordionPropertyCase[] = [
+  { property: '--swc-accordion-min-inline-size', value: '600px' },
+];
+
+// Short labels keep the reference case's natural width well under the 600px
+// override, so the override cell visibly widens instead of collapsing back
+// to the same footprint.
+const modAccordionProperty = (
+  _case: AccordionPropertyCase,
+  style?: string
+) => html`
+  <swc-accordion style=${style ?? nothing}>
+    <swc-accordion-item open>
+      <span slot="label">Info</span>
+      <p>Panel content.</p>
+    </swc-accordion-item>
+    <swc-accordion-item>
+      <span slot="label">Files</span>
+      <p>Panel content.</p>
+    </swc-accordion-item>
+  </swc-accordion>
+`;
+
+const coveredAccordionProperties = coveredCustomProperties(
+  ACCORDION_PROPERTY_CASES
+);
+
+// ─────────────────────────────────────
+//    swc-accordion-item CUSTOM PROPERTIES
+// ─────────────────────────────────────
+
+type AccordionItemPropertyCase =
+  CustomPropertyCase<`--swc-accordion-item-${string}`> & {
+    forceState?: ForcedPseudoState;
+    open?: boolean;
+  };
+
+const ACCORDION_ITEM_PROPERTY_CASES: readonly AccordionItemPropertyCase[] = [
+  {
+    property: '--swc-accordion-item-focus-indicator-corner-radius',
+    value: '24px',
+    forceState: 'focus-visible',
+  },
+  {
+    property: '--swc-accordion-item-header-corner-radius',
+    value: '24px',
+    forceState: 'hover',
+  },
+  { property: '--swc-accordion-item-padding-top', value: '48px' },
+  { property: '--swc-accordion-item-padding-bottom', value: '48px' },
+  {
+    property: '--swc-accordion-item-disclosure-indicator-gap',
+    value: '48px',
+  },
+  { property: '--swc-accordion-item-edge-to-content-area', value: '48px' },
+  { property: '--swc-accordion-item-header-font-size', value: '32px' },
+  {
+    property: '--swc-accordion-item-content-padding-inline',
+    value: '48px',
+    open: true,
+  },
+  { property: '--swc-accordion-item-divider-color', value: 'magenta' },
+];
+
+const modAccordionItemProperty = (
+  { forceState, open }: AccordionItemPropertyCase,
+  style?: string
+) => html`
+  <swc-accordion style="max-inline-size: 280px;">
+    <swc-accordion-item
+      ?open=${open}
+      data-force-state=${forceState ?? nothing}
+      style=${style ?? nothing}
+    >
+      <span slot="label">Label</span>
+      <p>Panel content.</p>
+    </swc-accordion-item>
+  </swc-accordion>
+`;
+
+const coveredAccordionItemProperties = coveredCustomProperties(
+  ACCORDION_ITEM_PROPERTY_CASES
+);
+
+// ────────────────────
+//    PLAY FUNCTION
+// ────────────────────
+
+const modPropertiesContent = () => html`
+  ${customPropertyRows(ACCORDION_PROPERTY_CASES, modAccordionProperty)}
+  ${customPropertyRows(ACCORDION_ITEM_PROPERTY_CASES, modAccordionItemProperty)}
+`;
+
+// Copy both `verifyCustomPropertyCoverage` calls (with the module/declaration
+// names and covered-properties list swapped) when porting this file's pattern
+// to a future two-declaration component.
+const forceStatesAndVerifyCoverage = async (
+  context: Parameters<ReturnType<typeof forcePseudoStates>>[0]
+) => {
+  await forceAccordionItemStates(context);
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/accordion/Accordion.ts',
+    declarationName: 'Accordion',
+    coveredProperties: coveredAccordionProperties,
+  });
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/accordion/AccordionItem.ts',
+    declarationName: 'AccordionItem',
+    coveredProperties: coveredAccordionItemProperties,
+  });
+};
+
+// VRT stories
+
+export const CustomProperties: Story = {
+  render: () => theme(modPropertiesContent(), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: forceStatesAndVerifyCoverage,
+};

--- a/2nd-gen/packages/swc/components/accordion/test/vrt/accordion.vrt.ts
+++ b/2nd-gen/packages/swc/components/accordion/test/vrt/accordion.vrt.ts
@@ -1,0 +1,347 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import {
+  ACCORDION_DENSITIES,
+  ACCORDION_VALID_SIZES,
+} from '@adobe/spectrum-wc-core/components/accordion';
+
+import '@adobe/spectrum-wc/components/accordion/swc-accordion.js';
+import '@adobe/spectrum-wc/components/accordion/swc-accordion-item.js';
+import '@adobe/spectrum-wc/components/button/swc-button.js';
+
+import type { ForcedPseudoState } from '../../../../.storybook/helpers/index.js';
+import {
+  FORCED_STATES,
+  forcedColorsVrtParameters,
+  forcePseudoStates,
+  row,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Accordion/Accordion VRT',
+  component: 'swc-accordion',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+const sizeLabels = {
+  s: 'Small',
+  m: 'Medium',
+  l: 'Large',
+  xl: 'Extra-large',
+} as const satisfies Record<(typeof ACCORDION_VALID_SIZES)[number], string>;
+
+const densityLabels = {
+  compact: 'Compact',
+  regular: 'Regular',
+  spacious: 'Spacious',
+} as const satisfies Record<(typeof ACCORDION_DENSITIES)[number], string>;
+
+type ItemCase = {
+  label: string;
+  open?: boolean;
+  disabled?: boolean;
+  actions?: unknown;
+  forceState?: ForcedPseudoState;
+  lang?: string;
+};
+
+// swc-accordion-item's own custom properties get dedicated coverage in
+// accordion-custom-properties.vrt.ts, so panel content here is kept minimal
+// and identical across cases.
+const renderItem = ({
+  label,
+  open = false,
+  disabled = false,
+  actions,
+  forceState,
+  lang,
+}: ItemCase) => html`
+  <swc-accordion-item
+    ?open=${open}
+    ?disabled=${disabled}
+    data-force-state=${forceState ?? nothing}
+    lang=${lang ?? nothing}
+  >
+    <span slot="label">${label}</span>
+    ${actions ?? nothing}
+    <p>Supporting panel content.</p>
+  </swc-accordion-item>
+`;
+
+type AccordionCase = {
+  size?: (typeof ACCORDION_VALID_SIZES)[number];
+  density?: (typeof ACCORDION_DENSITIES)[number];
+  quiet?: boolean;
+  disabled?: boolean;
+  allowMultiple?: boolean;
+  items: unknown;
+};
+
+// A fixed width keeps every row's accordions a comparable, compact size
+// regardless of how much label/content text a given case renders.
+const renderAccordion = ({
+  size,
+  density,
+  quiet = false,
+  disabled = false,
+  allowMultiple = false,
+  items,
+}: AccordionCase) => html`
+  <swc-accordion
+    size=${size ?? nothing}
+    density=${density ?? nothing}
+    ?quiet=${quiet}
+    ?disabled=${disabled}
+    ?allow-multiple=${allowMultiple}
+    style="max-inline-size: 280px;"
+  >
+    ${items}
+  </swc-accordion>
+`;
+
+const actionsButton = (label: string) => html`
+  <swc-button
+    slot="actions"
+    variant="secondary"
+    fill-style="outline"
+    size="s"
+    accessible-label=${label}
+  >
+    Edit
+  </swc-button>
+`;
+
+const forceAccordionItemStates = forcePseudoStates(
+  'swc-accordion-item[data-force-state]',
+  '.swc-AccordionItem-header'
+);
+
+// Every size and density (each with one open, one closed item), quiet vs.
+// default (with a forced-hover item, since quiet's rounded header corner is
+// otherwise invisible at rest — the header background it's drawn on only
+// appears on hover/focus; the missing divider is already visible on the
+// plain open/closed items above it, since that's a plain border color with
+// no hover gating), collapsed/expanded/disabled item states plus a
+// fully-disabled accordion (folded into one "States" row), a mixed disabled +
+// allow-multiple example, two simultaneously open items under allow-multiple,
+// the actions slot, forced hover/focus-visible/active on the header (each
+// crossed with both a collapsed and an open item, so a forced state's
+// interaction with the rotated chevron is covered too), label wrapping, and
+// CJK label rendering. `level` (heading level) is intentionally not covered —
+// it only changes the wrapping tag under a `font: inherit` reset, with no
+// visual difference to capture.
+const permutationContent = () => html`
+  ${row(
+    ACCORDION_VALID_SIZES.map((size) =>
+      renderAccordion({
+        size,
+        items: html`
+          ${renderItem({ label: `${sizeLabels[size]} · open`, open: true })}
+          ${renderItem({ label: `${sizeLabels[size]} · closed` })}
+        `,
+      })
+    ),
+    'Sizes'
+  )}
+  ${row(
+    ACCORDION_DENSITIES.map((density) =>
+      renderAccordion({
+        density,
+        items: html`
+          ${renderItem({
+            label: `${densityLabels[density]} · open`,
+            open: true,
+          })}
+          ${renderItem({ label: `${densityLabels[density]} · closed` })}
+        `,
+      })
+    ),
+    'Density'
+  )}
+  ${row(
+    [
+      renderAccordion({
+        items: html`
+          ${renderItem({ label: 'Default · open', open: true })}
+          ${renderItem({ label: 'Default · hover', forceState: 'hover' })}
+        `,
+      }),
+      renderAccordion({
+        quiet: true,
+        items: html`
+          ${renderItem({ label: 'Quiet · open', open: true })}
+          ${renderItem({ label: 'Quiet · hover', forceState: 'hover' })}
+        `,
+      }),
+    ],
+    'Quiet'
+  )}
+  ${row(
+    [
+      renderAccordion({
+        items: html`
+          ${renderItem({ label: 'Collapsed' })}
+          ${renderItem({ label: 'Expanded', open: true })}
+          ${renderItem({ label: 'Disabled', disabled: true })}
+        `,
+      }),
+      renderAccordion({
+        disabled: true,
+        items: html`
+          ${renderItem({
+            label: 'Disabled accordion · expanded',
+            open: true,
+          })}
+          ${renderItem({ label: 'Disabled accordion · collapsed' })}
+        `,
+      }),
+    ],
+    'States'
+  )}
+  ${row(
+    [
+      renderAccordion({
+        allowMultiple: true,
+        items: html`
+          ${renderItem({ label: 'Expanded', open: true })}
+          ${renderItem({ label: 'Collapsed' })}
+          ${renderItem({ label: 'Disabled', disabled: true })}
+        `,
+      }),
+    ],
+    'Mixed disabled + allow multiple'
+  )}
+  ${row(
+    [
+      renderAccordion({
+        allowMultiple: true,
+        items: html`
+          ${renderItem({ label: 'First open', open: true })}
+          ${renderItem({ label: 'Second open', open: true })}
+          ${renderItem({ label: 'Collapsed' })}
+        `,
+      }),
+    ],
+    'Allow multiple: two open'
+  )}
+  ${row(
+    [
+      renderAccordion({
+        items: html`
+          ${renderItem({
+            label: 'Personal information',
+            open: true,
+            actions: actionsButton('Edit personal information'),
+          })}
+          ${renderItem({
+            label: 'Billing address',
+            actions: actionsButton('Edit billing address'),
+          })}
+        `,
+      }),
+    ],
+    'Actions slot'
+  )}
+  ${FORCED_STATES.map((state) =>
+    row(
+      [
+        renderAccordion({
+          items: html`
+            ${renderItem({
+              label: `${state} · collapsed`,
+              forceState: state,
+            })}
+            ${renderItem({
+              label: `${state} · expanded`,
+              open: true,
+              forceState: state,
+            })}
+          `,
+        }),
+      ],
+      state
+    )
+  )}
+  ${row(
+    [
+      renderAccordion({
+        items: renderItem({
+          label:
+            'A heading label long enough to wrap onto multiple lines within the accordion',
+          open: true,
+        }),
+      }),
+    ],
+    'Wrapping'
+  )}
+  ${row(
+    [
+      renderAccordion({
+        items: renderItem({
+          label: '承認ワークフローを開始するセクション',
+          lang: 'ja',
+          open: true,
+        }),
+      }),
+      renderAccordion({
+        items: renderItem({
+          label: '승인 워크플로 시작 섹션',
+          lang: 'ko',
+          open: true,
+        }),
+      }),
+      renderAccordion({
+        items: renderItem({
+          label: '启动审批工作流部分',
+          lang: 'zh',
+          open: true,
+        }),
+      }),
+    ],
+    'CJK language'
+  )}
+`;
+
+// VRT stories
+
+// Rendered once in light/ltr and once in dark/rtl (that combination covers
+// both axes, including the chevron's RTL mirroring on already-open/closed
+// items above), all still in a single story so it costs one snapshot.
+export const Permutations: Story = {
+  render: () => html`
+    ${theme(permutationContent(), 'light', 'ltr')}
+    ${theme(permutationContent(), 'dark', 'rtl')}
+  `,
+  parameters: vrtParameters,
+  play: forceAccordionItemStates,
+};
+
+// `forced-colors` replaces the whole page palette, so it can't be scoped to a
+// subtree the way theme()'s light/dark split is, and needs its own snapshot
+// rather than folding into Permutations.
+export const ForcedColors: Story = {
+  render: () => theme(permutationContent(), 'light', 'ltr'),
+  parameters: forcedColorsVrtParameters,
+  play: forceAccordionItemStates,
+};


### PR DESCRIPTION
## Description

Adds dedicated Storybook VRT (visual regression testing) coverage for `swc-accordion` and `swc-accordion-item`, following the pattern established for `button` (see the VRT foundation PR, #6463).

Two new files, both scoped to the component's own `test/vrt/` folder:

- `2nd-gen/packages/swc/components/accordion/test/vrt/accordion.vrt.ts` — a `Permutations` story (rendered once in light/ltr and once in dark/rtl, covering both axes in one snapshot) and a `ForcedColors` story. Together they cover: every size (s/m/l/xl) and density (compact/regular/spacious), the quiet variant (including a forced-hover example to reveal its rounded header corner and missing divider, which are otherwise invisible at rest), collapsed/expanded/disabled item states plus a fully-disabled accordion, a mixed disabled + allow-multiple example, two items open simultaneously under allow-multiple, the `actions` slot, forced hover/focus-visible/active states on the item header, label wrapping, and CJK (ja/ko/zh) label rendering.
- `2nd-gen/packages/swc/components/accordion/test/vrt/accordion-custom-properties.vrt.ts` — reference/override rows for all 10 documented custom properties across both custom elements (1 on `swc-accordion`, 9 on `swc-accordion-item`), verified against `dist/custom-elements.json` so future CSS refactors that drop a property are caught. Accordion is the first component in the repo with two separate custom-elements-manifest declarations each carrying their own `cssProperties`, so this file also documents the pattern (two `verifyCustomPropertyCoverage` calls in one `play` function) for `tabs` (`Tabs`/`Tab`), the only other component with the same two-declaration shape, to reuse once it gets VRT coverage.

No `accordion-global-styles.vrt.ts` file is included — there is no generated `global-accordion.css` stylesheet for this component, unlike `button`.

## Motivation and context

Continues the component-by-component VRT rollout (SWC-2399) so `accordion` has the same dense, deterministic Storybook-driven Chromatic coverage already in place for `button`, `card`, and `dropzone`.

## Related issue(s)

- fixes SWC-2399

## Screenshots (if appropriate)

N/A — this PR only adds test fixtures; no shipped component visuals changed. Chromatic will generate the baseline snapshots for these new stories on first run.

## Author's checklist

- [ ] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

> No changeset is included: these are `test/vrt/*.vrt.ts` files tagged `dev`, excluded from
> the production build and docs pages — they don't affect the published package.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Accordion VRT permutations render as expected_
  1. Run the project's VRT command scoped to `accordion` (or open Storybook and navigate to **Accordion/Accordion VRT**).
  2. Review the `Permutations`, `ForcedColors`, and `CustomProperties` stories.
  3. Expect every row (sizes, density, quiet, states, mixed disabled, allow multiple, actions slot, forced states, wrapping, CJK) to render with no unintended layout differences and no console errors.

- [ ] _Custom property overrides visibly apply_
  1. Open the **CustomProperties** story.
  2. For each property row, compare the reference (left) and override (right) cells.
  3. Expect the override cell to visibly differ from the reference (e.g. magenta divider, widened min-inline-size, larger padding/font-size) — an unchanged cell would indicate a regression in that property's CSS wiring.

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

> This PR only adds Storybook VRT test fixtures (tagged `dev`, excluded from the production
> build and docs pages) — no accessibility-relevant component code changed. The steps below
> confirm the new fixtures exercise the accordion's existing keyboard and screen reader
> behavior correctly and don't regress it.

- [ ] **Keyboard** (required — document steps below)
  1. Run Storybook locally and open **Accordion/Accordion VRT → Permutations**.
  2. Tab through the item headers in the Sizes, Density, and States rows; confirm focus lands on every header (including disabled items, which stay focusable) in document order, with a visible focus ring.
  3. With focus on an enabled header, press <kbd>Enter</kbd> or <kbd>Space</kbd>; confirm the panel toggles open/closed and the chevron rotates (mirrored correctly in the dark/RTL half of the story).
  4. With focus on the disabled item's header in the **States** row, press <kbd>Enter</kbd>/<kbd>Space</kbd>; confirm it does **not** toggle.
  5. In the **Allow multiple: two open** row, confirm toggling one header does not close the other open item.

- [ ] **Screen reader** (required — document steps below)
  1. With VoiceOver (macOS/Safari) or NVDA (Windows/Firefox) running, navigate to the same **Permutations** story and move to an item header in the **States** row.
  2. Confirm the header announces its role (button), label text, and expanded/collapsed state (`aria-expanded`).
  3. Move into the panel region for an open item; confirm it announces as a labeled region (`aria-controls` / `aria-labelledby`) tied back to its header.
  4. Move to the disabled item's header; confirm it announces as disabled (`aria-disabled="true"`) and that its panel content is not reachable (`inert`).
  5. In the **Actions slot** row, confirm the slotted edit button announces its own accessible label independently of the header's toggle label.
