### PR TITLE
chore(illustrated-message): add vrt support

### DIFF
--- a/2nd-gen/packages/swc/components/illustrated-message/test/vrt/illustrated-message-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/vrt/illustrated-message-custom-properties.vrt.ts
@@ -68,7 +68,7 @@ const ILLUSTRATED_MESSAGE_PROPERTY_CASES: readonly IllustratedMessagePropertyCas
     { property: '--swc-illustrated-message-illustration-size', value: '40px' },
     {
       property: '--swc-illustrated-message-illustration-inline-size',
-      value: '200px',
+      value: '350px',
     },
     {
       property: '--swc-illustrated-message-illustration-block-size',

--- a/2nd-gen/packages/swc/components/illustrated-message/test/vrt/illustrated-message-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/vrt/illustrated-message-custom-properties.vrt.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '@adobe/spectrum-wc/components/illustrated-message/swc-illustrated-message.js';
+
+import type { CustomPropertyCase } from '../../../../.storybook/helpers/index.js';
+import {
+  coveredCustomProperties,
+  customPropertyRows,
+  theme,
+  verifyCustomPropertyCoverage,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import customElementsManifest from '../../../../dist/custom-elements.json';
+import { illustration } from './illustration.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Illustrated message/Illustrated message VRT',
+  component: 'swc-illustrated-message',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+// Every `--swc-illustrated-message-*` custom property is a public contract
+// (see the component's @cssprop JSDoc), so a future CSS refactor that quietly
+// drops one would be a breaking change. One row per property: a reference
+// message next to the same message with that one property overridden to an
+// obviously different value, so a real difference confirms the override
+// still works. `heading`/`description`/`containerInlineSize` let a case
+// customize content only where the default short copy wouldn't make the
+// override's effect visible (e.g. line-height needs wrapped text to show a
+// difference).
+type IllustratedMessagePropertyCase =
+  CustomPropertyCase<`--swc-illustrated-message-${string}`> & {
+    heading?: string;
+    description?: string;
+    containerInlineSize?: string;
+  };
+
+const DEFAULT_HEADING = 'Illustrated message title';
+const DEFAULT_DESCRIPTION = 'Supporting description text.';
+
+const ILLUSTRATED_MESSAGE_PROPERTY_CASES: readonly IllustratedMessagePropertyCase[] =
+  [
+    {
+      property: '--swc-illustrated-message-max-inline-size',
+      value: '160px',
+      description:
+        'Supporting description text long enough to wrap once the max inline size shrinks.',
+    },
+    { property: '--swc-illustrated-message-illustration-size', value: '40px' },
+    {
+      property: '--swc-illustrated-message-illustration-inline-size',
+      value: '200px',
+    },
+    {
+      property: '--swc-illustrated-message-illustration-block-size',
+      value: '40px',
+    },
+    {
+      property: '--swc-illustrated-message-illustration-color',
+      value: 'magenta',
+    },
+    {
+      property: '--swc-illustrated-message-illustration-to-content',
+      value: '0px',
+    },
+    { property: '--swc-illustrated-message-heading-font-size', value: '10px' },
+    {
+      property: '--swc-illustrated-message-heading-line-height',
+      value: '3',
+      heading: 'A heading long enough to wrap across two lines',
+      containerInlineSize: '160px',
+    },
+    {
+      property: '--swc-illustrated-message-description-font-size',
+      value: '10px',
+    },
+    {
+      property: '--swc-illustrated-message-description-line-height',
+      value: '3',
+      description:
+        'A description long enough to wrap across two lines so the line-height change is visible.',
+      containerInlineSize: '160px',
+    },
+  ];
+
+const renderPropertyCase = (
+  {
+    heading = DEFAULT_HEADING,
+    description = DEFAULT_DESCRIPTION,
+    containerInlineSize,
+  }: IllustratedMessagePropertyCase,
+  style?: string
+) => {
+  const message = html`
+    <swc-illustrated-message style=${style ?? nothing}>
+      ${illustration()}
+      <h2 slot="heading">${heading}</h2>
+      <span slot="description">${description}</span>
+    </swc-illustrated-message>
+  `;
+  return containerInlineSize
+    ? html`
+        <div style="inline-size: ${containerInlineSize};">${message}</div>
+      `
+    : message;
+};
+
+const modPropertiesContent = () =>
+  customPropertyRows(ILLUSTRATED_MESSAGE_PROPERTY_CASES, renderPropertyCase);
+
+const coveredIllustratedMessageCustomProperties = coveredCustomProperties(
+  ILLUSTRATED_MESSAGE_PROPERTY_CASES
+);
+
+const verifyCoverage = async () => {
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/illustrated-message/IllustratedMessage.ts',
+    declarationName: 'IllustratedMessage',
+    coveredProperties: coveredIllustratedMessageCustomProperties,
+  });
+};
+
+// VRT stories
+
+export const CustomProperties: Story = {
+  render: () => theme(modPropertiesContent(), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: verifyCoverage,
+};

--- a/2nd-gen/packages/swc/components/illustrated-message/test/vrt/illustrated-message.vrt.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/vrt/illustrated-message.vrt.ts
@@ -1,0 +1,329 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import {
+  ILLUSTRATED_MESSAGE_VALID_ORIENTATIONS,
+  ILLUSTRATED_MESSAGE_VALID_SIZES,
+  type IllustratedMessageOrientation,
+  type IllustratedMessageSize,
+} from '@adobe/spectrum-wc-core/components/illustrated-message';
+
+import '@adobe/spectrum-wc/components/illustrated-message/swc-illustrated-message.js';
+import '@adobe/spectrum-wc/components/button/swc-button.js';
+import '@adobe/spectrum-wc/components/button-group/swc-button-group.js';
+
+import {
+  createPermutations,
+  forcedColorsVrtParameters,
+  groupPermutationsBy,
+  row,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import { illustration } from './illustration.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Illustrated message/Illustrated message VRT',
+  component: 'swc-illustrated-message',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+type IllustratedMessageCase = {
+  size?: IllustratedMessageSize;
+  orientation?: IllustratedMessageOrientation;
+  lang?: string;
+};
+
+const standardSlots = (
+  heading: string,
+  description = 'Supporting description text.'
+) => html`
+  ${illustration()}
+  <h2 slot="heading">${heading}</h2>
+  <span slot="description">${description}</span>
+`;
+
+const renderIllustratedMessage = (
+  { size = 'm', orientation = 'vertical', lang }: IllustratedMessageCase,
+  slots: unknown = standardSlots('Illustrated message title')
+) => html`
+  <swc-illustrated-message
+    size=${size}
+    orientation=${orientation}
+    lang=${lang ?? nothing}
+  >
+    ${slots}
+  </swc-illustrated-message>
+`;
+
+// Size labels double as the item's own heading text; the row grouping already
+// conveys orientation, so size is the one axis each item needs to spell out.
+const SIZE_LABELS: Record<IllustratedMessageSize, string> = {
+  s: 'Small',
+  m: 'Medium',
+  l: 'Large',
+};
+
+const BASE_PERMUTATIONS = createPermutations([
+  {
+    size: ILLUSTRATED_MESSAGE_VALID_SIZES,
+    orientation: ILLUSTRATED_MESSAGE_VALID_ORIENTATIONS,
+  },
+]);
+
+const renderBasePermutation = (
+  permutation: (typeof BASE_PERMUTATIONS)[number]
+) =>
+  renderIllustratedMessage(
+    permutation,
+    standardSlots(SIZE_LABELS[permutation.size])
+  );
+
+// Anatomy: slot combinations that change the rendered structure (illustration
+// wrapper collapses entirely when the default slot has no assigned content),
+// at a single size/orientation so the differences read as structural.
+const anatomyCases = [
+  renderIllustratedMessage(
+    {},
+    html`
+      <h2 slot="heading">No illustration</h2>
+      <span slot="description">
+        Illustration slot left empty; its wrapper collapses instead of reserving
+        space.
+      </span>
+    `
+  ),
+  renderIllustratedMessage(
+    {},
+    html`
+      ${illustration()}
+      <h2 slot="heading">Heading only</h2>
+    `
+  ),
+  renderIllustratedMessage(
+    {},
+    standardSlots('Heading and description', 'Optional supporting description.')
+  ),
+  renderIllustratedMessage(
+    {},
+    html`
+      ${illustration()}
+      <h2 slot="heading">With a single action</h2>
+      <span slot="description">Optional supporting description.</span>
+      <swc-button slot="actions" variant="accent">Browse files</swc-button>
+    `
+  ),
+];
+
+// Actions receive `size` propagated automatically from the illustrated
+// message; render at every size to confirm the button-group scales with it.
+const actionsSizePropagationCases = ILLUSTRATED_MESSAGE_VALID_SIZES.map(
+  (size) =>
+    renderIllustratedMessage(
+      { size },
+      html`
+        ${illustration()}
+        <h2 slot="heading">No results found</h2>
+        <span slot="description">Try adjusting your search or filters.</span>
+        <swc-button-group slot="actions">
+          <swc-button variant="accent">Clear filters</swc-button>
+          <swc-button variant="secondary">Browse all</swc-button>
+        </swc-button-group>
+      `
+    )
+);
+
+// Heading level range the base class documents (h2-h6). Written as literal
+// cases since Lit templates can't take a dynamic tag name in tag position.
+const headingLevelCases = [
+  renderIllustratedMessage(
+    {},
+    html`
+      ${illustration()}
+      <h2 slot="heading">Heading h2</h2>
+      <span slot="description">Can be used for full-page empty states.</span>
+    `
+  ),
+  renderIllustratedMessage(
+    {},
+    html`
+      ${illustration()}
+      <h3 slot="heading">Heading h3</h3>
+      <span slot="description">Can be used inside a page section.</span>
+    `
+  ),
+  renderIllustratedMessage(
+    {},
+    html`
+      ${illustration()}
+      <h4 slot="heading">Heading h4</h4>
+      <span slot="description">Can be used inside a panel or card.</span>
+    `
+  ),
+  renderIllustratedMessage(
+    {},
+    html`
+      ${illustration()}
+      <h5 slot="heading">Heading h5</h5>
+      <span slot="description">Can be used inside a nested section.</span>
+    `
+  ),
+  renderIllustratedMessage(
+    {},
+    html`
+      ${illustration()}
+      <h6 slot="heading">Heading h6</h6>
+      <span slot="description">Can be used at the deepest nesting level.</span>
+    `
+  ),
+];
+
+// Unclassed slotted headings inherit the slot's typography; a classed heading
+// is left untouched by the `::slotted(...):not([class])` guard.
+const classedHeadingCase = renderIllustratedMessage(
+  {},
+  html`
+    ${illustration()}
+    <h2
+      slot="heading"
+      class="vrt-custom-heading"
+      style="color: green; font: italic 700 20px serif; margin: 0;"
+    >
+      Classed heading (unaffected)
+    </h2>
+    <span slot="description">
+      This heading has its own class, so it keeps its own styles instead of
+      inheriting the slot's typography.
+    </span>
+  `
+);
+
+// CJK content differs per language (not just an attribute swap), and each
+// size crosses with its own CJK title-font-size token (small/medium/large all
+// branch separately in illustrated-message.css), so render every size for
+// every language rather than a single representative case.
+const CJK_CONTENT: Record<
+  'ja' | 'ko' | 'zh',
+  { heading: string; description: string }
+> = {
+  ja: {
+    heading: '承認ワークフローを開始',
+    description: 'アップロードまたはインポートしてください。',
+  },
+  ko: {
+    heading: '승인 워크플로 시작',
+    description: '업로드하거나 가져와서 시작하세요.',
+  },
+  zh: {
+    heading: '启动审批工作流',
+    description: '上传或导入以开始使用。',
+  },
+};
+
+const renderCjkCase = (
+  lang: keyof typeof CJK_CONTENT,
+  size: IllustratedMessageSize
+) => {
+  const { heading, description } = CJK_CONTENT[lang];
+  return renderIllustratedMessage(
+    { size, lang },
+    html`
+      ${illustration()}
+      <h2 slot="heading">${heading}</h2>
+      <span slot="description">${description}</span>
+    `
+  );
+};
+
+const WRAPPING_HEADING =
+  'A heading long enough to wrap onto multiple lines within the illustrated message';
+const WRAPPING_DESCRIPTION =
+  'A description long enough to wrap across more than one line so the wrapping behavior is visible in the snapshot.';
+
+const wrappingCases = [
+  html`
+    <div style="inline-size: 200px;">
+      ${renderIllustratedMessage(
+        {},
+        html`
+          ${illustration()}
+          <h2 slot="heading">${WRAPPING_HEADING}</h2>
+          <span slot="description">${WRAPPING_DESCRIPTION}</span>
+        `
+      )}
+    </div>
+  `,
+  html`
+    <div style="inline-size: 280px;">
+      ${renderIllustratedMessage(
+        { orientation: 'horizontal' },
+        html`
+          ${illustration()}
+          <h2 slot="heading">${WRAPPING_HEADING}</h2>
+          <span slot="description">${WRAPPING_DESCRIPTION}</span>
+        `
+      )}
+    </div>
+  `,
+];
+
+const permutationContent = () => html`
+  ${groupPermutationsBy(BASE_PERMUTATIONS, 'orientation').map(
+    ([orientation, perms]) => row(perms.map(renderBasePermutation), orientation)
+  )}
+  ${row(anatomyCases, 'Anatomy')}
+  ${row(actionsSizePropagationCases, 'Actions · size propagation')}
+  ${row(headingLevelCases, 'Heading levels')}
+  ${row([classedHeadingCase], 'Classed heading override')}
+  ${(['ja', 'ko', 'zh'] as const).map((lang) =>
+    row(
+      ILLUSTRATED_MESSAGE_VALID_SIZES.map((size) => renderCjkCase(lang, size)),
+      lang
+    )
+  )}
+  ${row(wrappingCases, 'Wrapping')}
+`;
+
+// VRT stories
+
+// Every size x orientation combination, anatomy variations (including the
+// no-illustration collapsed state), actions size propagation, the full h2-h6
+// heading range, the classed-heading inheritance guard, CJK language x size
+// (each language's own content, since the CSS branches per size), and text
+// wrapping in both orientations. Rendered once in light/ltr and once in
+// dark/rtl below (that combination covers both axes), all still in a single
+// story so it costs one snapshot.
+export const Permutations: Story = {
+  render: () => html`
+    ${theme(permutationContent(), 'light', 'ltr')}
+    ${theme(permutationContent(), 'dark', 'rtl')}
+  `,
+  parameters: vrtParameters,
+};
+
+// `forced-colors` is a real browser media feature Chromatic can emulate
+// directly, unlike the (nonexistent, for this component) hover/focus/active
+// states. Forced-colors mode replaces the whole page's palette, so it needs
+// its own story/snapshot rather than folding into Permutations.
+export const ForcedColors: Story = {
+  render: () => theme(permutationContent(), 'light', 'ltr'),
+  parameters: forcedColorsVrtParameters,
+};

--- a/2nd-gen/packages/swc/components/illustrated-message/test/vrt/illustration.ts
+++ b/2nd-gen/packages/swc/components/illustrated-message/test/vrt/illustration.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+
+// Same illustration markup as illustrated-message.stories.ts's cloudSvg, kept
+// local to this component's VRT suite since the stories module doesn't
+// export it. Shared between illustrated-message.vrt.ts and
+// illustrated-message-custom-properties.vrt.ts so the path data and markup
+// have one source instead of drifting across two copies.
+const CLOUD_PATH =
+  'M89.3301 28.5C108.54 28.5001 124.013 43.9629 125.408 63.2666C140.627 66.0007 152 79.7946 152 96.1348C152 114.396 137.782 129.5 119.883 129.5C119.845 129.5 119.81 129.499 119.78 129.498C119.762 129.498 119.744 129.5 119.726 129.5H31.8809C31.7135 129.5 31.5486 129.489 31.3867 129.469C18.2497 129.009 8.00002 117.812 8 104.385C8 94.2106 13.8624 85.3674 22.4043 81.4414C22.3044 80.4799 22.2481 79.4992 22.248 78.5C22.248 62.9098 34.3925 49.9717 49.7344 49.9717C51.9927 49.9717 54.1852 50.2598 56.2822 50.7949C61.8951 37.7322 74.5088 28.5 89.3301 28.5ZM89.3301 36.5C76.8952 36.5 66.2004 45.0053 62.5117 57.0029C62.1777 58.0892 61.397 58.9825 60.3652 59.459C59.3335 59.9354 58.148 59.95 57.1045 59.5C54.8246 58.5167 52.3407 57.9717 49.7344 57.9717C39.1347 57.9717 30.248 66.997 30.248 78.5C30.2481 80.0858 30.4383 81.6436 30.7773 83.1748C31.2346 85.2397 30.006 87.3041 27.9727 87.8857C21.1679 89.8324 16 96.3956 16 104.385C16 113.898 23.2731 121.333 31.9502 121.482C32.0505 121.484 32.1497 121.491 32.248 121.5H119.548C119.614 121.497 119.681 121.496 119.747 121.496C119.805 121.496 119.854 121.497 119.889 121.498C119.901 121.498 119.912 121.499 119.923 121.499C133.063 121.477 144 110.295 144 96.1348C144 82.4618 133.788 71.5543 121.259 70.8145C119.114 70.6878 117.452 68.8891 117.495 66.7412C117.504 66.2932 117.512 66.3311 117.512 66.1104C117.512 49.5915 104.732 36.5001 89.3301 36.5Z';
+
+export const illustration = () => html`
+  <svg aria-hidden="true" viewBox="0 0 160 160">
+    <path d=${CLOUD_PATH} fill="currentColor" />
+  </svg>
+`;


### PR DESCRIPTION
## Description

Adds Storybook VRT coverage for `illustrated-message`: size x orientation permutations, anatomy variants (no illustration, heading-only, +description, +action), actions size-propagation, heading levels h2-h6, classed-heading guard, CJK language x size, text wrapping, forced-colors, and custom-property reference/override rows, plus a shared local `illustration.ts` helper; test-only, no runtime code changes.

## Motivation and context

SWC-2415 requires VRT coverage for `illustrated-message` following the button/divider/card VRT foundation (#6463); no global-styles VRT file since the component has no plain-element equivalent.

## Related issue(s)

- fixes SWC-2415

## Author's checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md) and [PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md) documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Accessibility testing checklist

- [ ] **Keyboard**: no focusable parts added; illustrated-message is non-interactive, so no keyboard flow to verify beyond confirming no regressions in existing stories.
- [ ] **Screen reader**: new stories only exercise existing behavior (aria-hidden illustration, h2-h6 heading slot, actions slot buttons); confirm role/name/label announcements are unchanged from pre-existing coverage.
