### PR TITLE
fix(progress-bar): correct broken deprecation guidance for side-label and progress

### DIFF
--- a/.changeset/progress-bar-fix-deprecation-guidance.md
+++ b/.changeset/progress-bar-fix-deprecation-guidance.md
@@ -1,0 +1,5 @@
+---
+'@spectrum-web-components/progress-bar': patch
+---
+
+Fix the `side-label` and `progress` deprecation warnings on `sp-progress-bar`, which pointed consumers to a `label-position` attribute and a `value` attribute that do not exist on `sp-progress-bar`. Those properties only exist on the 2nd-gen `swc-progress-bar`. The JSDoc and runtime warnings now state that there is no 1st-gen replacement and name `swc-progress-bar` as the actual replacement.

--- a/1st-gen/packages/progress-bar/src/ProgressBar.ts
+++ b/1st-gen/packages/progress-bar/src/ProgressBar.ts
@@ -87,15 +87,17 @@ export class ProgressBar extends SizedMixin(
   private _overBackground: boolean = false;
 
   /**
-   * @deprecated The `side-label` attribute will be replaced by
-   * `label-position="side"` in a future release.
+   * @deprecated The `side-label` attribute is deprecated and will be removed
+   * in Spectrum 2. There is no replacement on `sp-progress-bar`; use
+   * `label-position="side"` on `swc-progress-bar` instead.
    */
   @property({ type: Boolean, reflect: true, attribute: 'side-label' })
   public sideLabel = false;
 
   /**
-   * @deprecated The `progress` property will be replaced by `value` in a
-   * future release.
+   * @deprecated The `progress` property is deprecated and will be removed
+   * in Spectrum 2. There is no replacement on `sp-progress-bar`; use
+   * `value` on `swc-progress-bar` instead.
    */
   @property({ type: Number })
   public progress = 0;
@@ -199,7 +201,7 @@ export class ProgressBar extends SizedMixin(
       if (changes.has('sideLabel') && this.sideLabel) {
         window.__swc.warn(
           this,
-          `The "side-label" attribute on <${this.localName}> has been deprecated and will be removed in a future release. Use label-position="side" instead.`,
+          `The "side-label" attribute on <${this.localName}> has been deprecated and will be removed in a future release. There is no replacement on <${this.localName}>; use label-position="side" on <swc-progress-bar> instead.`,
           'https://opensource.adobe.com/spectrum-web-components/components/progress-bar/',
           { level: 'deprecation' }
         );
@@ -207,7 +209,7 @@ export class ProgressBar extends SizedMixin(
       if (changes.has('progress') && this.progress !== 0) {
         window.__swc.warn(
           this,
-          `The "progress" property on <${this.localName}> has been deprecated and will be removed in a future release. Use the "value" attribute instead.`,
+          `The "progress" property on <${this.localName}> has been deprecated and will be removed in a future release. There is no replacement on <${this.localName}>; use "value" on <swc-progress-bar> instead.`,
           'https://opensource.adobe.com/spectrum-web-components/components/progress-bar/',
           { level: 'deprecation' }
         );


### PR DESCRIPTION
## Summary
- `sp-progress-bar`'s deprecation warnings for `side-label` and `progress` told consumers to use a `label-position` attribute and a `value` attribute, but neither exists anywhere in the `progress-bar` package; they only exist on the 2nd-gen `swc-progress-bar`.
- Updated the JSDoc and the two runtime `window.__swc.warn()` messages to state plainly that there is no 1st-gen replacement and to name `swc-progress-bar` as the actual replacement.
- No behavior change; deprecation-message text only.

Found while auditing `@deprecated` properties across 1st-gen components in response to a support question about `sp-button`'s `quiet`/`treatment` deprecation.  this PR addresses the one item from that audit that was a clear bug (wrong guidance) rather than a documentation judgment call. The remaining follow-up items (README deprecation callouts, resolving no-replacement deprecations) are scoped separately in that issue.

## Test plan
- [ ] `yarn test --group progress-bar` (or the equivalent workspace test command) still passes
- [ ] Manually verify in a `DEBUG` build that toggling `side-label`/`progress` on `<sp-progress-bar>` logs the corrected warning text
- [ ] Confirm `yarn changeset` output picks up `.changeset/progress-bar-fix-deprecation-guidance.md`