### PR TITLE
chore(status-light): add VRT coverage

### DIFF
--- a/2nd-gen/packages/swc/components/status-light/status-light.css
+++ b/2nd-gen/packages/swc/components/status-light/status-light.css
@@ -155,12 +155,6 @@
 @media (forced-colors: active) {
   .swc-StatusLight {
     --swc-status-light-content-color: CanvasText;
-
-    forced-color-adjust: none;
-
-    &::before {
-      background-color: CanvasText;
-      border: token("border-width-100") solid;
-    }
+    --swc-status-light-dot-color: CanvasText;
   }
 }

--- a/2nd-gen/packages/swc/components/status-light/status-light.css
+++ b/2nd-gen/packages/swc/components/status-light/status-light.css
@@ -159,6 +159,7 @@
     forced-color-adjust: none;
 
     &::before {
+      background-color: CanvasText;
       border: token("border-width-100") solid;
     }
   }

--- a/2nd-gen/packages/swc/components/status-light/test/vrt/status-light-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/status-light/test/vrt/status-light-custom-properties.vrt.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '@adobe/spectrum-wc/components/status-light/swc-status-light.js';
+
+import type { CustomPropertyCase } from '../../../../.storybook/helpers/index.js';
+import {
+  coveredCustomProperties,
+  customPropertyRows,
+  theme,
+  verifyCustomPropertyCoverage,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import customElementsManifest from '../../../../dist/custom-elements.json';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Status light/Status light VRT',
+  component: 'swc-status-light',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+// --swc-status-light-line-height only becomes visibly distinct once the
+// label wraps to more than one line, so that case renders at a constrained
+// width with a multi-word label instead of the plain default.
+type StatusLightPropertyCase =
+  CustomPropertyCase<`--swc-status-light-${string}`> & {
+    wrap?: boolean;
+  };
+
+const STATUS_LIGHT_PROPERTY_CASES: readonly StatusLightPropertyCase[] = [
+  { property: '--swc-status-light-dot-size', value: '32px' },
+  { property: '--swc-status-light-dot-color', value: 'magenta' },
+  { property: '--swc-status-light-font-size', value: '24px' },
+  { property: '--swc-status-light-line-height', value: '32px', wrap: true },
+  { property: '--swc-status-light-text-to-visual', value: '32px' },
+  { property: '--swc-status-light-content-color', value: 'magenta' },
+];
+
+const renderPropertyCase = (
+  { wrap }: StatusLightPropertyCase,
+  style?: string
+) => {
+  const wrapStyle = wrap ? 'max-inline-size: 140px;' : '';
+  const combinedStyle = `${wrapStyle}${style ?? ''}`;
+  const label = wrap ? 'Document review pending approval' : 'Archived';
+
+  return html`
+    <swc-status-light style=${combinedStyle || nothing}>
+      ${label}
+    </swc-status-light>
+  `;
+};
+
+const modPropertiesContent = () =>
+  customPropertyRows(STATUS_LIGHT_PROPERTY_CASES, renderPropertyCase);
+
+const coveredStatusLightCustomProperties = coveredCustomProperties(
+  STATUS_LIGHT_PROPERTY_CASES
+);
+
+const verifyCoverage = async () => {
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/status-light/StatusLight.ts',
+    declarationName: 'StatusLight',
+    coveredProperties: coveredStatusLightCustomProperties,
+  });
+};
+
+// VRT stories
+
+export const CustomProperties: Story = {
+  render: () => theme(modPropertiesContent(), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: verifyCoverage,
+};

--- a/2nd-gen/packages/swc/components/status-light/test/vrt/status-light.vrt.ts
+++ b/2nd-gen/packages/swc/components/status-light/test/vrt/status-light.vrt.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import {
+  STATUS_LIGHT_VALID_SIZES,
+  STATUS_LIGHT_VARIANTS,
+} from '@adobe/spectrum-wc-core/components/status-light';
+
+import '@adobe/spectrum-wc/components/status-light/swc-status-light.js';
+
+import {
+  createPermutations,
+  forcedColorsVrtParameters,
+  groupPermutationsBy,
+  renderStorybookPermutation,
+  row,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Status light/Status light VRT',
+  component: 'swc-status-light',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+// Every variant (5 semantic + 14 non-semantic) x every size. Status light has
+// no icon slot, outline, subtle, or fixed API, so variant x size is the whole
+// permutation surface.
+const STATUS_LIGHT_PERMUTATIONS = createPermutations([
+  { variant: STATUS_LIGHT_VARIANTS, size: STATUS_LIGHT_VALID_SIZES },
+]);
+
+// Status light is non-interactive (no :hover/:focus/:active rules in
+// status-light.css), so unlike button there's no forced pseudo-state row to
+// add here. The row heading (variant) already identifies each item, so the
+// label stays plain rather than repeating the variant name.
+const renderStatusLightPermutation = renderStorybookPermutation(
+  'swc-status-light',
+  { 'default-slot': 'Status light' }
+);
+
+const permutationContent = () => html`
+  ${groupPermutationsBy(STATUS_LIGHT_PERMUTATIONS, 'variant').map(
+    ([variant, perms]) => row(perms.map(renderStatusLightPermutation), variant)
+  )}
+  ${row(
+    [
+      html`
+        <swc-status-light variant="notice" style="max-inline-size: 200px">
+          Document processing in progress - please wait while we validate your
+          submission
+        </swc-status-light>
+      `,
+    ],
+    'Wrapping'
+  )}
+  ${row(
+    [
+      html`
+        <swc-status-light variant="notice" lang="ja">承認待ち</swc-status-light>
+      `,
+      html`
+        <swc-status-light variant="notice" lang="ko">
+          승인 대기 중
+        </swc-status-light>
+      `,
+      html`
+        <swc-status-light variant="notice" lang="zh">待审批</swc-status-light>
+      `,
+    ],
+    'CJK language'
+  )}
+`;
+
+// VRT stories
+
+// Every variant x size, text wrapping, and CJK line-height (status-light.css
+// sets a distinct line-height for :lang(ja/zh/ko)). Rendered once in
+// light/ltr and once in dark/rtl in a single story so it costs one snapshot.
+export const Permutations: Story = {
+  render: () => html`
+    ${theme(permutationContent(), 'light', 'ltr')}
+    ${theme(permutationContent(), 'dark', 'rtl')}
+  `,
+  parameters: vrtParameters,
+};
+
+// Status light conveys most of its meaning through the dot's color, and
+// status-light.css sets `forced-color-adjust: none` on the whole component
+// (not just the dot), so every variant's authored color survives forced-colors
+// mode rather than being flattened to a system color. That makes the full
+// permutation set meaningful here too, rather than a narrowed subset.
+export const ForcedColors: Story = {
+  render: () => theme(permutationContent(), 'light', 'ltr'),
+  parameters: forcedColorsVrtParameters,
+};

--- a/2nd-gen/packages/swc/components/status-light/test/vrt/status-light.vrt.ts
+++ b/2nd-gen/packages/swc/components/status-light/test/vrt/status-light.vrt.ts
@@ -104,11 +104,12 @@ export const Permutations: Story = {
   parameters: vrtParameters,
 };
 
-// Status light conveys most of its meaning through the dot's color, and
-// status-light.css sets `forced-color-adjust: none` on the whole component
-// (not just the dot), so every variant's authored color survives forced-colors
-// mode rather than being flattened to a system color. That makes the full
-// permutation set meaningful here too, rather than a narrowed subset.
+// Relying on color alone to distinguish variants fails WCAG 1.4.1, and
+// out of context we can't know what a given color is meant to signal, so
+// status-light.css flattens every dot to CanvasText in forced-colors mode
+// rather than preserving the semantic variant color. Every variant renders
+// identically here; the permutation set is kept to confirm that flattening
+// holds across sizes and doesn't regress per-variant.
 export const ForcedColors: Story = {
   render: () => theme(permutationContent(), 'light', 'ltr'),
   parameters: forcedColorsVrtParameters,


### PR DESCRIPTION
### Description

Adds dedicated `test/vrt/` coverage for `status-light`, following the `button`/`badge` VRT pattern: `status-light.vrt.ts` covers every variant (5 semantic + 14 non-semantic) × size, grouped into one row per variant, plus a `Wrapping` row and a `CJK language` row (status-light.css sets a distinct line-height for `:lang(ja/zh/ko)`); `ForcedColors` reuses the full permutation set since `forced-color-adjust: none` is set on the whole component, so every variant's color survives forced-colors mode rather than collapsing to a system color. `status-light-custom-properties.vrt.ts` covers reference/override rows for all six documented custom properties (`dot-size`, `dot-color`, `font-size`, `line-height`, `text-to-visual`, `content-color`), with `verifyCustomPropertyCoverage()` checked against the manifest. No global-styles VRT file is included since `status-light` has no plain-class global stylesheet.

### Motivation and context

Closes the VRT coverage gap for `status-light` called out in SWC-2410.

### Related issue(s)

- Jira: SWC-2410

### Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have reviewed the Accessibility Practices for this feature.
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

### Accessibility testing checklist

- [ ] **Keyboard**: N/A. Visual-only test coverage; status-light is non-interactive with no focusable parts and no interactive changes.
- [ ] **Screen reader**: No accessibility-relevant changes. The component's existing semantics are untouched by this test-only addition.
