### PR TITLE
fix(ci): restore GITHUB_TOKEN and verify changelog generation for changeset version steps

### DIFF
--- a/.github/workflows/publish-2nd-gen.yml
+++ b/.github/workflows/publish-2nd-gen.yml
@@ -98,6 +98,8 @@ jobs:
 
       - name: Version packages (snapshot)
         working-directory: 2nd-gen
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn changeset version --snapshot ${{ steps.extract-tag.outputs.tag }}
 
       - name: Capture released versions
@@ -183,6 +185,8 @@ jobs:
 
       - name: Version 2nd-gen packages
         if: needs.check-changesets.outputs.has_changesets == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ ! -f 2nd-gen/.changeset/pre.json ]; then
             (cd 2nd-gen && yarn changeset pre enter beta)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,6 +122,8 @@ jobs:
         run: yarn workspace @spectrum-web-components/1st-gen build:confirm
 
       - name: Version 1st-gen packages (snapshot)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: (cd 1st-gen && yarn changeset version --snapshot ${{ steps.extract-tag.outputs.tag }})
 
       - name: Capture released versions
@@ -284,6 +286,8 @@ jobs:
 
       - name: Version 1st-gen packages
         if: needs.check-changesets.outputs.has_changesets == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           yarn workspace @spectrum-web-components/1st-gen changelog:1st-gen
           (cd 1st-gen && yarn changeset version)

--- a/CONTRIBUTOR-DOCS/01_contributor-guides/15_changelog-strategy.md
+++ b/CONTRIBUTOR-DOCS/01_contributor-guides/15_changelog-strategy.md
@@ -19,6 +19,8 @@
     - [Rules](#rules)
 - [CHANGELOG output](#changelog-output)
 - [How it works](#how-it-works)
+- [Gen1's changelog rollup](#gen1s-changelog-rollup)
+- [Gen2's beta pre-release channel](#gen2s-beta-pre-release-channel)
 
 </details>
 
@@ -172,3 +174,19 @@ Each entry is automatically prefixed with the PR link and commit reference by `@
 `2nd-gen/.changeset/config.json` uses `@changesets/changelog-github` with `disableThanks: true`. This is the standard changesets GitHub changelog generator — it auto-prepends the PR link and commit reference to each entry, groups entries by bump type (`### Minor Changes`, `### Patch Changes`), and handles version headings. The `disableThanks` option suppresses the `Thanks @author!` attribution so entries stay focused on the change itself.
 
 No custom scripts are involved. The changeset body you write is preserved as-is; changesets handles all formatting and collation.
+
+## Gen1's changelog rollup
+
+1st-gen (`1st-gen/.changeset/config.json`) also uses `@changesets/changelog-github`, so per-package `CHANGELOG.md` files (e.g. `1st-gen/packages/button/CHANGELOG.md`) are generated the same way as gen2's.
+
+On top of that, gen1 runs one additional step: `yarn workspace @spectrum-web-components/1st-gen changelog:1st-gen` (`1st-gen/scripts/update-changelog.js`), which rolls up the currently pending `1st-gen/.changeset/*.md` files into a single dated entry at the top of the root `1st-gen/CHANGELOG.md`. It builds this entry independently, straight from the changeset frontmatter and body text, rather than from `@changesets/changelog-github`'s output.
+
+This script must run before `yarn changeset version`, since `changeset version` deletes each `.changeset/*.md` file once it folds it into the per-package changelogs. In the release workflow (`.github/workflows/publish.yml`), both steps run in the same job, so the resulting `1st-gen/CHANGELOG.md` rollup entry and the per-package `CHANGELOG.md` updates land in the same Version PR commit for review.
+
+Gen2 has no equivalent rollup script; it relies solely on `@changesets/changelog-github`.
+
+## Gen2's beta pre-release channel
+
+Gen2 publishes exclusively on a persistent `beta` pre-release channel; there is no `latest` channel yet. The first time the release workflow runs with pending 2nd-gen changesets, it enters changesets' pre-release mode (`yarn changeset pre enter beta`), which creates `2nd-gen/.changeset/pre.json`. Every subsequent run checks for that file and skips re-entering pre-release mode, so it only happens once. There is currently no `changeset pre exit` step configured anywhere, so gen2 stays on the `beta` channel by design.
+
+Each release bumps the pre-release number (`beta.1`, `beta.2`, and so on). This is standard `@changesets/cli` pre-release behavior, not custom logic in this repo: each `.changeset/*.md` file is consumed and deleted the first time it is folded into a version, so a given change should not reappear in a later `beta.N` entry.


### PR DESCRIPTION
## Description

Restores the `GITHUB_TOKEN` environment variable to the four `Version ... packages` steps (release + snapshot, gen1 + gen2) in `.github/workflows/publish.yml` and `.github/workflows/publish-2nd-gen.yml`. Also documents gen1's `changelog:1st-gen` rollup script and gen2's persistent `beta` pre-release channel in `CONTRIBUTOR-DOCS/01_contributor-guides/15_changelog-strategy.md`, neither of which was previously written down.

## Motivation and context

Both `1st-gen/.changeset/config.json` and `2nd-gen/.changeset/config.json` use `@changesets/changelog-github` to generate per-package changelog entries. That generator's `get-github-info` dependency hard-throws (`Please create a GitHub personal access token...`) if `GITHUB_TOKEN` isn't set, rather than silently falling back to plain text.

The old shared publish step (before #6607 split the pipeline into independent gen1/gen2 Version PR flows) set this env var. During the rewrite it was dropped from all four of the new split `Version ... packages` steps — confirmed via `git log`, this exact regression was found and fixed twice in earlier iterations of that PR, but the fix didn't survive the final squash. Left as-is, the next real release with pending changesets would fail outright at `yarn changeset version`.

This is a CI/tooling-only change; no UI surface is affected.

## Related issue(s)

- SWC-2482

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Version PR opens without CI failure_
  1. Push a scratch changeset to a branch, open a PR, merge it to `main`.
  2. Watch the `release` job in the `Publish Packages` workflow (matching generation).
  3. Expect the `Version ... packages` step to succeed and a `changeset-release/1st-gen` or `changeset-release/2nd-gen` Version PR to open/update with a correct `CHANGELOG.md` diff (PR/commit links resolved, author attribution correct).

- [ ] _Gen2 successive beta bumps don't duplicate_
  1. With a gen2 Version PR already open, push a second, separate changeset to `main` before merging it.
  2. Expect the `release` job to re-run and force-update the same Version PR.
  3. Expect the new `beta.N+1` entry to be added cleanly, with no duplicated or garbled prior entries.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

Not applicable — this PR only changes GitHub Actions workflow YAML and a contributor-facing markdown doc. No component, UI, or user-facing surface is touched, so there is nothing to test for keyboard or screen reader behavior.

- [ ] **Keyboard** — N/A, no UI surface.
- [ ] **Screen reader** — N/A, no UI surface.
