### PR TITLE
style(prompt-field): mirror the AI brand gradients in RTL

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -68,7 +68,7 @@
   flex-direction: column;
   min-inline-size: 0;
   padding: token("spacing-300");
-  background: radial-gradient(circle at right bottom in oklch, var(--_swc-prompt-field-bg-stop-1) 0%, var(--_swc-prompt-field-bg-stop-2) 35%, var(--_swc-prompt-field-bg-stop-3) 82%, var(--_swc-prompt-field-bg-stop-4) 100%);
+  background: radial-gradient(circle at var(--_swc-prompt-field-wash-x, right) bottom in oklch, var(--_swc-prompt-field-bg-stop-1) 0%, var(--_swc-prompt-field-bg-stop-2) 35%, var(--_swc-prompt-field-bg-stop-3) 82%, var(--_swc-prompt-field-bg-stop-4) 100%);
   border-radius: 24px;
   box-shadow:
     0 20px 20px -24px var(--_swc-prompt-field-prominent-outer-glow-color, transparent),
@@ -120,7 +120,7 @@
   display: flex;
   padding: 6px;
   container-type: inline-size;
-  background: linear-gradient(to right in oklch, var(--_swc-prompt-field-outer-stop-1) 0%, var(--_swc-prompt-field-outer-stop-2) 37%, var(--_swc-prompt-field-outer-stop-3) 77%);
+  background: linear-gradient(var(--_swc-prompt-field-outer-dir, to right) in oklch, var(--_swc-prompt-field-outer-stop-1) 0%, var(--_swc-prompt-field-outer-stop-2) 37%, var(--_swc-prompt-field-outer-stop-3) 77%);
   border-radius: 30px;
   box-shadow:
     0 2px 4px var(--_swc-prompt-field-outer-shadow),
@@ -234,6 +234,19 @@
     radial-gradient(70% 50% at 40% 80% in oklch, oklch(from light-dark(oklch(from var(--swc-prompt-field-brand-color) 95.64% 0.036 calc(h + 0.6)), oklch(from var(--swc-prompt-field-brand-color) 31.55% 0.1704 calc(h - 24.5))) l c h / var(--_swc-prompt-field-con-hue-opacity)), transparent);
   pointer-events: none;
   content: "";
+}
+
+/* RTL: mirror the ambient brand gradients to the opposite side. */
+:host(:dir(rtl)) .swc-PromptField-box {
+  --_swc-prompt-field-wash-x: left;
+}
+
+:host(:dir(rtl)) .swc-PromptField-box::before {
+  transform: scaleX(-1);
+}
+
+:host(:dir(rtl)) .swc-PromptField-outer-border {
+  --_swc-prompt-field-outer-dir: to left;
 }
 
 @supports (rotate: atan(1px / 1cqw)) {


### PR DESCRIPTION
## Description

The AI brand treatment's ambient gradients (card wash, outer ring, hue-sweep) are anchored to the physical bottom-right. In RTL the composer layout flips (send button moves to the bottom-left) but the glow stays pinned to the right, so the two disagree. This mirrors the gradients to follow the layout.

Based on `ruben/feat-prompt-field-ai-branding-v3`.

## What changed

- Hoisted the horizontal anchor of the card wash and outer ring into custom properties (`--_swc-prompt-field-wash-x`, `--_swc-prompt-field-outer-dir`).
- Three `:host(:dir(rtl))` rules flip them (`right`→`left`, `to right`→`to left`) plus `scaleX(-1)` on the decorative `::before` hue-sweep (its animations use the independent `rotate`/`translate`/`scale` properties, so `transform` is free).

Net: two small base edits + three RTL rules.

## Motivation and context

> ⚠️ **Note:** the react reference does **not** mirror these gradients in RTL. This is a deliberate divergence for visual consistency with the mirrored composer layout, and should get a design nod before merge.

## Verification

Rendered prominent LTR vs RTL in Storybook: LTR glow sits bottom-right (send button), RTL glow mirrors to bottom-left (mirrored send button). Only the composer/gloss (vertical) is unaffected, as intended.

## Accessibility testing checklist

- [ ] **Keyboard**: no interactive changes; decorative-only. Confirm no focus or tab-order regressions in RTL.
- [ ] **Screen reader**: no semantic changes; gradients are decorative (`pointer-events: none`, not in the a11y tree).