### PR TITLE
chore(icons): add workflow icons generator

### DIFF
--- a/2nd-gen/packages/swc/package.json
+++ b/2nd-gen/packages/swc/package.json
@@ -79,6 +79,7 @@
     "dev:core": "yarn workspace @adobe/spectrum-wc-core dev",
     "generate:contributor-docs": "node .storybook/scripts/generate-contributor-docs.mjs",
     "generate:ui-icons": "node scripts/generate-ui-icons.mjs && prettier --write \"components/ui-icons/icon-set/*.ts\"",
+    "generate:workflow-icons": "node scripts/generate-workflow-icons.mjs && prettier --write \"components/workflow-icons/*.ts\"",
     "storybook": "yarn generate:contributor-docs && yarn analyze && storybook dev -p 6006",
     "storybook:build": "yarn generate:contributor-docs && yarn analyze && storybook build",
     "storybook:build:vrt": "yarn analyze && SWC_STORYBOOK_MODE=vrt storybook build",

--- a/2nd-gen/packages/swc/scripts/generate-workflow-icons.mjs
+++ b/2nd-gen/packages/swc/scripts/generate-workflow-icons.mjs
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Generates the public workflow-icon art (per-icon SVG-string function + per-icon
+ * custom element) from the A4U source SVGs. This generator is workflow-specific (it
+ * parses the workflow filename form and emits two modules per icon); the
+ * family-agnostic pieces it uses (SVG cleanup, kebab casing, license and banner) are
+ * shared with the UI generator via `icon-source/utils/`.
+ *
+ * Staged inside `swc` for now (`components/workflow-icons/`), mirroring where UI icons
+ * live (`components/ui-icons/`). Packaging this output into the dedicated
+ * `@adobe/spectrum-wc-icons` package is a separate, later phase (SWC-2441); this
+ * generator's output location will move at that point, not before.
+ *
+ * Input:  icon-source/workflow/S2_Icon_<Name>_20_N.svg
+ * Output: components/workflow-icons/<Name>.ts             (SVG-string function, e.g. StarIcon())
+ *         components/workflow-icons/swc-icon-<name>.ts    (custom element extending IconBase)
+ *
+ * Run with `yarn generate:workflow-icons`. Regenerate whenever the source SVGs change.
+ */
+import { globSync } from 'glob';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  generatedBanner,
+  LICENSE,
+  toKebab,
+} from '../icon-source/utils/format.mjs';
+import { cleanSvg } from '../icon-source/utils/svg.mjs';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, '..');
+const sourceDir = path.join(packageRoot, 'icon-source', 'workflow');
+const outDir = path.join(packageRoot, 'components', 'workflow-icons');
+
+// A4U source filename: S2_Icon_<LogicalName>_20_N.svg (one fixed-size drawing per
+// icon, no optical step).
+const SOURCE_NAME = /^S2_Icon_(?<name>.+?)_20_N\.svg$/;
+
+const GENERATED_BANNER = generatedBanner(
+  'yarn generate:workflow-icons',
+  'icon-source/workflow/'
+);
+
+// Collect: logical name -> cleaned svg string. One drawing per icon (no per-step map,
+// unlike UI icons), per the RFC's workflow sizing model: one asset scaled
+// to a token box, not discrete optically-tuned steps.
+const icons = new Map();
+const files = globSync('*.svg', { cwd: sourceDir }).sort();
+
+// Refuse to run without source SVGs. The source folder is git-ignored, so on a clean
+// checkout this would otherwise delete the committed workflow icon art and write
+// nothing, breaking every consumer.
+if (files.length === 0) {
+  throw new Error(
+    `No source SVGs found in ${sourceDir}. Download the workflow icon set into that ` +
+      `folder before running the generator.`
+  );
+}
+
+for (const file of files) {
+  const match = SOURCE_NAME.exec(file);
+  if (!match) {
+    console.warn(`Skipping unrecognized source file: ${file}`);
+    continue;
+  }
+  const { name } = match.groups;
+  // The captured name feeds directly into an output file path below; reject
+  // anything that isn't a plain identifier rather than trusting an
+  // unconstrained regex capture against locally-placed files.
+  if (!/^[A-Za-z0-9]+$/.test(name)) {
+    console.warn(`Skipping source file with an unsafe logical name: ${file}`);
+    continue;
+  }
+  let svg;
+  try {
+    svg = cleanSvg(readFileSync(path.join(sourceDir, file), 'utf8'), file);
+  } catch (error) {
+    throw new Error(`Failed to clean source SVG ${file}: ${error.message}`, {
+      cause: error,
+    });
+  }
+  icons.set(name, svg);
+}
+
+const names = [...icons.keys()].sort();
+
+// Ensure the output directory exists, then remove previously generated modules so
+// deletions in source propagate.
+mkdirSync(outDir, { recursive: true });
+// workflow-icons/ holds only generated modules, so clearing them all is safe.
+for (const stale of globSync('*.ts', { cwd: outDir })) {
+  rmSync(path.join(outDir, stale));
+}
+
+// Emit two modules per icon: the SVG-string function substrate, and the custom
+// element that bakes it in via `unsafeSVG` (RFC icon-rfc.md, section 6.4, item 2).
+for (const name of names) {
+  const svg = icons.get(name);
+  const kebabName = toKebab(name);
+  const tagName = `swc-icon-${kebabName}`;
+  const elementClassName = `Icon${name}`;
+  const functionName = `${name}Icon`;
+
+  // Emitted as a backtick-delimited string (still a plain `string` type, not a Lit
+  // TemplateResult, per the RFC) rather than a single-quoted one: template literals
+  // permit raw embedded newlines, so cleaned SVG content needs no newline-collapsing,
+  // only escaping the three sequences that could otherwise break out of it.
+  const escapedSvg = svg
+    .trim()
+    .replace(/\\/g, '\\\\')
+    .replace(/`/g, '\\`')
+    .replace(/\$\{/g, '\\${');
+
+  const functionModule = `${LICENSE}
+${GENERATED_BANNER}
+export function ${functionName}(): string {
+  return \`${escapedSvg}\`;
+}
+`;
+  writeFileSync(path.join(outDir, `${name}.ts`), functionModule);
+
+  const elementModule = `${LICENSE}
+${GENERATED_BANNER}
+import { CSSResultArray, html, TemplateResult } from 'lit';
+import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
+
+import { IconBase } from '@adobe/spectrum-wc-core/components/icon';
+import { defineElement } from '@adobe/spectrum-wc-core/element/index.js';
+
+import { ${functionName} } from './${name}.js';
+
+import iconBaseStyles from '../../stylesheets/_lit-styles/icon-base.css';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    '${tagName}': ${elementClassName};
+  }
+}
+
+export class ${elementClassName} extends IconBase {
+  public static override get styles(): CSSResultArray {
+    return [iconBaseStyles];
+  }
+
+  protected override render(): TemplateResult {
+    return html\`
+      <span class="swc-Icon">\${unsafeSVG(${functionName}())}</span>
+    \`;
+  }
+}
+
+defineElement('${tagName}', ${elementClassName});
+`;
+  writeFileSync(path.join(outDir, `swc-icon-${kebabName}.ts`), elementModule);
+}
+
+console.log(
+  `Generated ${names.length} workflow icon(s) (function + element each) from ${files.length} source SVG(s): ${names.join(', ')}`
+);


### PR DESCRIPTION
## Description

Adds `scripts/generate-workflow-icons.mjs`: converts A4U workflow SVGs into a per-icon function (`StarIcon(): string`) and a per-icon element (`<swc-icon-star>` extending `IconBase`), reusing Phase 0's shared `icon-source/utils/`. Staged in `swc/components/workflow-icons/` for now; packaging into `@adobe/spectrum-wc-icons` is Phase 4. Filename regex (`S2_Icon_<Name>_20_N.svg`) is derived from a public sibling repo's manifest, not a confirmed real A4U sample, flagged as such in the file header. Validated against synthetic fixtures only; no real icon art is included or committed.

## Motivation and context

Implements Phase 3 of the icon RFC (SWC-2442): public workflow icons as a Lit-free function plus a custom element.

## Related issue(s)

- Jira: SWC-2442
- Depends on SWC-2439 (Phase 2 gate) · feeds SWC-2441 (Phase 4 packaging)

## Screenshots (if appropriate)

N/A — build script only, no UI.

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have reviewed the Accessibility Practices for this feature.
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Drop a fixture SVG (`S2_Icon_Star_20_N.svg`, `--iconPrimary` fill) into `icon-source/workflow/`, run `yarn generate:workflow-icons`, confirm both output files are generated, fill is rewritten to `var(--swc-icon-color, currentColor)`, and lint/prettier pass. Delete the fixture and output after.
- [ ] Confirm running with an empty `icon-source/workflow/` throws instead of deleting anything.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard**: N/A, no UI in this PR.
- [ ] **Screen reader**: N/A, no UI in this PR. Generated elements extend `IconBase` (existing, already-tested a11y contract: decorative by default, `role="img"` + `aria-label` when `accessible-label` is set); no new behavior introduced.