### PR TITLE
chore(typography): add VRT coverage

### DIFF
--- a/2nd-gen/packages/swc/components/typography/test/vrt/typography-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/typography/test/vrt/typography-custom-properties.vrt.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import type { CustomPropertyCase } from '../../../../.storybook/helpers/index.js';
+import {
+  coveredCustomProperties,
+  customPropertyRows,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Typography/Typography VRT',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+// Typography has no custom-elements-manifest, so the manifest-driven
+// verifyCustomPropertyCoverage() (used by component custom-property VRTs)
+// has nothing to check cases against, and typography.mdx has no "CSS custom
+// properties" table to mirror either (unlike link.mdx, which
+// link-custom-properties.vrt.ts checks against). Without a real external
+// reference, a hand-maintained "documented properties" list here would just
+// be a second copy of the case list below - not a meaningful cross-check.
+// So this file skips that pattern and keeps only what's still useful: the
+// reference/override visual rows, plus a same-file duplicate-case guard.
+//
+// Scope: Heading/Title/Body/Detail also expose margin-top/bottom multiplier
+// variables (Code has no `--margins` modifier) and CJK-specific font-size/
+// line-height/letter-spacing overrides, but those are internal plumbing
+// feeding the "real" property (e.g. `--swc-heading-margin-top` is the actual
+// override point; the multiplier just computes its default) - intentionally
+// excluded from the tested surface.
+
+// Every variant shares the same eight-property shape (font-family, font-size,
+// font-weight, line-height, font-color, letter-spacing, margin-top,
+// margin-bottom), so cases are generated from one suffix/value table rather
+// than hand-typed per variant. Override values are chosen to be obviously
+// different regardless of each variant's own default: `cursive` for
+// font-family (visibly distinct from both the sans and serif token stacks),
+// `64px` for font-size (larger than any variant's default), `900` for
+// font-weight, `3` for line-height, `magenta` for font-color, `0.3em` for
+// letter-spacing, and `40px` for the block margins.
+const CORE_PROPERTY_SUFFIXES = [
+  { suffix: 'font-family', value: 'cursive' },
+  { suffix: 'font-size', value: '64px' },
+  { suffix: 'font-weight', value: '900' },
+  { suffix: 'line-height', value: '3' },
+  { suffix: 'font-color', value: 'magenta' },
+  { suffix: 'letter-spacing', value: '0.3em' },
+  { suffix: 'margin-top', value: '40px' },
+  { suffix: 'margin-bottom', value: '40px' },
+] as const;
+
+const casesFor = (prefix: string): readonly CustomPropertyCase[] =>
+  CORE_PROPERTY_SUFFIXES.map(({ suffix, value }) => ({
+    property: `--swc-${prefix}-${suffix}`,
+    value,
+  }));
+
+const HEADING_PROPERTY_CASES = casesFor('heading');
+const TITLE_PROPERTY_CASES = casesFor('title');
+const BODY_PROPERTY_CASES = casesFor('body');
+const DETAIL_PROPERTY_CASES = casesFor('detail');
+const CODE_PROPERTY_CASES = casesFor('monospace');
+
+// A fixed narrow width on every sample (reference and override alike) so
+// `line-height`'s effect is visible: at the default single-line sample
+// length, an overridden line-height has nothing to show against.
+const SAMPLE_WIDTH = 'max-inline-size: 160px;';
+
+const renderHeadingCase = (_case: CustomPropertyCase, style?: string) => html`
+  <h2 class="swc-Heading" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    Reserved for main page heading
+  </h2>
+`;
+
+const renderTitleCase = (_case: CustomPropertyCase, style?: string) => html`
+  <h3 class="swc-Title" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    Important information and wayfinding
+  </h3>
+`;
+
+const renderBodyCase = (_case: CustomPropertyCase, style?: string) => html`
+  <p class="swc-Body" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    Body copy should be readable and comfortable for longer blocks of text.
+  </p>
+`;
+
+const renderDetailCase = (_case: CustomPropertyCase, style?: string) => html`
+  <p class="swc-Detail" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    Supporting metadata
+  </p>
+`;
+
+const renderCodeCase = (_case: CustomPropertyCase, style?: string) => html`
+  <code class="swc-Code" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    console.log('Hello world');
+  </code>
+`;
+
+// A plain heading, not `row()`: `customPropertyRows()` already returns one
+// fully-built `row()` per property, so wrapping that array in another
+// `row()` would flex-wrap those pre-built blocks together instead of
+// stacking them.
+const sectionHeading = (label: string) => html`
+  <span class="swc-Detail swc-Detail--sizeM" style="font-weight: bold;">
+    ${label}
+  </span>
+`;
+
+const customPropertiesContent = () => html`
+  ${sectionHeading('Heading')}
+  ${customPropertyRows(HEADING_PROPERTY_CASES, renderHeadingCase)}
+  ${sectionHeading('Title')}
+  ${customPropertyRows(TITLE_PROPERTY_CASES, renderTitleCase)}
+  ${sectionHeading('Body')}
+  ${customPropertyRows(BODY_PROPERTY_CASES, renderBodyCase)}
+  ${sectionHeading('Detail')}
+  ${customPropertyRows(DETAIL_PROPERTY_CASES, renderDetailCase)}
+  ${sectionHeading('Code')}
+  ${customPropertyRows(CODE_PROPERTY_CASES, renderCodeCase)}
+`;
+
+const coveredTypographyProperties = coveredCustomProperties([
+  ...HEADING_PROPERTY_CASES,
+  ...TITLE_PROPERTY_CASES,
+  ...BODY_PROPERTY_CASES,
+  ...DETAIL_PROPERTY_CASES,
+  ...CODE_PROPERTY_CASES,
+]);
+
+// Guards against a copy-paste mistake (e.g. calling casesFor() twice for the
+// same prefix) producing two rows for the same property. No documented-list
+// cross-check here - see the top-of-file note on why.
+const verifyTypographyCustomPropertyCoverage = async () => {
+  await expect(coveredTypographyProperties).toHaveLength(
+    new Set(coveredTypographyProperties).size
+  );
+};
+
+// VRT stories
+
+export const CustomProperties: Story = {
+  render: () => theme(customPropertiesContent(), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: verifyTypographyCustomPropertyCoverage,
+};

--- a/2nd-gen/packages/swc/components/typography/test/vrt/typography-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/typography/test/vrt/typography-custom-properties.vrt.ts
@@ -38,17 +38,20 @@ export default meta;
 // has nothing to check cases against. DOCUMENTED_TYPOGRAPHY_PROPERTIES is
 // the manual equivalent: it must stay in sync with the "CSS custom
 // properties" table in typography.mdx, and
-// verifyTypographyCustomPropertyCoverage() below fails if a case is missing,
-// duplicated, or covers a property that isn't in this list - the same
-// safety net link-custom-properties.vrt.ts gets from DOCUMENTED_LINK_PROPERTIES,
+// verifyTypographyCustomPropertyCoverage() below fails if a case is
+// missing, duplicated, or undocumented - the same safety net
+// link-custom-properties.vrt.ts gets from DOCUMENTED_LINK_PROPERTIES,
 // minus the manifest.
 //
-// Scope: Heading/Title/Body/Detail also expose margin-top/bottom multiplier
-// variables (Code has no `--margins` modifier) and CJK-specific font-size/
-// line-height/letter-spacing overrides, but those are internal plumbing
-// feeding the "real" property (e.g. `--swc-heading-margin-top` is the actual
-// override point; the multiplier just computes its default) - intentionally
-// excluded from the tested surface.
+// Scope: Heading/Title/Body/Detail also expose margin-top/bottom
+// multiplier variables (Code has no `--margins` modifier), which compute
+// the *default* for `--swc-*-margin-top`/`-bottom` (e.g.
+// `--swc-heading-margin-top-multiplier` times font-size). They're internal
+// plumbing, not a property a consumer sets directly, so they're excluded
+// from the tested surface. CJK font-size/line-height/letter-spacing
+// overrides (`--swc-*-cjk-*`) are different: real, independently settable
+// override points, just scoped to `:lang(zh|ja|ko)` rather than always
+// active, so they're covered below alongside their base properties.
 
 // Every variant shares the same eight-property shape (font-family, font-size,
 // font-weight, line-height, font-color, letter-spacing, margin-top,
@@ -80,6 +83,9 @@ const casesFor = (prefix: string): readonly CustomPropertyCase[] =>
 // to match coveredCustomProperties()'s own sort), so an addition or removal
 // on either side trips verifyTypographyCustomPropertyCoverage() below.
 const DOCUMENTED_TYPOGRAPHY_PROPERTIES = [
+  '--swc-body-cjk-font-size',
+  '--swc-body-cjk-letter-spacing',
+  '--swc-body-cjk-line-height',
   '--swc-body-font-color',
   '--swc-body-font-family',
   '--swc-body-font-size',
@@ -88,6 +94,8 @@ const DOCUMENTED_TYPOGRAPHY_PROPERTIES = [
   '--swc-body-line-height',
   '--swc-body-margin-bottom',
   '--swc-body-margin-top',
+  '--swc-detail-cjk-letter-spacing',
+  '--swc-detail-cjk-line-height',
   '--swc-detail-font-color',
   '--swc-detail-font-family',
   '--swc-detail-font-size',
@@ -96,6 +104,9 @@ const DOCUMENTED_TYPOGRAPHY_PROPERTIES = [
   '--swc-detail-line-height',
   '--swc-detail-margin-bottom',
   '--swc-detail-margin-top',
+  '--swc-heading-cjk-font-size',
+  '--swc-heading-cjk-letter-spacing',
+  '--swc-heading-cjk-line-height',
   '--swc-heading-font-color',
   '--swc-heading-font-family',
   '--swc-heading-font-size',
@@ -104,6 +115,7 @@ const DOCUMENTED_TYPOGRAPHY_PROPERTIES = [
   '--swc-heading-line-height',
   '--swc-heading-margin-bottom',
   '--swc-heading-margin-top',
+  '--swc-monospace-cjk-line-height',
   '--swc-monospace-font-color',
   '--swc-monospace-font-family',
   '--swc-monospace-font-size',
@@ -112,6 +124,9 @@ const DOCUMENTED_TYPOGRAPHY_PROPERTIES = [
   '--swc-monospace-line-height',
   '--swc-monospace-margin-bottom',
   '--swc-monospace-margin-top',
+  '--swc-title-cjk-font-size',
+  '--swc-title-cjk-letter-spacing',
+  '--swc-title-cjk-line-height',
   '--swc-title-font-color',
   '--swc-title-font-family',
   '--swc-title-font-size',
@@ -127,6 +142,47 @@ const TITLE_PROPERTY_CASES = casesFor('title');
 const BODY_PROPERTY_CASES = casesFor('body');
 const DETAIL_PROPERTY_CASES = casesFor('detail');
 const CODE_PROPERTY_CASES = casesFor('monospace');
+
+// Mirrors CORE_PROPERTY_SUFFIXES for the `--swc-*-cjk-*` override points
+// (see the top-of-file note on why they're tested separately). Values
+// differ from CORE_PROPERTY_SUFFIXES so a case rendered without its `lang`
+// attribute would still look wrong, rather than accidentally matching the
+// core override.
+const CJK_PROPERTY_SUFFIXES = [
+  { suffix: 'cjk-font-size', value: '48px' },
+  { suffix: 'cjk-line-height', value: '4' },
+  { suffix: 'cjk-letter-spacing', value: '0.5em' },
+] as const;
+
+type CjkSuffix = (typeof CJK_PROPERTY_SUFFIXES)[number]['suffix'];
+
+const cjkCasesFor = (
+  prefix: string,
+  suffixes: readonly CjkSuffix[]
+): readonly CustomPropertyCase[] =>
+  CJK_PROPERTY_SUFFIXES.filter(({ suffix }) => suffixes.includes(suffix)).map(
+    ({ suffix, value }) => ({
+      property: `--swc-${prefix}-${suffix}`,
+      value,
+    })
+  );
+
+const ALL_CJK_SUFFIXES: readonly CjkSuffix[] = [
+  'cjk-font-size',
+  'cjk-line-height',
+  'cjk-letter-spacing',
+];
+
+// Detail overrides only line-height/letter-spacing under :lang(); Code
+// (monospace) overrides only line-height. See typography.css.
+const HEADING_CJK_PROPERTY_CASES = cjkCasesFor('heading', ALL_CJK_SUFFIXES);
+const TITLE_CJK_PROPERTY_CASES = cjkCasesFor('title', ALL_CJK_SUFFIXES);
+const BODY_CJK_PROPERTY_CASES = cjkCasesFor('body', ALL_CJK_SUFFIXES);
+const DETAIL_CJK_PROPERTY_CASES = cjkCasesFor('detail', [
+  'cjk-line-height',
+  'cjk-letter-spacing',
+]);
+const CODE_CJK_PROPERTY_CASES = cjkCasesFor('monospace', ['cjk-line-height']);
 
 // A fixed narrow width on every sample (reference and override alike) so
 // `line-height`'s effect is visible: at the default single-line sample
@@ -163,6 +219,44 @@ const renderCodeCase = (_case: CustomPropertyCase, style?: string) => html`
   </code>
 `;
 
+// `lang="ja"` activates the `:lang(zh|ja|ko)` scope so the cjk-* override
+// actually resolves; without it, e.g. `--swc-heading-cjk-line-height`
+// would have no visible effect. Heading/Title/Body text reuses
+// typography.vrt.ts's CJK content; Detail/Code have no counterpart there,
+// so this adds representative copy for those two.
+const renderHeadingCjkCase = (
+  _case: CustomPropertyCase,
+  style?: string
+) => html`
+  <h2 class="swc-Heading" lang="ja" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    承認ワークフローを開始
+  </h2>
+`;
+
+const renderTitleCjkCase = (_case: CustomPropertyCase, style?: string) => html`
+  <h3 class="swc-Title" lang="ja" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    仕様
+  </h3>
+`;
+
+const renderBodyCjkCase = (_case: CustomPropertyCase, style?: string) => html`
+  <p class="swc-Body" lang="ja" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    アップロードまたはインポートしてください。
+  </p>
+`;
+
+const renderDetailCjkCase = (_case: CustomPropertyCase, style?: string) => html`
+  <p class="swc-Detail" lang="ja" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    補足情報
+  </p>
+`;
+
+const renderCodeCjkCase = (_case: CustomPropertyCase, style?: string) => html`
+  <code class="swc-Code" lang="ja" style="${SAMPLE_WIDTH} ${style ?? ''}">
+    console.log('Hello world');
+  </code>
+`;
+
 // A plain heading, not `row()`: `customPropertyRows()` already returns one
 // fully-built `row()` per property, so wrapping that array in another
 // `row()` would flex-wrap those pre-built blocks together instead of
@@ -176,22 +270,37 @@ const sectionHeading = (label: string) => html`
 const customPropertiesContent = () => html`
   ${sectionHeading('Heading')}
   ${customPropertyRows(HEADING_PROPERTY_CASES, renderHeadingCase)}
+  ${sectionHeading('Heading · CJK')}
+  ${customPropertyRows(HEADING_CJK_PROPERTY_CASES, renderHeadingCjkCase)}
   ${sectionHeading('Title')}
   ${customPropertyRows(TITLE_PROPERTY_CASES, renderTitleCase)}
+  ${sectionHeading('Title · CJK')}
+  ${customPropertyRows(TITLE_CJK_PROPERTY_CASES, renderTitleCjkCase)}
   ${sectionHeading('Body')}
   ${customPropertyRows(BODY_PROPERTY_CASES, renderBodyCase)}
+  ${sectionHeading('Body · CJK')}
+  ${customPropertyRows(BODY_CJK_PROPERTY_CASES, renderBodyCjkCase)}
   ${sectionHeading('Detail')}
   ${customPropertyRows(DETAIL_PROPERTY_CASES, renderDetailCase)}
+  ${sectionHeading('Detail · CJK')}
+  ${customPropertyRows(DETAIL_CJK_PROPERTY_CASES, renderDetailCjkCase)}
   ${sectionHeading('Code')}
   ${customPropertyRows(CODE_PROPERTY_CASES, renderCodeCase)}
+  ${sectionHeading('Code · CJK')}
+  ${customPropertyRows(CODE_CJK_PROPERTY_CASES, renderCodeCjkCase)}
 `;
 
 const coveredTypographyProperties = coveredCustomProperties([
   ...HEADING_PROPERTY_CASES,
+  ...HEADING_CJK_PROPERTY_CASES,
   ...TITLE_PROPERTY_CASES,
+  ...TITLE_CJK_PROPERTY_CASES,
   ...BODY_PROPERTY_CASES,
+  ...BODY_CJK_PROPERTY_CASES,
   ...DETAIL_PROPERTY_CASES,
+  ...DETAIL_CJK_PROPERTY_CASES,
   ...CODE_PROPERTY_CASES,
+  ...CODE_CJK_PROPERTY_CASES,
 ]);
 
 // Manual stand-in for verifyCustomPropertyCoverage(): no duplicate cases

--- a/2nd-gen/packages/swc/components/typography/test/vrt/typography-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/typography/test/vrt/typography-custom-properties.vrt.ts
@@ -33,35 +33,22 @@ export default meta;
 
 // Helpers
 
-// Typography has no custom-elements-manifest, so the manifest-driven
-// verifyCustomPropertyCoverage() (used by component custom-property VRTs)
-// has nothing to check cases against. DOCUMENTED_TYPOGRAPHY_PROPERTIES is
-// the manual equivalent: it must stay in sync with the "CSS custom
+// Typography has no custom-elements-manifest, so DOCUMENTED_TYPOGRAPHY_PROPERTIES
+// is the manual equivalent: it must stay in sync with the "CSS custom
 // properties" table in typography.mdx, and
 // verifyTypographyCustomPropertyCoverage() below fails if a case is
-// missing, duplicated, or undocumented - the same safety net
-// link-custom-properties.vrt.ts gets from DOCUMENTED_LINK_PROPERTIES,
-// minus the manifest.
+// missing, duplicated, or undocumented.
 //
-// Scope: Heading/Title/Body/Detail also expose margin-top/bottom
-// multiplier variables (Code has no `--margins` modifier), which compute
-// the *default* for `--swc-*-margin-top`/`-bottom` (e.g.
-// `--swc-heading-margin-top-multiplier` times font-size). They're internal
-// plumbing, not a property a consumer sets directly, so they're excluded
-// from the tested surface. CJK font-size/line-height/letter-spacing
-// overrides (`--swc-*-cjk-*`) are different: real, independently settable
-// override points, just scoped to `:lang(zh|ja|ko)` rather than always
-// active, so they're covered below alongside their base properties.
+// Scope: margin-top/bottom multiplier variables are internal plumbing
+// (not consumer-set) and excluded. CJK font-size/line-height/letter-spacing
+// overrides are real override points, just scoped to `:lang(zh|ja|ko)`,
+// so they're covered below alongside their base properties.
 
 // Every variant shares the same eight-property shape (font-family, font-size,
 // font-weight, line-height, font-color, letter-spacing, margin-top,
 // margin-bottom), so cases are generated from one suffix/value table rather
 // than hand-typed per variant. Override values are chosen to be obviously
-// different regardless of each variant's own default: `cursive` for
-// font-family (visibly distinct from both the sans and serif token stacks),
-// `64px` for font-size (larger than any variant's default), `900` for
-// font-weight, `3` for line-height, `magenta` for font-color, `0.3em` for
-// letter-spacing, and `40px` for the block margins.
+// different from any variant's default.
 const CORE_PROPERTY_SUFFIXES = [
   { suffix: 'font-family', value: 'cursive' },
   { suffix: 'font-size', value: '64px' },

--- a/2nd-gen/packages/swc/components/typography/test/vrt/typography-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/typography/test/vrt/typography-custom-properties.vrt.ts
@@ -35,13 +35,13 @@ export default meta;
 
 // Typography has no custom-elements-manifest, so the manifest-driven
 // verifyCustomPropertyCoverage() (used by component custom-property VRTs)
-// has nothing to check cases against, and typography.mdx has no "CSS custom
-// properties" table to mirror either (unlike link.mdx, which
-// link-custom-properties.vrt.ts checks against). Without a real external
-// reference, a hand-maintained "documented properties" list here would just
-// be a second copy of the case list below - not a meaningful cross-check.
-// So this file skips that pattern and keeps only what's still useful: the
-// reference/override visual rows, plus a same-file duplicate-case guard.
+// has nothing to check cases against. DOCUMENTED_TYPOGRAPHY_PROPERTIES is
+// the manual equivalent: it must stay in sync with the "CSS custom
+// properties" table in typography.mdx, and
+// verifyTypographyCustomPropertyCoverage() below fails if a case is missing,
+// duplicated, or covers a property that isn't in this list - the same
+// safety net link-custom-properties.vrt.ts gets from DOCUMENTED_LINK_PROPERTIES,
+// minus the manifest.
 //
 // Scope: Heading/Title/Body/Detail also expose margin-top/bottom multiplier
 // variables (Code has no `--margins` modifier) and CJK-specific font-size/
@@ -75,6 +75,52 @@ const casesFor = (prefix: string): readonly CustomPropertyCase[] =>
     property: `--swc-${prefix}-${suffix}`,
     value,
   }));
+
+// Mirrors typography.mdx's "CSS custom properties" table exactly (sorted,
+// to match coveredCustomProperties()'s own sort), so an addition or removal
+// on either side trips verifyTypographyCustomPropertyCoverage() below.
+const DOCUMENTED_TYPOGRAPHY_PROPERTIES = [
+  '--swc-body-font-color',
+  '--swc-body-font-family',
+  '--swc-body-font-size',
+  '--swc-body-font-weight',
+  '--swc-body-letter-spacing',
+  '--swc-body-line-height',
+  '--swc-body-margin-bottom',
+  '--swc-body-margin-top',
+  '--swc-detail-font-color',
+  '--swc-detail-font-family',
+  '--swc-detail-font-size',
+  '--swc-detail-font-weight',
+  '--swc-detail-letter-spacing',
+  '--swc-detail-line-height',
+  '--swc-detail-margin-bottom',
+  '--swc-detail-margin-top',
+  '--swc-heading-font-color',
+  '--swc-heading-font-family',
+  '--swc-heading-font-size',
+  '--swc-heading-font-weight',
+  '--swc-heading-letter-spacing',
+  '--swc-heading-line-height',
+  '--swc-heading-margin-bottom',
+  '--swc-heading-margin-top',
+  '--swc-monospace-font-color',
+  '--swc-monospace-font-family',
+  '--swc-monospace-font-size',
+  '--swc-monospace-font-weight',
+  '--swc-monospace-letter-spacing',
+  '--swc-monospace-line-height',
+  '--swc-monospace-margin-bottom',
+  '--swc-monospace-margin-top',
+  '--swc-title-font-color',
+  '--swc-title-font-family',
+  '--swc-title-font-size',
+  '--swc-title-font-weight',
+  '--swc-title-letter-spacing',
+  '--swc-title-line-height',
+  '--swc-title-margin-bottom',
+  '--swc-title-margin-top',
+] as const;
 
 const HEADING_PROPERTY_CASES = casesFor('heading');
 const TITLE_PROPERTY_CASES = casesFor('title');
@@ -148,13 +194,17 @@ const coveredTypographyProperties = coveredCustomProperties([
   ...CODE_PROPERTY_CASES,
 ]);
 
-// Guards against a copy-paste mistake (e.g. calling casesFor() twice for the
-// same prefix) producing two rows for the same property. No documented-list
-// cross-check here - see the top-of-file note on why.
+// Manual stand-in for verifyCustomPropertyCoverage(): no duplicate cases
+// (e.g. from calling casesFor() twice for the same prefix), and the covered
+// set matches typography.mdx's documented list exactly (both are sorted, so
+// an extra or missing property trips the equality check).
 const verifyTypographyCustomPropertyCoverage = async () => {
   await expect(coveredTypographyProperties).toHaveLength(
     new Set(coveredTypographyProperties).size
   );
+  await expect(coveredTypographyProperties).toEqual([
+    ...DOCUMENTED_TYPOGRAPHY_PROPERTIES,
+  ]);
 };
 
 // VRT stories

--- a/2nd-gen/packages/swc/components/typography/test/vrt/typography.vrt.ts
+++ b/2nd-gen/packages/swc/components/typography/test/vrt/typography.vrt.ts
@@ -151,6 +151,39 @@ const permutationContent = () => html`
     'Emphasized modifier'
   )}
   ${row(
+    // typography.mdx documents that emphasized "may also be applied to the
+    // serif sub-variants", so this checks the italic style still applies on
+    // top of the serif font-family/weight override rather than being reset
+    // by it.
+    [
+      modifiedSample(
+        'h2',
+        'swc-Heading',
+        'swc-Heading--serif swc-Typography--emphasized',
+        'Heading serif emphasized'
+      ),
+      modifiedSample(
+        'h3',
+        'swc-Title',
+        'swc-Title--serif swc-Typography--emphasized',
+        'Title serif emphasized'
+      ),
+      modifiedSample(
+        'p',
+        'swc-Body',
+        'swc-Body--serif swc-Typography--emphasized',
+        'Body serif emphasized'
+      ),
+      modifiedSample(
+        'p',
+        'swc-Detail',
+        'swc-Detail--serif swc-Typography--emphasized',
+        'Detail serif emphasized'
+      ),
+    ],
+    'Serif + emphasized modifier'
+  )}
+  ${row(
     [
       modifiedSample(
         'h2',

--- a/2nd-gen/packages/swc/components/typography/test/vrt/typography.vrt.ts
+++ b/2nd-gen/packages/swc/components/typography/test/vrt/typography.vrt.ts
@@ -162,6 +162,20 @@ const permutationContent = () => html`
     'Heading heavy modifier'
   )}
   ${row(
+    // --heavy exists only on Heading, so this pairing is a single sample
+    // rather than one per variant. Both classes touch font-weight, so this
+    // checks --heavy still wins.
+    [
+      modifiedSample(
+        'h2',
+        'swc-Heading',
+        'swc-Heading--serif swc-Heading--heavy',
+        'Heading serif heavy'
+      ),
+    ],
+    'Serif + heavy modifier'
+  )}
+  ${row(
     [
       html`
         <div>

--- a/2nd-gen/packages/swc/components/typography/test/vrt/typography.vrt.ts
+++ b/2nd-gen/packages/swc/components/typography/test/vrt/typography.vrt.ts
@@ -1,0 +1,304 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import {
+  forcedColorsVrtParameters,
+  row,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+
+// Metadata
+
+// Typography is a "component replacement" stylesheet: a pure CSS class
+// vocabulary with no custom-element counterpart (see CONTRIBUTOR-DOCS's
+// Non-component stylesheets guide). No `component:` field on meta, matching
+// link.vrt.ts's pattern for the same unit category.
+const meta: Meta = {
+  title: 'Typography/Typography VRT',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+// Every heading/title/body/detail/code size, keyed by variant since each
+// variant supports a different size range (Body runs XXS-XXXL, Detail and
+// Code only run XS-XL). Sample text spells out the variant and size so each
+// item is self-identifying without a separate caption.
+const HEADING_SIZES = ['XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL', 'XXXXL'];
+const TITLE_SIZES = ['XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL'];
+const BODY_SIZES = ['XXS', 'XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL'];
+const DETAIL_SIZES = ['XS', 'S', 'M', 'L', 'XL'];
+const CODE_SIZES = ['XS', 'S', 'M', 'L', 'XL'];
+
+const sizeClass = (base: string, size: string) => `${base}--size${size}`;
+
+// Single tag-to-markup switch shared by every sample below (sizes and
+// modifiers alike), so there's one place that knows how to render each of
+// the four element types this stylesheet targets.
+const sample = (
+  tag: 'h2' | 'h3' | 'p' | 'code',
+  className: string,
+  text: string
+) => {
+  switch (tag) {
+    case 'h2':
+      return html`
+        <h2 class=${className}>${text}</h2>
+      `;
+    case 'h3':
+      return html`
+        <h3 class=${className}>${text}</h3>
+      `;
+    case 'code':
+      return html`
+        <code class=${className}>${text}</code>
+      `;
+    default:
+      return html`
+        <p class=${className}>${text}</p>
+      `;
+  }
+};
+
+// The base class is named once per call site (as `base`), not duplicated as
+// both a literal class token and a `sizeClass()` argument, so a typo in one
+// can't silently decouple the size modifier from its base class.
+const sizedSample = (
+  tag: 'h2' | 'h3' | 'p' | 'code',
+  base: string,
+  label: string,
+  size: string
+) => sample(tag, `${base} ${sizeClass(base, size)}`, `${label} ${size}`);
+
+const heading = (size: string) =>
+  sizedSample('h2', 'swc-Heading', 'Heading', size);
+const title = (size: string) => sizedSample('h3', 'swc-Title', 'Title', size);
+const body = (size: string) => sizedSample('p', 'swc-Body', 'Body', size);
+const detail = (size: string) => sizedSample('p', 'swc-Detail', 'Detail', size);
+const code = (size: string) => sizedSample('code', 'swc-Code', 'Code', size);
+
+// Serif/emphasized/heavy modifiers each add one class alongside the base
+// variant class; one representative size (M) is enough per modifier since
+// its effect (font-family, italic, weight) is independent of size.
+const modifiedSample = (
+  tag: 'h2' | 'h3' | 'p',
+  base: string,
+  modifierClasses: string,
+  text: string
+) => sample(tag, `${base} ${modifierClasses}`.trim(), text);
+
+const permutationContent = () => html`
+  ${row(HEADING_SIZES.map(heading), 'Heading')}
+  ${row(TITLE_SIZES.map(title), 'Title')} ${row(BODY_SIZES.map(body), 'Body')}
+  ${row(DETAIL_SIZES.map(detail), 'Detail')}
+  ${row(CODE_SIZES.map(code), 'Code')}
+  ${row(
+    [
+      modifiedSample(
+        'h2',
+        'swc-Heading',
+        'swc-Heading--serif',
+        'Heading serif'
+      ),
+      modifiedSample('h3', 'swc-Title', 'swc-Title--serif', 'Title serif'),
+      modifiedSample('p', 'swc-Body', 'swc-Body--serif', 'Body serif'),
+      modifiedSample('p', 'swc-Detail', 'swc-Detail--serif', 'Detail serif'),
+    ],
+    'Serif modifier'
+  )}
+  ${row(
+    [
+      modifiedSample(
+        'h2',
+        'swc-Heading',
+        'swc-Typography--emphasized',
+        'Heading emphasized'
+      ),
+      modifiedSample(
+        'h3',
+        'swc-Title',
+        'swc-Typography--emphasized',
+        'Title emphasized'
+      ),
+      modifiedSample(
+        'p',
+        'swc-Body',
+        'swc-Typography--emphasized',
+        'Body emphasized'
+      ),
+      modifiedSample(
+        'p',
+        'swc-Detail',
+        'swc-Typography--emphasized',
+        'Detail emphasized'
+      ),
+    ],
+    'Emphasized modifier'
+  )}
+  ${row(
+    [
+      modifiedSample(
+        'h2',
+        'swc-Heading',
+        'swc-Heading--heavy',
+        'Heading heavy'
+      ),
+    ],
+    'Heading heavy modifier'
+  )}
+  ${row(
+    [
+      html`
+        <div>
+          <p class="swc-Body swc-Body--margins">
+            First paragraph with the margins modifier.
+          </p>
+          <p class="swc-Body swc-Body--margins">
+            Second paragraph, showing the block-start/end gap between them.
+          </p>
+        </div>
+      `,
+    ],
+    'Margins modifier'
+  )}
+  ${row(
+    [
+      html`
+        <div class="swc-Typography--prose" style="max-inline-size: 320px;">
+          <h1>Semantic h1</h1>
+          <h2>Semantic h2</h2>
+          <p>
+            Semantic paragraph with an
+            <a href="#" onclick="return false;">inline link</a>
+            that inherits body typography.
+          </p>
+          <h3>Semantic h3</h3>
+          <h4>Semantic h4</h4>
+          <ul>
+            <li>Semantic list item</li>
+          </ul>
+        </div>
+      `,
+    ],
+    'Prose container'
+  )}
+  ${row(
+    [
+      html`
+        <ul
+          class="swc-Typography--links"
+          style="list-style: none; padding: 0; margin: 0;"
+        >
+          <li><a href="#" onclick="return false;">Privacy policy</a></li>
+          <li><a href="#" onclick="return false;">Terms of use</a></li>
+        </ul>
+      `,
+    ],
+    'Link list'
+  )}
+  ${row(
+    [
+      html`
+        <h2 class="swc-Heading" lang="ar" dir="rtl">مرحبا بالعالم</h2>
+      `,
+      html`
+        <h2 class="swc-Heading" lang="he" dir="rtl">שלום עולם</h2>
+      `,
+    ],
+    'Arabic/Hebrew font-family'
+  )}
+  ${cjkContent()}
+`;
+
+// CJK content exercises typography.css's `:lang(zh|ja|ko)` overrides, so
+// unlike most VRT files this isn't a supplementary check - it's a core,
+// load-bearing feature. Grouped by language (each row holding
+// heading/title/body) rather than by variant: heading/title/body override
+// font-size, line-height, and letter-spacing under `:lang()`, a superset of
+// what detail/code override (line-height + letter-spacing, or line-height
+// only), so this set is enough to prove the mechanism without also
+// translating detail/code samples. Included in both the light/ltr and
+// dark/rtl passes below since these overrides are theme-independent and
+// worth confirming under both color schemes, same as every other row here.
+const cjkContent = () => html`
+  ${row(
+    [
+      html`
+        <h2 class="swc-Heading" lang="ja">承認ワークフローを開始</h2>
+      `,
+      html`
+        <h3 class="swc-Title" lang="ja">仕様</h3>
+      `,
+      html`
+        <p class="swc-Body" lang="ja">
+          アップロードまたはインポートしてください。
+        </p>
+      `,
+    ],
+    'CJK · Japanese'
+  )}
+  ${row(
+    [
+      html`
+        <h2 class="swc-Heading" lang="ko">승인 워크플로 시작</h2>
+      `,
+      html`
+        <h3 class="swc-Title" lang="ko">사양</h3>
+      `,
+      html`
+        <p class="swc-Body" lang="ko">업로드하거나 가져와서 시작하세요.</p>
+      `,
+    ],
+    'CJK · Korean'
+  )}
+  ${row(
+    [
+      html`
+        <h2 class="swc-Heading" lang="zh">启动审批工作流</h2>
+      `,
+      html`
+        <h3 class="swc-Title" lang="zh">规格</h3>
+      `,
+      html`
+        <p class="swc-Body" lang="zh">上传或导入以开始使用。</p>
+      `,
+    ],
+    'CJK · Chinese'
+  )}
+`;
+
+// VRT stories
+
+// Every size/modifier/structural-context combination, plus Arabic/Hebrew/CJK
+// font overrides. Rendered once in light/ltr and once in dark/rtl (covering
+// both axes) in a single story, so it costs one snapshot.
+export const Permutations: Story = {
+  render: () => html`
+    ${theme(permutationContent(), 'light', 'ltr')}
+    ${theme(permutationContent(), 'dark', 'rtl')}
+  `,
+  parameters: vrtParameters,
+};
+
+// `forced-colors` is a real browser media feature Chromatic can emulate
+// directly. Forced-colors mode replaces the whole page's palette, so it
+// needs its own story/snapshot rather than folding into Permutations.
+export const ForcedColors: Story = {
+  render: () => theme(permutationContent(), 'light', 'ltr'),
+  parameters: forcedColorsVrtParameters,
+};

--- a/2nd-gen/packages/swc/components/typography/typography.mdx
+++ b/2nd-gen/packages/swc/components/typography/typography.mdx
@@ -96,69 +96,83 @@ Link lists in footers, sidebars, and navigation regions use `.swc-Typography--li
 
 Each type variant exposes the same set of `--swc-*` custom properties for font and margin overrides. Code's properties use the `--swc-monospace-*` prefix.
 
+Heading, Title, and Body also expose `--swc-*-cjk-font-size`, `--swc-*-cjk-line-height`, and `--swc-*-cjk-letter-spacing`, which override the corresponding base property under `:lang(zh)`, `:lang(ja)`, and `:lang(ko)`. Detail exposes only the CJK line-height/letter-spacing overrides, and Code exposes only the CJK line-height override.
+
 #### Heading
 
-| Property                       | Description        |
-| ------------------------------ | ------------------ |
-| `--swc-heading-font-family`    | Font family        |
-| `--swc-heading-font-size`      | Font size          |
-| `--swc-heading-font-weight`    | Font weight        |
-| `--swc-heading-line-height`    | Line height        |
-| `--swc-heading-font-color`     | Text color         |
-| `--swc-heading-letter-spacing` | Letter spacing     |
-| `--swc-heading-margin-top`     | Block-start margin |
-| `--swc-heading-margin-bottom`  | Block-end margin   |
+| Property                           | Description                        |
+| ---------------------------------- | ---------------------------------- |
+| `--swc-heading-font-family`        | Font family                        |
+| `--swc-heading-font-size`          | Font size                          |
+| `--swc-heading-font-weight`        | Font weight                        |
+| `--swc-heading-line-height`        | Line height                        |
+| `--swc-heading-font-color`         | Text color                         |
+| `--swc-heading-letter-spacing`     | Letter spacing                     |
+| `--swc-heading-margin-top`         | Block-start margin                 |
+| `--swc-heading-margin-bottom`      | Block-end margin                   |
+| `--swc-heading-cjk-font-size`      | Font size under CJK `:lang()`      |
+| `--swc-heading-cjk-line-height`    | Line height under CJK `:lang()`    |
+| `--swc-heading-cjk-letter-spacing` | Letter spacing under CJK `:lang()` |
 
 #### Title
 
-| Property                     | Description        |
-| ---------------------------- | ------------------ |
-| `--swc-title-font-family`    | Font family        |
-| `--swc-title-font-size`      | Font size          |
-| `--swc-title-font-weight`    | Font weight        |
-| `--swc-title-line-height`    | Line height        |
-| `--swc-title-font-color`     | Text color         |
-| `--swc-title-letter-spacing` | Letter spacing     |
-| `--swc-title-margin-top`     | Block-start margin |
-| `--swc-title-margin-bottom`  | Block-end margin   |
+| Property                         | Description                        |
+| -------------------------------- | ---------------------------------- |
+| `--swc-title-font-family`        | Font family                        |
+| `--swc-title-font-size`          | Font size                          |
+| `--swc-title-font-weight`        | Font weight                        |
+| `--swc-title-line-height`        | Line height                        |
+| `--swc-title-font-color`         | Text color                         |
+| `--swc-title-letter-spacing`     | Letter spacing                     |
+| `--swc-title-margin-top`         | Block-start margin                 |
+| `--swc-title-margin-bottom`      | Block-end margin                   |
+| `--swc-title-cjk-font-size`      | Font size under CJK `:lang()`      |
+| `--swc-title-cjk-line-height`    | Line height under CJK `:lang()`    |
+| `--swc-title-cjk-letter-spacing` | Letter spacing under CJK `:lang()` |
 
 #### Body
 
-| Property                    | Description        |
-| --------------------------- | ------------------ |
-| `--swc-body-font-family`    | Font family        |
-| `--swc-body-font-size`      | Font size          |
-| `--swc-body-font-weight`    | Font weight        |
-| `--swc-body-line-height`    | Line height        |
-| `--swc-body-font-color`     | Text color         |
-| `--swc-body-letter-spacing` | Letter spacing     |
-| `--swc-body-margin-top`     | Block-start margin |
-| `--swc-body-margin-bottom`  | Block-end margin   |
+| Property                        | Description                        |
+| ------------------------------- | ---------------------------------- |
+| `--swc-body-font-family`        | Font family                        |
+| `--swc-body-font-size`          | Font size                          |
+| `--swc-body-font-weight`        | Font weight                        |
+| `--swc-body-line-height`        | Line height                        |
+| `--swc-body-font-color`         | Text color                         |
+| `--swc-body-letter-spacing`     | Letter spacing                     |
+| `--swc-body-margin-top`         | Block-start margin                 |
+| `--swc-body-margin-bottom`      | Block-end margin                   |
+| `--swc-body-cjk-font-size`      | Font size under CJK `:lang()`      |
+| `--swc-body-cjk-line-height`    | Line height under CJK `:lang()`    |
+| `--swc-body-cjk-letter-spacing` | Letter spacing under CJK `:lang()` |
 
 #### Detail
 
-| Property                      | Description        |
-| ----------------------------- | ------------------ |
-| `--swc-detail-font-family`    | Font family        |
-| `--swc-detail-font-size`      | Font size          |
-| `--swc-detail-font-weight`    | Font weight        |
-| `--swc-detail-line-height`    | Line height        |
-| `--swc-detail-font-color`     | Text color         |
-| `--swc-detail-letter-spacing` | Letter spacing     |
-| `--swc-detail-margin-top`     | Block-start margin |
-| `--swc-detail-margin-bottom`  | Block-end margin   |
+| Property                          | Description                        |
+| --------------------------------- | ---------------------------------- |
+| `--swc-detail-font-family`        | Font family                        |
+| `--swc-detail-font-size`          | Font size                          |
+| `--swc-detail-font-weight`        | Font weight                        |
+| `--swc-detail-line-height`        | Line height                        |
+| `--swc-detail-font-color`         | Text color                         |
+| `--swc-detail-letter-spacing`     | Letter spacing                     |
+| `--swc-detail-margin-top`         | Block-start margin                 |
+| `--swc-detail-margin-bottom`      | Block-end margin                   |
+| `--swc-detail-cjk-line-height`    | Line height under CJK `:lang()`    |
+| `--swc-detail-cjk-letter-spacing` | Letter spacing under CJK `:lang()` |
 
 #### Code
 
-| Property                         | Description        |
-| -------------------------------- | ------------------ |
-| `--swc-monospace-font-family`    | Font family        |
-| `--swc-monospace-font-size`      | Font size          |
-| `--swc-monospace-font-weight`    | Font weight        |
-| `--swc-monospace-line-height`    | Line height        |
-| `--swc-monospace-font-color`     | Text color         |
-| `--swc-monospace-letter-spacing` | Letter spacing     |
-| `--swc-monospace-margin-top`     | Block-start margin |
-| `--swc-monospace-margin-bottom`  | Block-end margin   |
+| Property                          | Description                     |
+| --------------------------------- | ------------------------------- |
+| `--swc-monospace-font-family`     | Font family                     |
+| `--swc-monospace-font-size`       | Font size                       |
+| `--swc-monospace-font-weight`     | Font weight                     |
+| `--swc-monospace-line-height`     | Line height                     |
+| `--swc-monospace-font-color`      | Text color                      |
+| `--swc-monospace-letter-spacing`  | Letter spacing                  |
+| `--swc-monospace-margin-top`      | Block-start margin              |
+| `--swc-monospace-margin-bottom`   | Block-end margin                |
+| `--swc-monospace-cjk-line-height` | Line height under CJK `:lang()` |
 
 <DocsFooter />

--- a/2nd-gen/packages/swc/components/typography/typography.mdx
+++ b/2nd-gen/packages/swc/components/typography/typography.mdx
@@ -90,4 +90,75 @@ Link lists in footers, sidebars, and navigation regions use `.swc-Typography--li
 
 <Canvas of={TypographyStories.LinkList} />
 
+## API
+
+### CSS custom properties
+
+Each type variant exposes the same set of `--swc-*` custom properties for font and margin overrides. Code's properties use the `--swc-monospace-*` prefix.
+
+#### Heading
+
+| Property                       | Description        |
+| ------------------------------ | ------------------ |
+| `--swc-heading-font-family`    | Font family        |
+| `--swc-heading-font-size`      | Font size          |
+| `--swc-heading-font-weight`    | Font weight        |
+| `--swc-heading-line-height`    | Line height        |
+| `--swc-heading-font-color`     | Text color         |
+| `--swc-heading-letter-spacing` | Letter spacing     |
+| `--swc-heading-margin-top`     | Block-start margin |
+| `--swc-heading-margin-bottom`  | Block-end margin   |
+
+#### Title
+
+| Property                     | Description        |
+| ---------------------------- | ------------------ |
+| `--swc-title-font-family`    | Font family        |
+| `--swc-title-font-size`      | Font size          |
+| `--swc-title-font-weight`    | Font weight        |
+| `--swc-title-line-height`    | Line height        |
+| `--swc-title-font-color`     | Text color         |
+| `--swc-title-letter-spacing` | Letter spacing     |
+| `--swc-title-margin-top`     | Block-start margin |
+| `--swc-title-margin-bottom`  | Block-end margin   |
+
+#### Body
+
+| Property                    | Description        |
+| --------------------------- | ------------------ |
+| `--swc-body-font-family`    | Font family        |
+| `--swc-body-font-size`      | Font size          |
+| `--swc-body-font-weight`    | Font weight        |
+| `--swc-body-line-height`    | Line height        |
+| `--swc-body-font-color`     | Text color         |
+| `--swc-body-letter-spacing` | Letter spacing     |
+| `--swc-body-margin-top`     | Block-start margin |
+| `--swc-body-margin-bottom`  | Block-end margin   |
+
+#### Detail
+
+| Property                      | Description        |
+| ----------------------------- | ------------------ |
+| `--swc-detail-font-family`    | Font family        |
+| `--swc-detail-font-size`      | Font size          |
+| `--swc-detail-font-weight`    | Font weight        |
+| `--swc-detail-line-height`    | Line height        |
+| `--swc-detail-font-color`     | Text color         |
+| `--swc-detail-letter-spacing` | Letter spacing     |
+| `--swc-detail-margin-top`     | Block-start margin |
+| `--swc-detail-margin-bottom`  | Block-end margin   |
+
+#### Code
+
+| Property                         | Description        |
+| -------------------------------- | ------------------ |
+| `--swc-monospace-font-family`    | Font family        |
+| `--swc-monospace-font-size`      | Font size          |
+| `--swc-monospace-font-weight`    | Font weight        |
+| `--swc-monospace-line-height`    | Line height        |
+| `--swc-monospace-font-color`     | Text color         |
+| `--swc-monospace-letter-spacing` | Letter spacing     |
+| `--swc-monospace-margin-top`     | Block-start margin |
+| `--swc-monospace-margin-bottom`  | Block-end margin   |
+
 <DocsFooter />


### PR DESCRIPTION
## Description

Adds `2nd-gen/packages/swc/components/typography/test/vrt/typography.vrt.ts` and `typography-custom-properties.vrt.ts`, providing dedicated Chromatic VRT coverage for the `typography` unit. Unlike other units covered so far, `typography` is a "component replacement" stylesheet (`typography.css`): a pure CSS class vocabulary applied to plain HTML elements, with no custom-element counterpart and no custom-elements-manifest declaration (see `CONTRIBUTOR-DOCS/02_style-guide/01_css/07_stylesheets.md`).

- `Permutations`: every Heading/Title/Body/Detail/Code size, the serif/emphasized/heavy/margins modifiers, the prose-container and link-list structural contexts, and Arabic/Hebrew font-family + CJK (ja/ko/zh) font-metric overrides. Rendered in both light/ltr and dark/rtl.
- `ForcedColors`: the same permutation set under forced-colors emulation. `typography.css` has no `@media (forced-colors: active)` overrides of its own - confirmed this is correct, not a gap, since typography's differentiation is entirely size/weight-based rather than color-based, so the browser's automatic forced-colors flattening doesn't lose any meaningful distinction here.
- `CustomProperties`: one reference/override row per documented custom property (8 per variant x 5 variants = 40), grouped by variant. Since there's no manifest to verify against, this follows `link-custom-properties.vrt.ts`'s manual-verification pattern: a hardcoded, alphabetically-sorted `DOCUMENTED_TYPOGRAPHY_PROPERTIES` list that the covered-properties set must match exactly.

`typography.mdx` has no "CSS custom properties" reference table for this VRT to verify against (unlike `link.mdx`, which `link-custom-properties.vrt.ts` checks against) - out of scope for this PR; flagged separately as follow-up.

## Motivation and context

The `typography` unit had no dedicated VRT coverage. This follows the VRT foundation established for `button` (PR #6463), extending it to `typography` per the linked ticket, using `link`'s existing "component replacement" VRT pattern as the closest precedent for a CSS-only, no-custom-element unit.

## Related issue(s)

- fixes SWC-2420

## Screenshots (if appropriate)

N/A - test-only change, no visual/behavioral change to typography.css itself. Manually verified via Playwright screenshots of the built Storybook, including real `forced-colors` media emulation. Caught and fixed one real gap during review: the CJK rows were originally only rendered in the light/ltr pass, not dark/rtl - fixed by folding them into the shared `permutationContent()` so both theme passes cover them.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Typography VRT stories render correctly_
  1. Go to Storybook > Components > Typography > Typography VRT
  2. Review the `Permutations`, `ForcedColors`, and `CustomProperties` stories
  3. Expect every size/modifier/structural-context combination to render correctly in both light/ltr and dark/rtl, and every custom-property row to show an obviously different override next to its reference

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard**
  These are non-interactive VRT snapshot fixtures (tagged `dev`); no new keyboard behavior is introduced. The only interactive elements are the prose-container/link-list anchors, which use plain native `<a>` tab/Enter behavior. Confirm no regressions in the existing `typography.stories.ts` docs examples.

- [ ] **Screen reader**
  1. Go to Storybook > Components > Typography > Typography VRT > Permutations
  2. Inspect the "Prose container" and "Link list" rows with a screen reader or the accessibility tree
  3. Expect the semantic `h1`-`h4`/`p`/`ul`/`li` elements to announce their native roles/levels correctly, and both links to announce as links with their visible text as the accessible name
