### PR TITLE
chore(popover): add vrt support

### DIFF
--- a/.ai/skills/vrt-authoring/SKILL.md
+++ b/.ai/skills/vrt-authoring/SKILL.md
@@ -49,7 +49,7 @@ Full rationale (attribute-vs-class, nested-rule mirroring, the custom-function p
 
 ## Positioned overlay components
 
-Components that position a surface with `PlacementController` use Floating UI `shift` (clipping ancestors capped by the visual viewport; `autoUpdate` recomputes on scroll). Opening many instances on a taller-than-viewport page can clamp `start`/`end` (not `top`/`bottom`) onto the same spot. Keep those placements in the initial viewport, disable `shouldFlip`, and stack in a column rather than using `row()`. Full rationale and a worked example (popover's `test/vrt/`) are in the VRT testing guide's "Positioned overlay components" section.
+Components that position a surface with `PlacementController` use Floating UI `shift` (clipping ancestors capped by the visual viewport; `autoUpdate` recomputes on scroll). Opening many instances on a taller-than-viewport page can clamp `start`/`end` (not `top`/`bottom`) onto the same spot. Keep every trigger in the initial viewport (place `start`/`end` first, pin the capture viewport, or split the story), disable `shouldFlip`, and do not use `row()`. Full rationale and a worked example (popover's `test/vrt/`) are in the VRT testing guide's "Positioned overlay components" section.
 
 ## Custom properties
 

--- a/.ai/skills/vrt-authoring/SKILL.md
+++ b/.ai/skills/vrt-authoring/SKILL.md
@@ -47,6 +47,10 @@ A single dense row of every permutation is hard to scan in a Chromatic diff. Use
 
 Full rationale (attribute-vs-class, nested-rule mirroring, the custom-function pattern) lives in the VRT testing guide: `CONTRIBUTOR-DOCS/02_style-guide/04_testing/04_visual-regresssion-testing.md`.
 
+## Positioned overlay components
+
+Components built on `PlacementController` (popover, tooltip, picker, combobox, …) position via floating-ui's `shift` middleware, which clamps to the current viewport and recomputes on scroll. Opening many instances at once on a page taller than one viewport can clamp several onto the same spot instead of their real positions — only the axis perpendicular to the placement is affected (e.g. `start`/`end`, not `top`/`bottom`, on a vertically scrolling page). Render the affected placements first on the page and stack them in a column. Full rationale and a worked example (popover's `test/vrt/`) are in the VRT testing guide's "Positioned overlay components" section.
+
 ## Custom properties
 
 - Use `customPropertyRows()` to render reference vs override rows.

--- a/.ai/skills/vrt-authoring/SKILL.md
+++ b/.ai/skills/vrt-authoring/SKILL.md
@@ -49,7 +49,7 @@ Full rationale (attribute-vs-class, nested-rule mirroring, the custom-function p
 
 ## Positioned overlay components
 
-Components built on `PlacementController` (popover, tooltip, picker, combobox, …) position via floating-ui's `shift` middleware, which clamps to the current viewport and recomputes on scroll. Opening many instances at once on a page taller than one viewport can clamp several onto the same spot instead of their real positions — only the axis perpendicular to the placement is affected (e.g. `start`/`end`, not `top`/`bottom`, on a vertically scrolling page). Render the affected placements first on the page and stack them in a column. Full rationale and a worked example (popover's `test/vrt/`) are in the VRT testing guide's "Positioned overlay components" section.
+Components that position a surface with `PlacementController` use Floating UI `shift` (clipping ancestors capped by the visual viewport; `autoUpdate` recomputes on scroll). Opening many instances on a taller-than-viewport page can clamp `start`/`end` (not `top`/`bottom`) onto the same spot. Keep those placements in the initial viewport, disable `shouldFlip`, and stack in a column rather than using `row()`. Full rationale and a worked example (popover's `test/vrt/`) are in the VRT testing guide's "Positioned overlay components" section.
 
 ## Custom properties
 

--- a/2nd-gen/packages/swc/components/popover/stories/popover.stories.ts
+++ b/2nd-gen/packages/swc/components/popover/stories/popover.stories.ts
@@ -12,7 +12,6 @@
 
 import { html } from 'lit';
 import { ref } from 'lit/directives/ref.js';
-import { expect, waitFor } from '@storybook/test';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
@@ -85,11 +84,9 @@ const meta: Meta = {
       subtitle: `An overlay element positioned relative to a trigger`,
     },
     // Docs stories render the popover closed (just a trigger), which is not
-    // visually meaningful, so disable Chromatic snapshots by default. The
-    // VRT-only stories at the bottom of this file re-enable them and open the
-    // popover so the rendered surface is captured. `delay` lets the entry
-    // transition settle before the snapshot.
-    chromatic: { disableSnapshot: true, delay: 500 },
+    // visually meaningful, so disable Chromatic snapshots here. Dense VRT
+    // coverage of the open surface lives in test/vrt/popover.vrt.ts instead.
+    chromatic: { disableSnapshot: true },
   },
   tags: ['migrated'],
 };
@@ -544,135 +541,4 @@ export const Accessibility: Story = {
   args: { 'accessible-label': 'Account', 'default-slot': accountCard },
   render: (args) => triggered({ ...args }, 'a11y-trigger', 'Open popover'),
   tags: ['a11y'],
-};
-
-// ────────────────────────────────
-//    VRT-ONLY STORIES
-// ────────────────────────────────
-
-// Chromatic snapshots every story in this file, including those hidden from the
-// docs and sidebar by the global `!autodocs` / `!dev` tags. The docs stories
-// render the popover closed (just a trigger), so snapshots are disabled for them
-// at the meta level and re-enabled per story here. Each of these opens a single
-// popover (auto popovers light-dismiss one another, so only one can be open at a
-// time) to capture the rendered surface. They stay out of the docs and sidebar
-// and are not referenced by the a11y spec, so they do not affect either.
-
-// Opens the story's single popover and waits for it to anchor and reveal.
-const openForVrt: NonNullable<Story['play']> = async ({ canvasElement }) => {
-  const popover = canvasElement.querySelector('swc-popover') as Popover;
-  await popover.updateComplete;
-  popover.open = true;
-  await waitFor(() =>
-    expect(popover.hasAttribute('actual-placement'), 'popover anchored').toBe(
-      true
-    )
-  );
-};
-
-// A centered, padded trigger so any placement has room to render without flipping.
-const vrtRender = (args: Record<string, unknown>, id: string) => html`
-  <div
-    style="display: grid; place-items: center; min-block-size: 280px; padding: 64px;"
-  >
-    ${triggered({ ...args }, id, 'Open popover')}
-  </div>
-`;
-
-const vrtStory = (overrides: Record<string, unknown>, id: string): Story => ({
-  args: {
-    'accessible-label': 'Autosave',
-    'default-slot': 'Your changes are saved automatically as you edit.',
-    ...overrides,
-  },
-  render: (args) => vrtRender(args, id),
-  play: openForVrt,
-  parameters: { chromatic: { disableSnapshot: false } },
-});
-
-// Placements (with the arrow) — `should-flip` off so each renders on the
-// requested side and the tip orientation is captured deterministically.
-export const VrtPlacementTop = vrtStory(
-  { placement: 'top', 'should-flip': false },
-  'vrt-placement-top'
-);
-export const VrtPlacementBottom = vrtStory(
-  { placement: 'bottom', 'should-flip': false },
-  'vrt-placement-bottom'
-);
-export const VrtPlacementStart = vrtStory(
-  { placement: 'start', 'should-flip': false },
-  'vrt-placement-start'
-);
-export const VrtPlacementEnd = vrtStory(
-  { placement: 'end', 'should-flip': false },
-  'vrt-placement-end'
-);
-
-// Fixed sizes.
-export const VrtSizeSmall = vrtStory({ size: 's' }, 'vrt-size-s');
-export const VrtSizeMedium = vrtStory({ size: 'm' }, 'vrt-size-m');
-export const VrtSizeLarge = vrtStory({ size: 'l' }, 'vrt-size-l');
-
-// Arrowless surface (rectangular box-shadow, no tip).
-export const VrtHideArrow = vrtStory({ 'hide-arrow': true }, 'vrt-hide-arrow');
-
-// Modal surface (native `<dialog>`, transparent backdrop).
-export const VrtModal = vrtStory(
-  { modal: true, 'accessible-label': 'Account settings' },
-  'vrt-modal'
-);
-
-// Nested popovers with both layers open (the inner opened from inside the outer
-// forms an ancestor chain, so the outer stays open beneath it).
-export const VrtNested: Story = {
-  render: () => html`
-    <div
-      style="display: grid; place-items: center; min-block-size: 360px; padding: 64px;"
-    >
-      <swc-button id="vrt-nested-outer-trigger">Open outer</swc-button>
-      <swc-popover
-        id="vrt-nested-outer"
-        for="vrt-nested-outer-trigger"
-        accessible-label="Outer"
-      >
-        <div style="display: flex; flex-direction: column; gap: 12px;">
-          <p class="swc-Body swc-Body--sizeS" style="margin: 0;">
-            Outer popover
-          </p>
-          <swc-button id="vrt-nested-inner-trigger" size="s">
-            Open inner
-          </swc-button>
-          <swc-popover
-            id="vrt-nested-inner"
-            for="vrt-nested-inner-trigger"
-            placement="end"
-            accessible-label="Inner"
-          >
-            Inner popover
-          </swc-popover>
-        </div>
-      </swc-popover>
-    </div>
-  `,
-  play: async ({ canvasElement }) => {
-    const outer = canvasElement.querySelector('#vrt-nested-outer') as Popover;
-    const inner = canvasElement.querySelector('#vrt-nested-inner') as Popover;
-    await outer.updateComplete;
-    outer.open = true;
-    await waitFor(() =>
-      expect(outer.hasAttribute('actual-placement'), 'outer anchored').toBe(
-        true
-      )
-    );
-    inner.open = true;
-    await waitFor(() =>
-      expect(inner.hasAttribute('actual-placement'), 'inner anchored').toBe(
-        true
-      )
-    );
-    // The ancestor chain keeps the outer open beneath the inner.
-    expect(outer.open, 'outer stays open under the inner').toBe(true);
-  },
-  parameters: { chromatic: { disableSnapshot: false } },
 };

--- a/2nd-gen/packages/swc/components/popover/test/vrt/popover-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/popover/test/vrt/popover-custom-properties.vrt.ts
@@ -21,11 +21,11 @@ import {
   coveredCustomProperties,
   theme,
   verifyCustomPropertyCoverage,
-  vrtParameters,
 } from '../../../../.storybook/helpers/index.js';
 import customElementsManifest from '../../../../dist/custom-elements.json';
 import {
   openManyPopoversForVrt,
+  popoverVrtParameters,
   PROPERTY_GROUP_GAP,
   propertyCompareRow,
   vrtPage,
@@ -112,6 +112,6 @@ const openAndVerifyCoverage = async (
 
 export const CustomProperties: Story = {
   render: () => theme(modPropertiesContent(), 'light', 'ltr'),
-  parameters: vrtParameters,
+  parameters: popoverVrtParameters,
   play: openAndVerifyCoverage,
 };

--- a/2nd-gen/packages/swc/components/popover/test/vrt/popover-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/popover/test/vrt/popover-custom-properties.vrt.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '@adobe/spectrum-wc/components/button/swc-button.js';
+import '@adobe/spectrum-wc/components/popover/swc-popover.js';
+
+import type { CustomPropertyCase } from '../../../../.storybook/helpers/index.js';
+import {
+  coveredCustomProperties,
+  theme,
+  verifyCustomPropertyCoverage,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import customElementsManifest from '../../../../dist/custom-elements.json';
+import {
+  openManyPopoversForVrt,
+  PROPERTY_GROUP_GAP,
+  propertyCompareRow,
+  vrtPage,
+} from './vrt-helpers.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Popover/Popover VRT',
+  component: 'swc-popover',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+// Every `--swc-popover-*` custom property is a public contract (see
+// Popover.ts's `@cssprop` JSDoc): one row per property, a reference popover
+// next to the same popover with that one property overridden to an
+// obviously different value, so a real difference confirms the override
+// still works.
+type ModPropertyCase = CustomPropertyCase<`--swc-popover-${string}`>;
+
+const MOD_PROPERTY_CASES: readonly ModPropertyCase[] = [
+  { property: '--swc-popover-content-padding', value: '40px' },
+  { property: '--swc-popover-background-color', value: 'magenta' },
+  { property: '--swc-popover-border-color', value: 'magenta' },
+  { property: '--swc-popover-corner-radius', value: '0px' },
+];
+
+const idFor = (property: string, style?: string) =>
+  `${property.replace(/^--/, '')}-${style ? 'override' : 'reference'}`;
+
+const modPropertyPopover = ({ property }: ModPropertyCase, style?: string) => {
+  const id = idFor(property, style);
+  return html`
+    <div style="display: grid; place-items: center;">
+      <swc-button id=${id}>Open</swc-button>
+      <swc-popover
+        for=${id}
+        placement="bottom"
+        accessible-label="Autosave"
+        style=${style ?? nothing}
+      >
+        Your changes are saved automatically as you edit.
+      </swc-popover>
+    </div>
+  `;
+};
+
+// The shared `customPropertyRows()`/`row()` helpers flex-wrap the reference
+// and override side by side, which works for components whose visible bounds
+// stay inside their own box. Side-by-side pairs and vertical group spacing
+// live in `vrt-helpers.ts` for the same top-layer reasoning as `stack()`.
+const modPropertiesContent = () =>
+  vrtPage(
+    MOD_PROPERTY_CASES.map((testCase) =>
+      propertyCompareRow(
+        testCase.property,
+        modPropertyPopover(testCase),
+        modPropertyPopover(testCase, `${testCase.property}: ${testCase.value};`)
+      )
+    ),
+    PROPERTY_GROUP_GAP
+  );
+
+const coveredPopoverCustomProperties =
+  coveredCustomProperties(MOD_PROPERTY_CASES);
+
+const openAndVerifyCoverage = async (
+  context: Parameters<typeof openManyPopoversForVrt>[0]
+) => {
+  await openManyPopoversForVrt(context);
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/popover/Popover.ts',
+    declarationName: 'Popover',
+    coveredProperties: coveredPopoverCustomProperties,
+  });
+};
+
+// VRT stories
+
+export const CustomProperties: Story = {
+  render: () => theme(modPropertiesContent(), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: openAndVerifyCoverage,
+};

--- a/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
+++ b/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
@@ -200,44 +200,10 @@ const overflowRow = (prefix: string) =>
     'Content overflow'
   );
 
-const cjkLanguageRow = (prefix: string) =>
-  stack(
-    (
-      [
-        {
-          lang: 'ja',
-          label: 'Japanese',
-          text: '編集内容は自動的に保存されます。',
-        },
-        {
-          lang: 'ko',
-          label: 'Korean',
-          text: '변경 내용이 자동으로 저장됩니다.',
-        },
-        {
-          lang: 'zh',
-          label: 'Chinese',
-          text: '您的更改会在编辑时自动保存。',
-        },
-      ] as const
-    ).map(({ lang, label, text }, i) =>
-      renderPopoverPermutation(
-        {
-          placement: 'bottom',
-          'default-slot': `<span lang="${lang}" style="display: block; max-inline-size: 160px;">${text}</span>`,
-        },
-        `${prefix}-cjk-${i}`,
-        label
-      )
-    ),
-    'CJK language',
-    'tall'
-  );
-
 const permutationContent = (prefix: string) =>
   vrtPage(html`
     ${placementRows(prefix)} ${sizeRow(prefix)} ${hideArrowRow(prefix)}
-    ${modalRow(prefix)} ${cjkLanguageRow(prefix)} ${overflowRow(prefix)}
+    ${modalRow(prefix)} ${overflowRow(prefix)}
   `);
 
 // VRT stories

--- a/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
+++ b/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
@@ -24,14 +24,11 @@ import {
 import '@adobe/spectrum-wc/components/button/swc-button.js';
 import '@adobe/spectrum-wc/components/popover/swc-popover.js';
 
+import { theme } from '../../../../.storybook/helpers/index.js';
 import {
-  forcedColorsVrtParameters,
-  theme,
-  vrtParameters,
-} from '../../../../.storybook/helpers/index.js';
-import {
-  GROUP_GAP,
   openManyPopoversForVrt,
+  popoverForcedColorsVrtParameters,
+  popoverVrtParameters,
   stack,
   type StackLayout,
   vrtPage,
@@ -165,7 +162,9 @@ const modalRow = (prefix: string) =>
 // sets `max-block-size` / `overflow: auto`), so this needs plain content
 // long enough to exceed it, not a second nested scroll region — an inner
 // `overflow: auto` wrapper would give a visibly distinct nested scrollbar in
-// addition to the outer one.
+// addition to the outer one. Bottom shadow bleed comes from `vrtPage`'s extra
+// `padding-block-end`; capping `--swc-placement-available-height` here would
+// change the scroll scenario under test.
 const scrollableContent = `
   <div style="display: flex; flex-direction: column; gap: 8px; max-inline-size: 220px;">
     <span class="swc-Title swc-Title--sizeS">Release notes</span>
@@ -219,7 +218,7 @@ const permutationContent = (prefix: string) =>
 
 export const Permutations: Story = {
   render: () => theme(permutationContent('permutations'), 'light', 'ltr'),
-  parameters: vrtParameters,
+  parameters: popoverVrtParameters,
   play: openManyPopoversForVrt,
 };
 
@@ -229,18 +228,20 @@ export const PermutationsRtl: Story = {
     theme(
       html`
         <div
-          style="display: flex; flex-direction: column; align-items: center; gap: ${GROUP_GAP}px; min-inline-size: 900px; margin-block-end: 72px;"
+          style="display: flex; flex-direction: column; align-items: center;"
         >
-          ${(['start', 'end'] as const).map((base) =>
-            placementGroup(base, 'permutations-rtl')
-          )}
-          ${hideArrowRow('permutations-rtl')}
+          ${vrtPage(html`
+            ${(['start', 'end'] as const).map((base) =>
+              placementGroup(base, 'permutations-rtl')
+            )}
+            ${hideArrowRow('permutations-rtl')}
+          `)}
         </div>
       `,
       'dark',
       'rtl'
     ),
-  parameters: vrtParameters,
+  parameters: popoverVrtParameters,
   play: openManyPopoversForVrt,
 };
 PermutationsRtl.storyName = 'Permutations (RTL)';
@@ -260,7 +261,7 @@ export const ForcedColors: Story = {
       'light',
       'ltr'
     ),
-  parameters: forcedColorsVrtParameters,
+  parameters: popoverForcedColorsVrtParameters,
   play: openManyPopoversForVrt,
 };
 
@@ -274,7 +275,7 @@ export const ForcedColors: Story = {
 export const Nested: Story = {
   render: () => html`
     <div
-      style="display: grid; place-items: center; min-block-size: 360px; padding: 64px;"
+      style="display: grid; place-items: center; min-block-size: 360px; padding: 96px 128px;"
     >
       <swc-button id="nested-outer-trigger">Open outer</swc-button>
       <swc-popover
@@ -316,5 +317,5 @@ export const Nested: Story = {
       )
     );
   },
-  parameters: vrtParameters,
+  parameters: popoverVrtParameters,
 };

--- a/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
+++ b/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
@@ -102,10 +102,10 @@ const placementGroup = (base: PlacementBase, prefix: string) => {
   return stack(rendered, base, layout);
 };
 
-// All 12 placements. Direction (LTR/RTL) only changes where `start`/`end`
-// land, so only those two need re-verification under RTL — see
-// `PermutationsRtl` below, which covers that without paying for a second full
-// copy of `top`/`bottom` (which don't care about direction at all).
+// All 12 placements. Also run in full under RTL by `PermutationsRtl` below —
+// direction only changes where `start`/`end` land, but it's cheap to confirm
+// `top`/`bottom` render the same rather than assuming it from the mirroring
+// theory alone.
 const PLACEMENT_BASES = ['start', 'end', 'top', 'bottom'] as const;
 
 const placementRows = (prefix: string) =>
@@ -222,7 +222,11 @@ export const Permutations: Story = {
   play: openManyPopoversForVrt,
 };
 
-// RTL start/end and dark hide-arrow smoke; must lead the page.
+// All 12 placements under RTL (not just start/end): top/bottom don't mirror,
+// but running them here too catches anything direction-specific in their
+// rendering rather than assuming the mirror-only theory holds, and keeps
+// this story a full RTL counterpart to `Permutations` rather than a partial
+// one. Dark hide-arrow smoke also lives here rather than on `Permutations`.
 export const PermutationsRtl: Story = {
   render: () =>
     theme(
@@ -231,7 +235,7 @@ export const PermutationsRtl: Story = {
           style="display: flex; flex-direction: column; align-items: center;"
         >
           ${vrtPage(html`
-            ${(['start', 'end'] as const).map((base) =>
+            ${PLACEMENT_BASES.map((base) =>
               placementGroup(base, 'permutations-rtl')
             )}
             ${hideArrowRow('permutations-rtl')}

--- a/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
+++ b/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
@@ -1,0 +1,354 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import { expect, waitFor } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+
+import { Popover } from '@adobe/spectrum-wc/popover';
+import {
+  POPOVER_VALID_PLACEMENTS,
+  POPOVER_VALID_SIZES,
+} from '@adobe/spectrum-wc-core/components/popover';
+
+import '@adobe/spectrum-wc/components/button/swc-button.js';
+import '@adobe/spectrum-wc/components/popover/swc-popover.js';
+
+import {
+  forcedColorsVrtParameters,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import {
+  GROUP_GAP,
+  openManyPopoversForVrt,
+  stack,
+  type StackLayout,
+  vrtPage,
+} from './vrt-helpers.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Popover/Popover VRT',
+  component: 'swc-popover',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+const { args, template } = getStorybookHelpers('swc-popover');
+
+const DEFAULT_SLOT_MESSAGE =
+  'Your changes are saved automatically as you edit.';
+
+const DEFAULT_ARGS = {
+  'accessible-label': 'Autosave',
+  'default-slot': DEFAULT_SLOT_MESSAGE,
+};
+
+// `label` names the permutation on its trigger so each case is identifiable
+// in the layout; slotted content is often shared within a row, and open
+// surfaces can cover or leave their trigger.
+const renderPopoverPermutation = (
+  permutation: Record<string, unknown>,
+  id: string,
+  label: string
+) => html`
+  <div style="display: grid; place-items: center;">
+    <swc-button id=${id}>${label}</swc-button>
+    ${template({ ...args, ...DEFAULT_ARGS, ...permutation, for: id })}
+  </div>
+`;
+
+// Groups one base side (top/bottom/start/end) and its two alignment
+// variants, since the alignment is what visibly shifts the tip along the
+// trigger's edge. Flipping is disabled by `openManyPopoversForVrt` so each
+// renders on its requested side deterministically. Side placements are
+// viewport-sensitive; see the note at `// VRT stories`.
+type PlacementBase = 'top' | 'bottom' | 'start' | 'end';
+
+// Alignment variants only shift the tip when the surface is taller than
+// the trigger (~32px). Same copy as `DEFAULT_SLOT_MESSAGE`, wrapped so it
+// breaks to several lines and the offset between `-start`/`-end` is visible.
+const WRAPPED_DEFAULT_SLOT = `
+  <span style="display: block; max-inline-size: 160px;">
+    ${DEFAULT_SLOT_MESSAGE}
+  </span>
+`;
+
+const placementGroup = (base: PlacementBase, prefix: string) => {
+  const placements = POPOVER_VALID_PLACEMENTS.filter(
+    (placement) => placement === base || placement.startsWith(`${base}-`)
+  );
+  const rendered = placements.map((placement, i) =>
+    renderPopoverPermutation(
+      { placement, 'default-slot': WRAPPED_DEFAULT_SLOT },
+      `${prefix}-placement-${base}-${i}`,
+      placement
+    )
+  );
+  const layout: StackLayout =
+    base === 'top' ? 'upward' : base === 'bottom' ? 'tall' : 'default';
+  return stack(rendered, base, layout);
+};
+
+// All 12 placements. Direction (LTR/RTL) only changes where `start`/`end`
+// land, so only those two need re-verification under RTL — see
+// `PermutationsRtl` below, which covers that without paying for a second full
+// copy of `top`/`bottom` (which don't care about direction at all).
+const PLACEMENT_BASES = ['start', 'end', 'top', 'bottom'] as const;
+
+const placementRows = (prefix: string) =>
+  PLACEMENT_BASES.map((base) => placementGroup(base, prefix));
+
+// `undefined` is the fit-content default; the three fixed sizes each pin an
+// inline size regardless of content.
+const SIZE_CASES = [undefined, ...POPOVER_VALID_SIZES] as const;
+
+const SIZE_LABELS = { s: 'Small', m: 'Medium', l: 'Large' } as const;
+
+const sizeRow = (prefix: string) =>
+  stack(
+    SIZE_CASES.map((size, i) =>
+      renderPopoverPermutation(
+        { placement: 'bottom', ...(size ? { size } : {}) },
+        `${prefix}-size-${i}`,
+        size ? SIZE_LABELS[size] : 'Default'
+      )
+    ),
+    'Size'
+  );
+
+const hideArrowRow = (prefix: string) =>
+  stack(
+    [false, true].map((hideArrow, i) =>
+      renderPopoverPermutation(
+        { placement: 'bottom', 'hide-arrow': hideArrow },
+        `${prefix}-arrow-${i}`,
+        hideArrow ? 'Hidden' : 'Shown'
+      )
+    ),
+    'Hide arrow'
+  );
+
+// Modal mode renders a `<dialog>` instead of a `popover` div, but shares the
+// same positioning and surface styles, so a couple of placements are enough
+// to confirm the dialog path matches. No manual-mode flip needed here:
+// `showModal()` has no exclusivity with other open dialogs.
+const modalRow = (prefix: string) =>
+  stack(
+    (['top', 'bottom'] as const).map((placement, i) =>
+      renderPopoverPermutation(
+        { placement, modal: true },
+        `${prefix}-modal-${i}`,
+        placement
+      )
+    ),
+    'Modal',
+    'upward'
+  );
+
+// Long content overflows `.swc-Popover-content` itself (that element already
+// sets `max-block-size` / `overflow: auto`), so this needs plain content
+// long enough to exceed it, not a second nested scroll region — an inner
+// `overflow: auto` wrapper would give a visibly distinct nested scrollbar in
+// addition to the outer one.
+const scrollableContent = `
+  <div style="display: flex; flex-direction: column; gap: 8px; max-inline-size: 220px;">
+    <span class="swc-Title swc-Title--sizeS">Release notes</span>
+    <p class="swc-Body swc-Body--sizeS" style="margin: 0;">
+      <strong>2.4.0</strong> — Popover gained a modal mode, logical
+      placements, and a configurable arrow.
+    </p>
+    <p class="swc-Body swc-Body--sizeS" style="margin: 0;">
+      <strong>2.3.0</strong> — Focus now returns to the trigger on close, and
+      nested popovers dismiss one layer at a time.
+    </p>
+    <p class="swc-Body swc-Body--sizeS" style="margin: 0;">
+      <strong>2.2.0</strong> — Added the <code>size</code> attribute and
+      public styling custom properties.
+    </p>
+    <p class="swc-Body swc-Body--sizeS" style="margin: 0;">
+      <strong>2.1.0</strong> — Introduced the virtual-anchor positioning
+      option.
+    </p>
+  </div>
+`;
+
+const overflowRow = (prefix: string) =>
+  stack(
+    [
+      renderPopoverPermutation(
+        { placement: 'bottom', size: 's', 'default-slot': scrollableContent },
+        `${prefix}-overflow-0`,
+        'Long content'
+      ),
+    ],
+    'Content overflow'
+  );
+
+const cjkLanguageRow = (prefix: string) =>
+  stack(
+    (
+      [
+        {
+          lang: 'ja',
+          label: 'Japanese',
+          text: '編集内容は自動的に保存されます。',
+        },
+        {
+          lang: 'ko',
+          label: 'Korean',
+          text: '변경 내용이 자동으로 저장됩니다.',
+        },
+        {
+          lang: 'zh',
+          label: 'Chinese',
+          text: '您的更改会在编辑时自动保存。',
+        },
+      ] as const
+    ).map(({ lang, label, text }, i) =>
+      renderPopoverPermutation(
+        {
+          placement: 'bottom',
+          'default-slot': `<span lang="${lang}" style="display: block; max-inline-size: 160px;">${text}</span>`,
+        },
+        `${prefix}-cjk-${i}`,
+        label
+      )
+    ),
+    'CJK language',
+    'tall'
+  );
+
+const permutationContent = (prefix: string) =>
+  vrtPage(html`
+    ${placementRows(prefix)} ${sizeRow(prefix)} ${hideArrowRow(prefix)}
+    ${modalRow(prefix)} ${cjkLanguageRow(prefix)} ${overflowRow(prefix)}
+  `);
+
+// VRT stories
+//
+// `Permutations` is the light/ltr matrix. Dark hide-arrow smoke lives on
+// `PermutationsRtl` instead of appended here: the overflow row's open surface
+// is tall and sits in the top layer, which covered the dark block when both
+// were on one page.
+//
+// `start`/`end` side placements are viewport-sensitive: floating-ui's `shift`
+// middleware clamps cross-axis position on scroll, and for side placements
+// that axis is vertical. Keep them first in a story — see `PermutationsRtl`.
+
+export const Permutations: Story = {
+  render: () => theme(permutationContent('permutations'), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: openManyPopoversForVrt,
+};
+
+// RTL start/end and dark hide-arrow smoke; must lead the page.
+export const PermutationsRtl: Story = {
+  render: () =>
+    theme(
+      html`
+        <div
+          style="display: flex; flex-direction: column; align-items: center; gap: ${GROUP_GAP}px; min-inline-size: 900px; margin-block-end: 72px;"
+        >
+          ${(['start', 'end'] as const).map((base) =>
+            placementGroup(base, 'permutations-rtl')
+          )}
+          ${hideArrowRow('permutations-rtl')}
+        </div>
+      `,
+      'dark',
+      'rtl'
+    ),
+  parameters: vrtParameters,
+  play: openManyPopoversForVrt,
+};
+PermutationsRtl.storyName = 'Permutations (RTL)';
+
+// `forced-colors` replaces the whole page palette, so it needs its own
+// story/snapshot (same reasoning as button.vrt.ts's ForcedColors). Covers a
+// representative subset: the 4 base placements, arrow visibility, and modal,
+// enough to confirm the `@media (forced-colors: active)` rule's
+// `border-color: CanvasText` reaches both the surface and the tip.
+export const ForcedColors: Story = {
+  render: () =>
+    theme(
+      vrtPage(html`
+        ${placementRows('forced')} ${hideArrowRow('forced')}
+        ${modalRow('forced')}
+      `),
+      'light',
+      'ltr'
+    ),
+  parameters: forcedColorsVrtParameters,
+  play: openManyPopoversForVrt,
+};
+
+// Nested popovers (inner opened from inside the outer) form an ancestor
+// chain, which the native auto-popover algorithm exempts from light-dismiss,
+// so no manual-mode flip is needed. Uses its own open sequence instead of
+// `openManyPopoversForVrt`: the inner trigger is slotted inside the outer's
+// surface, so its on-screen rect is wrong until the outer has actually
+// anchored — opening inner before that settles would position it against the
+// outer's pre-anchor origin.
+export const Nested: Story = {
+  render: () => html`
+    <div
+      style="display: grid; place-items: center; min-block-size: 360px; padding: 64px;"
+    >
+      <swc-button id="nested-outer-trigger">Open outer</swc-button>
+      <swc-popover
+        id="nested-outer"
+        for="nested-outer-trigger"
+        accessible-label="Outer"
+      >
+        <div style="display: flex; flex-direction: column; gap: 12px;">
+          <p class="swc-Body swc-Body--sizeS" style="margin: 0;">
+            Outer popover
+          </p>
+          <swc-button id="nested-inner-trigger" size="s">Open inner</swc-button>
+          <swc-popover
+            id="nested-inner"
+            for="nested-inner-trigger"
+            placement="end"
+            accessible-label="Inner"
+          >
+            Inner popover
+          </swc-popover>
+        </div>
+      </swc-popover>
+    </div>
+  `,
+  play: async ({ canvasElement }) => {
+    const outer = canvasElement.querySelector('#nested-outer') as Popover;
+    const inner = canvasElement.querySelector('#nested-inner') as Popover;
+    await outer.updateComplete;
+    outer.open = true;
+    await waitFor(() =>
+      expect(outer.hasAttribute('actual-placement'), 'outer anchored').toBe(
+        true
+      )
+    );
+    inner.open = true;
+    await waitFor(() =>
+      expect(inner.hasAttribute('actual-placement'), 'inner anchored').toBe(
+        true
+      )
+    );
+  },
+  parameters: vrtParameters,
+};

--- a/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
+++ b/2nd-gen/packages/swc/components/popover/test/vrt/popover.vrt.ts
@@ -74,7 +74,8 @@ const renderPopoverPermutation = (
 // variants, since the alignment is what visibly shifts the tip along the
 // trigger's edge. Flipping is disabled by `openManyPopoversForVrt` so each
 // renders on its requested side deterministically. Side placements are
-// viewport-sensitive; see the note at `// VRT stories`.
+// viewport-sensitive; see the note at `// VRT stories` and the VRT testing
+// guide's "Positioned overlay components" section.
 type PlacementBase = 'top' | 'bottom' | 'start' | 'end';
 
 // Alignment variants only shift the tip when the surface is taller than
@@ -214,7 +215,10 @@ const permutationContent = (prefix: string) =>
 //
 // `start`/`end` side placements are viewport-sensitive: floating-ui's `shift`
 // middleware clamps cross-axis position on scroll, and for side placements
-// that axis is vertical. Keep them first in a story — see `PermutationsRtl`.
+// that axis is vertical. Keep them first in a story — see `PermutationsRtl`,
+// and the VRT testing guide's "Positioned overlay components" section for
+// the full explanation (this applies to any `PlacementController` component,
+// not just popover).
 
 export const Permutations: Story = {
   render: () => theme(permutationContent('permutations'), 'light', 'ltr'),

--- a/2nd-gen/packages/swc/components/popover/test/vrt/vrt-helpers.ts
+++ b/2nd-gen/packages/swc/components/popover/test/vrt/vrt-helpers.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import { expect, waitFor } from '@storybook/test';
+import type { StoryObj as Story } from '@storybook/web-components';
+
+import { Popover } from '@adobe/spectrum-wc/popover';
+
+// Open popovers escape into the top layer, so spacing keeps adjacent
+// surfaces from overlapping. GROUP_GAP separates labeled rows on a page;
+// PROPERTY_GROUP_GAP separates custom-property groups; PAIR_GAP separates
+// side-by-side reference/override pairs. Item gaps separate triggers within
+// a stack row. `tall` fits multi-line bottom surfaces; `upward` adds label
+// clearance when the first item opens toward its heading.
+export const GROUP_GAP = 96;
+export const PROPERTY_GROUP_GAP = 140;
+export const PAIR_GAP = 320;
+const ITEM_GAP = 64;
+const TALL_ITEM_GAP = 96;
+const UPWARD_LABEL_GAP = 64;
+
+export type StackLayout = 'default' | 'tall' | 'upward';
+
+const STACK_GAPS: Record<StackLayout, { itemGap: number; labelGap: number }> = {
+  default: { itemGap: ITEM_GAP, labelGap: 8 },
+  tall: { itemGap: TALL_ITEM_GAP, labelGap: 8 },
+  upward: { itemGap: TALL_ITEM_GAP, labelGap: UPWARD_LABEL_GAP },
+};
+
+export const stack = (
+  children: readonly unknown[],
+  label?: string,
+  layout: StackLayout = 'default'
+) => {
+  const { itemGap, labelGap } = STACK_GAPS[layout];
+  return html`
+    <div style="display: flex; flex-direction: column; gap: ${labelGap}px;">
+      ${label
+        ? html`
+            <span class="swc-Detail swc-Detail--sizeM">${label}</span>
+          `
+        : nothing}
+      <div style="display: flex; flex-direction: column; gap: ${itemGap}px;">
+        ${children}
+      </div>
+    </div>
+  `;
+};
+
+export const vrtPage = (children: unknown, groupGap = GROUP_GAP) => html`
+  <div style="display: flex; flex-direction: column; gap: ${groupGap}px;">
+    ${children}
+  </div>
+`;
+
+export const propertyCompareRow = (
+  label: string,
+  reference: unknown,
+  override: unknown
+) => html`
+  <div
+    style="display: flex; flex-direction: column; gap: var(--swc-spacing-100);"
+  >
+    <span class="swc-Detail swc-Detail--sizeM">${label}</span>
+    <div style="display: flex; gap: ${PAIR_GAP}px;">
+      ${reference} ${override}
+    </div>
+  </div>
+`;
+
+// Native `popover="auto"` light-dismisses every other open auto popover, so
+// only one can be open at a time in a real page. Flipping each non-modal
+// instance's internal surface to `popover="manual"` before opening it skips
+// that step, letting a whole permutation matrix render open in one snapshot;
+// `<dialog>` (modal mode) has no such exclusivity and needs no flip. This is
+// a VRT-only hack: it only matters for visual fidelity, never for actual
+// popover behavior.
+export const openManyPopoversForVrt: NonNullable<Story['play']> = async ({
+  canvasElement,
+}) => {
+  const popovers = [...canvasElement.querySelectorAll<Popover>('swc-popover')];
+  await Promise.all(popovers.map((popover) => popover.updateComplete));
+  popovers.forEach((popover) => {
+    // Force via the property, not the `should-flip` attribute: `template()`
+    // serializes boolean args as a plain attribute string, and HTML boolean
+    // attributes are presence-based, so `should-flip="false"` still reads as
+    // true. A real flip (driven by viewport space, not the requested
+    // placement) would make the snapshot depend on layout rather than the
+    // axis under test.
+    popover.shouldFlip = false;
+    if (popover.modal) {
+      return;
+    }
+    popover.shadowRoot
+      ?.querySelector('.swc-Popover')
+      ?.setAttribute('popover', 'manual');
+  });
+  popovers.forEach((popover) => {
+    popover.open = true;
+  });
+  await Promise.all(
+    popovers.map((popover) =>
+      waitFor(() => expect(popover.hasAttribute('actual-placement')).toBe(true))
+    )
+  );
+  // Every open `modal` instance locks page scroll for the (correct) real
+  // lifecycle reason: a modal dialog should block the page behind it. Several
+  // opened at once for a snapshot means that lock never releases while the
+  // story is mounted, which only matters for a human scrolling through this
+  // dev-only page; Chromatic captures the full rendered height without
+  // scrolling, so overriding it back is safe here and nowhere else.
+  document.documentElement.style.overflow = '';
+};

--- a/2nd-gen/packages/swc/components/popover/test/vrt/vrt-helpers.ts
+++ b/2nd-gen/packages/swc/components/popover/test/vrt/vrt-helpers.ts
@@ -16,6 +16,44 @@ import type { StoryObj as Story } from '@storybook/web-components';
 
 import { Popover } from '@adobe/spectrum-wc/popover';
 
+import {
+  forcedColorsVrtParameters,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+
+// `.swc-Popover` paints `filter: drop-shadow` outside its border box; pad VRT
+// canvases so Chromatic does not crop the halo at story edges. Inline bleed is
+// larger because open surfaces (especially size `l` and side placements) paint
+// in the top layer and do not expand their ancestor's in-flow width.
+export const SURFACE_SHADOW_BLEED = 24;
+export const INLINE_SHADOW_BLEED = 48;
+
+// Wide enough for side `start`/`end` alignment variants and size `l` (576px)
+// surfaces centered on a trigger with inline shadow bleed on both sides.
+export const VRT_MIN_INLINE_SIZE = 900;
+
+// Open bottom surfaces sit in the top layer and do not expand their ancestor's
+// box, so reserve in-flow space below the last bottom-opening row for `theme()`
+// backgrounds and snapshot bleed. Internal scroll sizing is unchanged.
+export const BOTTOM_SURFACE_RESERVE = 72;
+
+const popoverCanvasPadding = `padding-block: ${SURFACE_SHADOW_BLEED}px; padding-block-end: ${SURFACE_SHADOW_BLEED + BOTTOM_SURFACE_RESERVE}px; padding-inline: ${INLINE_SHADOW_BLEED}px;`;
+
+export const popoverVrtParameters = {
+  ...vrtParameters,
+  styles: {
+    ...vrtParameters.styles,
+    paddingBlock: `${SURFACE_SHADOW_BLEED}px`,
+    paddingBlockEnd: `${SURFACE_SHADOW_BLEED + BOTTOM_SURFACE_RESERVE}px`,
+    paddingInline: `${INLINE_SHADOW_BLEED}px`,
+  },
+};
+
+export const popoverForcedColorsVrtParameters = {
+  ...popoverVrtParameters,
+  chromatic: forcedColorsVrtParameters.chromatic,
+};
+
 // Open popovers escape into the top layer, so spacing keeps adjacent
 // surfaces from overlapping. GROUP_GAP separates labeled rows on a page;
 // PROPERTY_GROUP_GAP separates custom-property groups; PAIR_GAP separates
@@ -57,8 +95,14 @@ export const stack = (
   `;
 };
 
-export const vrtPage = (children: unknown, groupGap = GROUP_GAP) => html`
-  <div style="display: flex; flex-direction: column; gap: ${groupGap}px;">
+export const vrtPage = (
+  children: unknown,
+  groupGap = GROUP_GAP,
+  minInlineSize = VRT_MIN_INLINE_SIZE
+) => html`
+  <div
+    style="display: flex; flex-direction: column; gap: ${groupGap}px; min-inline-size: ${minInlineSize}px; ${popoverCanvasPadding}"
+  >
     ${children}
   </div>
 `;
@@ -72,7 +116,7 @@ export const propertyCompareRow = (
     style="display: flex; flex-direction: column; gap: var(--swc-spacing-100);"
   >
     <span class="swc-Detail swc-Detail--sizeM">${label}</span>
-    <div style="display: flex; gap: ${PAIR_GAP}px;">
+    <div style="display: flex; gap: ${PAIR_GAP}px; justify-content: center;">
       ${reference} ${override}
     </div>
   </div>

--- a/CONTRIBUTOR-DOCS/02_style-guide/04_testing/04_visual-regresssion-testing.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/04_testing/04_visual-regresssion-testing.md
@@ -15,6 +15,7 @@
 - [How to author VRT stories](#how-to-author-vrt-stories)
     - [Grouping permutations into rows](#grouping-permutations-into-rows)
     - [Forced pseudo-states](#forced-pseudo-states)
+    - [Positioned overlay components](#positioned-overlay-components)
 - [Tips for reliable VRT](#tips-for-reliable-vrt)
 
 </details>
@@ -101,6 +102,20 @@ const forceCardStates = async ({ canvasElement }) => {
 Because this uses the same `data-forced-<state>` attribute the shared helper applies, the child still satisfies any `:not([class])` guard on its default styles. This stays component-specific for now — which slotted element carries the pseudo-state rule differs per component — rather than being generalized into the shared helper on a single case.
 
 Pseudo-state rules with nested rules — such as an `::after` focus ring or a nested `&:hover` — are mirrored in full, so their nested appearance renders correctly in the forced snapshot with no extra authoring.
+
+### Positioned overlay components
+
+Components built on `PlacementController` (popover, tooltip, and future components such as picker and combobox) position their surface with floating-ui's `shift` middleware. `shift` has no configurable boundary; it defaults to the current viewport, and `autoUpdate` recomputes the position on every scroll. This is correct production behavior (a popover pinned near a screen edge should slide rather than clip off-screen), but it means a trigger positioned outside the viewport at the moment its popover opens gets clamped to wherever the viewport currently is, not to its actual (off-screen) trigger.
+
+A dense VRT matrix that opens many instances at once on a page taller than one viewport can hit this: instances whose triggers land outside the initial viewport collapse onto the same clamped position instead of resolving distinct ones. Only the axis perpendicular to the requested placement (the cross-axis) is affected — a `top`/`bottom` placement's cross-axis is horizontal, so it is unaffected on a page that only scrolls vertically; a `start`/`end` placement's cross-axis is vertical, so it is affected.
+
+To avoid it:
+
+- Render the affected placements first on the page (or as the only content in their own story), so their triggers stay within the viewport's initial bounds when they open.
+- Stack them in a column rather than packing them side by side, so siblings extending along the same axis don't overlap each other either.
+- If an axis needs its own RTL or theme variant and doesn't fit on the same page as everything else for this reason, give it its own story rather than making the page taller.
+
+See popover's `test/vrt/popover.vrt.ts` and `test/vrt/vrt-helpers.ts` (`stack`, `vrtPage`, `openManyPopoversForVrt`) for a worked example.
 
 ## Tips for reliable VRT
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/04_testing/04_visual-regresssion-testing.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/04_testing/04_visual-regresssion-testing.md
@@ -111,8 +111,8 @@ A dense VRT matrix that opens many instances at once on a page taller than one v
 
 To keep snapshots deterministic:
 
-- Render the affected placements first (or in their own story) so their triggers stay in the initial viewport when they open. Split the story if growing the page would push those triggers below the fold.
-- Do not use the shared `row()` helper. Open surfaces paint in the top layer and overlap if packed horizontally; stack them in a column with local helpers instead.
+- Keep every trigger in the viewport at open time. Put `start`/`end` first, pin the Chromatic viewport so the story fits, or split the story. Growing the page without growing the viewport is what clamps bubbles off their triggers.
+- Do not use the shared `row()` helper. Open surfaces paint in the top layer and overlap at its default gaps. Stack in a column, or use a grid whose cells reserve enough room that adjacent bubbles cannot collide.
 
 See popover's `test/vrt/popover.vrt.ts` and `test/vrt/vrt-helpers.ts` (`stack`, `vrtPage`, `openManyPopoversForVrt`) for a worked example.
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/04_testing/04_visual-regresssion-testing.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/04_testing/04_visual-regresssion-testing.md
@@ -105,15 +105,14 @@ Pseudo-state rules with nested rules — such as an `::after` focus ring or a ne
 
 ### Positioned overlay components
 
-Components built on `PlacementController` (popover, tooltip, and future components such as picker and combobox) position their surface with floating-ui's `shift` middleware. `shift` has no configurable boundary; it defaults to the current viewport, and `autoUpdate` recomputes the position on every scroll. This is correct production behavior (a popover pinned near a screen edge should slide rather than clip off-screen), but it means a trigger positioned outside the viewport at the moment its popover opens gets clamped to wherever the viewport currently is, not to its actual (off-screen) trigger.
+Components that position a surface with `PlacementController` use Floating UI's `shift` middleware. The controller does not expose a custom overflow boundary, so `shift` uses clipping ancestors capped by the visual viewport, and `autoUpdate` recomputes on scroll. That is correct production behavior (a popover pinned near a screen edge should slide rather than clip off-screen), but a trigger outside the viewport at open time gets clamped to the current viewport, not to its off-screen position.
 
-A dense VRT matrix that opens many instances at once on a page taller than one viewport can hit this: instances whose triggers land outside the initial viewport collapse onto the same clamped position instead of resolving distinct ones. Only the axis perpendicular to the requested placement (the cross-axis) is affected — a `top`/`bottom` placement's cross-axis is horizontal, so it is unaffected on a page that only scrolls vertically; a `start`/`end` placement's cross-axis is vertical, so it is affected.
+A dense VRT matrix that opens many instances at once on a page taller than one viewport can collapse those off-screen triggers onto the same spot. Only the cross-axis is affected: `top`/`bottom` is horizontal, so it is safe on a vertically scrolling page; `start`/`end` is vertical, so it is not. Disable `shouldFlip` in the play function so leftover viewport space cannot flip a surface to the other side.
 
-To avoid it:
+To keep snapshots deterministic:
 
-- Render the affected placements first on the page (or as the only content in their own story), so their triggers stay within the viewport's initial bounds when they open.
-- Stack them in a column rather than packing them side by side, so siblings extending along the same axis don't overlap each other either.
-- If an axis needs its own RTL or theme variant and doesn't fit on the same page as everything else for this reason, give it its own story rather than making the page taller.
+- Render the affected placements first (or in their own story) so their triggers stay in the initial viewport when they open. Split the story if growing the page would push those triggers below the fold.
+- Do not use the shared `row()` helper. Open surfaces paint in the top layer and overlap if packed horizontally; stack them in a column with local helpers instead.
 
 See popover's `test/vrt/popover.vrt.ts` and `test/vrt/vrt-helpers.ts` (`stack`, `vrtPage`, `openManyPopoversForVrt`) for a worked example.
 


### PR DESCRIPTION
## Description

Adds dedicated Chromatic VRT coverage for popover under `test/vrt/`, following the pattern established for button.

### `test/vrt/popover.vrt.ts`

- **Permutations** — light/LTR matrix: all 12 placements, size (default + s/m/l), hide-arrow, modal (top/bottom), and content overflow (scrollable slot).
- **Permutations (RTL)** — dark/RTL smoke for `start`/`end` placement mirroring plus hide-arrow under dark theme. Split from Permutations because the overflow row’s tall top-layer surface covers a trailing dark block when both live on one page.
- **Forced Colors** — representative subset (placements, hide-arrow, modal) under `forced-colors: active`.
- **Nested** — outer + inner popovers open together via an ancestor chain (custom open sequence so the inner anchors after the outer).

### `test/vrt/popover-custom-properties.vrt.ts`

Reference vs. override rows for the four documented `--swc-popover-*` custom properties, with coverage verification in `play`.

### `test/vrt/vrt-helpers.ts`

Popover-specific VRT layout and capture helpers:

- **`openManyPopoversForVrt`** — flips non-modal instances to `popover="manual"` and disables flip so a full matrix can render open in one snapshot (VRT-only; does not change real popover behavior).
- **`stack`**, **`vrtPage`**, **`propertyCompareRow`** — row/page layout for top-layer surfaces.
- **`popoverVrtParameters`** / **`popoverForcedColorsVrtParameters`** — canvas padding and min inline size so `filter: drop-shadow` halos are not clipped in Chromatic (including size `l` and side placements).

Also removes the ad hoc VRT-only stories/helpers that previously lived in `popover.stories.ts` (predating this pattern); that coverage now lives in the dedicated files above.

## Related issue(s)

- SWC-2402

## Screenshots

N/A — see Chromatic build on this PR for the new snapshots.

## Author's checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md) and [PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md) documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Popover VRT snapshots render correctly_
  1. Open the Chromatic build linked on this PR
  2. Review `Popover/Popover VRT` — `Placements`, `Placements (RTL)`, `ForcedColors`, `Nested`, `CustomProperties`
  3. Confirm every open popover is fully visible, correctly anchored, and legible against its background, with no unintended diffs against the existing docs stories

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard**
  No new interactive surface: these are VRT-only stories tagged `dev`/`!autodocs`, not part of the docs page or sidebar. No keyboard regressions expected.

- [ ] **Screen reader**
  No new interactive surface for the same reason as above.