### PR TITLE
chore(icon): add vrt test coverage

### DIFF
--- a/2nd-gen/packages/swc/components/icon/test/vrt/icon-custom-properties.vrt.ts
+++ b/2nd-gen/packages/swc/components/icon/test/vrt/icon-custom-properties.vrt.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '@adobe/spectrum-wc/components/icon/swc-icon.js';
+
+import type { CustomPropertyCase } from '../../../../.storybook/helpers/index.js';
+import {
+  coveredCustomProperties,
+  customPropertyRows,
+  theme,
+  verifyCustomPropertyCoverage,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import customElementsManifest from '../../../../dist/custom-elements.json';
+import { Chevron100Icon } from '../../elements/Chevron100Icon.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Icon/Icon VRT',
+  component: 'swc-icon',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+const iconSvg = Chevron100Icon();
+
+// Every `--swc-icon-*` property documented via `@cssprop` in Icon.ts is a
+// public contract: one row per property, a reference icon next to the same
+// icon with that one property overridden to an obviously different value.
+type IconPropertyCase = CustomPropertyCase<`--swc-icon-${string}`>;
+
+const MOD_PROPERTY_CASES: readonly IconPropertyCase[] = [
+  { property: '--swc-icon-color', value: 'magenta' },
+  { property: '--swc-icon-inline-size', value: '48px' },
+  { property: '--swc-icon-block-size', value: '48px' },
+];
+
+const modPropertyIcon = (_testCase: IconPropertyCase, style?: string) => html`
+  <swc-icon accessible-label="Chevron icon" style=${style ?? nothing}>
+    ${iconSvg}
+  </swc-icon>
+`;
+
+const modPropertiesContent = () =>
+  customPropertyRows(MOD_PROPERTY_CASES, modPropertyIcon);
+
+const coveredIconCustomProperties = coveredCustomProperties(MOD_PROPERTY_CASES);
+
+const verifyIconCustomPropertyCoverage = async () => {
+  await verifyCustomPropertyCoverage({
+    customElementsManifest,
+    modulePath: 'components/icon/Icon.ts',
+    declarationName: 'Icon',
+    coveredProperties: coveredIconCustomProperties,
+  });
+};
+
+// VRT stories
+
+export const CustomProperties: Story = {
+  render: () => theme(modPropertiesContent(), 'light', 'ltr'),
+  parameters: vrtParameters,
+  play: verifyIconCustomPropertyCoverage,
+};

--- a/2nd-gen/packages/swc/components/icon/test/vrt/icon.vrt.ts
+++ b/2nd-gen/packages/swc/components/icon/test/vrt/icon.vrt.ts
@@ -50,15 +50,14 @@ const sizeLabels = {
   xl: 'Extra-large',
 } as const satisfies Record<IconSize, string>;
 
-const icon = (
-  { size, accessibleLabel }: { size: IconSize; accessibleLabel?: string },
-  style?: string
-) => html`
-  <swc-icon
-    size=${size}
-    accessible-label=${accessibleLabel ?? nothing}
-    style=${style ?? nothing}
-  >
+const icon = ({
+  size,
+  accessibleLabel,
+}: {
+  size: IconSize;
+  accessibleLabel?: string;
+}) => html`
+  <swc-icon size=${size} accessible-label=${accessibleLabel ?? nothing}>
     ${iconSvg}
   </swc-icon>
 `;
@@ -73,7 +72,13 @@ const permutationContent = () => html`
   ${row([icon({ size: 'm', accessibleLabel: 'Search' })], 'Labeled (role=img)')}
   ${row([icon({ size: 'm' })], 'Decorative (aria-hidden)')}
   ${row(
-    [icon({ size: 'm', accessibleLabel: 'Search' }, 'color: blueviolet;')],
+    [
+      html`
+        <div style="color: blueviolet;">
+          ${icon({ size: 'm', accessibleLabel: 'Search' })}
+        </div>
+      `,
+    ],
     'Inherited color (currentColor)'
   )}
 `;

--- a/2nd-gen/packages/swc/components/icon/test/vrt/icon.vrt.ts
+++ b/2nd-gen/packages/swc/components/icon/test/vrt/icon.vrt.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import {
+  ICON_VALID_SIZES,
+  type IconSize,
+} from '@adobe/spectrum-wc-core/components/icon';
+
+import '@adobe/spectrum-wc/components/icon/swc-icon.js';
+
+import {
+  forcedColorsVrtParameters,
+  row,
+  theme,
+  vrtParameters,
+} from '../../../../.storybook/helpers/index.js';
+import { Chevron100Icon } from '../../elements/Chevron100Icon.js';
+
+// Metadata
+
+const meta: Meta = {
+  title: 'Icon/Icon VRT',
+  component: 'swc-icon',
+  tags: ['dev'],
+};
+
+export default meta;
+
+// Helpers
+
+const iconSvg = Chevron100Icon();
+
+const sizeLabels = {
+  xs: 'Extra-small',
+  s: 'Small',
+  m: 'Medium',
+  l: 'Large',
+  xl: 'Extra-large',
+} as const satisfies Record<IconSize, string>;
+
+const icon = (
+  { size, accessibleLabel }: { size: IconSize; accessibleLabel?: string },
+  style?: string
+) => html`
+  <swc-icon
+    size=${size}
+    accessible-label=${accessibleLabel ?? nothing}
+    style=${style ?? nothing}
+  >
+    ${iconSvg}
+  </swc-icon>
+`;
+
+const permutationContent = () => html`
+  ${row(
+    ICON_VALID_SIZES.map((size) =>
+      icon({ size, accessibleLabel: sizeLabels[size] })
+    ),
+    'Sizes'
+  )}
+  ${row([icon({ size: 'm', accessibleLabel: 'Search' })], 'Labeled (role=img)')}
+  ${row([icon({ size: 'm' })], 'Decorative (aria-hidden)')}
+  ${row(
+    [icon({ size: 'm', accessibleLabel: 'Search' }, 'color: blueviolet;')],
+    'Inherited color (currentColor)'
+  )}
+`;
+
+// VRT stories
+
+// Every size, labeled (role="img") vs. decorative (aria-hidden, the
+// default with no accessible-label) host semantics, and the `color:
+// var(--swc-icon-color, currentColor)` fallback that inherits an ancestor's
+// `color` when the custom property is unset (see icon-custom-properties.vrt.ts
+// for the property override itself). Rendered once in light/ltr and once in
+// dark/rtl, since that fallback tracks the surrounding theme's content color
+// rather than a fixed token.
+export const Permutations: Story = {
+  render: () => html`
+    ${theme(permutationContent(), 'light', 'ltr')}
+    ${theme(permutationContent(), 'dark', 'rtl')}
+  `,
+  parameters: vrtParameters,
+};
+
+// `forced-colors` replaces the page palette wholesale, and the icon's fill
+// resolves through `currentColor`, so it's worth confirming size and
+// labeled/decorative permutations still render legibly under the system
+// palette.
+export const ForcedColors: Story = {
+  render: () => theme(permutationContent(), 'light', 'ltr'),
+  parameters: forcedColorsVrtParameters,
+};


### PR DESCRIPTION
## Description

Adds `icon.vrt.ts` and `icon-custom-properties.vrt.ts` under `components/icon/test/vrt/`, covering sizes, labeled/decorative (aria-hidden) usage, forced-colors, and the three `--swc-icon-*` custom properties.

## Motivation and context

Icon had no dedicated VRT suite; this follows the VRT foundation pattern established for button.

## Related issue(s)

- SWC-2400

## Screenshots (if appropriate)

N/A

## Author's checklist

- [x] I have read the CONTRIBUTING and PULL_REQUESTS documents.
- [x] I have reviewed the Accessibility Practices for this feature, see: Aria Practices.
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Storybook VRT stories render correctly
  1. Go to Storybook, `Icon/Icon VRT`
  2. Open `Permutations`, `Forced colors`, and `Custom properties`
  3. Expect sizes, labeled/decorative icons, and custom-property overrides to render as described

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard**: `<swc-icon>` has no focusable parts; confirm no focus stops occur when tabbing through the `Icon/Icon VRT → Permutations` story.
- [ ] **Screen reader**: 1. Open `Icon/Icon VRT → Permutations`. 2. Confirm the labeled icon is announced as an image with its label (e.g. "Search"). 3. Confirm the decorative icon is not announced (aria-hidden).