### PR TITLE
perf(icons): scope workflow icon registration to cut webkit CI memory

### DIFF
--- a/2nd-gen/packages/icons/stories/workflow-icons.stories.ts
+++ b/2nd-gen/packages/icons/stories/workflow-icons.stories.ts
@@ -19,8 +19,16 @@ import {
   type IconSize,
 } from '@adobe/spectrum-wc-core/components/icon';
 
-// Registers every `<swc-icon-*>` workflow element.
-import '../src/elements.js';
+// Register only the icons the light stories render. The full set (413 elements) is
+// registered lazily by the Gallery story's loader, so opening a compact story does
+// not pull the whole barrel into the page.
+import '../src/swc-icon-star.js';
+import '../src/swc-icon-folder.js';
+import '../src/swc-icon-heart.js';
+import '../src/swc-icon-settings.js';
+import '../src/swc-icon-search.js';
+import '../src/swc-icon-delete.js';
+import '../src/swc-icon-alert-triangle.js';
 
 import { WORKFLOW_ICONS } from '../src/manifest.js';
 
@@ -188,6 +196,14 @@ export const Color: Story = {
 // run is disproportionately slow with no behavioral coverage beyond the lighter
 // stories; the dedicated VRT story snapshots the grid instead.
 export const Gallery: Story = {
+  // Register the full workflow set only when this story renders, keeping the 413
+  // element modules out of the lighter stories' page.
+  loaders: [
+    async () => {
+      await import('../src/elements.js');
+      return {};
+    },
+  ],
   render: (args) => html`
     ${WORKFLOW_ICONS.map(
       ({ name, tag }) => html`

--- a/2nd-gen/packages/icons/test/workflow-icons.manifest.test.ts
+++ b/2nd-gen/packages/icons/test/workflow-icons.manifest.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { html } from 'lit';
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+// Register every workflow element so the coverage test can resolve each tag. This is
+// the only test page that pulls the whole barrel, keeping the 413 element modules off
+// the lighter per-icon test pages.
+import '../src/elements.js';
+
+import { WORKFLOW_ICONS } from '../src/manifest.js';
+
+// Dev-only test story, isolated so the full-set registration stays on one page.
+export default {
+  title: 'Workflow icons/Tests/Manifest',
+  parameters: {
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+// ──────────────────────────────────────────────────────────────
+// TEST: the manifest matches the registered elements
+// ──────────────────────────────────────────────────────────────
+
+export const ManifestCoverageTest: Story = {
+  render: () => html`
+    <span></span>
+  `,
+  play: async ({ step }) => {
+    await step('every manifest tag is a registered custom element', () => {
+      expect(WORKFLOW_ICONS.length, 'ships the full set').toBeGreaterThan(400);
+      const missing = WORKFLOW_ICONS.filter(
+        ({ tag }) => customElements.get(tag) === undefined
+      );
+      expect(missing, 'no manifest tag is unregistered').toStrictEqual([]);
+    });
+
+    await step('tags are unique', () => {
+      const tags = WORKFLOW_ICONS.map((i) => i.tag);
+      expect(new Set(tags).size, 'all tags are distinct').toBe(tags.length);
+    });
+  },
+};

--- a/2nd-gen/packages/icons/test/workflow-icons.test.ts
+++ b/2nd-gen/packages/icons/test/workflow-icons.test.ts
@@ -15,10 +15,11 @@ import type { Meta, StoryObj as Story } from '@storybook/web-components';
 
 import type { IconBase } from '@adobe/spectrum-wc-core/components/icon';
 
-// Register every workflow element so the manifest coverage test can resolve each tag.
-import '../src/elements.js';
+// Register only the elements these stories render. Full-set coverage lives in
+// workflow-icons.manifest.test.ts, which imports the whole barrel on its own page.
+import '../src/swc-icon-star.js';
+import '../src/swc-icon-alert-triangle.js';
 
-import { WORKFLOW_ICONS } from '../src/manifest.js';
 import { Icon_Star } from '../src/Star.js';
 import meta from '../stories/workflow-icons.stories.js';
 
@@ -157,30 +158,6 @@ export const DecorativeHostAccessibilityTest: Story = {
       expect(icon.hasAttribute('aria-label'), 'host has no aria-label').toBe(
         false
       );
-    });
-  },
-};
-
-// ──────────────────────────────────────────────────────────────
-// TEST: the manifest matches the registered elements
-// ──────────────────────────────────────────────────────────────
-
-export const ManifestCoverageTest: Story = {
-  render: () => html`
-    <span></span>
-  `,
-  play: async ({ step }) => {
-    await step('every manifest tag is a registered custom element', () => {
-      expect(WORKFLOW_ICONS.length, 'ships the full set').toBeGreaterThan(400);
-      const missing = WORKFLOW_ICONS.filter(
-        ({ tag }) => customElements.get(tag) === undefined
-      );
-      expect(missing, 'no manifest tag is unregistered').toStrictEqual([]);
-    });
-
-    await step('tags are unique', () => {
-      const tags = WORKFLOW_ICONS.map((i) => i.tag);
-      expect(new Set(tags).size, 'all tags are distinct').toBe(tags.length);
     });
   },
 };


### PR DESCRIPTION
## Hypothesis

Draft experiment to check whether this relieves the WebKit resource exhaustion seen on `caseyisonit/swc-2442-2441-tickets-6ca1ff`.

The `test-2ndgen-browser` CircleCI job runs the 2nd-gen Storybook stories in a real browser via `@storybook/addon-vitest` (`VITEST_BROWSER_INSTANCES=webkit`). This PR's parent added the `icons` package into that run (`.storybook/main.ts` `TEST_FIXTURES`). Both `workflow-icons.stories.ts` and `workflow-icons.test.ts` imported `../src/elements.js` at module top, which registers **all ~413** `<swc-icon-*>` custom elements — each carrying a baked-in SVG — into **every** icons page WebKit loads, even for stories that render a single icon. WebKit is far more memory-hungry per custom element / shadow root than Chromium, so this is the most likely driver of the exhaustion.

## Change

- **Stories:** register only the icons the light stories render; the `Gallery` story (the only one needing the full set, and already `!test`) lazy-loads the barrel through a Storybook `loaders` entry, so the 413 element modules stay off the compact stories' page.
- **Unit tests:** `workflow-icons.test.ts` now imports only `swc-icon-star` + `swc-icon-alert-triangle`.
- **Manifest coverage:** the one test that genuinely needs all tags registered moves to its own `workflow-icons.manifest.test.ts`, isolating the full-set registration to a single page.

No coverage removed — same stories, same assertions, reorganized so the heavy registration is confined to the few pages that actually need it.

## How to validate

Compare the `test-2ndgen-browser` (webkit) job memory/duration on this PR vs the parent branch. If WebKit is still exhausting, the driver is elsewhere (e.g. the Chromatic VRT `Gallery` snapshot rendering all 413 in one page) and we iterate.