### PR TITLE
fix(builds): skip keytar native build

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
     "basic-ftp": "5.2.0",
     "playwright": "1.53.1"
   },
+  "dependenciesMeta": {
+    "keytar@7.9.0": {
+      "built": false
+    }
+  },
   "devDependencies": {
     "@axe-core/playwright": "4.11.2",
     "@changesets/cli": "2.29.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29597,6 +29597,9 @@ __metadata:
     stylelint-order: "npm:7.0.1"
     typescript-eslint: "npm:8.54.0"
     yargs: "npm:17.7.2"
+  dependenciesMeta:
+    keytar@7.9.0:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Disables the native build for `keytar` (a transitive dev dependency of `vsce`, used only for packaging the VS Code extension) since it fails to compile in CI containers lacking `pkg-config`/`libsecret-1`, breaking `yarn install` before any tests run.

## Motivation and context

CI installs were failing on `keytar@7.9.0`'s `node-gyp` build step (`pkg-config --cflags libsecret-1` exit 127), blocking every job. `keytar` isn't invoked anywhere in this repo's build/test paths, so its native binary isn't needed.

## Fix

Adds `dependenciesMeta["keytar@7.9.0"].built = false` to root `package.json`, telling Yarn to skip the build script entirely. Verified locally: `yarn install` now completes with `keytar@npm:7.9.0 lists build scripts, but its build has been explicitly disabled through configuration.` instead of erroring.

## Related issues

SWC-2485