### PR TITLE
refactor(prompt-field): use swc-action-button for action buttons

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -28,7 +28,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { ResizeController } from '@lit-labs/observers/resize-controller.js';
 
-import { Chevron75Icon } from '@adobe/spectrum-wc/icon/elements/index.js';
 import {
   focusgroupNavigationActiveChange,
   type FocusgroupNavigationActiveChangeDetail,
@@ -40,6 +39,7 @@ import {
   getActiveElement,
 } from '@adobe/spectrum-wc-core/utils/index.js';
 
+import '@adobe/spectrum-wc/components/action-button/swc-action-button.js';
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 import '../../../components/ui-icons/swc-ui-icon.js';
 
@@ -541,6 +541,14 @@ export class PromptField extends SpectrumElement {
       '.swc-PromptField-artifacts-scroll-prev'
     );
 
+    // The chevrons are swc-action-buttons with delegatesFocus, so the active
+    // element is their inner shadow <button>, not the host. Match either the
+    // host itself or an element inside its shadow root.
+    const isChevron = (host: Element | null | undefined): boolean =>
+      !!host &&
+      (active === host ||
+        (active.getRootNode() as ShadowRoot | null)?.host === host);
+
     // From the active tile: Tab reveals its Close button. Shift+Tab is left
     // to native default, which (roving tabindex leaves every other tile at
     // -1) exits the group entirely regardless of which tile is active.
@@ -583,7 +591,7 @@ export class PromptField extends SpectrumElement {
     // wherever focus was before the page turned) — its Close button when
     // visible, mirroring the forward tile -> Close -> Next chain in reverse,
     // otherwise the tile itself.
-    if (active === nextButton && event.shiftKey) {
+    if (isChevron(nextButton) && event.shiftKey) {
       const activeTile = this._artifactNavigation.getActiveItem();
       if (activeTile) {
         event.preventDefault();
@@ -594,7 +602,7 @@ export class PromptField extends SpectrumElement {
 
     // From the Prev chevron: plain Tab moves forward into the roving
     // controller's current active tile, for the same reason as above.
-    if (active === prevButton && !event.shiftKey) {
+    if (isChevron(prevButton) && !event.shiftKey) {
       const activeTile = this._artifactNavigation.getActiveItem();
       if (activeTile) {
         event.preventDefault();
@@ -908,18 +916,22 @@ export class PromptField extends SpectrumElement {
         >
           ${this._artifactScrollOverflow
             ? html`
-                <button
-                  type="button"
+                <swc-action-button
+                  quiet
+                  size="s"
                   class="swc-PromptField-artifacts-scroll-prev"
-                  aria-label=${this.artifactScrollPrevLabel}
+                  accessible-label=${this.artifactScrollPrevLabel}
                   aria-disabled=${!this._artifactCanScrollPrev}
                   tabindex=${this._artifactCanScrollPrev ? nothing : -1}
                   @click=${this._handleArtifactScrollPrev}
                 >
-                  <swc-icon size="s" aria-hidden="true">
-                    ${Chevron75Icon()}
-                  </swc-icon>
-                </button>
+                  <swc-ui-icon
+                    slot="icon"
+                    icon="chevron"
+                    size="s"
+                    aria-hidden="true"
+                  ></swc-ui-icon>
+                </swc-action-button>
               `
             : nothing}
           <div
@@ -963,18 +975,22 @@ export class PromptField extends SpectrumElement {
           </div>
           ${this._artifactScrollOverflow
             ? html`
-                <button
-                  type="button"
+                <swc-action-button
+                  quiet
+                  size="s"
                   class="swc-PromptField-artifacts-scroll-next"
-                  aria-label=${this.artifactScrollNextLabel}
+                  accessible-label=${this.artifactScrollNextLabel}
                   aria-disabled=${!this._artifactCanScrollNext}
                   tabindex=${this._artifactCanScrollNext ? nothing : -1}
                   @click=${this._handleArtifactScrollNext}
                 >
-                  <swc-icon size="s" aria-hidden="true">
-                    ${Chevron75Icon()}
-                  </swc-icon>
-                </button>
+                  <swc-ui-icon
+                    slot="icon"
+                    icon="chevron"
+                    size="s"
+                    aria-hidden="true"
+                  ></swc-ui-icon>
+                </swc-action-button>
               `
             : nothing}
         </div>
@@ -984,26 +1000,26 @@ export class PromptField extends SpectrumElement {
 
   private _renderSendButton(): TemplateResult {
     return html`
-      <button
+      <swc-action-button
         class="swc-PromptField-send"
         ?disabled=${!this._isPopulated || this.disabled}
-        aria-label=${this.sendLabel}
+        accessible-label=${this.sendLabel}
         @click=${this._handleSendClick}
       >
-        <swc-icon aria-hidden="true">${ChevronUpIcon()}</swc-icon>
-      </button>
+        <swc-icon slot="icon" aria-hidden="true">${ChevronUpIcon()}</swc-icon>
+      </swc-action-button>
     `;
   }
 
   private _renderStopButton(): TemplateResult {
     return html`
-      <button
+      <swc-action-button
         class="swc-PromptField-stop"
-        aria-label=${this.stopLabel}
+        accessible-label=${this.stopLabel}
         @click=${this._handleStopClick}
       >
-        <swc-icon aria-hidden="true">${StopIcon()}</swc-icon>
-      </button>
+        <swc-icon slot="icon" aria-hidden="true">${StopIcon()}</swc-icon>
+      </swc-action-button>
     `;
   }
 
@@ -1070,14 +1086,17 @@ export class PromptField extends SpectrumElement {
                 .inert=${this.collapsed}
               >
                 <div class="swc-PromptField-leading-actions-row">
-                  <button
+                  <swc-action-button
+                    quiet
                     class="swc-PromptField-upload"
-                    aria-label=${this.uploadLabel}
+                    accessible-label=${this.uploadLabel}
                     ?disabled=${this.disabled}
                     @click=${this._handleUploadClick}
                   >
-                    <swc-icon aria-hidden="true">${PlusIcon()}</swc-icon>
-                  </button>
+                    <swc-icon slot="icon" aria-hidden="true">
+                      ${PlusIcon()}
+                    </swc-icon>
+                  </swc-action-button>
                 </div>
               </div>
               ${showStop ? this._renderStopButton() : this._renderSendButton()}

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -583,8 +583,7 @@ export class PromptField extends SpectrumElement {
     // wherever focus was before the page turned) — its Close button when
     // visible, mirroring the forward tile -> Close -> Next chain in reverse,
     // otherwise the tile itself.
-    // deepContains, not ===: the chevron is an swc-action-button with
-    // delegatesFocus, so `active` is its inner shadow <button>, not the host.
+    // deepContains: focus delegates to the chevron's inner shadow button.
     if (nextButton && deepContains(nextButton, active) && event.shiftKey) {
       const activeTile = this._artifactNavigation.getActiveItem();
       if (activeTile) {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -541,14 +541,6 @@ export class PromptField extends SpectrumElement {
       '.swc-PromptField-artifacts-scroll-prev'
     );
 
-    // The chevrons are swc-action-buttons with delegatesFocus, so the active
-    // element is their inner shadow <button>, not the host. Match either the
-    // host itself or an element inside its shadow root.
-    const isChevron = (host: Element | null | undefined): boolean =>
-      !!host &&
-      (active === host ||
-        (active.getRootNode() as ShadowRoot | null)?.host === host);
-
     // From the active tile: Tab reveals its Close button. Shift+Tab is left
     // to native default, which (roving tabindex leaves every other tile at
     // -1) exits the group entirely regardless of which tile is active.
@@ -591,7 +583,9 @@ export class PromptField extends SpectrumElement {
     // wherever focus was before the page turned) — its Close button when
     // visible, mirroring the forward tile -> Close -> Next chain in reverse,
     // otherwise the tile itself.
-    if (isChevron(nextButton) && event.shiftKey) {
+    // deepContains, not ===: the chevron is an swc-action-button with
+    // delegatesFocus, so `active` is its inner shadow <button>, not the host.
+    if (nextButton && deepContains(nextButton, active) && event.shiftKey) {
       const activeTile = this._artifactNavigation.getActiveItem();
       if (activeTile) {
         event.preventDefault();
@@ -602,7 +596,7 @@ export class PromptField extends SpectrumElement {
 
     // From the Prev chevron: plain Tab moves forward into the roving
     // controller's current active tile, for the same reason as above.
-    if (isChevron(prevButton) && !event.shiftKey) {
+    if (prevButton && deepContains(prevButton, active) && !event.shiftKey) {
       const activeTile = this._artifactNavigation.getActiveItem();
       if (activeTile) {
         event.preventDefault();

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -282,12 +282,6 @@
   aspect-ratio: 1 / 1;
 }
 
-/* Scroll chevrons are quiet swc-action-buttons. The round face, hover, and
- * focus ring come from the component's own custom properties. The ::before
- * mask (an opaque panel extending toward the strip) sits at z-index -1, behind
- * the shadow-DOM button face, and caps the scrolling tiles at the strip edge.
- * No ::after is needed: the shadow button face is a descendant that paints
- * above the negative-z mask, so the face is never hidden by it. */
 .swc-PromptField-artifacts-scroll-prev,
 .swc-PromptField-artifacts-scroll-next {
   position: absolute;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -282,32 +282,35 @@
   aspect-ratio: 1 / 1;
 }
 
+/* Scroll chevrons are quiet swc-action-buttons. The round face, hover, and
+ * focus ring come from the component's own custom properties. The ::before
+ * mask (an opaque panel extending toward the strip) sits at z-index -1, behind
+ * the shadow-DOM button face, and caps the scrolling tiles at the strip edge.
+ * No ::after is needed: the shadow button face is a descendant that paints
+ * above the negative-z mask, so the face is never hidden by it. */
 .swc-PromptField-artifacts-scroll-prev,
 .swc-PromptField-artifacts-scroll-next {
-  display: inline-flex;
   position: absolute;
   inset-block-start: calc((var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px)) / 2);
   z-index: 4;
-  flex: 0 0 auto;
-  align-items: center;
-  justify-content: center;
-  inline-size: var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px);
-  block-size: var(--swc-prompt-field-artifact-scroll-button-block-size, 32px);
-  padding: 0;
-  color: token("gray-800");
-  background: var(--_swc-prompt-field-artifact-scroll-button-background);
-  border: 1px solid transparent;
-  border-radius: token("corner-radius-800");
   cursor: pointer;
   transform: translateY(-50%);
 
-  --_swc-prompt-field-artifact-scroll-button-background: token("gray-100");
   --_swc-prompt-field-artifact-scroll-icon-transform: none;
+  --swc-action-button-min-block-size: var(--swc-prompt-field-artifact-scroll-button-block-size, 32px);
+  --swc-action-button-icon-size: token("ui-icon-small");
+  --swc-action-button-edge-to-visual-only: calc((var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) - token("ui-icon-small")) / 2);
+  --swc-action-button-border-radius: token("corner-radius-800");
+  --swc-action-button-content-color-default: token("gray-800");
+  --swc-action-button-content-color-hover: token("gray-800");
+  --swc-action-button-background-color-default: token("gray-100");
+  --swc-action-button-background-color-hover: token("gray-200");
+  --swc-action-button-down-state-transform: none;
 }
 
 /* aria-disabled, not the disabled attribute, and hidden with opacity, not
  * display/visibility: a chevron at the end of the strip stays mounted and
- * keeps any focus it already has (native disabled and display/visibility
+ * keeps any focus it already has (the disabled property and display/visibility
  * removal both blur it), so the button never needs a manual focus-redirect
  * when scrolling makes it unusable. */
 .swc-PromptField-artifacts-scroll-prev[aria-disabled="true"],
@@ -324,10 +327,8 @@
  * not landing on a clean device pixel, which can leave a 1px unpainted
  * sliver at a mask boundary that touches its edge exactly.
  *
- * z-index: -1, not 0: the button's own :focus-visible outline paints with
- * its background/border layer, before z-index: 0 positioned descendants,
- * so a z-index: 0 mask paints over (hides) the outline. A negative z-index
- * puts this mask in the layer painted before that, so the outline is never
+ * z-index: -1 keeps the mask behind the shadow button face and its focus
+ * ring, which paint in the descendants layer above it, so neither is
  * covered. */
 .swc-PromptField-artifacts-scroll-prev::before,
 .swc-PromptField-artifacts-scroll-next::before {
@@ -336,17 +337,6 @@
   z-index: -1;
   inline-size: calc(var(--swc-prompt-field-artifact-scroll-button-inline-size, 32px) + (token("spacing-400") / 2) + 2px);
   block-size: calc(var(--swc-prompt-field-artifact-badge-clearance, 0) + var(--swc-prompt-field-artifact-media-block-size, 68px));
-  pointer-events: none;
-  content: "";
-}
-
-.swc-PromptField-artifacts-scroll-prev::after,
-.swc-PromptField-artifacts-scroll-next::after {
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  background: var(--_swc-prompt-field-artifact-scroll-button-background);
-  border-radius: inherit;
   pointer-events: none;
   content: "";
 }
@@ -371,25 +361,9 @@
   background: token("background-layer-2-color");
 }
 
-.swc-PromptField-artifacts-scroll-prev:hover,
-.swc-PromptField-artifacts-scroll-next:hover {
-  --_swc-prompt-field-artifact-scroll-button-background: token("gray-200");
-}
-
-.swc-PromptField-artifacts-scroll-prev swc-icon,
-.swc-PromptField-artifacts-scroll-next swc-icon {
-  display: inline-flex;
-  position: relative;
-  z-index: 2;
-  align-items: center;
-  justify-content: center;
+.swc-PromptField-artifacts-scroll-prev swc-ui-icon,
+.swc-PromptField-artifacts-scroll-next swc-ui-icon {
   transform: var(--_swc-prompt-field-artifact-scroll-icon-transform);
-}
-
-.swc-PromptField-artifacts-scroll-prev:focus-visible,
-.swc-PromptField-artifacts-scroll-next:focus-visible {
-  outline: token("focus-indicator-thickness") solid token("focus-indicator-color");
-  outline-offset: token("focus-ring-gap");
 }
 
 :host(:dir(rtl)) .swc-PromptField-artifacts-scroll-prev {
@@ -476,63 +450,26 @@
   display: none;
 }
 
-/* Upload button (quiet, left side) */
-
+/* Upload button (quiet swc-action-button, left side). Square icon-only size,
+ * corner radius, and colors are pinned via the component's custom properties
+ * to preserve the pattern's look; geometry (edge-to-visual-only) may need a
+ * VRT tune to land an exact 32x32. */
 .swc-PromptField-upload {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: var(--swc-prompt-field-upload-inline-size, 32px);
-  block-size: var(--swc-prompt-field-upload-block-size, 32px);
-  padding: 0;
-  color: token("gray-800");
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: token("corner-radius-500");
+  --swc-action-button-min-block-size: var(--swc-prompt-field-upload-block-size, 32px);
+  --swc-action-button-edge-to-visual-only: calc((var(--swc-prompt-field-upload-inline-size, 32px) - token("workflow-icon-medium")) / 2);
+  --swc-action-button-icon-size: token("workflow-icon-medium");
+  --swc-action-button-border-radius: token("corner-radius-500");
+  --swc-action-button-content-color-default: token("gray-800");
+  --swc-action-button-content-color-hover: token("gray-800");
+  --swc-action-button-background-color-hover: token("gray-75");
+  --swc-action-button-content-color-disabled: token("gray-400");
+  --swc-action-button-background-color-disabled: transparent;
 }
 
-.swc-PromptField-upload:hover {
-  color: token("gray-800");
-  background: token("gray-75");
-}
-
-.swc-PromptField-upload:disabled {
-  color: token("gray-400");
-  background: transparent;
-}
-
-.swc-PromptField-upload swc-icon {
-  --swc-icon-inline-size: token("workflow-icon-medium");
-  --swc-icon-block-size: token("workflow-icon-medium");
-}
-
-/* Send button (filled circle, right side) */
-
-.swc-PromptField-send {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: var(--swc-prompt-field-send-inline-size, 32px);
-  block-size: var(--swc-prompt-field-send-block-size, 32px);
-  padding: 0;
-  color: token("gray-25");
-  background: token("neutral-background-color-default");
-  border: 1px solid transparent;
-  border-radius: token("corner-radius-full");
-}
-
-.swc-PromptField-stop {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: var(--swc-prompt-field-stop-inline-size, 32px);
-  block-size: var(--swc-prompt-field-stop-block-size, 32px);
-  padding: 0;
-  color: token("gray-25");
-  background: token("gray-900");
-  border: 1px solid transparent;
-  border-radius: token("corner-radius-full");
-}
+/* Send/stop are filled round swc-action-buttons. The round look and colors are
+ * reproduced through the component's custom properties: corner-radius-full on a
+ * square (min-block-size + edge-to-visual-only) yields a circle. The exact
+ * square geometry may need a VRT tune. */
 
 /* Anchored to .controls's own bottom-right, so it re-aligns on its own as .controls grows or shrinks with either row's content. */
 .swc-PromptField-send,
@@ -540,46 +477,34 @@
   position: absolute;
   inset-block-end: 0;
   inset-inline-end: 0;
-  transition: background token("animation-duration-100") ease;
+
+  --swc-action-button-min-block-size: var(--swc-prompt-field-send-block-size, 32px);
+  --swc-action-button-edge-to-visual-only: calc((var(--swc-prompt-field-send-inline-size, 32px) - token("workflow-icon-medium")) / 2);
+  --swc-action-button-icon-size: token("workflow-icon-medium");
+  --swc-action-button-border-radius: token("corner-radius-full");
+  --swc-action-button-down-state-transform: perspective(64px) translate3d(0, 0, -1px);
 }
 
-.swc-PromptField-send:disabled {
-  color: token("gray-400");
-  background: token("gray-100");
+/* Send button (filled neutral circle) */
+.swc-PromptField-send {
+  --swc-action-button-content-color-default: token("gray-25");
+  --swc-action-button-content-color-hover: token("gray-25");
+  --swc-action-button-content-color-down: token("gray-25");
+  --swc-action-button-background-color-default: token("neutral-background-color-default");
+  --swc-action-button-background-color-hover: token("neutral-background-color-hover");
+  --swc-action-button-background-color-down: token("neutral-background-color-default");
+  --swc-action-button-content-color-disabled: token("gray-400");
+  --swc-action-button-background-color-disabled: token("gray-100");
 }
 
-.swc-PromptField-send:focus-visible,
-.swc-PromptField-stop:focus-visible {
-  outline: token("focus-indicator-thickness") solid token("focus-indicator-color");
-  outline-offset: token("focus-ring-gap");
-}
-
-.swc-PromptField-send:active,
-.swc-PromptField-stop:active {
-  transform: perspective(64px) translate3d(0, 0, -1px);
-  transition: transform token("animation-duration-200") ease;
-  transition-timing-function: token("animation-ease-in-out");
-  will-change: transform;
-}
-
-.swc-PromptField-send:hover:not(:disabled) {
-  background: token("neutral-background-color-hover");
-}
-
-.swc-PromptField-send swc-icon {
-  --swc-icon-inline-size: token("workflow-icon-medium");
-  --swc-icon-block-size: token("workflow-icon-medium");
-}
-
-/* Stop button (filled black circle, right side) */
-
-.swc-PromptField-stop:hover {
-  background: token("gray-800");
-}
-
-.swc-PromptField-stop swc-icon {
-  --swc-icon-inline-size: token("workflow-icon-medium");
-  --swc-icon-block-size: token("workflow-icon-medium");
+/* Stop button (filled black circle) */
+.swc-PromptField-stop {
+  --swc-action-button-content-color-default: token("gray-25");
+  --swc-action-button-content-color-hover: token("gray-25");
+  --swc-action-button-content-color-down: token("gray-25");
+  --swc-action-button-background-color-default: token("gray-900");
+  --swc-action-button-background-color-hover: token("gray-800");
+  --swc-action-button-background-color-down: token("gray-900");
 }
 
 /* ─────────────────────────────────────

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -444,10 +444,7 @@
   display: none;
 }
 
-/* Upload button (quiet swc-action-button, left side). Square icon-only size,
- * corner radius, and colors are pinned via the component's custom properties
- * to preserve the pattern's look; geometry (edge-to-visual-only) may need a
- * VRT tune to land an exact 32x32. */
+/* Upload button (quiet, left side) */
 .swc-PromptField-upload {
   --swc-action-button-min-block-size: var(--swc-prompt-field-upload-block-size, 32px);
   --swc-action-button-edge-to-visual-only: calc((var(--swc-prompt-field-upload-inline-size, 32px) - token("workflow-icon-medium")) / 2);
@@ -460,10 +457,7 @@
   --swc-action-button-background-color-disabled: transparent;
 }
 
-/* Send/stop are filled round swc-action-buttons. The round look and colors are
- * reproduced through the component's custom properties: corner-radius-full on a
- * square (min-block-size + edge-to-visual-only) yields a circle. The exact
- * square geometry may need a VRT tune. */
+/* Send/stop buttons (filled round, anchored bottom-right) */
 
 /* Anchored to .controls's own bottom-right, so it re-aligns on its own as .controls grows or shrinks with either row's content. */
 .swc-PromptField-send,

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -23,6 +23,24 @@ import { getComponent, withWarningSpy } from '../../../../utils/test-utils.js';
 import { PromptField } from '../PromptField.js';
 import { meta, Overview } from '../stories/prompt-field.stories.js';
 
+/**
+ * The scroll chevrons are `swc-action-button`s with `delegatesFocus`, so
+ * focusing one lands the active element on its inner shadow `<button>`, not on
+ * the host. Treat focus as "on" a chevron when the active element is the host
+ * itself or lives inside its shadow root.
+ */
+const focusIsWithinChevron = (host: Element | null | undefined): boolean => {
+  const active = getActiveElement();
+  if (!active || !host) {
+    return false;
+  }
+  if (active === host) {
+    return true;
+  }
+  const root = active.getRootNode();
+  return root instanceof ShadowRoot && root.host === host;
+};
+
 export default {
   ...meta,
   title: 'Conversational AI/Prompt field/Tests',
@@ -310,7 +328,12 @@ export const ArtifactScrollPaginationTest: Story = {
         el.artifactScrollPrevLabel = 'Show earlier attachments';
         el.artifactScrollNextLabel = 'Show later attachments';
         await el.updateComplete;
-        expect(nextButton?.ariaLabel).toBe('Show later attachments');
+        // The chevron is an swc-action-button; the accessible name is passed
+        // via accessible-label (which the component forwards to its inner
+        // button's aria-label).
+        expect(nextButton?.getAttribute('accessible-label')).toBe(
+          'Show later attachments'
+        );
       }
     );
 
@@ -340,9 +363,9 @@ export const ArtifactScrollPaginationTest: Story = {
           clientWidth / 2
         );
         expect(
-          el.shadowRoot?.querySelector<HTMLButtonElement>(
-            '.swc-PromptField-artifacts-scroll-prev'
-          )?.ariaLabel
+          el.shadowRoot
+            ?.querySelector('.swc-PromptField-artifacts-scroll-prev')
+            ?.getAttribute('accessible-label')
         ).toBe('Show earlier attachments');
 
         const tiles = scrollEl
@@ -613,7 +636,7 @@ export const ArtifactFocusOrderTest: Story = {
         const nextButton = getNextButton();
         expect(nextButton).toBeTruthy();
         expect(event.defaultPrevented).toBe(true);
-        expect(getActiveElement()).toBe(nextButton);
+        expect(focusIsWithinChevron(nextButton)).toBe(true);
       }
     );
 
@@ -654,7 +677,7 @@ export const ArtifactFocusOrderTest: Story = {
         const prevButton = getPrevButton();
         expect(prevButton?.getAttribute('aria-disabled')).toBe('false');
         prevButton?.focus();
-        expect(getActiveElement()).toBe(prevButton);
+        expect(focusIsWithinChevron(prevButton)).toBe(true);
 
         const secondScrollEnd = waitForScrollEnd(scrollEl);
         scrollEl?.scrollTo({ left: 0, behavior: 'instant' });
@@ -662,7 +685,7 @@ export const ArtifactFocusOrderTest: Story = {
         await el.updateComplete;
 
         expect(getPrevButton()?.getAttribute('aria-disabled')).toBe('true');
-        expect(getActiveElement()).toBe(prevButton);
+        expect(focusIsWithinChevron(prevButton)).toBe(true);
       }
     );
 
@@ -758,7 +781,7 @@ export const ArtifactChevronPagingFocusTest: Story = {
         await scrollEnd;
         await el.updateComplete;
 
-        expect(getActiveElement()).toBe(nextButton);
+        expect(focusIsWithinChevron(nextButton)).toBe(true);
       }
     );
 
@@ -806,7 +829,7 @@ export const ArtifactChevronPagingFocusTest: Story = {
         await backPage;
         await el.updateComplete;
 
-        expect(getActiveElement()).toBe(prevButton);
+        expect(focusIsWithinChevron(prevButton)).toBe(true);
 
         const tilesAfterPagingBack = visibleTiles();
         expect(

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -23,12 +23,7 @@ import { getComponent, withWarningSpy } from '../../../../utils/test-utils.js';
 import { PromptField } from '../PromptField.js';
 import { meta, Overview } from '../stories/prompt-field.stories.js';
 
-/**
- * The scroll chevrons are `swc-action-button`s with `delegatesFocus`, so
- * focusing one lands the active element on its inner shadow `<button>`, not on
- * the host. Treat focus as "on" a chevron when the active element is the host
- * itself or lives inside its shadow root.
- */
+/** True when focus is on a chevron or its inner shadow button. */
 const focusIsWithinChevron = (host: Element | null | undefined): boolean => {
   const active = getActiveElement();
   if (!active || !host) {
@@ -328,9 +323,7 @@ export const ArtifactScrollPaginationTest: Story = {
         el.artifactScrollPrevLabel = 'Show earlier attachments';
         el.artifactScrollNextLabel = 'Show later attachments';
         await el.updateComplete;
-        // The chevron is an swc-action-button; the accessible name is passed
-        // via accessible-label (which the component forwards to its inner
-        // button's aria-label).
+        // Accessible name is passed via accessible-label on the action button.
         expect(nextButton?.getAttribute('accessible-label')).toBe(
           'Show later attachments'
         );

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -14,7 +14,10 @@ import { html, nothing, render } from 'lit';
 import { expect, userEvent } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
-import { getActiveElement } from '@adobe/spectrum-wc-core/utils/index.js';
+import {
+  deepContains,
+  getActiveElement,
+} from '@adobe/spectrum-wc-core/utils/index.js';
 
 import '../../upload-artifact/swc-upload-artifact.js';
 import '../swc-prompt-field.js';
@@ -24,17 +27,8 @@ import { PromptField } from '../PromptField.js';
 import { meta, Overview } from '../stories/prompt-field.stories.js';
 
 /** True when focus is on a chevron or its inner shadow button. */
-const focusIsWithinChevron = (host: Element | null | undefined): boolean => {
-  const active = getActiveElement();
-  if (!active || !host) {
-    return false;
-  }
-  if (active === host) {
-    return true;
-  }
-  const root = active.getRootNode();
-  return root instanceof ShadowRoot && root.host === host;
-};
+const focusIsWithinChevron = (host: Element | null | undefined): boolean =>
+  !!host && deepContains(host, getActiveElement());
 
 export default {
   ...meta,


### PR DESCRIPTION
## Description

Replaces the five bespoke native `<button>` elements in the Prompt field pattern (send, stop, upload, and the two artifact scroll chevrons) with `<swc-action-button>`, reproducing their existing looks through the component's public custom properties. Net −65 lines.

- **Send / stop** — round via `--swc-action-button-border-radius: corner-radius-full` plus background/content-color/`down-state-transform` overrides.
- **Upload** — quiet icon-only action button.
- **Scroll prev/next** — converted while preserving the fade mask. The `::before` opaque panel stays on the host at `z-index: -1`, behind the shadow-DOM button face, so the old `::after` repaint is no longer needed (the face is a descendant that paints above the negative-z mask).
- Accessible names move from `aria-label` to `accessible-label` (the component forwards it to the inner `<button>`'s `aria-label`).
- Scroll chevrons use `<swc-ui-icon icon="chevron">`; send, stop, and upload keep their existing SVG icons.
- **Focus handling:** the artifact-strip keyboard handler matched a focused chevron by strict identity (`active === button`), which breaks once the chevron is an `swc-action-button` with `delegatesFocus` — focus lands on its inner shadow `<button>`, not the host. It now uses `deepContains(button, active)`, the util already used elsewhere in the file for the same cross-shadow check. The tests use the same idiom.

## Motivation and context

The Prompt field's action affordances were hand-rolled native buttons with ~180 lines of bespoke CSS, duplicating states (hover/focus/disabled/press) that `swc-action-button` already provides. Consolidating onto the shared component removes that surface and keeps the pattern consistent with the rest of the 2nd-gen set.

## Related issue(s)

- fixes [Issue Number]

## Screenshots (if appropriate)

_Send/stop circle geometry and the scroll-chevron mask compositing should be confirmed via Chromatic; expect a VRT re-baseline._

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Send and stop render as filled round buttons_
  1. Open the Prompt field pattern in Storybook
  2. Type text, then observe the send button; set `generating` to see the stop button
  3. Expect both to be filled circles with correct hover/press/disabled treatment

- [ ] _Artifact scroll chevrons page and mask correctly_
  1. Open a Prompt field story with enough artifacts to overflow the strip
  2. Use the prev/next chevrons to page
  3. Expect the fade mask to cap the tiles cleanly at each edge, with the chevron circle painted over it

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  1. Open a Prompt field story with overflowing artifacts
  2. <kbd>Tab</kbd> into the strip; from a tile <kbd>Tab</kbd> reaches its Close button, then the Next (`>`) chevron
  3. <kbd>Shift</kbd> + <kbd>Tab</kbd> from the Next chevron returns focus into the currently visible tiles (not wherever focus was before paging)
  4. Activate a chevron with <kbd>Enter</kbd>/<kbd>Space</kbd>; expect the strip to page and focus to remain on the chevron control
  5. When a chevron becomes non-actionable at a strip end, expect focus to stay on it (it uses `aria-disabled`, not the `disabled` property) with no focus jump
  6. Confirm the send/stop button activates with <kbd>Enter</kbd> and <kbd>Space</kbd>

- [ ] **Screen reader** (required — document steps below)
  1. With VoiceOver/NVDA, focus each control
  2. Expect the send, stop, upload, and scroll buttons to announce role "button" with their accessible names ("Send", "Stop generating", "Add attachment", "Show previous/more attachments")
  3. Confirm the chevrons announce their disabled state via `aria-disabled` at the strip ends
