### PR TITLE
[Fix] Externalize Lit Labs observers from SWC builds

### DIFF
--- a/2nd-gen/packages/swc/vite.config.ts
+++ b/2nd-gen/packages/swc/vite.config.ts
@@ -142,6 +142,7 @@ export default defineConfig({
           id === 'lit' ||
           id.startsWith('lit/') ||
           id.startsWith('@lit/') ||
+          id.startsWith('@lit-labs/') ||
           id.startsWith('@adobe/spectrum-wc-core/')
         );
       },


### PR DESCRIPTION
Externalize @lit-labs/* dependencies in the SWC Vite build.

**Motivation and context**
The Vite externalization rule handled lit, lit/*, and @lit/*, but not the separate @lit-labs/* scope. As a result, @lit-labs/observers was copied into dist/node_modules, and generated component modules imported it through a relative [node_modules](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) path.

The updated rule now treats @lit-labs/* as an external runtime dependency. Generated files retain the package specifier:

This matches the package’s declared runtime dependency and prevents implementation files from being emitted into dist/node_modules.