### PR TITLE
test(tokens): transparent-white/black deprecation → static-* (Chromatic contrast check)

### DIFF
--- a/2nd-gen/packages/swc/components/accordion/accordion-item.css
+++ b/2nd-gen/packages/swc/components/accordion/accordion-item.css
@@ -82,7 +82,7 @@
    outline and border-radius stay on the button so the focus ring matches
    the hover footprint (toggle area only, independent of the actions slot). */
 .swc-AccordionItem:has(.swc-AccordionItem-header:focus-visible) {
-  --_swc-accordion-item-header-background: token("transparent-black-100");
+  --_swc-accordion-item-header-background: rgb(0 0 0 / 8%);
   --_swc-accordion-item-header-text-color: token("neutral-content-color-key-focus");
 }
 
@@ -93,12 +93,12 @@
 }
 
 .swc-AccordionItem:has(.swc-AccordionItem-header:hover) {
-  --_swc-accordion-item-header-background: token("transparent-black-100");
+  --_swc-accordion-item-header-background: rgb(0 0 0 / 8%);
   --_swc-accordion-item-header-text-color: token("neutral-content-color-hover");
 }
 
 .swc-AccordionItem:has(.swc-AccordionItem-header:active) {
-  --_swc-accordion-item-header-background: token("transparent-black-300");
+  --_swc-accordion-item-header-background: rgb(0 0 0 / 16%);
   --_swc-accordion-item-header-text-color: token("neutral-content-color-down");
 }
 

--- a/2nd-gen/packages/swc/components/action-button/action-button.css
+++ b/2nd-gen/packages/swc/components/action-button/action-button.css
@@ -180,15 +180,15 @@ slot[name="icon"]::slotted(swc-avatar) {
 
 :host([static-color="white"]) {
   --swc-action-button-focus-indicator-color: token("static-white-focus-indicator-color");
-  --swc-action-button-background-color-default: token("transparent-white-100");
-  --swc-action-button-background-color-hover: token("transparent-white-200");
-  --swc-action-button-background-color-down: token("transparent-white-200");
-  --swc-action-button-background-color-focus: token("transparent-white-200");
+  --swc-action-button-background-color-default: rgb(255 255 255 / 12%);
+  --swc-action-button-background-color-hover: rgb(255 255 255 / 16%);
+  --swc-action-button-background-color-down: rgb(255 255 255 / 16%);
+  --swc-action-button-background-color-focus: rgb(255 255 255 / 16%);
   --swc-action-button-background-color-disabled: token("disabled-static-white-background-color");
-  --swc-action-button-content-color-default: token("transparent-white-800");
-  --swc-action-button-content-color-hover: token("transparent-white-900");
-  --swc-action-button-content-color-down: token("transparent-white-900");
-  --swc-action-button-content-color-focus: token("transparent-white-900");
+  --swc-action-button-content-color-default: rgb(255 255 255 / 80%);
+  --swc-action-button-content-color-hover: rgb(255 255 255 / 96%);
+  --swc-action-button-content-color-down: rgb(255 255 255 / 96%);
+  --swc-action-button-content-color-focus: rgb(255 255 255 / 96%);
   --swc-action-button-content-color-disabled: token("disabled-static-white-content-color");
 }
 
@@ -201,15 +201,15 @@ slot[name="icon"]::slotted(swc-avatar) {
 
 :host([static-color="black"]) {
   --swc-action-button-focus-indicator-color: token("static-black-focus-indicator-color");
-  --swc-action-button-background-color-default: token("transparent-black-100");
+  --swc-action-button-background-color-default: rgb(0 0 0 / 8%);
   --swc-action-button-background-color-hover: token("transparent-black-200");
   --swc-action-button-background-color-down: token("transparent-black-200");
   --swc-action-button-background-color-focus: token("transparent-black-200");
   --swc-action-button-background-color-disabled: token("disabled-static-black-background-color");
-  --swc-action-button-content-color-default: token("transparent-black-800");
-  --swc-action-button-content-color-hover: token("transparent-black-900");
-  --swc-action-button-content-color-down: token("transparent-black-900");
-  --swc-action-button-content-color-focus: token("transparent-black-900");
+  --swc-action-button-content-color-default: rgb(0 0 0 / 80%);
+  --swc-action-button-content-color-hover: rgb(0 0 0 / 96%);
+  --swc-action-button-content-color-down: rgb(0 0 0 / 96%);
+  --swc-action-button-content-color-focus: rgb(0 0 0 / 96%);
   --swc-action-button-content-color-disabled: token("disabled-static-black-content-color");
 }
 

--- a/2nd-gen/packages/swc/components/button/button.css
+++ b/2nd-gen/packages/swc/components/button/button.css
@@ -124,7 +124,7 @@ slot[name="icon"]::slotted(*) {
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
   --swc-button-content-color-focus: token("white");
-  --swc-button-background-color-default: rgb(255 255 255 / 20%);
+  --swc-button-background-color-default: token("accent-background-color-default");
   --swc-button-background-color-hover: token("accent-background-color-hover");
   --swc-button-background-color-down: token("accent-background-color-down");
   --swc-button-background-color-focus: token("accent-background-color-key-focus");
@@ -188,7 +188,7 @@ slot[name="icon"]::slotted(*) {
 
 :host([static-color="white"]) {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
-  --swc-button-background-color-default: rgb(255 255 255 / 80%);
+  --swc-button-background-color-default: rgb(255 255 255 / 40%);
   --swc-button-background-color-hover: rgb(255 255 255 / 96%);
   --swc-button-background-color-down: rgb(255 255 255 / 96%);
   --swc-button-background-color-focus: rgb(255 255 255 / 96%);

--- a/2nd-gen/packages/swc/components/button/button.css
+++ b/2nd-gen/packages/swc/components/button/button.css
@@ -124,7 +124,7 @@ slot[name="icon"]::slotted(*) {
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
   --swc-button-content-color-focus: token("white");
-  --swc-button-background-color-default: token("accent-background-color-default");
+  --swc-button-background-color-default: rgb(255 255 255 / 20%);
   --swc-button-background-color-hover: token("accent-background-color-hover");
   --swc-button-background-color-down: token("accent-background-color-down");
   --swc-button-background-color-focus: token("accent-background-color-key-focus");

--- a/2nd-gen/packages/swc/components/button/button.css
+++ b/2nd-gen/packages/swc/components/button/button.css
@@ -188,10 +188,10 @@ slot[name="icon"]::slotted(*) {
 
 :host([static-color="white"]) {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
-  --swc-button-background-color-default: token("transparent-white-800");
-  --swc-button-background-color-hover: token("transparent-white-900");
-  --swc-button-background-color-down: token("transparent-white-900");
-  --swc-button-background-color-focus: token("transparent-white-900");
+  --swc-button-background-color-default: rgb(255 255 255 / 80%);
+  --swc-button-background-color-hover: rgb(255 255 255 / 96%);
+  --swc-button-background-color-down: rgb(255 255 255 / 96%);
+  --swc-button-background-color-focus: rgb(255 255 255 / 96%);
   --swc-button-content-color-default: token("black");
   --swc-button-content-color-hover: token("black");
   --swc-button-content-color-down: token("black");
@@ -202,29 +202,29 @@ slot[name="icon"]::slotted(*) {
 }
 
 :host([static-color="white"][variant="secondary"]) {
-  --swc-button-background-color-default: token("transparent-white-100");
-  --swc-button-background-color-hover: token("transparent-white-200");
-  --swc-button-background-color-down: token("transparent-white-200");
-  --swc-button-background-color-focus: token("transparent-white-200");
-  --swc-button-content-color-default: token("transparent-white-800");
-  --swc-button-content-color-hover: token("transparent-white-900");
-  --swc-button-content-color-down: token("transparent-white-900");
-  --swc-button-content-color-focus: token("transparent-white-900");
+  --swc-button-background-color-default: rgb(255 255 255 / 12%);
+  --swc-button-background-color-hover: rgb(255 255 255 / 16%);
+  --swc-button-background-color-down: rgb(255 255 255 / 16%);
+  --swc-button-background-color-focus: rgb(255 255 255 / 16%);
+  --swc-button-content-color-default: rgb(255 255 255 / 80%);
+  --swc-button-content-color-hover: rgb(255 255 255 / 96%);
+  --swc-button-content-color-down: rgb(255 255 255 / 96%);
+  --swc-button-content-color-focus: rgb(255 255 255 / 96%);
 }
 
 :host([static-color="white"][fill-style="outline"]) {
   --swc-button-background-color-default: token("transparent-white-25");
-  --swc-button-background-color-hover: token("transparent-white-100");
-  --swc-button-background-color-down: token("transparent-white-100");
-  --swc-button-background-color-focus: token("transparent-white-100");
-  --swc-button-border-color-default: token("transparent-white-800");
-  --swc-button-border-color-hover: token("transparent-white-900");
-  --swc-button-border-color-down: token("transparent-white-900");
-  --swc-button-border-color-focus: token("transparent-white-900");
-  --swc-button-content-color-default: token("transparent-white-800");
-  --swc-button-content-color-hover: token("transparent-white-900");
-  --swc-button-content-color-down: token("transparent-white-900");
-  --swc-button-content-color-focus: token("transparent-white-900");
+  --swc-button-background-color-hover: rgb(255 255 255 / 12%);
+  --swc-button-background-color-down: rgb(255 255 255 / 12%);
+  --swc-button-background-color-focus: rgb(255 255 255 / 12%);
+  --swc-button-border-color-default: rgb(255 255 255 / 80%);
+  --swc-button-border-color-hover: rgb(255 255 255 / 96%);
+  --swc-button-border-color-down: rgb(255 255 255 / 96%);
+  --swc-button-border-color-focus: rgb(255 255 255 / 96%);
+  --swc-button-content-color-default: rgb(255 255 255 / 80%);
+  --swc-button-content-color-hover: rgb(255 255 255 / 96%);
+  --swc-button-content-color-down: rgb(255 255 255 / 96%);
+  --swc-button-content-color-focus: rgb(255 255 255 / 96%);
   --swc-button-background-color-disabled: token("transparent-white-25");
   --swc-button-border-color-disabled: token("disabled-static-white-border-color");
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
@@ -232,23 +232,23 @@ slot[name="icon"]::slotted(*) {
 
 :host([static-color="white"][variant="secondary"][fill-style="outline"]) {
   --swc-button-background-color-default: token("transparent-white-25");
-  --swc-button-background-color-hover: token("transparent-white-100");
-  --swc-button-background-color-down: token("transparent-white-100");
-  --swc-button-background-color-focus: token("transparent-white-100");
-  --swc-button-border-color-default: token("transparent-white-300");
-  --swc-button-border-color-hover: token("transparent-white-400");
-  --swc-button-border-color-down: token("transparent-white-400");
-  --swc-button-border-color-focus: token("transparent-white-400");
+  --swc-button-background-color-hover: rgb(255 255 255 / 12%);
+  --swc-button-background-color-down: rgb(255 255 255 / 12%);
+  --swc-button-background-color-focus: rgb(255 255 255 / 12%);
+  --swc-button-border-color-default: rgb(255 255 255 / 16%);
+  --swc-button-border-color-hover: rgb(255 255 255 / 20%);
+  --swc-button-border-color-down: rgb(255 255 255 / 20%);
+  --swc-button-border-color-focus: rgb(255 255 255 / 20%);
 }
 
 /* ── Static black ─────────────────────────────────── */
 
 :host([static-color="black"]) {
   --swc-button-focus-indicator-color: token("static-black-focus-indicator-color");
-  --swc-button-background-color-default: token("transparent-black-800");
-  --swc-button-background-color-hover: token("transparent-black-900");
-  --swc-button-background-color-down: token("transparent-black-900");
-  --swc-button-background-color-focus: token("transparent-black-900");
+  --swc-button-background-color-default: rgb(0 0 0 / 80%);
+  --swc-button-background-color-hover: rgb(0 0 0 / 96%);
+  --swc-button-background-color-down: rgb(0 0 0 / 96%);
+  --swc-button-background-color-focus: rgb(0 0 0 / 96%);
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -259,29 +259,29 @@ slot[name="icon"]::slotted(*) {
 }
 
 :host([static-color="black"][variant="secondary"]) {
-  --swc-button-background-color-default: token("transparent-black-100");
+  --swc-button-background-color-default: rgb(0 0 0 / 8%);
   --swc-button-background-color-hover: token("transparent-black-200");
   --swc-button-background-color-down: token("transparent-black-200");
   --swc-button-background-color-focus: token("transparent-black-200");
-  --swc-button-content-color-default: token("transparent-black-800");
-  --swc-button-content-color-hover: token("transparent-black-900");
-  --swc-button-content-color-down: token("transparent-black-900");
-  --swc-button-content-color-focus: token("transparent-black-900");
+  --swc-button-content-color-default: rgb(0 0 0 / 80%);
+  --swc-button-content-color-hover: rgb(0 0 0 / 96%);
+  --swc-button-content-color-down: rgb(0 0 0 / 96%);
+  --swc-button-content-color-focus: rgb(0 0 0 / 96%);
 }
 
 :host([static-color="black"][fill-style="outline"]) {
   --swc-button-background-color-default: token("transparent-black-25");
-  --swc-button-background-color-hover: token("transparent-black-100");
-  --swc-button-background-color-down: token("transparent-black-100");
-  --swc-button-background-color-focus: token("transparent-black-100");
-  --swc-button-border-color-default: token("transparent-black-800");
-  --swc-button-border-color-hover: token("transparent-black-900");
-  --swc-button-border-color-down: token("transparent-black-900");
-  --swc-button-border-color-focus: token("transparent-black-900");
-  --swc-button-content-color-default: token("transparent-black-800");
-  --swc-button-content-color-hover: token("transparent-black-900");
-  --swc-button-content-color-down: token("transparent-black-900");
-  --swc-button-content-color-focus: token("transparent-black-900");
+  --swc-button-background-color-hover: rgb(0 0 0 / 8%);
+  --swc-button-background-color-down: rgb(0 0 0 / 8%);
+  --swc-button-background-color-focus: rgb(0 0 0 / 8%);
+  --swc-button-border-color-default: rgb(0 0 0 / 80%);
+  --swc-button-border-color-hover: rgb(0 0 0 / 96%);
+  --swc-button-border-color-down: rgb(0 0 0 / 96%);
+  --swc-button-border-color-focus: rgb(0 0 0 / 96%);
+  --swc-button-content-color-default: rgb(0 0 0 / 80%);
+  --swc-button-content-color-hover: rgb(0 0 0 / 96%);
+  --swc-button-content-color-down: rgb(0 0 0 / 96%);
+  --swc-button-content-color-focus: rgb(0 0 0 / 96%);
   --swc-button-background-color-disabled: token("transparent-black-25");
   --swc-button-border-color-disabled: token("disabled-static-black-border-color");
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
@@ -289,13 +289,13 @@ slot[name="icon"]::slotted(*) {
 
 :host([static-color="black"][variant="secondary"][fill-style="outline"]) {
   --swc-button-background-color-default: token("transparent-black-25");
-  --swc-button-background-color-hover: token("transparent-black-100");
-  --swc-button-background-color-down: token("transparent-black-100");
-  --swc-button-background-color-focus: token("transparent-black-100");
-  --swc-button-border-color-default: token("transparent-black-300");
-  --swc-button-border-color-hover: token("transparent-black-400");
-  --swc-button-border-color-down: token("transparent-black-400");
-  --swc-button-border-color-focus: token("transparent-black-400");
+  --swc-button-background-color-hover: rgb(0 0 0 / 8%);
+  --swc-button-background-color-down: rgb(0 0 0 / 8%);
+  --swc-button-background-color-focus: rgb(0 0 0 / 8%);
+  --swc-button-border-color-default: rgb(0 0 0 / 16%);
+  --swc-button-border-color-hover: rgb(0 0 0 / 24%);
+  --swc-button-border-color-down: rgb(0 0 0 / 24%);
+  --swc-button-border-color-focus: rgb(0 0 0 / 24%);
 }
 
 /* ── Icon only ────────────────────────────────────── */

--- a/2nd-gen/packages/swc/components/button/button.css
+++ b/2nd-gen/packages/swc/components/button/button.css
@@ -188,7 +188,7 @@ slot[name="icon"]::slotted(*) {
 
 :host([static-color="white"]) {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
-  --swc-button-background-color-default: rgb(255 255 255 / 40%);
+  --swc-button-background-color-default: rgb(255 255 255 / 72%);
   --swc-button-background-color-hover: rgb(255 255 255 / 96%);
   --swc-button-background-color-down: rgb(255 255 255 / 96%);
   --swc-button-background-color-focus: rgb(255 255 255 / 96%);

--- a/2nd-gen/packages/swc/components/button/button.css
+++ b/2nd-gen/packages/swc/components/button/button.css
@@ -188,7 +188,7 @@ slot[name="icon"]::slotted(*) {
 
 :host([static-color="white"]) {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
-  --swc-button-background-color-default: rgb(255 255 255 / 72%);
+  --swc-button-background-color-default: rgb(255 255 255 / 77%);
   --swc-button-background-color-hover: rgb(255 255 255 / 96%);
   --swc-button-background-color-down: rgb(255 255 255 / 96%);
   --swc-button-background-color-focus: rgb(255 255 255 / 96%);

--- a/2nd-gen/packages/swc/components/card/card.css
+++ b/2nd-gen/packages/swc/components/card/card.css
@@ -132,7 +132,7 @@
       z-index: 2;
       border-radius: var(--_swc-card-base-border-radius);
       pointer-events: none;
-      outline: token("focus-indicator-thickness") solid token("transparent-white-600");
+      outline: token("focus-indicator-thickness") solid rgb(255 255 255 / 48%);
       outline-offset: calc(token("focus-indicator-thickness") * -1);
       content: "";
     }

--- a/2nd-gen/packages/swc/components/close-button/close-button.css
+++ b/2nd-gen/packages/swc/components/close-button/close-button.css
@@ -103,26 +103,26 @@
 
 :host([static-color="white"]) {
   --swc-close-button-background-color-default: transparent;
-  --swc-close-button-background-color-down: token("transparent-white-100");
-  --swc-close-button-background-color-focus: token("transparent-white-100");
-  --swc-close-button-background-color-hover: token("transparent-white-100");
+  --swc-close-button-background-color-down: rgb(255 255 255 / 12%);
+  --swc-close-button-background-color-focus: rgb(255 255 255 / 12%);
+  --swc-close-button-background-color-hover: rgb(255 255 255 / 12%);
   --swc-close-button-focus-indicator-color: token("static-white-focus-indicator-color");
-  --swc-close-button-icon-color-default: token("transparent-white-800");
+  --swc-close-button-icon-color-default: rgb(255 255 255 / 80%);
   --swc-close-button-icon-color-disabled: token("disabled-static-white-background-color");
-  --swc-close-button-icon-color-down: token("transparent-white-900");
-  --swc-close-button-icon-color-focus: token("transparent-white-900");
-  --swc-close-button-icon-color-hover: token("transparent-white-900");
+  --swc-close-button-icon-color-down: rgb(255 255 255 / 96%);
+  --swc-close-button-icon-color-focus: rgb(255 255 255 / 96%);
+  --swc-close-button-icon-color-hover: rgb(255 255 255 / 96%);
 }
 
 :host([static-color="black"]) {
   --swc-close-button-background-color-default: transparent;
-  --swc-close-button-background-color-down: token("transparent-black-100");
-  --swc-close-button-background-color-focus: token("transparent-black-100");
-  --swc-close-button-background-color-hover: token("transparent-black-100");
+  --swc-close-button-background-color-down: rgb(0 0 0 / 8%);
+  --swc-close-button-background-color-focus: rgb(0 0 0 / 8%);
+  --swc-close-button-background-color-hover: rgb(0 0 0 / 8%);
   --swc-close-button-focus-indicator-color: token("static-black-focus-indicator-color");
-  --swc-close-button-icon-color-default: token("transparent-black-800");
+  --swc-close-button-icon-color-default: rgb(0 0 0 / 80%);
   --swc-close-button-icon-color-disabled: token("disabled-static-black-background-color");
-  --swc-close-button-icon-color-down: token("transparent-black-900");
-  --swc-close-button-icon-color-focus: token("transparent-black-900");
-  --swc-close-button-icon-color-hover: token("transparent-black-900");
+  --swc-close-button-icon-color-down: rgb(0 0 0 / 96%);
+  --swc-close-button-icon-color-focus: rgb(0 0 0 / 96%);
+  --swc-close-button-icon-color-hover: rgb(0 0 0 / 96%);
 }

--- a/2nd-gen/packages/swc/components/divider/divider.css
+++ b/2nd-gen/packages/swc/components/divider/divider.css
@@ -52,11 +52,11 @@
 }
 
 .swc-Divider--staticWhite {
-  --swc-divider-background-color: token("transparent-white-200");
+  --swc-divider-background-color: rgb(255 255 255 / 16%);
 }
 
 .swc-Divider--staticWhite:where(.swc-Divider--sizeL) {
-  --swc-divider-background-color: token("transparent-white-800");
+  --swc-divider-background-color: rgb(255 255 255 / 80%);
 }
 
 .swc-Divider--staticBlack {
@@ -64,7 +64,7 @@
 }
 
 .swc-Divider--staticBlack:where(.swc-Divider--sizeL) {
-  --swc-divider-background-color: token("transparent-black-800");
+  --swc-divider-background-color: rgb(0 0 0 / 80%);
 }
 
 @media (forced-colors: active) {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/upload-artifact/upload-artifact.css
@@ -338,7 +338,7 @@
   font-weight: token("medium-font-weight");
   line-height: token("line-height-font-size-75");
   color: token("gray-25");
-  background: token("transparent-black-700");
+  background: rgb(0 0 0 / 64%);
   border-radius: token("corner-radius-400");
 }
 

--- a/2nd-gen/packages/swc/stylesheets/_lit-styles/card-template.css
+++ b/2nd-gen/packages/swc/stylesheets/_lit-styles/card-template.css
@@ -357,7 +357,7 @@
     z-index: 2;
     border-radius: var(--_swc-card-base-border-radius);
     pointer-events: none;
-    outline: token("focus-indicator-thickness") solid token("transparent-white-600");
+    outline: token("focus-indicator-thickness") solid rgb(255 255 255 / 48%);
     outline-offset: calc(token("focus-indicator-thickness") * -1);
     content: "";
   }

--- a/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
@@ -160,15 +160,15 @@
 
 .swc-ActionButton--staticWhite {
   --swc-action-button-focus-indicator-color: token("static-white-focus-indicator-color");
-  --swc-action-button-background-color-default: token("transparent-white-100");
-  --swc-action-button-background-color-hover: token("transparent-white-200");
-  --swc-action-button-background-color-down: token("transparent-white-200");
-  --swc-action-button-background-color-focus: token("transparent-white-200");
+  --swc-action-button-background-color-default: rgb(255 255 255 / 12%);
+  --swc-action-button-background-color-hover: rgb(255 255 255 / 16%);
+  --swc-action-button-background-color-down: rgb(255 255 255 / 16%);
+  --swc-action-button-background-color-focus: rgb(255 255 255 / 16%);
   --swc-action-button-background-color-disabled: token("disabled-static-white-background-color");
-  --swc-action-button-content-color-default: token("transparent-white-800");
-  --swc-action-button-content-color-hover: token("transparent-white-900");
-  --swc-action-button-content-color-down: token("transparent-white-900");
-  --swc-action-button-content-color-focus: token("transparent-white-900");
+  --swc-action-button-content-color-default: rgb(255 255 255 / 80%);
+  --swc-action-button-content-color-hover: rgb(255 255 255 / 96%);
+  --swc-action-button-content-color-down: rgb(255 255 255 / 96%);
+  --swc-action-button-content-color-focus: rgb(255 255 255 / 96%);
   --swc-action-button-content-color-disabled: token("disabled-static-white-content-color");
 }
 
@@ -179,15 +179,15 @@
 
 .swc-ActionButton--staticBlack {
   --swc-action-button-focus-indicator-color: token("static-black-focus-indicator-color");
-  --swc-action-button-background-color-default: token("transparent-black-100");
+  --swc-action-button-background-color-default: rgb(0 0 0 / 8%);
   --swc-action-button-background-color-hover: token("transparent-black-200");
   --swc-action-button-background-color-down: token("transparent-black-200");
   --swc-action-button-background-color-focus: token("transparent-black-200");
   --swc-action-button-background-color-disabled: token("disabled-static-black-background-color");
-  --swc-action-button-content-color-default: token("transparent-black-800");
-  --swc-action-button-content-color-hover: token("transparent-black-900");
-  --swc-action-button-content-color-down: token("transparent-black-900");
-  --swc-action-button-content-color-focus: token("transparent-black-900");
+  --swc-action-button-content-color-default: rgb(0 0 0 / 80%);
+  --swc-action-button-content-color-hover: rgb(0 0 0 / 96%);
+  --swc-action-button-content-color-down: rgb(0 0 0 / 96%);
+  --swc-action-button-content-color-focus: rgb(0 0 0 / 96%);
   --swc-action-button-content-color-disabled: token("disabled-static-black-content-color");
 }
 

--- a/2nd-gen/packages/swc/stylesheets/global/global-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-button.css
@@ -211,10 +211,10 @@
 
 .swc-Button--staticWhite {
   --swc-button-focus-indicator-color: token("static-white-focus-indicator-color");
-  --swc-button-background-color-default: token("transparent-white-800");
-  --swc-button-background-color-hover: token("transparent-white-900");
-  --swc-button-background-color-down: token("transparent-white-900");
-  --swc-button-background-color-focus: token("transparent-white-900");
+  --swc-button-background-color-default: rgb(255 255 255 / 80%);
+  --swc-button-background-color-hover: rgb(255 255 255 / 96%);
+  --swc-button-background-color-down: rgb(255 255 255 / 96%);
+  --swc-button-background-color-focus: rgb(255 255 255 / 96%);
   --swc-button-content-color-default: token("black");
   --swc-button-content-color-hover: token("black");
   --swc-button-content-color-down: token("black");
@@ -225,29 +225,29 @@
 }
 
 .swc-Button--staticWhite.swc-Button--secondary {
-  --swc-button-background-color-default: token("transparent-white-100");
-  --swc-button-background-color-hover: token("transparent-white-200");
-  --swc-button-background-color-down: token("transparent-white-200");
-  --swc-button-background-color-focus: token("transparent-white-200");
-  --swc-button-content-color-default: token("transparent-white-800");
-  --swc-button-content-color-hover: token("transparent-white-900");
-  --swc-button-content-color-down: token("transparent-white-900");
-  --swc-button-content-color-focus: token("transparent-white-900");
+  --swc-button-background-color-default: rgb(255 255 255 / 12%);
+  --swc-button-background-color-hover: rgb(255 255 255 / 16%);
+  --swc-button-background-color-down: rgb(255 255 255 / 16%);
+  --swc-button-background-color-focus: rgb(255 255 255 / 16%);
+  --swc-button-content-color-default: rgb(255 255 255 / 80%);
+  --swc-button-content-color-hover: rgb(255 255 255 / 96%);
+  --swc-button-content-color-down: rgb(255 255 255 / 96%);
+  --swc-button-content-color-focus: rgb(255 255 255 / 96%);
 }
 
 .swc-Button--staticWhite.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
-  --swc-button-background-color-hover: token("transparent-white-100");
-  --swc-button-background-color-down: token("transparent-white-100");
-  --swc-button-background-color-focus: token("transparent-white-100");
-  --swc-button-border-color-default: token("transparent-white-800");
-  --swc-button-border-color-hover: token("transparent-white-900");
-  --swc-button-border-color-down: token("transparent-white-900");
-  --swc-button-border-color-focus: token("transparent-white-900");
-  --swc-button-content-color-default: token("transparent-white-800");
-  --swc-button-content-color-hover: token("transparent-white-900");
-  --swc-button-content-color-down: token("transparent-white-900");
-  --swc-button-content-color-focus: token("transparent-white-900");
+  --swc-button-background-color-hover: rgb(255 255 255 / 12%);
+  --swc-button-background-color-down: rgb(255 255 255 / 12%);
+  --swc-button-background-color-focus: rgb(255 255 255 / 12%);
+  --swc-button-border-color-default: rgb(255 255 255 / 80%);
+  --swc-button-border-color-hover: rgb(255 255 255 / 96%);
+  --swc-button-border-color-down: rgb(255 255 255 / 96%);
+  --swc-button-border-color-focus: rgb(255 255 255 / 96%);
+  --swc-button-content-color-default: rgb(255 255 255 / 80%);
+  --swc-button-content-color-hover: rgb(255 255 255 / 96%);
+  --swc-button-content-color-down: rgb(255 255 255 / 96%);
+  --swc-button-content-color-focus: rgb(255 255 255 / 96%);
   --swc-button-background-color-disabled: token("transparent-white-25");
   --swc-button-border-color-disabled: token("disabled-static-white-border-color");
   --swc-button-content-color-disabled: token("disabled-static-white-content-color");
@@ -255,21 +255,21 @@
 
 .swc-Button--staticWhite.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-white-25");
-  --swc-button-background-color-hover: token("transparent-white-100");
-  --swc-button-background-color-down: token("transparent-white-100");
-  --swc-button-background-color-focus: token("transparent-white-100");
-  --swc-button-border-color-default: token("transparent-white-300");
-  --swc-button-border-color-hover: token("transparent-white-400");
-  --swc-button-border-color-down: token("transparent-white-400");
-  --swc-button-border-color-focus: token("transparent-white-400");
+  --swc-button-background-color-hover: rgb(255 255 255 / 12%);
+  --swc-button-background-color-down: rgb(255 255 255 / 12%);
+  --swc-button-background-color-focus: rgb(255 255 255 / 12%);
+  --swc-button-border-color-default: rgb(255 255 255 / 16%);
+  --swc-button-border-color-hover: rgb(255 255 255 / 20%);
+  --swc-button-border-color-down: rgb(255 255 255 / 20%);
+  --swc-button-border-color-focus: rgb(255 255 255 / 20%);
 }
 
 .swc-Button--staticBlack {
   --swc-button-focus-indicator-color: token("static-black-focus-indicator-color");
-  --swc-button-background-color-default: token("transparent-black-800");
-  --swc-button-background-color-hover: token("transparent-black-900");
-  --swc-button-background-color-down: token("transparent-black-900");
-  --swc-button-background-color-focus: token("transparent-black-900");
+  --swc-button-background-color-default: rgb(0 0 0 / 80%);
+  --swc-button-background-color-hover: rgb(0 0 0 / 96%);
+  --swc-button-background-color-down: rgb(0 0 0 / 96%);
+  --swc-button-background-color-focus: rgb(0 0 0 / 96%);
   --swc-button-content-color-default: token("white");
   --swc-button-content-color-hover: token("white");
   --swc-button-content-color-down: token("white");
@@ -280,29 +280,29 @@
 }
 
 .swc-Button--staticBlack.swc-Button--secondary {
-  --swc-button-background-color-default: token("transparent-black-100");
+  --swc-button-background-color-default: rgb(0 0 0 / 8%);
   --swc-button-background-color-hover: token("transparent-black-200");
   --swc-button-background-color-down: token("transparent-black-200");
   --swc-button-background-color-focus: token("transparent-black-200");
-  --swc-button-content-color-default: token("transparent-black-800");
-  --swc-button-content-color-hover: token("transparent-black-900");
-  --swc-button-content-color-down: token("transparent-black-900");
-  --swc-button-content-color-focus: token("transparent-black-900");
+  --swc-button-content-color-default: rgb(0 0 0 / 80%);
+  --swc-button-content-color-hover: rgb(0 0 0 / 96%);
+  --swc-button-content-color-down: rgb(0 0 0 / 96%);
+  --swc-button-content-color-focus: rgb(0 0 0 / 96%);
 }
 
 .swc-Button--staticBlack.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
-  --swc-button-background-color-hover: token("transparent-black-100");
-  --swc-button-background-color-down: token("transparent-black-100");
-  --swc-button-background-color-focus: token("transparent-black-100");
-  --swc-button-border-color-default: token("transparent-black-800");
-  --swc-button-border-color-hover: token("transparent-black-900");
-  --swc-button-border-color-down: token("transparent-black-900");
-  --swc-button-border-color-focus: token("transparent-black-900");
-  --swc-button-content-color-default: token("transparent-black-800");
-  --swc-button-content-color-hover: token("transparent-black-900");
-  --swc-button-content-color-down: token("transparent-black-900");
-  --swc-button-content-color-focus: token("transparent-black-900");
+  --swc-button-background-color-hover: rgb(0 0 0 / 8%);
+  --swc-button-background-color-down: rgb(0 0 0 / 8%);
+  --swc-button-background-color-focus: rgb(0 0 0 / 8%);
+  --swc-button-border-color-default: rgb(0 0 0 / 80%);
+  --swc-button-border-color-hover: rgb(0 0 0 / 96%);
+  --swc-button-border-color-down: rgb(0 0 0 / 96%);
+  --swc-button-border-color-focus: rgb(0 0 0 / 96%);
+  --swc-button-content-color-default: rgb(0 0 0 / 80%);
+  --swc-button-content-color-hover: rgb(0 0 0 / 96%);
+  --swc-button-content-color-down: rgb(0 0 0 / 96%);
+  --swc-button-content-color-focus: rgb(0 0 0 / 96%);
   --swc-button-background-color-disabled: token("transparent-black-25");
   --swc-button-border-color-disabled: token("disabled-static-black-border-color");
   --swc-button-content-color-disabled: token("disabled-static-black-content-color");
@@ -310,13 +310,13 @@
 
 .swc-Button--staticBlack.swc-Button--secondary.swc-Button--outline {
   --swc-button-background-color-default: token("transparent-black-25");
-  --swc-button-background-color-hover: token("transparent-black-100");
-  --swc-button-background-color-down: token("transparent-black-100");
-  --swc-button-background-color-focus: token("transparent-black-100");
-  --swc-button-border-color-default: token("transparent-black-300");
-  --swc-button-border-color-hover: token("transparent-black-400");
-  --swc-button-border-color-down: token("transparent-black-400");
-  --swc-button-border-color-focus: token("transparent-black-400");
+  --swc-button-background-color-hover: rgb(0 0 0 / 8%);
+  --swc-button-background-color-down: rgb(0 0 0 / 8%);
+  --swc-button-background-color-focus: rgb(0 0 0 / 8%);
+  --swc-button-border-color-default: rgb(0 0 0 / 16%);
+  --swc-button-border-color-hover: rgb(0 0 0 / 24%);
+  --swc-button-border-color-down: rgb(0 0 0 / 24%);
+  --swc-button-border-color-focus: rgb(0 0 0 / 24%);
 }
 
 .swc-Button--iconOnly {


### PR DESCRIPTION
## Description

**Experimental — for Chromatic only, not to merge.**

Simulates the proposed `transparent-white/black-*` → `static-*` token deprecation so Chromatic shows the real per-component visual + contrast impact.

### Why the earlier attempts showed zero changes
- Editing `tokens.css` (`--swc-...` vars) is inert — `token()` inlines foundation values at build time, so nothing reads those vars.
- A custom token-override changed what `lookupToken` returns, but `token()` reads its data **out-of-band** (`readFile`), so the build cache never invalidated the component CSS — Chromatic re-served the stale transform.

### What this does instead
Writes the resolved deprecation values **directly into the consuming component CSS** (163 replacements across 10 files). Changing the file content forces a re-transform, so the new values actually reach the snapshots.

## The shifts (nearest-stop, per the deprecation sheet)

| Token | was | now | Δ |
|---|---|---|---|
| transparent-white-800 | 85% | 80% | −0.05 |
| transparent-black-800 | 84% | 80% | −0.04 |
| transparent-black-700 | 69% | 64% | −0.05 |
| transparent-white-600 | 51% | 48% | −0.03 |
| …other changed stops | | | ≤ ±0.02 |

## Where to look

Static-color variants of **button, action-button, close-button** (text/icon), **divider** (line), **card** (focus ring), plus **accordion** and **upload-artifact**. The heavily-used `-900` stop moves the *safe* (more-opaque) direction.

## Caveat

Only Gen2-migrated components are in this Storybook, so the sample is smaller than the eventual full surface — but it indicates where the contrast-critical usages are.
