### PR TITLE
docs(prompt-field): hide collapsed from public docs

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/PromptField.ts
@@ -105,7 +105,13 @@ export class PromptField extends SpectrumElement {
   @property({ type: Boolean, reflect: true })
   public generating = false;
 
-  /** Starts as a single-line layout with send/stop inline instead of the default layout with a separate action bar; the textarea still wraps and grows with content either way. */
+  /**
+   * Starts as a single-line layout with send/stop inline instead of the default
+   * layout with a separate action bar; the textarea still wraps and grows with
+   * content either way.
+   *
+   * @internal
+   */
   @property({ type: Boolean, reflect: true })
   public collapsed = false;
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/prompt-field.mdx
@@ -11,9 +11,9 @@ import * as PromptFieldStories from './stories/prompt-field.stories';
 
 A prompt field consists of:
 
-1. **Box**: white card container with shadow, starting as a taller multiline card by default or a single-line row via the `collapsed` attribute.
+1. **Box**: white card container with shadow, starting as a taller multiline card by default.
 2. **Input area**: visually hidden label + textarea.
-3. **Action bar**: upload trigger (left) and send/stop action (right); shown on its own row by default, otherwise (when `collapsed`) the send/stop action sits inline with the textarea instead.
+3. **Action bar**: upload trigger (left) and send/stop action (right), shown on its own row.
 4. **Footer**: legal disclaimer rendered below the prompt surface. Required in product implementations.
 
 <Canvas of={PromptFieldStories.Anatomy} />
@@ -43,15 +43,6 @@ The two name sets don't overlap, so one attribute covers both.
 
 The indicator is decorative (`aria-hidden`); the generating state is conveyed to assistive technology by the stop button that replaces send.
 
-### Layout
-
-The `collapsed` attribute controls the field's expanded/collapsed layout:
-
-- **Expanded (default)**: taller card with a separate action bar below the textarea, showing the upload button alongside send/stop.
-- **`collapsed`**: starts as a single-line row with the send/stop button inline with the textarea and no upload button shown; the textarea still wraps and grows with content like the expanded layout, it just starts more compact.
-
-Toggling `collapsed` animates between the two layouts.
-
 The textarea grows with content up to `--swc-prompt-field-max-block-size` (default `40vh`). Override the custom property to raise or lower this ceiling, e.g. `40%` of a sized parent:
 
 ```html
@@ -63,8 +54,6 @@ The textarea grows with content up to `--swc-prompt-field-max-block-size` (defau
 ```
 
 `min-rows`/`max-rows` add an optional row-count cap on top of this. Unset, only `--swc-prompt-field-max-block-size` applies.
-
-<Canvas of={PromptFieldStories.Layout} />
 
 ### Legal disclaimer
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -228,7 +228,7 @@ export const Layout: Story = {
       </div>
     </div>
   `,
-  tags: ['dev'],
+  tags: ['!dev'],
 };
 
 export const Attachment: Story = {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -228,7 +228,7 @@ export const Layout: Story = {
       </div>
     </div>
   `,
-  tags: ['options'],
+  tags: ['dev'],
 };
 
 export const Attachment: Story = {

--- a/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/prompt-field/stories/prompt-field.stories.ts
@@ -54,7 +54,6 @@ function renderPromptField(
       loader=${storyArgs.loader ?? 'aiLogo'}
       ?disabled=${storyArgs.disabled ?? false}
       ?generating=${storyArgs.generating ?? false}
-      ?collapsed=${storyArgs.collapsed ?? false}
       accessible-label=${storyArgs['accessible-label'] ?? ''}
       send-label=${storyArgs['send-label'] ?? 'Send'}
       stop-label=${storyArgs['stop-label'] ?? 'Stop generating'}
@@ -228,7 +227,6 @@ export const Layout: Story = {
       </div>
     </div>
   `,
-  tags: ['!dev'],
 };
 
 export const Attachment: Story = {


### PR DESCRIPTION
## Description

  Mark `collapsed` as an internal PromptField property while preserving its reflected HTML attribute and runtime behavior.
  Remove it from the public PromptField documentation and mark the Layout story as development-only.

  ## Motivation and context

  `collapsed` is still needed internally while the PromptField API is being evaluated. This keeps the implementation
  available without presenting it as a public API or public Storybook example.

  ## Screenshots (if appropriate)

  Not applicable. The runtime behavior is unchanged; this change updates API visibility and documentation.

  ---

  ## Author's checklist

  - [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and
  **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
  - [ ] I have reviewed the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-
  aria-practices/)
  - [ ] I have added automated tests to cover my changes. Existing PromptField tests continue to cover the runtime
  behavior.
  - [x] No changeset is needed because this keeps the property internal and changes its public documentation visibility.
  - [x] I have included updated documentation where required.

  ---

  ## Reviewer's checklist

  - [ ] Automated tests cover all use cases and follow best practices for writing
  - [ ] Validated on all supported browsers
  - [ ] All VRTs are approved before the author can update Golden Hash

  ### Manual review test cases

  - [ ] Public PromptField documentation does not expose `collapsed`
    1. Go [here](http://localhost:6006/?path=/docs/patterns-conversational-ai-prompt-field--docs)
    2. Review the PromptField documentation and API surface.
    3. Expect no public `collapsed` API description or Layout story.

  - [ ] Internal Layout story remains available
    1. Go [here](http://localhost:6006/?path=/story/patterns-conversational-ai-prompt-field--layout)
    2. Open the development-only Layout story.
    3. Expect the compact PromptField layout to render and the `collapsed` attribute to remain reflected.

  ### Device review

  - [ ] Did it pass in Desktop?
  - [ ] Did it pass in (emulated) Mobile?
  - [ ] Did it pass in (emulated) iPad?

  ### Accessibility testing checklist

  - [ ] **Keyboard** (required — document steps below)
    1. Go [here](http://localhost:6006/?path=/docs/patterns-conversational-ai-prompt-field--docs)
    2. Tab through the PromptField and its interactive controls.
    3. Expect a logical focus order, visible focus indicators, and no focus trap.

  - [ ] **Screen reader** (required — document steps below)
    1. Go [here](http://localhost:6006/?path=/docs/patterns-conversational-ai-prompt-field--docs)
    2. Navigate to the PromptField and inspect its label, actions, and state announcements.
    3. Expect the component name, interactive controls, and state information to be announced clearly.