### PR TITLE
fix(prompt-field): reserve scrollbar room so it doesn't overlap artifact tiles

### DIFF
--- a/.changeset/prompt-field-artifact-scrollbar-overlap.md
+++ b/.changeset/prompt-field-artifact-scrollbar-overlap.md
@@ -1,0 +1,5 @@
+---
+'@adobe/spectrum-wc': patch
+---
+
+Fix the `swc-prompt-field` multi-attachment strip so a classic (space-consuming) horizontal scrollbar no longer draws over the bottom edge of the artifact tiles. The scroll container now reserves scrollbar room with `scrollbar-gutter: stable`, which has no effect where scrollbars are overlay.

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -620,6 +620,11 @@
   padding-inline: token("spacing-75");
   overflow-x: auto;
   overflow-y: hidden;
+
+  /* Reserve room for the horizontal scrollbar so a classic (space-consuming)
+   * scrollbar draws below the tiles instead of over their bottom edge.
+   * No effect where scrollbars are overlay, so it adds no dead space there. */
+  scrollbar-gutter: stable;
   scroll-behavior: smooth;
 
   /* proximity avoids a forced re-snap when the chevrons change scroll-padding */


### PR DESCRIPTION
## Description

The `swc-prompt-field` multi-attachment strip did not reserve any space for the horizontal scrollbar. In `.swc-PromptField-artifacts-scroll` the tile row's bottom sits exactly flush with the scrollport edge, so on platforms that use classic (space-consuming) scrollbars (Windows, Linux, macOS with "always show scrollbars", and Chromatic's Linux Chrome) the scrollbar draws over the bottom of the artifact tiles.

Adding `scrollbar-gutter: stable` reserves room for that scrollbar below the tiles. It has no effect where scrollbars are overlay (macOS default), so it adds no dead space there.

```css
.swc-PromptField-artifacts-scroll {
  overflow-x: auto;
  overflow-y: hidden;
  scrollbar-gutter: stable; /* added */
  ...
}
```

## Motivation and context

The native horizontal scrollbar on the overflowing attachment strip visually overlapped the attachment tiles wherever classic scrollbars are in use.

## Related issue(s)

- No tracked issue; reported during review of the prompt-field attachment strip.

## How has this been tested?

- `stylelint` passes on the changed file.
- Verified the mechanism with a Playwright layout probe: the tile row's bottom is flush with the scrollport (0px gap) without the fix, so a classic scrollbar overlaps it; reserving gutter room clears it.
- Visual result on classic-scrollbar platforms will be confirmed by Chromatic VRT (new golden expected: the strip grows by the scrollbar height).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have included a well-written changeset if my change needs to be published.

## Reviewer's checklist

- [ ] All VRTs are approved before the author can update Golden Hash
