### PR TITLE
chore(action-button): add vrt coverage

### DIFF
--- a/2nd-gen/packages/swc/components/action-button/test/vrt/action-button-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/action-button/test/vrt/action-button-custom-properties.vrt.ts
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '@adobe/spectrum-wc/components/action-button/swc-action-button.js';
+
+import type {
+  CustomPropertyCase,
+  ForcedPseudoState,
+} from '../../../../.storybook/helpers/index.js';
+import {
+  coveredCustomProperties,
+  customPropertyRows,
+  forcePseudoStates,
+  theme,
+  verifyCustomPropertyCoverage,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import customElementsManifest from '../../../../dist/custom-elements.json';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Action Button/Action Button VRT',
+  component: 'swc-action-button',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+const forceActionButtonStates = forcePseudoStates(
+  'swc-action-button[data-force-state]',
+  '.swc-ActionButton'
+);
+
+const iconSvg = () => html`
+  <svg
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 36 36"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path
+      d="M33.567 8.2 27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945ZM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73Z"
+    />
+  </svg>
+`;
+
+// Every `--swc-action-button-*` custom property is a public contract: consumers
+// override these directly (see the Global Element Styling guide's "Custom
+// properties" section), so a future CSS refactor that quietly drops one would
+// be a breaking change. One row per property: a reference button next to the
+// same button with that one property overridden to an obviously different
+// value, so a real difference confirms the override still works. The set below
+// must cover every property the manifest documents for the component; the
+// coverage assertion in the `play` function enforces this.
+type ModPropertyCase = CustomPropertyCase<`--swc-action-button-${string}`> & {
+  forceState?: ForcedPseudoState;
+  disabled?: boolean;
+  withIcon?: boolean;
+  iconOnly?: boolean;
+};
+
+const MOD_PROPERTY_CASES: readonly ModPropertyCase[] = [
+  { property: '--swc-action-button-min-block-size', value: '80px' },
+  { property: '--swc-action-button-border-radius', value: '0px' },
+  { property: '--swc-action-button-font-size', value: '24px' },
+  { property: '--swc-action-button-gap', value: '40px', withIcon: true },
+  { property: '--swc-action-button-edge-to-text', value: '40px' },
+  {
+    property: '--swc-action-button-edge-to-visual',
+    value: '40px',
+    withIcon: true,
+  },
+  {
+    property: '--swc-action-button-edge-to-visual-only',
+    value: '40px',
+    iconOnly: true,
+  },
+  { property: '--swc-action-button-icon-size', value: '32px', withIcon: true },
+  {
+    property: '--swc-action-button-icon-inline-size',
+    value: '32px',
+    withIcon: true,
+  },
+  {
+    property: '--swc-action-button-icon-block-size',
+    value: '32px',
+    withIcon: true,
+  },
+  {
+    property: '--swc-action-button-focus-indicator-color',
+    value: 'magenta',
+    forceState: 'focus-visible',
+  },
+  {
+    property: '--swc-action-button-background-color-default',
+    value: 'magenta',
+  },
+  { property: '--swc-action-button-border-color-default', value: 'magenta' },
+  { property: '--swc-action-button-content-color-default', value: 'magenta' },
+  {
+    property: '--swc-action-button-background-color-hover',
+    value: 'magenta',
+    forceState: 'hover',
+  },
+  {
+    property: '--swc-action-button-border-color-hover',
+    value: 'magenta',
+    forceState: 'hover',
+  },
+  {
+    property: '--swc-action-button-content-color-hover',
+    value: 'magenta',
+    forceState: 'hover',
+  },
+  {
+    property: '--swc-action-button-background-color-focus',
+    value: 'magenta',
+    forceState: 'focus-visible',
+  },
+  {
+    property: '--swc-action-button-border-color-focus',
+    value: 'magenta',
+    forceState: 'focus-visible',
+  },
+  {
+    property: '--swc-action-button-content-color-focus',
+    value: 'magenta',
+    forceState: 'focus-visible',
+  },
+  {
+    property: '--swc-action-button-background-color-down',
+    value: 'magenta',
+    forceState: 'active',
+  },
+  {
+    property: '--swc-action-button-border-color-down',
+    value: 'magenta',
+    forceState: 'active',
+  },
+  {
+    property: '--swc-action-button-content-color-down',
+    value: 'magenta',
+    forceState: 'active',
+  },
+  {
+    property: '--swc-action-button-down-state-transform',
+    value: 'rotate(15deg)',
+    forceState: 'active',
+  },
+  {
+    property: '--swc-action-button-background-color-disabled',
+    value: 'magenta',
+    disabled: true,
+  },
+  {
+    property: '--swc-action-button-border-color-disabled',
+    value: 'magenta',
+    disabled: true,
+  },
+  {
+    property: '--swc-action-button-content-color-disabled',
+    value: 'magenta',
+    disabled: true,
+  },
+];
+
+const modPropertyButton = (
+  { forceState, disabled, withIcon, iconOnly }: ModPropertyCase,
+  style?: string
+) => html`
+  <swc-action-button
+    ?disabled=${disabled}
+    accessible-label=${iconOnly ? 'Edit' : nothing}
+    data-force-state=${forceState ?? nothing}
+    style=${style ?? nothing}
+  >
+    ${withIcon || iconOnly ? iconSvg() : nothing}${iconOnly ? nothing : 'Edit'}
+  </swc-action-button>
+`;
+
+const modPropertiesContent = () =>
+  customPropertyRows(MOD_PROPERTY_CASES, modPropertyButton);
+
+const coveredActionButtonCustomProperties =
+  coveredCustomProperties(MOD_PROPERTY_CASES);
+
+const forceStatesAndVerifyCoverage = async (
+  context: Parameters<ReturnType<typeof forcePseudoStates>>[0]
+) => {
+  await forceActionButtonStates(context);
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/action-button/ActionButton.ts',
+    declarationName: 'ActionButton',
+    coveredProperties: coveredActionButtonCustomProperties,
+  });
+};
+
+// VRT stories
+
+export const CustomProperties: Story = {
+  render: () => theme(modPropertiesContent(), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: forceStatesAndVerifyCoverage,
+};

--- a/2nd-gen/packages/swc/components/action-button/test/vrt/action-button-global-styles.vrt.ts
+++ b/2nd-gen/packages/swc/components/action-button/test/vrt/action-button-global-styles.vrt.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import {
+  FORCED_STATES,
+  forcePseudoStates,
+  row,
+  staticColorBackground,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Action Button/Action Button VRT',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+const globalIconSvg = html`
+  <svg
+    class="swc-ActionButton-icon"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 36 36"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path
+      d="M33.567 8.2 27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945ZM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73Z"
+    ></path>
+  </svg>
+`;
+
+// One <a> and one <button>, both with the same classes. The whole point of the
+// global stylesheet is that both element types render identically. Labels are
+// wrapped in `.swc-ActionButton-label`, matching the component's shadow DOM.
+const asLinkAndButton = (classes: string, label: string) => [
+  html`
+    <a href="#" class="swc-ActionButton ${classes}" onclick="return false;">
+      <span class="swc-ActionButton-label">${label} (link)</span>
+    </a>
+  `,
+  html`
+    <button type="button" class="swc-ActionButton ${classes}">
+      <span class="swc-ActionButton-label">${label} (button)</span>
+    </button>
+  `,
+];
+
+// Medium is the default (no size class); the rest map to their modifier class.
+const SIZE_CASES = [
+  { classes: 'swc-ActionButton--sizeXs', label: 'Extra-small' },
+  { classes: 'swc-ActionButton--sizeS', label: 'Small' },
+  { classes: '', label: 'Medium' },
+  { classes: 'swc-ActionButton--sizeL', label: 'Large' },
+  { classes: 'swc-ActionButton--sizeXl', label: 'Extra-large' },
+];
+
+// Same size, quiet, icon anatomy, static-color, and forced-state permutations
+// as Action Button/VRT, but for global-action-button.css's class-based delivery
+// on plain <a>/<button> elements (global-elements.css is imported in
+// preview.ts, so these classes work with no swc-action-button import),
+// confirming the shared stylesheet (generated from the same action-button.css
+// the component uses) produces identical results regardless of element type.
+// `disabled` is button-only, matching the documented limitation that native
+// links can't support a real disabled state. Pending is excluded from the
+// global stylesheet (it requires the PendingMixin JS runtime), so it isn't
+// covered here.
+const globalStylesContent = () => html`
+  ${row(
+    SIZE_CASES.flatMap(({ classes, label }) => asLinkAndButton(classes, label)),
+    'Sizes'
+  )}
+  ${row(asLinkAndButton('swc-ActionButton--quiet', 'Quiet'), 'Quiet')}
+  ${row(
+    [
+      html`
+        <button type="button" class="swc-ActionButton" disabled>
+          <span class="swc-ActionButton-label">Disabled (button)</span>
+        </button>
+      `,
+    ],
+    'Disabled'
+  )}
+  ${row(
+    [
+      html`
+        <a href="#" class="swc-ActionButton" onclick="return false;">
+          <span class="swc-ActionButton-label">Label only (link)</span>
+        </a>
+      `,
+      html`
+        <button
+          type="button"
+          class="swc-ActionButton swc-ActionButton--hasIcon"
+        >
+          ${globalIconSvg}
+          <span class="swc-ActionButton-label">With icon (button)</span>
+        </button>
+      `,
+      html`
+        <button
+          type="button"
+          class="swc-ActionButton swc-ActionButton--iconOnly"
+          aria-label="Icon only"
+        >
+          ${globalIconSvg}
+        </button>
+      `,
+    ],
+    'Anatomy'
+  )}
+  ${staticColorBackground(
+    row(
+      [
+        ...asLinkAndButton('swc-ActionButton--staticWhite', 'White'),
+        ...asLinkAndButton(
+          'swc-ActionButton--staticWhite swc-ActionButton--quiet',
+          'White quiet'
+        ),
+      ],
+      'Static white'
+    ),
+    'white'
+  )}
+  ${staticColorBackground(
+    row(
+      [
+        ...asLinkAndButton('swc-ActionButton--staticBlack', 'Black'),
+        ...asLinkAndButton(
+          'swc-ActionButton--staticBlack swc-ActionButton--quiet',
+          'Black quiet'
+        ),
+      ],
+      'Static black'
+    ),
+    'black'
+  )}
+  ${row(
+    FORCED_STATES.flatMap((state) => [
+      html`
+        <a
+          href="#"
+          class="swc-ActionButton"
+          data-force-state=${state}
+          onclick="return false;"
+        >
+          <span class="swc-ActionButton-label">${state} (link)</span>
+        </a>
+      `,
+      html`
+        <button
+          type="button"
+          class="swc-ActionButton"
+          data-force-state=${state}
+        >
+          <span class="swc-ActionButton-label">${state} (button)</span>
+        </button>
+      `,
+    ]),
+    'Forced states'
+  )}
+`;
+
+// VRT stories
+
+export const GlobalStyles: Story = {
+  render: () => html`
+    ${theme(globalStylesContent(), 'light', 'ltr')}
+    ${theme(globalStylesContent(), 'dark', 'rtl')}
+  `,
+  parameters: vrtParameters,
+  // No shadowRoot on these plain elements, so forcePseudoState() mirrors from
+  // document.styleSheets instead. See helpers/pseudo-state.ts.
+  play: forcePseudoStates('.swc-ActionButton[data-force-state]'),
+};

--- a/2nd-gen/packages/swc/components/action-button/test/vrt/action-button.vrt.ts
+++ b/2nd-gen/packages/swc/components/action-button/test/vrt/action-button.vrt.ts
@@ -1,0 +1,266 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import {
+  ACTION_BUTTON_STATIC_COLORS,
+  ACTION_BUTTON_VALID_SIZES,
+} from '@adobe/spectrum-wc-core/components/action-button';
+
+import '@adobe/spectrum-wc/components/action-button/swc-action-button.js';
+
+import {
+  createPermutations,
+  FORCED_STATES,
+  forcedColorsVrtParameters,
+  forcePseudoStates,
+  groupPermutationsBy,
+  renderStorybookPermutation,
+  row,
+  staticColorBackground,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Action Button/Action Button VRT',
+  component: 'swc-action-button',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+// A plain <svg> assigned to the icon slot, matching how the stories file passes
+// `editIconSvg`. `template()`'s named-slot rendering sets `slot="icon"` for us,
+// so the markup itself carries no slot attribute.
+const ICON_SLOT_MARKUP =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" aria-hidden="true" focusable="false"><path d="M33.567 8.2 27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945ZM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73Z"></path></svg>';
+
+// Group labels for the `quiet` axis, since `groupPermutationsBy` would
+// otherwise render raw 'true'/'false' row headings.
+const QUIET_LABELS: Record<string, string> = {
+  false: 'Default',
+  true: 'Quiet',
+};
+
+// Main permutations: the default and quiet treatments across every size, in
+// label-only and icon+label anatomy, plus disabled/pending states (which don't
+// cross with the size axis above) and forced hover/focus-visible/active per
+// treatment. Icon-only anatomy and static-color are deliberately separate
+// below.
+const ACTION_BUTTON_PERMUTATIONS = createPermutations([
+  { quiet: [false, true], size: ACTION_BUTTON_VALID_SIZES },
+  {
+    quiet: [false, true],
+    size: ACTION_BUTTON_VALID_SIZES,
+    'icon-slot': [ICON_SLOT_MARKUP],
+  },
+  { quiet: [false, true], disabled: [true] },
+  { quiet: [false, true], pending: [true] },
+  { quiet: [false, true], 'data-force-state': FORCED_STATES },
+]);
+
+// Static-color action buttons need contrast backgrounds, so keep their
+// permutations separate from the main set instead of filtering them at render
+// time.
+const STATIC_COLOR_PERMUTATION_GROUPS = ACTION_BUTTON_STATIC_COLORS.map(
+  (color) => ({
+    color,
+    permutations: createPermutations([
+      {
+        'static-color': [color],
+        quiet: [false, true],
+        'icon-slot': [ICON_SLOT_MARKUP],
+      },
+      {
+        'static-color': [color],
+        quiet: [false, true],
+        'data-force-state': FORCED_STATES,
+      },
+      { 'static-color': [color], quiet: [false, true], disabled: [true] },
+      { 'static-color': [color], quiet: [false, true], pending: [true] },
+    ]),
+  })
+);
+
+// Spreads onto the default `args` (not just `permutation`) because
+// template()'s named-slot rendering (unlike default-slot) doesn't guard
+// against a missing key: an omitted `icon-slot` reads as `undefined` and gets
+// serialized into a literal "undefined" text node. `args` already carries every
+// declared slot/attr at its real default (empty string for slots), so only the
+// axes each permutation actually sets override it.
+const renderActionButtonPermutation = renderStorybookPermutation(
+  'swc-action-button',
+  { 'default-slot': 'Edit' }
+);
+
+// Icon-only is the one anatomy variant `template()` can't render correctly: its
+// icon-slot content goes through an extra DOM-parsing step that leaves a Lit
+// child-position marker comment inside <swc-action-button>. The slotted-text
+// observer misreads that marker as label text and `iconOnly` never activates.
+// The stories file's own Icon only story sidesteps it the same way: writing the
+// markup directly instead of going through template()'s icon-slot.
+const ICON_ONLY_PERMUTATIONS = createPermutations([
+  { size: ACTION_BUTTON_VALID_SIZES },
+  { quiet: [true], size: ACTION_BUTTON_VALID_SIZES },
+  { disabled: [true] },
+  { pending: [true] },
+]);
+
+type IconOnlyCase = {
+  size?: (typeof ACTION_BUTTON_VALID_SIZES)[number];
+  quiet?: boolean;
+  disabled?: boolean;
+  pending?: boolean;
+};
+
+const renderIconOnlyPermutation = ({
+  size = 'm',
+  quiet = false,
+  disabled = false,
+  pending = false,
+}: IconOnlyCase) => html`
+  <swc-action-button
+    size=${size}
+    ?quiet=${quiet}
+    ?disabled=${disabled}
+    ?pending=${pending}
+    accessible-label="Edit"
+  >
+    <svg
+      slot="icon"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 36 36"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M33.567 8.2 27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945ZM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73Z"
+      />
+    </svg>
+  </swc-action-button>
+`;
+
+const forceActionButtonStates = forcePseudoStates(
+  'swc-action-button[data-force-state]',
+  '.swc-ActionButton'
+);
+
+// Forced pseudo-state permutations render in their own titled row rather than
+// folded into the per-treatment grouping.
+const isPseudoState = (permutation: Record<string, unknown>) =>
+  'data-force-state' in permutation;
+
+const permutationContent = () => html`
+  ${groupPermutationsBy(
+    ACTION_BUTTON_PERMUTATIONS.filter(
+      (permutation) => !isPseudoState(permutation)
+    ),
+    'quiet'
+  ).map(([quiet, perms]) =>
+    row(perms.map(renderActionButtonPermutation), QUIET_LABELS[quiet] ?? quiet)
+  )}
+  ${groupPermutationsBy(
+    ACTION_BUTTON_PERMUTATIONS.filter(isPseudoState),
+    'data-force-state'
+  ).map(([state, perms]) =>
+    row(perms.map(renderActionButtonPermutation), state)
+  )}
+  ${row(
+    ICON_ONLY_PERMUTATIONS.map(renderIconOnlyPermutation),
+    'Icon-only anatomy'
+  )}
+  ${row(
+    [
+      html`
+        <swc-action-button lang="ja">承認ワークフローを開始</swc-action-button>
+      `,
+      html`
+        <swc-action-button lang="ko">승인 워크플로 시작</swc-action-button>
+      `,
+      html`
+        <swc-action-button lang="zh">启动审批工作流</swc-action-button>
+      `,
+    ],
+    'CJK language'
+  )}
+  ${STATIC_COLOR_PERMUTATION_GROUPS.map(({ color, permutations }) =>
+    staticColorBackground(
+      [
+        ...groupPermutationsBy(
+          permutations.filter((permutation) => !isPseudoState(permutation)),
+          'quiet'
+        ).map(([quiet, perms]) =>
+          row(
+            perms.map(renderActionButtonPermutation),
+            `Static ${color} · ${QUIET_LABELS[quiet] ?? quiet}`
+          )
+        ),
+        ...groupPermutationsBy(
+          permutations.filter(isPseudoState),
+          'data-force-state'
+        ).map(([state, perms]) =>
+          row(
+            perms.map(renderActionButtonPermutation),
+            `Static ${color} · ${state}`
+          )
+        ),
+      ],
+      color
+    )
+  )}
+`;
+
+// VRT stories
+
+// Every size in the default and quiet treatments, label-only and icon+label
+// anatomy, disabled/pending states, icon-only anatomy across sizes, CJK label
+// rendering, static-color variants (each with their own forced hover/
+// focus-visible/active, since static-color buttons keep their own contrast
+// rules regardless of app theme) on their contrast backgrounds, and forced
+// hover/focus-visible/active per treatment (see the `play` function below).
+// Rendered once in light/ltr and once in dark/rtl below (that combination
+// covers both axes), all still in a single story so it costs one snapshot.
+export const Permutations: Story = {
+  render: () => html`
+    ${theme(permutationContent(), 'light', 'ltr')}
+    ${theme(permutationContent(), 'dark', 'rtl')}
+  `,
+  // Autoplay runs forced pseudo-state setup in local dev and Chromatic.
+  parameters: vrtParameters,
+  // :hover/:active can't be triggered by synthetic events, and static VRT
+  // captures have no real pointer. See helpers/pseudo-state.ts. Applying this
+  // after render (rather than baking the forced-state attribute into the markup
+  // above) is what lets it target the real internal `.swc-ActionButton` element
+  // inside the shadow root, which the light-DOM markup above has no access to.
+  play: forceActionButtonStates,
+};
+
+// `forced-colors` is a real browser media feature Chromatic can emulate
+// directly (parameters.chromatic.forcedColors), unlike :hover/:active/
+// :focus-visible above. But that also means it can't be scoped to a subtree the
+// way theme()'s light/dark split is. Forced-colors mode replaces the whole
+// page's palette, so it needs its own story/snapshot rather than folding into
+// Permutations. Still forces hover/focus-visible/active (same play-function
+// pattern) since forced-colors mode has its own UA-mandated focus-ring behavior
+// worth confirming.
+export const ForcedColors: Story = {
+  render: () => theme(permutationContent(), 'light', 'ltr'),
+  parameters: forcedColorsVrtParameters,
+  play: forceActionButtonStates,
+};

--- a/2nd-gen/packages/swc/vitest.config.js
+++ b/2nd-gen/packages/swc/vitest.config.js
@@ -74,9 +74,9 @@ export default mergeConfig(
 
           // SWC component implementations
           'components/**/*.{ts,js}': {
-            lines: 98,
+            lines: 99,
             functions: 98,
-            statements: 98,
+            statements: 99,
           },
 
           // Core component logic

--- a/2nd-gen/packages/swc/vitest.config.js
+++ b/2nd-gen/packages/swc/vitest.config.js
@@ -74,9 +74,9 @@ export default mergeConfig(
 
           // SWC component implementations
           'components/**/*.{ts,js}': {
-            lines: 99,
+            lines: 98,
             functions: 98,
-            statements: 99,
+            statements: 98,
           },
 
           // Core component logic


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

<!--- Describe your changes in detail -->

Adds Storybook VRT coverage `swc-action-button` which follows the same VRT model as `swc-button`

Files added:
- `action-button.vrt.ts`: 
- `action-button-custom-properties.vrt.ts`
- `action-button-global-styles.vrt.ts`

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## Related issue(s)

<!---
    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, include the issue number where the reviewers can find a description of the bug with steps to reproduce.
    - If you're an Adobe employee, add a Jira ticket number but DO NOT LINK directly to Jira.
-->

- fixes SWC-2398

## Screenshots (if appropriate)

---

## Author's checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** and **[PULL_REQUESTS](<(https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)>)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

<!---
    - For the author, please describe in detail what reviewers should test.
    - Include links and manual steps for how the reviewer should go through to verify your changes.
    - Be sure to include all areas of the codebase that might be affected. Any components that use these changes for a dependency should be cross-checked for regressions.
    - For example, changes to Menu Item will affect Picker, Menu, and Action Menu.
-->

This PR only adds `.vrt.ts` test stories; it does not change the `swc-action-button` component, so no dependent components are affected. Review focuses on the new stories rendering as intended.

- [ ] _Permutations story renders every size, treatment, anatomy, and state_
  1. Run `yarn storybook` and open **Components → Action button → Action button VRT → Permutations** (or view the Chromatic snapshot)
  2. Confirm the grid shows every size (`xs`–`xl`) in both the default and quiet treatments, in label-only and icon+label anatomy, plus the icon-only anatomy row
  3. Confirm the disabled and pending rows render, and the forced hover / focus-visible / active rows each show the corresponding interaction state
  4. Confirm the full matrix is repeated in light/LTR and dark/RTL, the static-color white/black groups sit on their dark/light contrast backgrounds, and the CJK language row renders correctly

- [ ] _Forced colors story renders under high-contrast emulation_
  1. Open **Action button VRT → Forced colors**
  2. Confirm the buttons render with system (forced) colors and that a visible focus indicator appears on the forced focus-visible row

- [ ] _Custom property overrides visibly apply_
  1. Open **Action button VRT → Custom properties**
  2. For each `--swc-action-button-*` row, compare the reference button (left) with the overridden button (right)
  3. Confirm every overridden button differs visibly from its reference (color, min-block-size, radius, spacing, font/icon size, or down-state transform), confirming each documented custom property still resolves

- [ ] _Global styles match the component_
  1. Open **Action button VRT → Global styles**
  2. Confirm the plain `<a>` and `<button>` elements (styled only by `global-action-button.css` classes) render identically to each other and match the `swc-action-button` component across sizes, quiet, anatomy, static color, and forced states

- [ ] _Chromatic snapshots reviewed_
  1. Open the Chromatic build for this PR
  2. Confirm the new Action button VRT snapshots are intentional, then approve them before the golden hash is updated

### Device review

<!--- Verify the above manual tests and visual accuracy utilizing an emulator like Polypane browser or on an actual device. -->

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

<!---
    Manual accessibility testing is required because automated tools cannot catch all issues (e.g. focus order, screen reader announcements, keyboard flow).
    You must document your keyboard and screen reader testing steps below. Reviewers will use this checklist during review.
    See: [Accessibility testing guide](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTOR-DOCS/01_contributor-guides/09_accessibility-testing.md)
-->

**Required:** Complete each applicable item and document your testing steps (replace the placeholders with your component-specific instructions).

> This PR adds visual-regression test stories only; it does not change `swc-action-button`'s markup or behavior. The steps below confirm there is no regression against the existing Action button stories.

- [ ] **Keyboard** (required — document steps below) — _What to test for:_ Focus order is logical; <kbd>Tab</kbd> reaches the component and all interactive descendants; <kbd>Enter</kbd>/<kbd>Space</kbd> activate where appropriate; arrow keys work for tabs, menus, sliders, etc.; no focus traps; <kbd>Escape</kbd> dismisses when applicable; focus indicator is visible.
  1. Run `yarn storybook` and open **Components → Action button → Playground**
  2. Press <kbd>Tab</kbd> and confirm focus lands on the action button with a visible focus indicator
  3. Press <kbd>Enter</kbd>, then <kbd>Space</kbd>, and confirm each activates the button (the **Actions** panel logs a `click`)
  4. Open the **States** story, <kbd>Tab</kbd> through it, and confirm the disabled button is skipped in the tab order and focus flows on to the next control with no trap
  5. Open the **Icon only** story and confirm the icon-only button is reachable with <kbd>Tab</kbd> and shows a focus indicator

- [ ] **Screen reader** (required — document steps below) — _What to test for:_ Role and name are announced correctly; state changes (e.g. expanded, selected) are announced; labels and relationships are clear; no unnecessary or duplicate announcements.
  1. Enable VoiceOver (macOS, <kbd>Cmd</kbd> + <kbd>F5</kbd>) and open **Components → Action button → Playground**
  2. Move the VoiceOver cursor to the button and confirm it is announced as "Edit, button"
  3. In the **Icon only** story, confirm the button announces its `accessible-label` ("Edit, button") rather than an empty name
  4. In the **States** story, confirm the disabled button is announced as dimmed/unavailable, and the pending button announces its pending accessible name and busy state
