### PR TITLE
fix(prompt-field): scroll artifact paging to the snap-aligned target tile

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -702,10 +702,7 @@ export class PromptField extends SpectrumElement {
       return;
     }
 
-    // Scroll to the tile that starts the next/previous page rather than a
-    // blind clientWidth: near the end only one item may remain, and a full
-    // page-width would overshoot and then snap back. scrollIntoView lands on
-    // the tile's snap point directly and clamps to the content edge.
+    // Scroll the page-start tile into view: snap-aligned, clamps at the edge.
     const scrollRect = scrollEl.getBoundingClientRect();
     const pageStart = this._isRtl()
       ? scrollRect.right - direction * scrollEl.clientWidth

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -702,17 +702,17 @@ export class PromptField extends SpectrumElement {
       return;
     }
 
-    scrollEl.scrollBy({
-      left: direction * scrollEl.clientWidth * (this._isRtl() ? -1 : 1),
-    });
-
+    // Scroll to the tile that starts the next/previous page rather than a
+    // blind clientWidth: near the end only one item may remain, and a full
+    // page-width would overshoot and then snap back. scrollIntoView lands on
+    // the tile's snap point directly and clamps to the content edge.
     const scrollRect = scrollEl.getBoundingClientRect();
     const pageStart = this._isRtl()
       ? scrollRect.right - direction * scrollEl.clientWidth
       : scrollRect.left + direction * scrollEl.clientWidth;
-    this._artifactNavigation.setActiveItem(
-      this._findArtifactAtOrPastBoundary(pageStart)
-    );
+    const target = this._findArtifactAtOrPastBoundary(pageStart);
+    this._artifactNavigation.setActiveItem(target);
+    target.scrollIntoView({ block: 'nearest', inline: 'start' });
   }
 
   // aria-disabled, not disabled: a chevron the user just activated stays

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -216,7 +216,12 @@
   overflow-x: auto;
   overflow-y: hidden;
   scroll-behavior: smooth;
-  scroll-snap-type: inline mandatory;
+
+  /* proximity, not mandatory: the has-scroll-prev/next classes change
+   * scroll-padding-inline when a chevron appears, and mandatory would force an
+   * instant re-snap to the new alignment (a visible yank). Paging still lands
+   * aligned because it scrollIntoViews the target tile. */
+  scroll-snap-type: inline proximity;
   scroll-padding-inline: token("spacing-75");
   scrollbar-color: token("gray-400") transparent;
 }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -217,10 +217,7 @@
   overflow-y: hidden;
   scroll-behavior: smooth;
 
-  /* proximity, not mandatory: the has-scroll-prev/next classes change
-   * scroll-padding-inline when a chevron appears, and mandatory would force an
-   * instant re-snap to the new alignment (a visible yank). Paging still lands
-   * aligned because it scrollIntoViews the target tile. */
+  /* proximity avoids a forced re-snap when the chevrons change scroll-padding */
   scroll-snap-type: inline proximity;
   scroll-padding-inline: token("spacing-75");
   scrollbar-color: token("gray-400") transparent;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -348,8 +348,7 @@ export const ArtifactScrollPaginationTest: Story = {
         const tiles = scrollEl
           ?.querySelector('slot')
           ?.assignedElements({ flatten: true }) as HTMLElement[] | undefined;
-        // proximity is the default strictness, so it is omitted from the
-        // computed value ('inline'); only mandatory would be serialized.
+        // Computed scroll-snap-type omits proximity (the default); only mandatory serializes.
         const snapType = getComputedStyle(scrollEl!).scrollSnapType;
         expect(snapType).toContain('inline');
         expect(snapType).not.toContain('mandatory');

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -348,9 +348,11 @@ export const ArtifactScrollPaginationTest: Story = {
         const tiles = scrollEl
           ?.querySelector('slot')
           ?.assignedElements({ flatten: true }) as HTMLElement[] | undefined;
-        expect(getComputedStyle(scrollEl!).scrollSnapType).toContain(
-          'mandatory'
-        );
+        // proximity is the default strictness, so it is omitted from the
+        // computed value ('inline'); only mandatory would be serialized.
+        const snapType = getComputedStyle(scrollEl!).scrollSnapType;
+        expect(snapType).toContain('inline');
+        expect(snapType).not.toContain('mandatory');
         expect(getComputedStyle(tiles![0]!).scrollSnapAlign).toContain('start');
       }
     );


### PR DESCRIPTION
## Description

Fixes janky artifact-strip paging when using the prev/next scroll chevrons. Two related causes:

**1. Blind page-width scroll (`_scrollArtifactsByPage`).** It did `scrollBy({ left: ±clientWidth })` — a fixed full-viewport distance regardless of remaining content. Near the end (e.g. one extra item off-screen) that overshoots and snaps back. It now scrolls the tile that starts the next/previous page into view — the same target already used for the roving active item:

```ts
target.scrollIntoView({ block: 'nearest', inline: 'start' });
```

This lands directly on the tile's snap point, clamps to the content edge (so a short remaining distance moves only as far as needed), and `inline: 'start'` is RTL-aware.

**2. Chevron-toggle re-snap (`scroll-snap-type`).** When a chevron becomes actionable, the `.has-scroll-prev` / `.has-scroll-next` classes grow `scroll-padding-inline` so tiles clear the opaque chevron overlay. `scroll-padding` defines the snapport, so changing it shifts every snap position — and under `scroll-snap-type: inline mandatory` the container must re-align to a snap point instantly, yanking the whole strip the moment a chevron appears or disappears. Switching to `inline proximity` keeps snapping (and paging still lands aligned via `scrollIntoView`) without forcing that resting re-snap.

## Motivation and context

Reported as: pressing the scroll chevrons "tries to scroll more than it needs to and gets stuck for a moment" (most noticeable with one extra item on the next page), plus a distinct yank right as the prev/next chevron appears or disappears.

## Related issue(s)

- fixes [Issue Number]

## Screenshots (if appropriate)

_Behavioral/motion change; best verified interactively. No visual (VRT) change expected._

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Paging near the end of the strip is smooth_
  1. Open a Prompt field story with enough artifacts that only one or two overflow past the right edge
  2. Press the next (`>`) chevron
  3. Expect a short, smooth move that lands aligned on the next tile, with no overshoot-and-snap-back

- [ ] _No yank when a chevron appears/disappears_
  1. From the start of a long strip, press next once (the prev chevron appears)
  2. Continue paging to the end (the next chevron disappears)
  3. Expect each transition to be smooth, with no sideways jump at the moment a chevron toggles

- [ ] _Full-page paging still works, LTR and RTL_
  1. From the start of a long strip, press next repeatedly, then prev back
  2. Expect each press to advance/retreat aligned to a tile edge in both directions

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  1. Open a Prompt field story with overflowing artifacts
  2. Focus a chevron and activate it with <kbd>Enter</kbd>/<kbd>Space</kbd>
  3. Expect the strip to page and the roving active tile to match the newly displayed set (focus behavior unchanged by this fix)

- [ ] **Screen reader** (required — document steps below)
  1. With VoiceOver/NVDA, page the strip with the chevrons
  2. Expect no change in announcements versus before; this is a scroll-motion fix only
