### PR TITLE
fix(prompt-field): reserve scrollbar room so it doesn't overlap artifact tiles

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -473,9 +473,17 @@
   padding-inline: 0;
 }
 
-/* Tighten the attachments-to-text spacing. */
+/* Attachments-to-text spacing. The single layout uses this flex gap; the
+ * multiple layout drops it (gap: 0 below) and gets the same distance from its
+ * scroll container's padding-block-end, so the scrollbar draws in that space
+ * instead of adding to it. This keeps the distance consistent whether or not a
+ * scrollbar is present. */
 .swc-PromptField-input-area.has-attachment {
   gap: token("spacing-200");
+}
+
+.swc-PromptField-input-area:has(.swc-PromptField-attachments--multiple) {
+  gap: 0;
 }
 
 /* ─────────────────────────────────────

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -679,7 +679,10 @@
   align-items: start;
   inline-size: max-content;
   min-inline-size: 100%;
-  block-size: var(--swc-prompt-field-attachment-media-block-size, 68px);
+
+  /* min, not a fixed size: media rows stay 68px while taller card tiles grow
+   * the row instead of being clipped by the scroll container's overflow-y. */
+  min-block-size: var(--swc-prompt-field-attachment-media-block-size, 68px);
 }
 
 .swc-PromptField-attachments-tiles > slot {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -465,6 +465,10 @@
    ───────────────────────────────────── */
 
 .swc-PromptField-input-area {
+  /* Room reserved below the tiles for the scrollbar when the strip overflows;
+   * inherits down to the scroll container and is subtracted from the gap. */
+  --_swc-prompt-field-attachment-scrollbar-size: token("spacing-75");
+
   display: flex;
   flex-direction: column;
   gap: token("spacing-300");
@@ -477,7 +481,7 @@
  * scrollbar; trim the attachments-to-text gap by that same amount so the total
  * distance matches the non-scrolling case (the default spacing-300 gap). */
 .swc-PromptField-input-area:has(.swc-PromptField-attachments-scroll:is(.has-scroll-prev, .has-scroll-next)) {
-  gap: calc(token("spacing-300") - token("spacing-75"));
+  gap: calc(token("spacing-300") - var(--_swc-prompt-field-attachment-scrollbar-size));
 }
 
 /* ─────────────────────────────────────
@@ -659,7 +663,7 @@
  * tiles for the scrollbar. The input-area trims the attachments-to-text gap by
  * the same amount, so the total distance stays constant with or without it. */
 .swc-PromptField-attachments-scroll:is(.has-scroll-prev, .has-scroll-next) {
-  padding-block-end: token("spacing-75");
+  padding-block-end: var(--_swc-prompt-field-attachment-scrollbar-size);
 }
 
 /* Flip the physical mask direction in RTL so fade-start/end (driven by the

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -477,9 +477,10 @@
   padding-inline: 0;
 }
 
-/* When the strip overflows, its scroll container adds padding-block-end for the
- * scrollbar; trim the attachments-to-text gap by that same amount so the total
- * distance matches the non-scrolling case (the default spacing-300 gap). */
+/* When the strip overflows, the scroll container reserves padding-block-end
+ * (--_swc-prompt-field-attachment-scrollbar-size) for the scrollbar. Subtract
+ * that from the gap so the total tiles-to-text distance stays spacing-300 (16px),
+ * the same as the non-overflowing case above. */
 .swc-PromptField-input-area:has(.swc-PromptField-attachments-scroll:is(.has-scroll-prev, .has-scroll-next)) {
   gap: calc(token("spacing-300") - var(--_swc-prompt-field-attachment-scrollbar-size));
 }

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -617,6 +617,12 @@
   inline-size: 100%;
   max-inline-size: 100%;
   padding-block-start: var(--_swc-prompt-field-attachment-badge-clearance, 0);
+
+  /* padding-block-end reserves room for the horizontal scrollbar below the
+   * tiles so it draws in this strip instead of over their bottom edge.
+   * scrollbar-gutter only reserves the inline-axis gutter, so it can't cover
+   * a horizontal scrollbar. */
+  padding-block-end: token("spacing-200");
   padding-inline: token("spacing-75");
   overflow-x: auto;
   overflow-y: hidden;
@@ -625,7 +631,6 @@
   /* proximity avoids a forced re-snap when the chevrons change scroll-padding */
   scroll-snap-type: inline proximity;
   scroll-padding-inline: token("spacing-75");
-  scrollbar-color: token("gray-400") transparent;
   mask-image: linear-gradient(to right, transparent 0, transparent calc(var(--_swc-prompt-field-attachment-fade-start) - var(--_swc-prompt-field-attachment-fade-soft)), black var(--_swc-prompt-field-attachment-fade-start), black calc(100% - var(--_swc-prompt-field-attachment-fade-end)), transparent calc(100% - var(--_swc-prompt-field-attachment-fade-end) + var(--_swc-prompt-field-attachment-fade-soft)), transparent 100%);
 }
 
@@ -653,14 +658,6 @@
  * logical prev/next scroll state above) still land on the correct edge. */
 :host(:dir(rtl)) .swc-PromptField-attachments-scroll {
   mask-image: linear-gradient(to left, transparent 0, transparent calc(var(--_swc-prompt-field-attachment-fade-start) - var(--_swc-prompt-field-attachment-fade-soft)), black var(--_swc-prompt-field-attachment-fade-start), black calc(100% - var(--_swc-prompt-field-attachment-fade-end)), transparent calc(100% - var(--_swc-prompt-field-attachment-fade-end) + var(--_swc-prompt-field-attachment-fade-soft)), transparent 100%);
-}
-
-.swc-PromptField-attachments-scroll::-webkit-scrollbar {
-  background: transparent;
-}
-
-.swc-PromptField-attachments-scroll::-webkit-scrollbar-track {
-  background: transparent;
 }
 
 .swc-PromptField-attachments-tiles {
@@ -717,6 +714,16 @@
   z-index: 4;
   flex: 0 0 auto;
   transform: translateY(-50%);
+
+  /* Fade the edge chevrons in and out as they enable/disable instead of popping. */
+  transition: opacity token("animation-duration-100") token("animation-ease-in-out");
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .swc-PromptField-attachments-scroll-prev,
+  .swc-PromptField-attachments-scroll-next {
+    transition: none;
+  }
 }
 
 /* aria-disabled, not the disabled attribute, and hidden with opacity, not

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -473,10 +473,9 @@
   padding-inline: 0;
 }
 
-/* Tighten the attachments-to-text spacing to 14px (no single spacing token
- * lands on 14, so sum 12 + 2). */
+/* Tighten the attachments-to-text spacing. */
 .swc-PromptField-input-area.has-attachment {
-  gap: calc(token("spacing-200") + token("spacing-50"));
+  gap: token("spacing-200");
 }
 
 /* ─────────────────────────────────────

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -731,13 +731,6 @@
   transition: opacity token("animation-duration-100") token("animation-ease-in-out");
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .swc-PromptField-attachments-scroll-prev,
-  .swc-PromptField-attachments-scroll-next {
-    transition: none;
-  }
-}
-
 /* aria-disabled, not the disabled attribute, and hidden with opacity, not
  * display/visibility: a chevron at the end of the strip stays mounted so the
  * layout and edge fades don't shift. If it had focus, the component moves focus
@@ -928,6 +921,11 @@ slot[name="legal"] {
 @media (prefers-reduced-motion: reduce) {
   .swc-PromptField-attachments-scroll {
     scroll-behavior: auto;
+  }
+
+  .swc-PromptField-attachments-scroll-prev,
+  .swc-PromptField-attachments-scroll-next {
+    transition: none;
   }
 }
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -467,7 +467,7 @@
 .swc-PromptField-input-area {
   /* Room reserved below the tiles for the scrollbar when the strip overflows;
    * inherits down to the scroll container and is subtracted from the gap. */
-  --_swc-prompt-field-attachment-scrollbar-size: token("spacing-75");
+  --_swc-prompt-field-attachment-scrollbar-size: token("spacing-200");
 
   display: flex;
   flex-direction: column;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -473,17 +473,11 @@
   padding-inline: 0;
 }
 
-/* Attachments-to-text spacing. The single layout uses this flex gap; the
- * multiple layout drops it (gap: 0 below) and gets the same distance from its
- * scroll container's padding-block-end, so the scrollbar draws in that space
- * instead of adding to it. This keeps the distance consistent whether or not a
- * scrollbar is present. */
-.swc-PromptField-input-area.has-attachment {
-  gap: token("spacing-200");
-}
-
-.swc-PromptField-input-area:has(.swc-PromptField-attachments--multiple) {
-  gap: 0;
+/* When the strip overflows, its scroll container adds padding-block-end for the
+ * scrollbar; trim the attachments-to-text gap by that same amount so the total
+ * distance matches the non-scrolling case (the default spacing-300 gap). */
+.swc-PromptField-input-area:has(.swc-PromptField-attachments-scroll:is(.has-scroll-prev, .has-scroll-next)) {
+  gap: calc(token("spacing-300") - token("spacing-75"));
 }
 
 /* ─────────────────────────────────────
@@ -630,12 +624,6 @@
   inline-size: 100%;
   max-inline-size: 100%;
   padding-block-start: var(--_swc-prompt-field-attachment-badge-clearance, 0);
-
-  /* padding-block-end reserves room for the horizontal scrollbar below the
-   * tiles so it draws in this strip instead of over their bottom edge.
-   * scrollbar-gutter only reserves the inline-axis gutter, so it can't cover
-   * a horizontal scrollbar. */
-  padding-block-end: token("spacing-200");
   padding-inline: token("spacing-75");
   overflow-x: auto;
   overflow-y: hidden;
@@ -665,6 +653,13 @@
   --_swc-prompt-field-attachment-fade-end: var(--_swc-prompt-field-attachment-fade);
 
   scroll-padding-inline-end: calc(token("component-height-100") + token("spacing-400") + token("spacing-75"));
+}
+
+/* When the strip overflows (either chevron active), reserve room below the
+ * tiles for the scrollbar. The input-area trims the attachments-to-text gap by
+ * the same amount, so the total distance stays constant with or without it. */
+.swc-PromptField-attachments-scroll:is(.has-scroll-prev, .has-scroll-next) {
+  padding-block-end: token("spacing-75");
 }
 
 /* Flip the physical mask direction in RTL so fade-start/end (driven by the

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.css
@@ -473,6 +473,12 @@
   padding-inline: 0;
 }
 
+/* Tighten the attachments-to-text spacing to 14px (no single spacing token
+ * lands on 14, so sum 12 + 2). */
+.swc-PromptField-input-area.has-attachment {
+  gap: calc(token("spacing-200") + token("spacing-50"));
+}
+
 /* ─────────────────────────────────────
    Controls (status icon, textarea, upload button, send/stop button)
    ───────────────────────────────────── */

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/test/prompt-field.test.ts
@@ -469,21 +469,34 @@ function waitForScrollEnd(
 
     scrollEl.addEventListener('scrollend', finish, { once: true });
 
-    let lastScrollLeft = scrollEl.scrollLeft;
+    const startScrollLeft = scrollEl.scrollLeft;
+    let lastScrollLeft = startScrollLeft;
+    let hasMoved = false;
     let stableFrames = 0;
+    // Smooth scrolling does not start on the first frames after the click, so
+    // the position is briefly stable at its start value. Only treat a run of
+    // stable frames as "settled" once movement has actually been observed;
+    // the frame cap keeps this from hanging if the scroll never moves.
+    let framesLeft = 120;
     const poll = (): void => {
       if (settled) {
         return;
       }
-      if (scrollEl.scrollLeft === lastScrollLeft) {
+      if (scrollEl.scrollLeft !== lastScrollLeft) {
+        hasMoved = true;
+        stableFrames = 0;
+        lastScrollLeft = scrollEl.scrollLeft;
+      } else if (hasMoved) {
         stableFrames += 1;
         if (stableFrames >= 3) {
           finish();
           return;
         }
-      } else {
-        stableFrames = 0;
-        lastScrollLeft = scrollEl.scrollLeft;
+      }
+      framesLeft -= 1;
+      if (framesLeft <= 0) {
+        finish();
+        return;
       }
       requestAnimationFrame(poll);
     };


### PR DESCRIPTION
## Description

Fixes the `swc-prompt-field` multi-attachment strip's horizontal scrollbar and paging chevrons.

- **Scrollbar overlap**: the strip customized the scrollbar (`scrollbar-color`, `::-webkit-scrollbar` rules) and reserved no room for it, so in `.swc-PromptField-artifacts-scroll` the tile row's bottom sat flush with the scrollport edge and the scrollbar drew over the bottom of the tiles. This removes the custom styling so the strip uses the platform's native scrollbar, and reserves room for it below the tiles with `padding-block-end: token("spacing-300")` (16px, matching the top badge clearance). `scrollbar-gutter` only reserves the inline-axis gutter, so it cannot cover a horizontal scrollbar.
- **Chevron fade**: the paging chevrons appeared and disappeared instantly as they enabled/disabled. They now fade with `transition: opacity token("animation-duration-100") token("animation-ease-in-out")`, guarded by `prefers-reduced-motion`.
- **Flaky RTL test**: `waitForScrollEnd` in `prompt-field.test.ts` could settle at the scroll's start position before smooth scrolling began, running the geometric assertion too early. It now only treats a run of stable frames as settled after movement is observed, with a frame cap so it still cannot hang.

## Motivation and context

The native horizontal scrollbar overlapped the attachment tiles wherever classic scrollbars are in use, the strip carried scrollbar styling that diverged from the platform default, and the paging chevrons popped in and out without a transition.

## Related issue(s)

- No tracked issue; reported during review of the prompt-field attachment strip.

## How has this been tested?

- `stylelint` passes on the changed CSS.
- `vitest --run --project storybook prompt-field` passes (22 tests, including Artifact Scroll RTL Test).
- Playwright headless on macOS uses overlay scrollbars, so the classic-scrollbar overlap can't be screenshotted locally; Chromatic VRT (Linux, classic scrollbars) will confirm the visual result and produce a new golden.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Author's checklist

- [x] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [x] I have included a well-written changeset if my change needs to be published.

## Reviewer's checklist

- [ ] All VRTs are approved before the author can update Golden Hash