### PR TITLE
chore(avatar): add vrt support

### DIFF
--- a/2nd-gen/packages/swc/components/avatar/test/vrt/avatar-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/avatar/test/vrt/avatar-custom-properties.vrt.ts
@@ -45,12 +45,22 @@ const PLACEHOLDER_SRC = 'https://picsum.photos/id/64/500/500';
 type AvatarPropertyCase = CustomPropertyCase<`--swc-avatar-${string}`> & {
   outline?: boolean;
   disabled?: boolean;
+  // Fixed style applied to both the default and modified renders. Used by
+  // --swc-avatar-outline-width to pin a visible outline color, since the
+  // default token color is too pale against the light background to reveal
+  // a width change on its own.
+  baseStyle?: string;
 };
 
 const AVATAR_PROPERTY_CASES: readonly AvatarPropertyCase[] = [
   { property: '--swc-avatar-size', value: '120px' },
   { property: '--swc-avatar-outline-color', value: 'magenta', outline: true },
-  { property: '--swc-avatar-outline-width', value: '8px', outline: true },
+  {
+    property: '--swc-avatar-outline-width',
+    value: '8px',
+    outline: true,
+    baseStyle: '--swc-avatar-outline-color: magenta;',
+  },
   {
     property: '--swc-avatar-opacity-disabled',
     value: '1',
@@ -59,17 +69,20 @@ const AVATAR_PROPERTY_CASES: readonly AvatarPropertyCase[] = [
 ];
 
 const renderPropertyCase = (
-  { outline, disabled }: AvatarPropertyCase,
+  { outline, disabled, baseStyle }: AvatarPropertyCase,
   style?: string
-) => html`
-  <swc-avatar
-    src=${PLACEHOLDER_SRC}
-    alt="Jane Doe"
-    ?outline=${outline}
-    ?disabled=${disabled}
-    style=${style ?? nothing}
-  ></swc-avatar>
-`;
+) => {
+  const combinedStyle = [baseStyle, style].filter(Boolean).join(' ');
+  return html`
+    <swc-avatar
+      src=${PLACEHOLDER_SRC}
+      alt="Jane Doe"
+      ?outline=${outline}
+      ?disabled=${disabled}
+      style=${combinedStyle || nothing}
+    ></swc-avatar>
+  `;
+};
 
 const modPropertiesContent = () =>
   customPropertyRows(AVATAR_PROPERTY_CASES, renderPropertyCase);

--- a/2nd-gen/packages/swc/components/avatar/test/vrt/avatar-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/avatar/test/vrt/avatar-custom-properties.vrt.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '@adobe/spectrum-wc/components/avatar/swc-avatar.js';
+
+import type { CustomPropertyCase } from '../../../../.storybook/helpers/index.js';
+import {
+  coveredCustomProperties,
+  customPropertyRows,
+  theme,
+  verifyCustomPropertyCoverage,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import customElementsManifest from '../../../../dist/custom-elements.json';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Avatar/Avatar VRT',
+  component: 'swc-avatar',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+const PLACEHOLDER_SRC = 'https://picsum.photos/id/64/500/500';
+
+// --swc-avatar-outline-color/-width only resolve when `outline` is set, and
+// --swc-avatar-opacity-disabled only resolves when `disabled` is set, so each
+// case renders in the state where its property is actually live.
+type AvatarPropertyCase = CustomPropertyCase<`--swc-avatar-${string}`> & {
+  outline?: boolean;
+  disabled?: boolean;
+};
+
+const AVATAR_PROPERTY_CASES: readonly AvatarPropertyCase[] = [
+  { property: '--swc-avatar-size', value: '120px' },
+  { property: '--swc-avatar-outline-color', value: 'magenta', outline: true },
+  { property: '--swc-avatar-outline-width', value: '8px', outline: true },
+  {
+    property: '--swc-avatar-opacity-disabled',
+    value: '1',
+    disabled: true,
+  },
+];
+
+const renderPropertyCase = (
+  { outline, disabled }: AvatarPropertyCase,
+  style?: string
+) => html`
+  <swc-avatar
+    src=${PLACEHOLDER_SRC}
+    alt="Jane Doe"
+    ?outline=${outline}
+    ?disabled=${disabled}
+    style=${style ?? nothing}
+  ></swc-avatar>
+`;
+
+const modPropertiesContent = () =>
+  customPropertyRows(AVATAR_PROPERTY_CASES, renderPropertyCase);
+
+const coveredAvatarCustomProperties = coveredCustomProperties(
+  AVATAR_PROPERTY_CASES
+);
+
+const verifyCoverage = async () => {
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/avatar/Avatar.ts',
+    declarationName: 'Avatar',
+    coveredProperties: coveredAvatarCustomProperties,
+  });
+};
+
+// VRT stories
+
+export const CustomProperties: Story = {
+  render: () => theme(modPropertiesContent(), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: verifyCoverage,
+};

--- a/2nd-gen/packages/swc/components/avatar/test/vrt/avatar.vrt.ts
+++ b/2nd-gen/packages/swc/components/avatar/test/vrt/avatar.vrt.ts
@@ -45,6 +45,24 @@ const renderAvatar = (size: AvatarSize) => html`
   <swc-avatar src=${PLACEHOLDER_SRC} alt="Jane Doe" size=${size}></swc-avatar>
 `;
 
+// `alt` is aria-only (no visible text), and sizes are plain numbers with no
+// named s/m/l equivalent, so a visible caption is added underneath -
+// otherwise a reviewer can't tell which rendered avatar corresponds to which
+// size value from the snapshot alone (same reasoning as
+// color-handle.vrt.ts's renderHandle and progress-circle.vrt.ts's
+// renderSizedCircle captions).
+const captioned = (content: unknown, label: string) => html`
+  <div
+    style="display: flex; flex-direction: column; align-items: center; gap: var(--swc-spacing-100);"
+  >
+    ${content}
+    <span class="swc-Detail swc-Detail--sizeM">${label}</span>
+  </div>
+`;
+
+const renderSizedAvatar = (size: AvatarSize) =>
+  captioned(renderAvatar(size), `${size}`);
+
 // Outline needs a contrasting backdrop to read, same as avatar.stories.ts's
 // own Outline story: the outline color/width tokens are subtle against the
 // default page background.
@@ -60,6 +78,9 @@ const renderOutline = (size: AvatarSize) => html`
     ></swc-avatar>
   </div>
 `;
+
+const renderCaptionedOutline = (size: AvatarSize) =>
+  captioned(renderOutline(size), `${size}`);
 
 const renderDisabled = () => html`
   <swc-avatar
@@ -77,14 +98,14 @@ const renderDisabled = () => html`
 // focusable, no :hover/:focus/:active rules in avatar.css), so neither story
 // below needs forcePseudoStates.
 const permutationContent = () => html`
-  ${row(AVATAR_VALID_SIZES.map(renderAvatar), 'Sizes')}
-  ${row([renderOutline(500), renderOutline(1000)], 'Outline')}
+  ${row(AVATAR_VALID_SIZES.map(renderSizedAvatar), 'Sizes')}
+  ${row([renderCaptionedOutline(500), renderCaptionedOutline(1000)], 'Outline')}
   ${row([renderDisabled()], 'Disabled')}
 `;
 
 const forcedColorsContent = () => html`
   ${row([renderAvatar(500)], 'Default')}
-  ${row([renderOutline(500), renderOutline(1000)], 'Outline')}
+  ${row([renderCaptionedOutline(500), renderCaptionedOutline(1000)], 'Outline')}
   ${row([renderDisabled()], 'Disabled')}
 `;
 

--- a/2nd-gen/packages/swc/components/avatar/test/vrt/avatar.vrt.ts
+++ b/2nd-gen/packages/swc/components/avatar/test/vrt/avatar.vrt.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import {
+  AVATAR_VALID_SIZES,
+  type AvatarSize,
+} from '@adobe/spectrum-wc-core/components/avatar';
+
+import '@adobe/spectrum-wc/components/avatar/swc-avatar.js';
+
+import {
+  forcedColorsVrtParameters,
+  row,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Avatar/Avatar VRT',
+  component: 'swc-avatar',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+const PLACEHOLDER_SRC = 'https://picsum.photos/id/64/500/500';
+
+const renderAvatar = (size: AvatarSize) => html`
+  <swc-avatar src=${PLACEHOLDER_SRC} alt="Jane Doe" size=${size}></swc-avatar>
+`;
+
+// Outline needs a contrasting backdrop to read, same as avatar.stories.ts's
+// own Outline story: the outline color/width tokens are subtle against the
+// default page background.
+const renderOutline = (size: AvatarSize) => html`
+  <div
+    style="display: inline-flex; padding: 16px; background: linear-gradient(to right, rgb(15, 23, 42), rgb(51, 65, 85)); border-radius: 8px;"
+  >
+    <swc-avatar
+      src=${PLACEHOLDER_SRC}
+      alt="Jane Doe"
+      size=${size}
+      outline
+    ></swc-avatar>
+  </div>
+`;
+
+const renderDisabled = () => html`
+  <swc-avatar
+    src=${PLACEHOLDER_SRC}
+    alt="Jane Doe"
+    size="500"
+    disabled
+  ></swc-avatar>
+`;
+
+// `decorative` is deliberately not covered anywhere in this file: it only
+// toggles `aria-hidden` and produces no pixel difference, so a VRT row for
+// it can never usefully diff. That behavior is covered by
+// avatar.a11y.spec.ts instead. Avatar also has no interactive states (not
+// focusable, no :hover/:focus/:active rules in avatar.css), so neither story
+// below needs forcePseudoStates.
+const permutationContent = () => html`
+  ${row(AVATAR_VALID_SIZES.map(renderAvatar), 'Sizes')}
+  ${row([renderOutline(500), renderOutline(1000)], 'Outline')}
+  ${row([renderDisabled()], 'Disabled')}
+`;
+
+const forcedColorsContent = () => html`
+  ${row([renderAvatar(500)], 'Default')}
+  ${row([renderOutline(500), renderOutline(1000)], 'Outline')}
+  ${row([renderDisabled()], 'Disabled')}
+`;
+
+// VRT stories
+
+// Every size (50–1500), the outline modifier at the default size and at the
+// large-size breakpoint (>=1000, where the outline width doubles per
+// avatar.css), and the disabled state. Rendered once in light/ltr and once
+// in dark/rtl below (that combination covers both axes), all in a single
+// story so it costs one snapshot.
+export const Permutations: Story = {
+  render: () => html`
+    ${theme(permutationContent(), 'light', 'ltr')}
+    ${theme(permutationContent(), 'dark', 'rtl')}
+  `,
+  parameters: vrtParameters,
+};
+
+// `forced-colors` replaces the whole page palette. avatar.css has no
+// component-level forced-colors override (unlike divider/button), so this
+// story verifies the token-level behavior rather than a bespoke rule. A
+// single representative size covers the default and disabled cases, since
+// size doesn't interact with forced-colors differently; outline is still
+// checked at both width breakpoints in case forced-colors affects the
+// outline color independent of its width.
+export const ForcedColors: Story = {
+  render: () => theme(forcedColorsContent(), 'light', 'ltr'),
+  parameters: forcedColorsVrtParameters,
+};


### PR DESCRIPTION
## Description

Adds `avatar.vrt.ts` and `avatar-custom-properties.vrt.ts` under `avatar/test/vrt/`: sizes, outline, disabled, forced-colors, and all 4 custom properties.

## Motivation and context

Extends the VRT foundation (button/link/divider) to Avatar.

## Related issue(s)

- fixes SWC-2417

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have reviewed the Accessibility Practices for this feature.
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Accessibility testing checklist

- [ ] **Keyboard**: N/A — Avatar is non-interactive and not focusable; no keyboard behavior to test.
- [ ] **Screen reader**: 1. Open Storybook → Avatar → Avatar VRT. 2. Confirm no console errors/warnings on load. 3. Spot-check one avatar per row with a screen reader; expect `alt` text announced, no extra noise.
