### PR TITLE
chore(tabs): add VRT coverage

### DIFF
--- a/.changeset/tabs-cjk-line-height.md
+++ b/.changeset/tabs-cjk-line-height.md
@@ -1,0 +1,5 @@
+---
+'@adobe/spectrum-wc': patch
+---
+
+Refine 2nd-gen tabs styling: `swc-tab` labels now use `cjk-line-height-100` for Japanese, Chinese, and Korean text so CJK glyphs are not vertically clipped, and `swc-tab-panel` top padding uses the `spacing-200` token via a private `--_swc-tab-panel-padding-top` custom property instead of a hardcoded `12px` fallback.

--- a/2nd-gen/packages/swc/components/tabs/tab-panel.css
+++ b/2nd-gen/packages/swc/components/tabs/tab-panel.css
@@ -12,7 +12,7 @@
 
 :host {
   display: block;
-  padding-block-start: var(--swc-tab-panel-padding-top, 12px);
+  padding-block-start: var(--_swc-tab-panel-padding-top, token("spacing-200"));
 }
 
 :host([aria-hidden="true"]) {

--- a/2nd-gen/packages/swc/components/tabs/tab.css
+++ b/2nd-gen/packages/swc/components/tabs/tab.css
@@ -45,6 +45,12 @@
   font-size: token("font-size-100");
   font-weight: token("regular-font-weight");
   line-height: token("line-height-100");
+
+  &:lang(ja),
+  &:lang(zh),
+  &:lang(ko) {
+    line-height: token("cjk-line-height-100");
+  }
 }
 
 /* ── Icon slot ─────────────────────────────────────────── */

--- a/2nd-gen/packages/swc/components/tabs/test/vrt/tabs-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/tabs/test/vrt/tabs-custom-properties.vrt.ts
@@ -45,8 +45,8 @@ export default meta;
 // into two groups (Tabs, Tab) since the three-element architecture documents
 // custom properties on separate classes (Tabs.ts, Tab.ts), each verified
 // against its own manifest entry below. TabPanel.ts has no documented
-// `@cssprop` (the `--swc-tab-panel-padding-top` its CSS uses isn't part of
-// its public API contract), so there's nothing to verify coverage for there.
+// `@cssprop` (its CSS only uses the private `--_swc-tab-panel-padding-top`),
+// so there's nothing to verify coverage for there.
 
 const TABS_CUSTOM_PROPERTY_CASES: readonly CustomPropertyCase<`--swc-tabs-${string}`>[] =
   [{ property: '--swc-tabs-indicator-color', value: 'magenta' }];

--- a/2nd-gen/packages/swc/components/tabs/test/vrt/tabs-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/tabs/test/vrt/tabs-custom-properties.vrt.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '@adobe/spectrum-wc/components/tabs/swc-tabs.js';
+import '@adobe/spectrum-wc/components/tabs/swc-tab.js';
+import '@adobe/spectrum-wc/components/tabs/swc-tab-panel.js';
+
+import type { CustomPropertyCase } from '../../../../.storybook/helpers/index.js';
+import {
+  coveredCustomProperties,
+  customPropertyRows,
+  theme,
+  verifyCustomPropertyCoverage,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import customElementsManifest from '../../../../dist/custom-elements.json';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Tabs/Tabs VRT',
+  component: 'swc-tabs',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+// One row per public custom property: a reference element beside the same
+// element with that one property overridden to an obviously different
+// value, so a real difference confirms the override still applies. Split
+// into two groups (Tabs, Tab) since the three-element architecture documents
+// custom properties on separate classes (Tabs.ts, Tab.ts), each verified
+// against its own manifest entry below. TabPanel.ts has no documented
+// `@cssprop` (the `--swc-tab-panel-padding-top` its CSS uses isn't part of
+// its public API contract), so there's nothing to verify coverage for there.
+
+const TABS_CUSTOM_PROPERTY_CASES: readonly CustomPropertyCase<`--swc-tabs-${string}`>[] =
+  [{ property: '--swc-tabs-indicator-color', value: 'magenta' }];
+
+const renderTabsCase = (_testCase: CustomPropertyCase, style?: string) => html`
+  <swc-tabs
+    selected="1"
+    accessible-label="Product details"
+    style=${style ?? ''}
+  >
+    <swc-tab tab-id="1">Overview</swc-tab>
+    <swc-tab tab-id="2">Specifications</swc-tab>
+    <swc-tab-panel tab-id="1">
+      <p>Overview content.</p>
+    </swc-tab-panel>
+    <swc-tab-panel tab-id="2">
+      <p>Specifications content.</p>
+    </swc-tab-panel>
+  </swc-tabs>
+`;
+
+// Tab renders meaningfully as a standalone custom element (its template has
+// no dependency on a parent `swc-tabs`), so these properties are tested
+// directly on `<swc-tab>` rather than wrapped in a full tab group - the same
+// granularity button-custom-properties.vrt.ts uses for `<swc-button>` outside
+// of button-group.
+const TAB_CUSTOM_PROPERTY_CASES: readonly CustomPropertyCase<`--swc-tab-${string}`>[] =
+  [
+    { property: '--swc-tab-height', value: '80px' },
+    { property: '--swc-tab-padding-block', value: '40px' },
+    { property: '--swc-tab-padding-block-end', value: '40px' },
+    { property: '--swc-tab-text-color', value: 'magenta' },
+  ];
+
+const renderTabCase = (_testCase: CustomPropertyCase, style?: string) => html`
+  <swc-tab tab-id="1" style=${style ?? ''}>Overview</swc-tab>
+`;
+
+// A plain heading, not `row()`: `customPropertyRows()` already returns one
+// fully-built `row()` per property (its own caption plus a flex-wrap line of
+// items), so wrapping that array in another `row()` would flex-wrap those
+// pre-built blocks together as if they were plain items, corrupting the
+// per-property layout instead of stacking them.
+const sectionHeading = (label: string) => html`
+  <span class="swc-Detail swc-Detail--sizeM" style="font-weight: bold;">
+    ${label}
+  </span>
+`;
+
+const customPropertiesContent = () => html`
+  ${sectionHeading('Tabs')}
+  ${customPropertyRows(TABS_CUSTOM_PROPERTY_CASES, renderTabsCase)}
+  ${sectionHeading('Tab')}
+  ${customPropertyRows(TAB_CUSTOM_PROPERTY_CASES, renderTabCase)}
+`;
+
+const coveredTabsCustomProperties = coveredCustomProperties(
+  TABS_CUSTOM_PROPERTY_CASES
+);
+const coveredTabCustomProperties = coveredCustomProperties(
+  TAB_CUSTOM_PROPERTY_CASES
+);
+
+const verifyCoverage = async () => {
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/tabs/Tabs.ts',
+    declarationName: 'Tabs',
+    coveredProperties: coveredTabsCustomProperties,
+  });
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/tabs/Tab.ts',
+    declarationName: 'Tab',
+    coveredProperties: coveredTabCustomProperties,
+  });
+};
+
+// VRT stories
+
+export const CustomProperties: Story = {
+  render: () => theme(customPropertiesContent(), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: verifyCoverage,
+};

--- a/2nd-gen/packages/swc/components/tabs/test/vrt/tabs.vrt.ts
+++ b/2nd-gen/packages/swc/components/tabs/test/vrt/tabs.vrt.ts
@@ -1,0 +1,320 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import {
+  TAB_DENSITIES,
+  type TabDensity,
+  TABS_DIRECTIONS,
+  type TabsDirection,
+} from '@adobe/spectrum-wc-core/components/tabs';
+
+import '@adobe/spectrum-wc/components/tabs/swc-tabs.js';
+import '@adobe/spectrum-wc/components/tabs/swc-tab.js';
+import '@adobe/spectrum-wc/components/tabs/swc-tab-panel.js';
+
+import type { ForcedPseudoState } from '../../../../.storybook/helpers/index.js';
+import {
+  forcedColorsVrtParameters,
+  forcePseudoStates,
+  row,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Tabs/Tabs VRT',
+  component: 'swc-tabs',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+type TabCase = {
+  id: string;
+  label: string;
+  disabled?: boolean;
+  icon?: string;
+  iconOnly?: boolean;
+  forceState?: ForcedPseudoState;
+};
+
+const tab = ({
+  id,
+  label,
+  disabled = false,
+  icon,
+  iconOnly = false,
+  forceState,
+}: TabCase) => html`
+  <swc-tab
+    tab-id=${id}
+    ?disabled=${disabled}
+    data-force-state=${forceState ?? nothing}
+    aria-label=${iconOnly ? label : nothing}
+  >
+    ${icon
+      ? html`
+          <span slot="icon" aria-hidden="true">${icon}</span>
+        `
+      : nothing}
+    ${iconOnly ? nothing : label}
+  </swc-tab>
+`;
+
+const panel = (id: string, content: string) => html`
+  <swc-tab-panel tab-id=${id}>
+    <p>${content}</p>
+  </swc-tab-panel>
+`;
+
+// Default 3-tab content shared by every case below that doesn't need its own
+// custom anatomy/state combination. `tab-id` is reused across separate
+// `swc-tabs` instances deliberately: each container only ever queries its own
+// direct children (Tabs.base.ts's `managePanels`/`handleTabSlotChange`), so
+// IDs don't need to be page-unique the way the auto-generated `id` attribute
+// (used for ARIA wiring) does.
+const DEFAULT_TABS = html`
+  ${tab({ id: '1', label: 'Overview' })}
+  ${tab({ id: '2', label: 'Specifications' })}
+  ${tab({ id: '3', label: 'Guidelines' })}
+`;
+
+const DEFAULT_PANELS = html`
+  ${panel('1', 'Overview content for the selected tab.')}
+  ${panel('2', 'Specifications content goes here.')}
+  ${panel('3', 'Guidelines content goes here.')}
+`;
+
+type TabsGroupCase = {
+  direction?: TabsDirection;
+  density?: TabDensity;
+  disabled?: boolean;
+  selected?: string;
+  accessibleLabel: string;
+  tabs?: unknown;
+  panels?: unknown;
+};
+
+const renderTabs = ({
+  direction,
+  density,
+  disabled = false,
+  selected = '1',
+  accessibleLabel,
+  tabs = DEFAULT_TABS,
+  panels = DEFAULT_PANELS,
+}: TabsGroupCase) => html`
+  <swc-tabs
+    direction=${ifDefined(direction)}
+    density=${ifDefined(density)}
+    ?disabled=${disabled}
+    selected=${selected}
+    accessible-label=${accessibleLabel}
+  >
+    ${tabs} ${panels}
+  </swc-tabs>
+`;
+
+// Density labels double as captions: `accessible-label` is aria-only (see
+// Tabs.ts's render), so nothing in the visible output otherwise distinguishes
+// a `compact` group from a `regular` one within the same direction row. Kept
+// local rather than added to the shared `.storybook/helpers/vrt.ts` (which
+// would affect every other VRT file using it) to keep this VRT-only PR
+// scoped to tabs.
+const DENSITY_LABELS = {
+  regular: 'Regular',
+  compact: 'Compact',
+} as const satisfies Record<TabDensity, string>;
+
+const withCaption = (content: unknown, label: string) => html`
+  <div
+    style="display: flex; flex-direction: column; align-items: center; gap: var(--swc-spacing-100);"
+  >
+    ${content}
+    <span class="swc-Detail swc-Detail--sizeM">${label}</span>
+  </div>
+`;
+
+const permutationContent = () => html`
+  ${TABS_DIRECTIONS.map((direction) =>
+    row(
+      TAB_DENSITIES.map((density) =>
+        withCaption(
+          renderTabs({
+            direction,
+            density,
+            accessibleLabel: `${direction} ${density} example`,
+          }),
+          DENSITY_LABELS[density]
+        )
+      ),
+      direction
+    )
+  )}
+  ${row(
+    [
+      renderTabs({
+        selected: 'selected',
+        accessibleLabel: 'Individual tab states',
+        tabs: html`
+          ${tab({ id: 'default', label: 'Default' })}
+          ${tab({ id: 'selected', label: 'Selected' })}
+          ${tab({ id: 'disabled', label: 'Disabled', disabled: true })}
+        `,
+        panels: html`
+          ${panel('default', 'Default tab content.')}
+          ${panel('selected', 'Selected tab content.')}
+          ${panel('disabled', 'Disabled tab content.')}
+        `,
+      }),
+    ],
+    'Tab states'
+  )}
+  ${row(
+    [renderTabs({ disabled: true, accessibleLabel: 'Disabled container' })],
+    'Disabled container'
+  )}
+  ${row(
+    [
+      renderTabs({
+        accessibleLabel: 'Text-only anatomy',
+      }),
+      renderTabs({
+        accessibleLabel: 'Icon and text anatomy',
+        tabs: html`
+          ${tab({ id: '1', label: 'Dashboard', icon: '☰' })}
+          ${tab({ id: '2', label: 'Reports', icon: '📊' })}
+          ${tab({ id: '3', label: 'Settings', icon: '⚙' })}
+        `,
+        panels: html`
+          ${panel('1', 'Dashboard content.')} ${panel('2', 'Reports content.')}
+          ${panel('3', 'Settings content.')}
+        `,
+      }),
+      renderTabs({
+        accessibleLabel: 'Icon-only anatomy',
+        tabs: html`
+          ${tab({ id: '1', label: 'Dashboard', icon: '☰', iconOnly: true })}
+          ${tab({ id: '2', label: 'Reports', icon: '📊', iconOnly: true })}
+          ${tab({ id: '3', label: 'Settings', icon: '⚙', iconOnly: true })}
+        `,
+        panels: html`
+          ${panel('1', 'Dashboard content.')} ${panel('2', 'Reports content.')}
+          ${panel('3', 'Settings content.')}
+        `,
+      }),
+    ],
+    'Anatomy'
+  )}
+  ${row(
+    [
+      renderTabs({
+        accessibleLabel: 'Forced pseudo-states',
+        tabs: html`
+          ${tab({ id: '1', label: 'Hover', forceState: 'hover' })}
+          ${tab({
+            id: '2',
+            label: 'Focus-visible',
+            forceState: 'focus-visible',
+          })}
+          ${tab({ id: '3', label: 'Active', forceState: 'active' })}
+        `,
+        panels: html`
+          ${panel('1', 'Hover content.')} ${panel('2', 'Focus content.')}
+          ${panel('3', 'Active content.')}
+        `,
+      }),
+    ],
+    'Forced states'
+  )}
+  ${row(
+    [
+      renderTabs({
+        accessibleLabel: '承認ワークフロー',
+        tabs: html`
+          ${tab({ id: '1', label: '概要' })} ${tab({ id: '2', label: '仕様' })}
+          ${tab({ id: '3', label: 'ガイドライン' })}
+        `,
+        panels: html`
+          ${panel('1', '概要コンテンツ。')} ${panel('2', '仕様コンテンツ。')}
+          ${panel('3', 'ガイドラインコンテンツ。')}
+        `,
+      }),
+      renderTabs({
+        accessibleLabel: '승인 워크플로',
+        tabs: html`
+          ${tab({ id: '1', label: '개요' })} ${tab({ id: '2', label: '사양' })}
+          ${tab({ id: '3', label: '가이드라인' })}
+        `,
+        panels: html`
+          ${panel('1', '개요 콘텐츠.')} ${panel('2', '사양 콘텐츠.')}
+          ${panel('3', '가이드라인 콘텐츠.')}
+        `,
+      }),
+      renderTabs({
+        accessibleLabel: '审批工作流',
+        tabs: html`
+          ${tab({ id: '1', label: '概览' })} ${tab({ id: '2', label: '规格' })}
+          ${tab({ id: '3', label: '准则' })}
+        `,
+        panels: html`
+          ${panel('1', '概览内容。')} ${panel('2', '规格内容。')}
+          ${panel('3', '准则内容。')}
+        `,
+      }),
+    ],
+    'CJK language'
+  )}
+`;
+
+const forceTabStates = forcePseudoStates('swc-tab[data-force-state]');
+
+// VRT stories
+
+// Direction (horizontal, vertical) x density (regular, compact), individual
+// tab states (default/selected/disabled within one group), a fully disabled
+// container, anatomy (text-only, icon+text, icon-only), forced
+// hover/focus-visible/active on individual tabs (see the `play` function
+// below - tab.css styles these on `:host()` directly, so no internal
+// selector is needed), and CJK tab labels. Rendered once in light/ltr and
+// once in dark/rtl below (that combination covers both axes; RTL also
+// exercises the selection indicator's mirrored `transform-origin` for
+// horizontal direction), all still in a single story so it costs one
+// snapshot.
+export const Permutations: Story = {
+  render: () => html`
+    ${theme(permutationContent(), 'light', 'ltr')}
+    ${theme(permutationContent(), 'dark', 'rtl')}
+  `,
+  parameters: vrtParameters,
+  play: forceTabStates,
+};
+
+// `forced-colors` is a real browser media feature Chromatic can emulate
+// directly, unlike :hover/:active/:focus-visible above. Forced-colors mode
+// replaces the whole page's palette, so it needs its own story/snapshot
+// rather than folding into Permutations. Tab, Tabs' selection indicator, and
+// TabPanel all define their own forced-colors overrides, so this covers all
+// three parts of the three-element architecture.
+export const ForcedColors: Story = {
+  render: () => theme(permutationContent(), 'light', 'ltr'),
+  parameters: forcedColorsVrtParameters,
+  play: forceTabStates,
+};

--- a/2nd-gen/packages/swc/components/tabs/test/vrt/tabs.vrt.ts
+++ b/2nd-gen/packages/swc/components/tabs/test/vrt/tabs.vrt.ts
@@ -226,8 +226,12 @@ const permutationContent = () => html`
   ${row(
     [
       renderTabs({
+        // Baseline "Selected" tab isolates the underline from the forced
+        // pseudo-states below, so it doesn't read as part of Hover/Active.
+        selected: '0',
         accessibleLabel: 'Forced pseudo-states',
         tabs: html`
+          ${tab({ id: '0', label: 'Selected' })}
           ${tab({ id: '1', label: 'Hover', forceState: 'hover' })}
           ${tab({
             id: '2',
@@ -237,8 +241,8 @@ const permutationContent = () => html`
           ${tab({ id: '3', label: 'Active', forceState: 'active' })}
         `,
         panels: html`
-          ${panel('1', 'Hover content.')} ${panel('2', 'Focus content.')}
-          ${panel('3', 'Active content.')}
+          ${panel('0', 'Selected content.')} ${panel('1', 'Hover content.')}
+          ${panel('2', 'Focus content.')} ${panel('3', 'Active content.')}
         `,
       }),
     ],

--- a/2nd-gen/packages/swc/components/tabs/test/vrt/tabs.vrt.ts
+++ b/2nd-gen/packages/swc/components/tabs/test/vrt/tabs.vrt.ts
@@ -245,6 +245,22 @@ const permutationContent = () => html`
           ${panel('2', 'Focus content.')} ${panel('3', 'Active content.')}
         `,
       }),
+      renderTabs({
+        selected: '0',
+        accessibleLabel: 'Selected and focus-visible',
+        tabs: html`
+          ${tab({
+            id: '0',
+            label: 'Selected + focus-visible',
+            forceState: 'focus-visible',
+          })}
+          ${tab({ id: '1', label: 'Default' })}
+        `,
+        panels: html`
+          ${panel('0', 'Selected and focused content.')}
+          ${panel('1', 'Default content.')}
+        `,
+      }),
     ],
     'Forced states'
   )}


### PR DESCRIPTION
## Description

Adds `2nd-gen/packages/swc/components/tabs/test/vrt/tabs.vrt.ts` and `tabs-custom-properties.vrt.ts`, providing dedicated Chromatic VRT coverage for the `tabs` three-element component (`swc-tabs`, `swc-tab`, `swc-tab-panel`):

- `Permutations`: direction (horizontal/vertical) x density (regular/compact), individual tab states (default/selected/disabled), a fully disabled container, anatomy (text-only/icon+text/icon-only), forced hover/focus-visible/active on individual tabs, and CJK tab labels (ja/ko/zh).
- `ForcedColors`: the same permutation set under forced-colors emulation, covering the forced-colors overrides defined on all three parts of the architecture.
- `CustomProperties`: one reference/override row per documented custom property, split into two groups (Tabs, Tab) and verified against the manifest for each of the two declarations independently. `TabPanel` has no documented `@cssprop` (the `--swc-tab-panel-padding-top` its CSS uses isn't part of its public API contract), so it has no custom-properties row here - that's expected, not a gap.

This PR touches only files under `components/tabs/test/vrt/` - no component source and no shared `.storybook/helpers` changes. (An earlier version of this PR also documented a missing `@cssprop` on `TabPanel.ts` and re-added a shared VRT caption helper; both were reverted to keep this change scoped purely to test coverage for `tabs`, per review discussion.)

## Motivation and context

The `tabs` component had no dedicated VRT coverage. This follows the VRT foundation established for `button` (PR #6463), extending it to `tabs` per the linked ticket.

The ticket's acceptance criteria asked for a "quiet variant" snapshot, but `swc-tabs` has no `quiet` property - it was explicitly removed in the 2nd-gen migration (`migration-guide.mdx`: "No replacement; not part of Spectrum 2 surface"). Substituted `density` (regular/compact) instead, since that's the actual replacement axis for the removed quiet treatment.

## Related issue(s)

- fixes SWC-2414

## Screenshots (if appropriate)

N/A - test-only change, no visual/behavioral change to the components themselves. Manually verified via Playwright screenshots of the built Storybook (including real `forced-colors` media emulation, not just the inert Chromatic parameter) during development; a nesting bug in the custom-properties layout was caught and fixed this way before landing.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Tabs VRT stories render correctly_
  1. Go to Storybook > Components > Tabs > Tabs VRT
  2. Review the `Permutations`, `ForcedColors`, and `CustomProperties` stories
  3. Expect direction/density/state/anatomy/forced-state/CJK combinations to render correctly in both light/ltr and dark/rtl, with the selection indicator correctly positioned under the selected tab in every group

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard**
  These are non-interactive VRT snapshot fixtures (tagged `dev`, excluded from the interactive Storybook sidebar in normal use); no new keyboard behavior is introduced. Confirm no regressions in the existing `tabs.stories.ts` docs examples' keyboard navigation (arrow keys, Home/End, Enter/Space activation).

- [ ] **Screen reader**
  1. Go to Storybook > Components > Tabs > Tabs VRT > Permutations
  2. Inspect the icon-only anatomy group and the individual tab-states group with a screen reader or the accessibility tree
  3. Expect icon-only tabs to announce their `aria-label` (e.g. "Dashboard"), the disabled tab to announce as unavailable, and the selected tab to announce `aria-selected="true"`
