### PR TITLE
fix(*): apply box-sizing to sized slotted elements

### DIFF
--- a/.ai/skills/migration-styling/references/tldr-component-css-guidelines.md
+++ b/.ai/skills/migration-styling/references/tldr-component-css-guidelines.md
@@ -182,3 +182,17 @@ CSS nesting inside a `:host([...])` rule — e.g. `&:dir(rtl)` — expands to `:
 
 **Migration note**: `:dir()` is a common place this surfaces. Whenever you add `:dir()` to a `:host`-level rule, write a separate `:host(:dir(rtl)[...])` rule instead of nesting.
 → See [05_anti-patterns#9](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/05_anti-patterns.md#9-nesting-compound-pseudo-classes-on-host-via-css-nesting)
+
+### 11. `box-sizing` on sized `::slotted()` rules
+
+The component's `* { box-sizing: border-box; }` reset only matches elements inside the shadow tree; it never reaches `::slotted()` content, which lives in the consumer's light DOM. Any `::slotted()` rule that sets `inline-size`, `block-size`, `width`, `height`, `aspect-ratio`, or a `max-*` size cap needs its own explicit `box-sizing: border-box` declaration, or the consumer's element can overflow the intended box if it carries its own `padding`/`border`. Does not apply to `min-*`-only constraints or keyword sizes like `fit-content`.
+
+```css
+::slotted([slot='preview']) {
+  box-sizing: border-box;
+  inline-size: 100%;
+  aspect-ratio: 3 / 2;
+}
+```
+
+→ See [05_anti-patterns#13](../../../../CONTRIBUTOR-DOCS/02_style-guide/01_css/05_anti-patterns.md#13-missing-box-sizing-on-sized-slotted-rules)

--- a/.changeset/fix-slotted-box-sizing.md
+++ b/.changeset/fix-slotted-box-sizing.md
@@ -1,0 +1,5 @@
+---
+'@adobe/spectrum-wc': patch
+---
+
+**fix(\*):** Added explicit `box-sizing: border-box` to `::slotted()` rules that constrain slotted content to a fixed `inline-size`, `block-size`, `aspect-ratio`, or `max-*` size across `<swc-card>`, `<swc-action-button>`, `<swc-button>`, `<swc-infield-button>`, `<swc-tab>`, `<swc-illustrated-message>`, `<swc-icon>`, `<swc-asset>`, and the conversational-ai `<swc-prompt-field>`, `<swc-upload-artifact>`, and `<swc-user-message>` patterns. This prevents slotted elements breaking an aspect ratio or overflowing their container.

--- a/2nd-gen/packages/swc/components/action-button/action-button.css
+++ b/2nd-gen/packages/swc/components/action-button/action-button.css
@@ -104,6 +104,7 @@ slot[name="icon"]::slotted(*),
   --_swc-action-button-icon-block-size: var(--swc-action-button-icon-block-size, var(--_swc-action-button-icon-size));
   --_swc-pending-spinner-size: var(--_swc-action-button-icon-size);
 
+  box-sizing: border-box;
   flex-shrink: 0;
   align-self: center;
   inline-size: var(--swc-action-button-icon-inline-size, var(--_swc-action-button-icon-size));

--- a/2nd-gen/packages/swc/components/asset/asset.css
+++ b/2nd-gen/packages/swc/components/asset/asset.css
@@ -28,6 +28,7 @@
 
 /* Slotted image */
 ::slotted(*) {
+  box-sizing: border-box;
   max-inline-size: 100%;
   max-block-size: 100%;
   object-fit: contain;

--- a/2nd-gen/packages/swc/components/button/button.css
+++ b/2nd-gen/packages/swc/components/button/button.css
@@ -68,6 +68,7 @@ slot[name="icon"]::slotted(*),
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
   --_swc-pending-spinner-size: var(--_swc-button-icon-size);
 
+  box-sizing: border-box;
   flex-shrink: 0;
   align-self: flex-start;
   inline-size: var(--swc-button-icon-inline-size, var(--_swc-button-icon-size));

--- a/2nd-gen/packages/swc/components/card/card.css
+++ b/2nd-gen/packages/swc/components/card/card.css
@@ -52,6 +52,7 @@
 }
 
 ::slotted([slot="collection"]) {
+  box-sizing: border-box;
   inline-size: 100%;
   aspect-ratio: var(--_swc-card-collection-item-aspect-ratio);
   pointer-events: none;

--- a/2nd-gen/packages/swc/components/illustrated-message/illustrated-message.css
+++ b/2nd-gen/packages/swc/components/illustrated-message/illustrated-message.css
@@ -157,6 +157,7 @@ slot[name="heading"] {
  * and use the component illustration color via currentcolor.
  */
 ::slotted(svg) {
+  box-sizing: border-box;
   display: block;
   inline-size: 100%;
   block-size: 100%;

--- a/2nd-gen/packages/swc/components/infield-button/infield-button.css
+++ b/2nd-gen/packages/swc/components/infield-button/infield-button.css
@@ -99,6 +99,7 @@
 /* ── Icon slot ────────────────────────────────────── */
 
 ::slotted([slot="icon"]) {
+  box-sizing: border-box;
   flex-shrink: 0;
   inline-size: var(--_swc-infield-button-icon-size);
   block-size: var(--_swc-infield-button-icon-size);

--- a/2nd-gen/packages/swc/components/tabs/tab.css
+++ b/2nd-gen/packages/swc/components/tabs/tab.css
@@ -50,6 +50,7 @@
 /* ── Icon slot ─────────────────────────────────────────── */
 
 ::slotted([slot="icon"]) {
+  box-sizing: border-box;
   display: grid;
   flex-shrink: 0;
   place-content: center;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -139,6 +139,7 @@
 }
 
 .swc-PromptField-artifacts--single > slot::slotted([type="media"]) {
+  box-sizing: border-box;
   inline-size: var(--swc-prompt-field-artifact-media-inline-size, 68px);
   min-inline-size: var(--swc-prompt-field-artifact-media-min-inline-size, 68px);
   block-size: var(--swc-prompt-field-artifact-media-block-size, 68px);
@@ -268,12 +269,14 @@
 }
 
 .swc-PromptField-artifacts-tiles > slot::slotted([type="card"]) {
+  box-sizing: border-box;
   inline-size: var(--swc-prompt-field-artifact-card-inline-size, 240px);
   min-inline-size: var(--swc-prompt-field-artifact-card-inline-size, 240px);
   max-inline-size: var(--swc-prompt-field-artifact-card-inline-size, 240px);
 }
 
 .swc-PromptField-artifacts-tiles > slot::slotted([type="media"]) {
+  box-sizing: border-box;
   inline-size: var(--swc-prompt-field-artifact-media-inline-size, 68px);
   min-inline-size: var(--swc-prompt-field-artifact-media-min-inline-size, 68px);
   max-inline-size: var(--swc-prompt-field-artifact-media-inline-size, 68px);

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -304,6 +304,7 @@
 }
 
 :host([type="media"]) .swc-UploadArtifact-thumbnail ::slotted(img) {
+  box-sizing: border-box;
   display: block;
   position: absolute;
   inset: 0;
@@ -313,6 +314,7 @@
 }
 
 :host([type="media"]) .swc-UploadArtifact-thumbnail ::slotted(*) {
+  box-sizing: border-box;
   display: block;
   position: absolute;
   inset: 0;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/user-message/user-message.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/user-message/user-message.css
@@ -93,6 +93,7 @@
 }
 
 :host([type="card"]) .swc-UserMessage-thumbnail ::slotted(*) {
+  box-sizing: border-box;
   flex-shrink: 0;
   inline-size: 32px;
   block-size: 32px;
@@ -114,6 +115,7 @@
 }
 
 :host([type="media"]) .swc-UserMessage-thumbnail ::slotted(*) {
+  box-sizing: border-box;
   position: absolute;
   inset: 0;
   inline-size: 100%;

--- a/2nd-gen/packages/swc/stylesheets/_lit-styles/card-template.css
+++ b/2nd-gen/packages/swc/stylesheets/_lit-styles/card-template.css
@@ -136,6 +136,7 @@
 }
 
 ::slotted([slot="preview"]) {
+  box-sizing: border-box;
   display: block;
   grid-area: preview;
   inline-size: 100%;

--- a/2nd-gen/packages/swc/stylesheets/_lit-styles/icon-base.css
+++ b/2nd-gen/packages/swc/stylesheets/_lit-styles/icon-base.css
@@ -62,6 +62,7 @@
 svg,
 .swc-Icon > svg,
 ::slotted(*) {
+  box-sizing: border-box;
   display: block;
   inline-size: 100%;
   block-size: 100%;

--- a/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
@@ -95,6 +95,7 @@
   --_swc-action-button-icon-block-size: var(--swc-action-button-icon-block-size, var(--_swc-action-button-icon-size));
   --_swc-pending-spinner-size: var(--_swc-action-button-icon-size);
 
+  box-sizing: border-box;
   flex-shrink: 0;
   align-self: center;
   inline-size: var(--swc-action-button-icon-inline-size, var(--_swc-action-button-icon-size));

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -99,6 +99,7 @@
   --_swc-button-icon-block-size: var(--swc-button-icon-block-size, var(--_swc-button-icon-size));
   --_swc-pending-spinner-size: var(--_swc-button-icon-size);
 
+  box-sizing: border-box;
   flex-shrink: 0;
   align-self: flex-start;
   inline-size: var(--swc-button-icon-inline-size, var(--_swc-button-icon-size));

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/01_component-css.md
@@ -71,6 +71,7 @@ Follow this outline for ordering rulesets within component stylesheets. This wil
 3. `* { box-sizing: border-box; }`
     - Unless there is a strong reason not to, this rule should be included in all components. Expand to pseudo-elements if in use.
     - Required if the component or its descendants set  `padding` and/or `border` to avoid the compounding effect against the element's size.
+    - This `*` reset does **not** reach `::slotted()` rules: slotted content lives in the consumer's light DOM, outside the shadow tree the universal selector matches. Any `::slotted()` rule that sets `inline-size`, `block-size`, `width`, `height`, `aspect-ratio`, or a `max-*` size cap needs its own explicit `box-sizing: border-box` declaration. See [anti-pattern 13](05_anti-patterns.md#13-missing-box-sizing-on-sized-slotted-rules).
 4. component styles
     - base class: `.swc-ComponentName`
     - subcomponents: `.swc-ComponentName-sub-component`

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/03_component-css-pr-checklist.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/03_component-css-pr-checklist.md
@@ -38,6 +38,7 @@ Use this checklist when opening or reviewing a PR.
 - [ ]  Non-tokenized values are limited to allowed properties (layout, alignment)
 - [ ]  Layout primitives (`gap`, alignment, min/max sizes) are preferred over margins/padding hacks
 - [ ]  Padding values are defensive, not layout-driven, where possible
+- [ ]  `::slotted()` rules that set `inline-size`, `block-size`, `width`, `height`, `aspect-ratio`, or a `max-*` size cap also declare `box-sizing: border-box` explicitly (the component's `* { box-sizing: border-box; }` reset does not reach light DOM slotted content)
 
 ## Specificity
 

--- a/CONTRIBUTOR-DOCS/02_style-guide/01_css/05_anti-patterns.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/01_css/05_anti-patterns.md
@@ -77,6 +77,11 @@
     - [Why This Happens](#why-this-happens)
     - [Why This Is a Problem](#why-this-is-a-problem)
     - [✅ Correct Approach](#-correct-approach)
+- [13. Missing `box-sizing` on Sized `::slotted()` Rules](#13-missing-box-sizing-on-sized-slotted-rules)
+    - [❌ Anti-Pattern](#-anti-pattern)
+    - [Why This Happens](#why-this-happens)
+    - [Why This Is a Problem](#why-this-is-a-problem)
+    - [✅ Correct Approach](#-correct-approach)
 - [Final Reminder](#final-reminder)
 
 </details>
@@ -626,6 +631,45 @@ During migration, this removal may affect alignment of accessories (ex. status l
 
 🔎 **Status light reference:**
 [status-light.css](../../../2nd-gen/packages/swc/components/status-light/status-light.css) sets only `font-size` and `line-height` per size; `min-block-size` and `padding-block` are absent.
+
+## 13. Missing `box-sizing` on Sized `::slotted()` Rules
+
+### ❌ Anti-Pattern
+
+```css
+* {
+  box-sizing: border-box;
+}
+
+::slotted([slot="preview"]) {
+  inline-size: 100%;
+  aspect-ratio: 3 / 2;
+}
+```
+
+### Why This Happens
+
+The component's own `* { box-sizing: border-box; }` reset (see [Rule Order, item 3](01_component-css.md#rule-order)) looks like it covers every element rendered by the component, including slotted content. It's easy to assume `::slotted()` rules inherit that reset for free.
+
+### Why This Is a Problem
+
+A universal selector written inside a shadow-scoped stylesheet only matches elements inside that shadow tree. Slotted content is authored in the consumer's light DOM; the `*` reset never reaches it. Any `::slotted()` rule that assigns a real dimensional constraint (`inline-size`, `block-size`, `width`, `height`, `aspect-ratio`, or a `max-inline-size`/`max-block-size`/`max-width`/`max-height` cap) is sized against whatever `box-sizing` the consumer's element happens to have, which defaults to `content-box`. If that element also has its own `padding` or `border` (from consumer styles, a UA stylesheet, or another library), the rendered box grows past the constraint the component intended, breaking layout, aspect ratio, or grid placement.
+
+This does not apply to `min-inline-size`/`min-block-size`-only rules (a floor, not a rendered box) or to keyword sizes like `inline-size: fit-content` (self-sizing regardless of box model).
+
+### ✅ Correct Approach
+
+Add `box-sizing: border-box` directly to every `::slotted()` rule that sets one of the dimensional properties above, even though the component already has a `*` reset elsewhere.
+
+```css
+::slotted([slot="preview"]) {
+  box-sizing: border-box;
+  inline-size: 100%;
+  aspect-ratio: 3 / 2;
+}
+```
+
+🔎 **Reference implementations:** [card.css](../../../2nd-gen/packages/swc/components/card/card.css) and [card-template.css](../../../2nd-gen/packages/swc/stylesheets/_lit-styles/card-template.css) both declare `box-sizing: border-box` on their sized `::slotted()` rules.
 
 ## Final Reminder
 


### PR DESCRIPTION
## Description

Adds an explicit `box-sizing: border-box` declaration to every `::slotted()` rule across 2nd-gen components and patterns that sets a real dimensional constraint — `inline-size`, `block-size`, `aspect-ratio`, or a `max-inline-size`/`max-block-size` cap — and didn't already declare it.

Affected files:
- `card.css`, `card-template.css` (collection/preview slots)
- `upload-artifact.css`, `user-message.css` (media thumbnails)
- `prompt-field.css` (artifact tiles)
- `tab.css`, `action-button.css`, `button.css`, `infield-button.css` (icon slots)
- `illustrated-message.css` (slotted SVG)
- `icon-base.css` (shared icon frame, also fixes the non-slotted `svg` selectors sharing the rule)
- `global-action-button.css`, `global-button.css` (generated global-style mirrors of the icon slot fix)

Also updates the style guide and migration skill docs so this isn't lost on future components:
- New anti-pattern entry (`05_anti-patterns.md`) explaining why the reset doesn't reach slotted content
- Note added to the box-sizing rule in `01_component-css.md`
- New checklist item in `03_component-css-pr-checklist.md`
- New rule added to the migration-styling skill's TL;DR reference

`min-*`-only constraints and keyword sizes like `fit-content` are intentionally excluded — they don't produce a rendered box that can overflow.

## Motivation and context

Every 2nd-gen component resets box-sizing with `* { box-sizing: border-box; }` inside its shadow-scoped stylesheet. That universal selector only matches elements in the shadow tree — it never reaches `::slotted()` content, which lives in the consumer's light DOM. Any `::slotted()` rule that constrains size (e.g. `inline-size: 100%` + `aspect-ratio`) is therefore sized against whatever box-sizing the *consumer's* element happens to have (`content-box` by default). If that element also carries its own `padding` or `border` — from consumer styles, a UA stylesheet, or another library — the rendered box grows past the intended constraint, breaking aspect ratio, causing overflow, or misaligning grid layouts. This was caught while resolving the same issue on Card's collection/preview slots and generalized across the rest of the 2nd-gen component set.

## Manual review test cases

- [ ] _Box-sizing does not change any current visual output_
  1. Run Storybook and open each affected component's Overview/Options docs page: Card, Action Button, Button, Infield Button, Tabs, Illustrated Message, Icon, Asset, and the Prompt Field / Upload Artifact / User Message conversational-ai patterns.
  2. Compare rendering against `main` and VRTs.
  3. Expect pixel-identical output — `box-sizing` only changes behavior when the slotted element also has its own padding/border, which none of the current stories set.

- [ ] _Slotted content with its own border/padding no longer overflows its constrained box_
  1. In the Card `Preview`/`Collection` story (or Prompt Field's artifact tiles), temporarily add `border: 4px solid red; padding: 8px` to the slotted element via devtools.
  2. Confirm the element stays within its constrained `inline-size`/`aspect-ratio` box instead of growing past it.
  3. Remove the temporary override — this is a manual verification step, not a permanent story change.
