### PR TITLE
fix(menu): reset mobile drill-down state when tray closes

### DIFF
--- a/.changeset/fix-menu-mobile-drilldown-tray-close.md
+++ b/.changeset/fix-menu-mobile-drilldown-tray-close.md
@@ -1,0 +1,7 @@
+---
+'@spectrum-web-components/menu': patch
+---
+
+**fix(menu):** Reset the mobile-view drill-down submenu stack when the containing `<sp-tray>` closes.
+
+`resetMobileSubmenus()` was only called from `disconnectedCallback` (when `<sp-menu>` is removed from the DOM) or when the `mobile-view` attribute was toggled off at runtime. Since `<sp-tray>` hides itself visually on close without disconnecting its slotted content, dismissing the tray (e.g. by clicking outside) left the drill-down stack intact, so reopening the tray dropped the user back into the previously active submenu instead of the top-level menu. `<sp-menu mobile-view>` now listens for the containing tray's `close` event and resets the stack accordingly.

--- a/1st-gen/packages/menu/src/Menu.ts
+++ b/1st-gen/packages/menu/src/Menu.ts
@@ -408,6 +408,44 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
   }
 
   /**
+   * The nearest ancestor `<sp-tray>`, if any, that this mobile-view menu
+   * is being displayed within. Trays hide themselves visually rather than
+   * disconnecting their slotted content, so `disconnectedCallback` never
+   * runs on close; this reference lets us listen for the tray's `close`
+   * event directly instead.
+   */
+  private _mobileTrayAncestor: HTMLElement | null = null;
+
+  private handleMobileTrayClosed = (): void => {
+    this.resetMobileSubmenus();
+  };
+
+  /**
+   * Listens for the containing `<sp-tray>`'s `close` event so the
+   * drill-down stack resets whenever the tray is dismissed (e.g. via
+   * click-outside), rather than persisting until the menu is removed
+   * from the DOM.
+   */
+  private _attachMobileTrayCloseListener(): void {
+    if (!this.mobileView) {
+      return;
+    }
+    this._mobileTrayAncestor = this.closest('sp-tray');
+    this._mobileTrayAncestor?.addEventListener(
+      'close',
+      this.handleMobileTrayClosed
+    );
+  }
+
+  private _detachMobileTrayCloseListener(): void {
+    this._mobileTrayAncestor?.removeEventListener(
+      'close',
+      this.handleMobileTrayClosed
+    );
+    this._mobileTrayAncestor = null;
+  }
+
+  /**
    * Moves the submenu element from its MenuItem parent into this Menu's
    * light DOM with a `mobile-submenu` slot, so it projects through the
    * named slot in the shadow DOM. Any previously visible projected submenu
@@ -1611,11 +1649,16 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
       this._refreshMobileBackElements();
     }
     if (changes.has('mobileView') && this.hasUpdated) {
-      // When mobile view is turned off at runtime, restore any
-      // projected submenus to their original parents so the menu
-      // returns to a normal flyout layout cleanly.
-      if (!this.mobileView && this._mobileSubmenuStack.length > 0) {
-        this.resetMobileSubmenus();
+      if (this.mobileView) {
+        this._attachMobileTrayCloseListener();
+      } else {
+        // When mobile view is turned off at runtime, restore any
+        // projected submenus to their original parents so the menu
+        // returns to a normal flyout layout cleanly.
+        this._detachMobileTrayCloseListener();
+        if (this._mobileSubmenuStack.length > 0) {
+          this.resetMobileSubmenus();
+        }
       }
     }
   }
@@ -1635,6 +1678,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
     if (!this.hasAttribute('role') && !this.ignore) {
       this.setAttribute('role', this.ownRole);
     }
+    this._attachMobileTrayCloseListener();
     this.updateComplete.then(() => this.updateItemFocus());
   }
 
@@ -1648,6 +1692,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
     this.selectedItemsMap.clear();
     this.childItemSet.clear();
     this.descendentOverlays = new Map<Overlay, Overlay>();
+    this._detachMobileTrayCloseListener();
     this.resetMobileSubmenus();
     this._mobileSubmenuOriginalParents.clear();
     super.disconnectedCallback();

--- a/1st-gen/packages/menu/stories/submenu.stories.ts
+++ b/1st-gen/packages/menu/stories/submenu.stories.ts
@@ -446,13 +446,7 @@ customRootSubmenu.swc_vrt = {
 
 export const mobileView = (): TemplateResult => {
   return html`
-    <sp-tray
-      open
-      @close=${(event: Event) => {
-        event.preventDefault();
-        (event.target as HTMLElement).toggleAttribute('open', true);
-      }}
-    >
+    <sp-tray open>
       <sp-menu mobile-view>
         <sp-menu-item>Home</sp-menu-item>
         <sp-menu-item>

--- a/1st-gen/packages/menu/test/submenu.test.ts
+++ b/1st-gen/packages/menu/test/submenu.test.ts
@@ -26,6 +26,7 @@ import { spy } from 'sinon';
 import { ActionMenu } from '@spectrum-web-components/action-menu';
 import { Menu, MenuItem } from '@spectrum-web-components/menu';
 import { slottableRequest } from '@spectrum-web-components/overlay/src/slottable-request-directive.js';
+import { Tray } from '@spectrum-web-components/tray/src/Tray.js';
 
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
@@ -33,6 +34,7 @@ import '@spectrum-web-components/menu/sp-menu-group.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/overlay/sp-overlay.js';
+import '@spectrum-web-components/tray/sp-tray.js';
 
 import { sendMouse } from '../../../test/plugins/browser.js';
 import {
@@ -1216,6 +1218,35 @@ describe('Submenu', () => {
       await elementUpdated(menu);
 
       expect(menu.currentMobileSubmenu).to.be.undefined;
+    });
+    it('resets mobile submenu stack when the containing tray closes', async function () {
+      const tray = await fixture<Tray>(html`
+        <sp-tray open>
+          <sp-menu mobile-view>
+            <sp-menu-item>No submenu</sp-menu-item>
+            <sp-menu-item class="root">
+              Has submenu
+              <sp-menu slot="submenu">
+                <sp-menu-item class="submenu-item-1">One</sp-menu-item>
+              </sp-menu>
+            </sp-menu-item>
+          </sp-menu>
+        </sp-tray>
+      `);
+      const menu = tray.querySelector('sp-menu') as Menu;
+      const rootItem = tray.querySelector('.root') as MenuItem;
+      await elementUpdated(menu);
+
+      menu.openMobileSubmenu(rootItem);
+      await elementUpdated(menu);
+      expect(menu.currentMobileSubmenu).to.equal(rootItem);
+
+      const closed = oneEvent(tray, 'close');
+      tray.close();
+      await closed;
+      await elementUpdated(menu);
+
+      expect(menu.currentMobileSubmenu, 'reset by tray close').to.be.undefined;
     });
     it('does not open overlay on hover in mobile mode', async function () {
       expect(this.rootItem.open).to.be.false;


### PR DESCRIPTION
## Description

`<sp-menu mobile-view>` now resets its drill-down submenu stack when the closest ancestor `<sp-tray>` fires its `close` event, in addition to the existing reset paths (`disconnectedCallback` and `mobile-view` toggling off at runtime).

Also updates the `mobileView` story so it reflects real tray-close behavior (it previously called `preventDefault()` on the tray's `close` event and forced the tray back open, which masked this regression in the published docs demo).

## Motivation and context

`resetMobileSubmenus()` was only invoked from:
- `disconnectedCallback` — when `<sp-menu>` is actually removed from the DOM
- `updated()` — when the `mobile-view` attribute is toggled off at runtime

`<sp-tray>` never disconnects its slotted content on close; it only toggles its `open` attribute, which drives a CSS transform/opacity transition. So dismissing the tray (e.g. clicking outside it) left `_mobileSubmenuStack` untouched, and reopening the tray dropped the user back into whichever submenu they'd drilled into instead of the top-level menu.

## Related issue(s)

- Jira: SWC-2525
## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [x] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Drill-down state resets after tray close/reopen_
  1. Go to the [Menu mobile-view (drill-down navigation) story](https://opensource.adobe.com/spectrum-web-components/components/menu/#mobile-view-(drill-down-navigation)) (or run Storybook locally)
  2. Tap a menu item with a submenu to drill down, then click outside the tray to dismiss it
  3. Reopen the tray — expect the top-level menu, not the previously active submenu

- [ ] _No regression to desktop/flyout submenus_
  1. Go to the `Submenu` default story (no `mobile-view`)
  2. Hover/click to open a nested submenu, close it, reopen it
  3. Expect unchanged flyout behavior

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  1. Open the mobile-view story in a touch/mobile emulated viewport and tab to a menu item with a submenu
  2. Press <kbd>Enter</kbd> to drill down, then <kbd>Escape</kbd> to dismiss the tray
  3. Reopen the tray via its trigger and tab into the menu — expect focus to land on the top-level menu's first item, not inside the previously open submenu

- [ ] **Screen reader** (required — document steps below)
  1. With VoiceOver/NVDA running, open the mobile-view tray and drill into a submenu
  2. Dismiss the tray (click-outside or Escape) and reopen it
  3. Expect the screen reader to announce the top-level menu's items, not the submenu's back button/items, confirming the reset is reflected in the accessibility tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)