### PR TITLE
docs(button-group): convert button-group docs to mdx

### DIFF
--- a/2nd-gen/packages/swc/components/button-group/button-group.mdx
+++ b/2nd-gen/packages/swc/components/button-group/button-group.mdx
@@ -27,22 +27,13 @@ Button groups come in four sizes that propagate to all child buttons: small (`s`
 
 ### Orientations
 
-Button groups support two orientations:
-
-- **Horizontal** (default): buttons that flow left-to-right (or inline-start to inline-end)
-- **Vertical**: buttons stacked top-to-bottom; useful when horizontal space is limited
-
-The `orientation` attribute reflects on the host for CSS styling hooks.
+Button groups support two orientations: `horizontal` (default) and `vertical`. The `orientation` attribute reflects on the host for CSS styling hooks.
 
 <Canvas of={ButtonGroupStories.Orientations} />
 
 ### Alignment
 
-The `align` property controls the alignment of buttons within the group along the main axis:
-
-- **`start`** (default): buttons aligned to the inline start
-- **`center`**: buttons centered within the available space
-- **`end`**: buttons aligned to the inline end
+The `align` property controls alignment along the main axis: `start` (default), `center`, and `end`.
 
 <Canvas of={ButtonGroupStories.Alignment} />
 

--- a/2nd-gen/packages/swc/components/button-group/button-group.mdx
+++ b/2nd-gen/packages/swc/components/button-group/button-group.mdx
@@ -1,0 +1,96 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { DocsFooter, DocsHeader } from '../../.storybook/blocks';
+
+import * as ButtonGroupStories from './stories/button-group.stories';
+
+<Meta of={ButtonGroupStories} />
+
+<DocsHeader />
+
+## Anatomy
+
+A button group consists of:
+
+- **Default slot**: one or more `<swc-button>` elements that form the action set
+
+The group propagates its `size` and `disabled` state to all slotted button children automatically, ensuring visual and behavioral consistency without requiring per-button configuration.
+
+<Canvas of={ButtonGroupStories.Anatomy} />
+
+## Options
+
+### Sizes
+
+Button groups come in four sizes that propagate to all child buttons: small (`s`), medium (`m`), large (`l`), and extra-large (`xl`). Medium is the default size.
+
+<Canvas of={ButtonGroupStories.Sizes} />
+
+### Orientations
+
+Button groups support two orientations:
+
+- **Horizontal** (default): buttons that flow left-to-right (or inline-start to inline-end)
+- **Vertical**: buttons stacked top-to-bottom; useful when horizontal space is limited
+
+The `orientation` attribute reflects on the host for CSS styling hooks.
+
+<Canvas of={ButtonGroupStories.Orientations} />
+
+### Alignment
+
+The `align` property controls the alignment of buttons within the group along the main axis:
+
+- **`start`** (default): buttons aligned to the inline start
+- **`center`**: buttons centered within the available space
+- **`end`**: buttons aligned to the inline end
+
+<Canvas of={ButtonGroupStories.Alignment} />
+
+## States
+
+### Disabled
+
+Setting `disabled` on the group propagates the disabled state to all child buttons, preventing interaction. This is a convenience API; individual buttons can also be disabled independently when the group is not disabled.
+
+<Canvas of={ButtonGroupStories.Disabled} />
+
+## Accessibility
+
+### Features
+
+The `<swc-button-group>` element implements several accessibility features:
+
+#### ARIA implementation
+
+1. **ARIA role**: automatically sets `role="group"` on the host element
+2. **Group naming**: supports `aria-label` or `aria-labelledby` for screen readers; provide a name when the group's purpose is not obvious from context
+
+#### Keyboard navigation
+
+- <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd>: moves focus between
+  buttons in DOM order
+- <kbd>Enter</kbd> / <kbd>Space</kbd>: activates the focused button
+- Each button is a **separate tab stop**. The group does not use roving `tabindex`
+- The group host is **not focusable**
+
+#### Why `aria-orientation` is not set
+
+The `orientation` property controls only the visual layout direction. Because button group does not use roving tabindex or arrow-key navigation, `aria-orientation` is not applicable (it is only valid for roles that manage directional key navigation, such as `toolbar` or `listbox`).
+
+If your use case has many buttons and would benefit from arrow-key navigation, consider using `FocusgroupNavigationController` (an internal core controller) on a parent composite with `role="toolbar"` instead.
+
+#### What button group is not
+
+- **Not a radio group**: Do not use for exclusive selection. That pattern is planned for `swc-segmented-control` in a future release.
+- **Not a toggle group**: Do not use for pressed/toggle states. That pattern is planned for `swc-toggle-button-group` in a future release.
+- **Not a toolbar**: Does not implement arrow-key navigation. For toolbar semantics, use `role="toolbar"` on a parent composite with `FocusgroupNavigationController`.
+
+### Best practices
+
+- Provide an `aria-label` when the group's purpose is not clear from surrounding content (for example, when used inside a dialog footer)
+- Keep slotted children as `<swc-button>` elements for proper semantic delegation
+- Do not apply `role="radiogroup"` or `role="toolbar"` to this component
+
+<Canvas of={ButtonGroupStories.Accessibility} />
+
+<DocsFooter />

--- a/2nd-gen/packages/swc/components/button-group/stories/button-group.stories.ts
+++ b/2nd-gen/packages/swc/components/button-group/stories/button-group.stories.ts
@@ -123,11 +123,11 @@ const sizeLabels = {
 } as const satisfies Record<(typeof BUTTON_GROUP_SIZES)[number], string>;
 
 // ────────────────────
-//    AUTODOCS STORY
+//    PLAYGROUND STORY
 // ────────────────────
 
 export const Playground: Story = {
-  tags: ['autodocs', 'dev'],
+  tags: ['dev'],
   args: {
     size: 'm',
     orientation: 'horizontal',
@@ -154,15 +154,6 @@ export const Overview: Story = {
 //    ANATOMY STORIES
 // ──────────────────────────
 
-/**
- * A button group consists of:
- *
- * - **Default slot**: one or more `<swc-button>` elements that form the action set
- *
- * The group propagates its `size` and `disabled` state to all slotted button children
- * automatically, ensuring visual and behavioral consistency without requiring per-button
- * configuration.
- */
 export const Anatomy: Story = {
   render: () => html`
     <swc-button-group>
@@ -178,14 +169,6 @@ export const Anatomy: Story = {
 //    OPTIONS STORIES
 // ──────────────────────────
 
-/**
- * Button groups come in four sizes that propagate to all child buttons:
- *
- * - **Small (`s`)**: for compact interfaces with limited space
- * - **Medium (`m`)**: default size for most contexts
- * - **Large (`l`)**: for prominent actions needing more visual weight
- * - **Extra-large (`xl`)**: for hero sections or primary call-to-action areas
- */
 export const Sizes: Story = {
   render: () => html`
     ${BUTTON_GROUP_SIZES.map(
@@ -200,14 +183,6 @@ export const Sizes: Story = {
   tags: ['options'],
 };
 
-/**
- * Button groups support two orientations:
- *
- * - **Horizontal** (default): buttons that flow left-to-right (or inline-start to inline-end)
- * - **Vertical**: buttons stacked top-to-bottom; useful when horizontal space is limited
- *
- * The `orientation` attribute reflects on the host for CSS styling hooks.
- */
 export const Orientations: Story = {
   render: () => html`
     ${BUTTON_GROUP_ORIENTATIONS.map(
@@ -222,14 +197,6 @@ export const Orientations: Story = {
   tags: ['options'],
 };
 
-/**
- * The `align` property controls the alignment of buttons within the group along
- * the main axis:
- *
- * - **`start`** (default): buttons aligned to the inline start
- * - **`center`**: buttons centered within the available space
- * - **`end`**: buttons aligned to the inline end (useful for dialog footers)
- */
 export const Alignment: Story = {
   render: () => html`
     ${BUTTON_GROUP_ALIGNMENTS.map(
@@ -248,11 +215,6 @@ export const Alignment: Story = {
 //    STATES STORIES
 // ──────────────────────────
 
-/**
- * Setting `disabled` on the group propagates the disabled state to all child
- * buttons, preventing interaction. This is a convenience API — individual buttons
- * can also be disabled independently when the group is not disabled.
- */
 export const Disabled: Story = {
   render: () => html`
     <swc-button-group disabled>
@@ -268,52 +230,6 @@ export const Disabled: Story = {
 //    ACCESSIBILITY STORIES
 // ────────────────────────────────
 
-/**
- * ### Features
- *
- * The `<swc-button-group>` element implements several accessibility features:
- *
- * #### ARIA implementation
- *
- * 1. **ARIA role**: automatically sets `role="group"` on the host element
- * 2. **Group naming**: supports `aria-label` or `aria-labelledby` for screen readers;
- *    provide a name when the group's purpose is not obvious from context
- *
- * #### Keyboard navigation
- *
- * - <kbd>Tab</kbd> / <kbd>Shift+Tab</kbd>: moves focus between buttons in DOM order
- * - <kbd>Enter</kbd> / <kbd>Space</kbd>: activates the focused button
- * - Each button is a **separate tab stop**. The group does NOT use roving `tabindex`
- * - The group host is **NOT focusable**
- *
- * #### Why `aria-orientation` is not set
- *
- * The `orientation` property controls only the visual layout direction. Because
- * button-group does not use roving tabindex or arrow-key navigation,
- * `aria-orientation` is not applicable (it is only valid for roles that manage
- * directional key navigation, such as `toolbar` or `listbox`).
- *
- * If your use case has many buttons and would benefit from arrow-key navigation,
- * consider using `FocusgroupNavigationController` (an internal core controller)
- * on a parent composite with `role="toolbar"` instead.
- *
- * #### What button-group is NOT
- *
- * - **Not a radio group**: Do not use for exclusive selection.
- *   Use Segmented Control instead.
- * - **Not a toggle group**: Do not use for pressed/toggle states.
- *   Use Toggle Group instead.
- * - **Not a toolbar**: Does not implement arrow-key navigation.
- *   For toolbar semantics, use `role="toolbar"` on a parent composite with
- *   `FocusgroupNavigationController`.
- *
- * ### Best practices
- *
- * - Provide an `aria-label` when the group's purpose is not clear from surrounding
- *   content (for example, when used inside a dialog footer)
- * - Keep slotted children as `<swc-button>` elements for proper semantic delegation
- * - Do not apply `role="radiogroup"` or `role="toolbar"` to this component
- */
 export const Accessibility: Story = {
   render: () => html`
     <swc-button-group aria-label="Document actions">
@@ -324,53 +240,3 @@ export const Accessibility: Story = {
   `,
   tags: ['a11y'],
 };
-
-// ────────────────────────────────
-//    LOCAL-ONLY STORIES
-// ────────────────────────────────
-
-/**
- * Combination of all orientations at all sizes — useful for visual regression testing
- * during local development. Not included in production documentation.
- */
-export const AllCombinations: Story = {
-  render: () => html`
-    ${BUTTON_GROUP_ORIENTATIONS.map(
-      (orientation) => html`
-        ${BUTTON_GROUP_SIZES.map(
-          (size) => html`
-            <swc-button-group orientation=${orientation} size=${size}>
-              <swc-button>${orientation} ${size.toUpperCase()}</swc-button>
-              <swc-button>Action</swc-button>
-            </swc-button-group>
-          `
-        )}
-      `
-    )}
-  `,
-  tags: ['!dev'],
-};
-AllCombinations.storyName = 'All combinations';
-
-/**
- * Tests vertical orientation with alignment variations. Used for local visual
- * verification that vertical layout respects alignment in all directions.
- */
-export const VerticalAlignment: Story = {
-  render: () => html`
-    ${BUTTON_GROUP_ALIGNMENTS.map(
-      (align) => html`
-        <swc-button-group
-          orientation="vertical"
-          align=${align}
-          style="inline-size: 300px;"
-        >
-          <swc-button>Vertical ${align}</swc-button>
-          <swc-button>Action</swc-button>
-        </swc-button-group>
-      `
-    )}
-  `,
-  tags: ['!dev'],
-};
-VerticalAlignment.storyName = 'Vertical alignment';


### PR DESCRIPTION
## Description

Adds `button-group.mdx` as the per-unit docs page for `swc-button-group`, following the same structure as other migrated components (Anatomy, Options, States, Accessibility, each with a `<Canvas>` reference). Moves the six JSDoc blocks with real documentation prose (Anatomy, Sizes, Orientations, Alignment, Disabled, Accessibility) out of `button-group.stories.ts` into the corresponding MDX sections, then removes them from the stories file per the "no JSDoc above story exports" convention. Local-only dev/VRT stories (`AllCombinations`, `VerticalAlignment`) are untouched.

## Motivation and context

`swc-button-group` had no per-unit MDX page and was still rendering its docs from story-level JSDoc via the `DocumentTemplate.mdx` fallback, unlike every other migrated component. This brings it in line with the standard per-unit MDX pattern and preserves the existing documentation prose (including the full Accessibility section) rather than losing it.

## Related issue(s)

- fixes SWC-2382

## Screenshots (if appropriate)

N/A (docs-only change)

---

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

---

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] Confirm the button group docs page (`/?path=/docs/components-button-group--docs`) now renders from `button-group.mdx`, not the `DocumentTemplate.mdx` fallback
  1. Run Storybook
  2. Open the Button group docs page
  3. Verify Anatomy, Options (Sizes/Orientations/Alignment), States (Disabled), and Accessibility sections render with prose and canvases

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

Docs-only change; no component behavior modified. Existing Accessibility story/behavior is unchanged, only its documentation location moved.

- [ ] **Keyboard** — N/A, no behavior change
- [ ] **Screen reader** — N/A, no behavior change