### PR TITLE
fix(global styles): retain reflected aria attribute selectors

### DIFF
--- a/.changeset/fix-global-reflected-aria-attribute-selectors.md
+++ b/.changeset/fix-global-reflected-aria-attribute-selectors.md
@@ -1,0 +1,5 @@
+---
+'@adobe/spectrum-wc': patch
+---
+
+Fix the global stylesheet generator collapsing reflected ARIA host attributes (`aria-disabled="true"`, `aria-hidden="true"`, etc.) into a shared, meaningless `--true`/`--false` BEM modifier class — `:host([aria-disabled="true"])` and `:host([aria-hidden="true"])` both produced `.swc-Foo--true`, so styling one affected the other. Reflected ARIA attributes are now emitted as native `[attr="value"]` attribute selectors on the block class instead (e.g. `.swc-ActionButton[aria-disabled="true"]`), matching the attributes the generated global element actually carries at runtime. A related collapse that missed attribute-selector suffixes (`.block[open]`) is also fixed so it folds onto the host selector instead of producing an unreachable descendant selector.

--- a/2nd-gen/packages/swc/.storybook/guides/customization/global-elements.mdx
+++ b/2nd-gen/packages/swc/.storybook/guides/customization/global-elements.mdx
@@ -167,6 +167,22 @@ The quiet variant removes the default background.
 </button>
 ```
 
+Action buttons support `disabled` state styles via the native `disabled` attribute, as well as via `aria-disabled="true"` for group-level disabling (for example, when disabled as part of a `swc-action-group`) where the button must remain focusable and in the tab order.
+
+{/* prettier-ignore */}
+<button type="button" class="swc-ActionButton" disabled>As Button (Disabled)</button>
+{/* prettier-ignore */}
+<button type="button" class="swc-ActionButton" aria-disabled="true">As Button (aria-disabled)</button>
+
+```html
+<button type="button" class="swc-ActionButton" disabled>
+  As Button (Disabled)
+</button>
+<button type="button" class="swc-ActionButton" aria-disabled="true">
+  As Button (aria-disabled)
+</button>
+```
+
 Icons are supported with the class `swc-ActionButton-icon`. Add `swc-ActionButton--hasIcon` when combining an icon with a label, or `swc-ActionButton--iconOnly` with `aria-label` for icon-only variants.
 
 {/* prettier-ignore */}

--- a/2nd-gen/packages/swc/components/action-button/action-button.css
+++ b/2nd-gen/packages/swc/components/action-button/action-button.css
@@ -105,7 +105,6 @@
   transform: none;
 }
 
-/* @global-exclude: :host([aria-disabled]) converts to invalid .swc-ActionButton--true until SWC-2511 */
 :host([aria-disabled="true"]) .swc-ActionButton:is(*, :hover) {
   color: var(--swc-action-button-content-color-disabled, token("disabled-content-color"));
   background-color: var(--swc-action-button-background-color-disabled, token("disabled-background-color"));
@@ -113,8 +112,6 @@
   cursor: default;
   transform: none;
 }
-
-/* @global-exclude-end */
 
 /* ── Sub-elements ─────────────────────────────────── */
 

--- a/2nd-gen/packages/swc/components/action-button/action-button.css
+++ b/2nd-gen/packages/swc/components/action-button/action-button.css
@@ -315,14 +315,11 @@ slot[name="icon"]::slotted(swc-avatar) {
      disabled custom properties with system colors so the button reads as
      unavailable in high-contrast mode. */
 
-  /* @global-exclude: :host([aria-disabled]) converts to invalid .swc-ActionButton--true until SWC-2511 */
   :host([aria-disabled="true"]) {
     --swc-action-button-background-color-disabled: ButtonFace;
     --swc-action-button-content-color-disabled: GrayText;
     --swc-action-button-border-color-disabled: GrayText;
   }
-
-  /* @global-exclude-end */
 }
 
 /* @global-exclude: pending state requires JS runtime (PendingMixin.pendingActive) */

--- a/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
@@ -84,6 +84,14 @@
   transform: none;
 }
 
+.swc-ActionButton[aria-disabled="true"]:is(*, :hover) {
+  color: var(--swc-action-button-content-color-disabled, token("disabled-content-color"));
+  background-color: var(--swc-action-button-background-color-disabled, token("disabled-background-color"));
+  border-color: var(--swc-action-button-border-color-disabled, transparent);
+  cursor: default;
+  transform: none;
+}
+
 .swc-ActionButton-label {
   text-align: center;
   pointer-events: none;

--- a/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
+++ b/2nd-gen/packages/swc/stylesheets/global/global-action-button.css
@@ -228,6 +228,12 @@
   .swc-ActionButton {
     border-color: ButtonBorder;
   }
+
+  .swc-ActionButton[aria-disabled="true"] {
+    --swc-action-button-background-color-disabled: ButtonFace;
+    --swc-action-button-content-color-disabled: GrayText;
+    --swc-action-button-border-color-disabled: GrayText;
+  }
 }
 }
 

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.js
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.js
@@ -35,7 +35,7 @@ const SWC_PREFIXED_ATTRS = ['size', 'static-color'];
  * @param {string} attrName
  * @returns {boolean}
  */
-function isReflectedAttr(attrName) {
+function isAriaAttr(attrName) {
   return attrName.startsWith('aria-');
 }
 
@@ -225,8 +225,8 @@ function transformSingle(selector, block) {
   // modifier conversion and stay as native [attr="value"] attribute selectors,
   // since the generated global element genuinely carries them at runtime.
   const attrs = parseHostAttrs(rawArgs);
-  const ariaAttrs = attrs.filter(({ name }) => isReflectedAttr(name));
-  const bemAttrs = attrs.filter(({ name }) => !isReflectedAttr(name));
+  const ariaAttrs = attrs.filter(({ name }) => isAriaAttr(name));
+  const bemAttrs = attrs.filter(({ name }) => !isAriaAttr(name));
 
   const bemClass = bemAttrs
     .map(({ name, value }) => `.${block}--${buildModifier(name, value)}`)
@@ -254,7 +254,11 @@ function transformSingle(selector, block) {
   // `.block[open]`), it's still the same single element in global context —
   // fold the suffix onto the host selector rather than joining as a
   // descendant of a second, non-existent element.
-  if hostClass && (r.startsWith(blockClass) && /^[:[]/.test(r[blockClass.length])) {
+  if (
+    hostClass &&
+    r.startsWith(blockClass) &&
+    /^[:[]/.test(r[blockClass.length])
+  ) {
     return hostClass + r.slice(blockClass.length);
   }
 

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.js
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.js
@@ -24,6 +24,21 @@ const FENCE_CLOSE = '@global-exclude-end';
 //   static-color="white" → staticWhite  ("static" is the semantic distinguisher)
 const SWC_PREFIXED_ATTRS = ['size', 'static-color'];
 
+/**
+ * Reflected ARIA attributes carry boolean-like string values ("true"/"false")
+ * shared across many unrelated attributes, so a value-only BEM modifier (the
+ * default in buildModifier) would collide — aria-disabled="true" and
+ * aria-hidden="true" would both produce the same meaningless modifier. The
+ * generated global custom element genuinely carries these attributes at
+ * runtime, so they're kept as native attribute selectors instead.
+ *
+ * @param {string} attrName
+ * @returns {boolean}
+ */
+function isReflectedAttr(attrName) {
+  return attrName.startsWith('aria-');
+}
+
 // ── File header ─────────────────────────────────────────────────────────────
 
 /**
@@ -176,6 +191,7 @@ function transformSlotted(fragment, block) {
  *   :host([boolAttr])            → .block--boolAttr (attr name becomes modifier)
  *   :host([a="x"][b="y"])        → .block--x.block--y (compound, same element)
  *   :host([a="x"]) .block__el   → .block--x .block-el
+ *   :host([aria-x="y"])         → .block[aria-x="y"] (reflected ARIA attrs stay native)
  *   slot[name="X"]::slotted(*)  → .block__X
  *
  * @param {string} selector
@@ -204,19 +220,42 @@ function transformSingle(selector, block) {
     return r ? `.${block} ${r}` : `.${block}`;
   }
 
-  // :host([attr="value"][boolAttr]) → modifier classes joined (no space = same element)
+  // :host([attr="value"][boolAttr]) → BEM modifier classes for component-API
+  // attributes, joined onto the same element. Reflected ARIA attributes bypass
+  // modifier conversion and stay as native [attr="value"] attribute selectors,
+  // since the generated global element genuinely carries them at runtime.
   const attrs = parseHostAttrs(rawArgs);
-  const hostClass = attrs
+  const ariaAttrs = attrs.filter(({ name }) => isReflectedAttr(name));
+  const bemAttrs = attrs.filter(({ name }) => !isReflectedAttr(name));
+
+  const bemClass = bemAttrs
     .map(({ name, value }) => `.${block}--${buildModifier(name, value)}`)
     .join('');
+  const ariaSelector = ariaAttrs
+    .map(({ name, value }) =>
+      value === undefined ? `[${name}]` : `[${name}="${value}"]`
+    )
+    .join('');
+  const hostClass =
+    (bemClass || (ariaAttrs.length > 0 ? `.${block}` : '')) + ariaSelector;
 
   const r = transformSlotted(rest, block);
+  const blockClass = `.${block}`;
 
   // When the rest is exactly the block class, the shadow-DOM inner element is
   // the root element in global context — collapse into the modifier so styles
   // apply directly rather than producing an unreachable descendant combinator.
-  if (r === `.${block}`) {
+  if (r === blockClass) {
     return hostClass;
+  }
+
+  // When the rest starts with the block class followed by pseudo-classes,
+  // pseudo-elements, or attribute selectors (e.g. `.block:is(*, :hover)`,
+  // `.block[open]`), it's still the same single element in global context —
+  // fold the suffix onto the host selector rather than joining as a
+  // descendant of a second, non-existent element.
+  if (r.startsWith(blockClass) && /^[:[]/.test(r[blockClass.length])) {
+    return hostClass + r.slice(blockClass.length);
   }
 
   return r ? `${hostClass} ${r}` : hostClass;

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.js
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.js
@@ -254,7 +254,7 @@ function transformSingle(selector, block) {
   // `.block[open]`), it's still the same single element in global context —
   // fold the suffix onto the host selector rather than joining as a
   // descendant of a second, non-existent element.
-  if (r.startsWith(blockClass) && /^[:[]/.test(r[blockClass.length])) {
+  if hostClass && (r.startsWith(blockClass) && /^[:[]/.test(r[blockClass.length])) {
     return hostClass + r.slice(blockClass.length);
   }
 

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.test.js
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.test.js
@@ -181,16 +181,18 @@ describe('transformSelector — reflected ARIA attributes', () => {
     ).toBe('.swc-ActionButton[aria-disabled="true"]');
   });
 
-  it('distinguishes aria-hidden="true" from aria-disabled="true" (no shared modifier collision)', () => {
-    expect(
-      transformSelector(':host([aria-hidden="true"])', 'swc-TabPanel')
-    ).toBe('.swc-TabPanel[aria-hidden="true"]');
-  });
-
-  it('real-world case: tab-panel.css :host([aria-hidden="true"])', () => {
-    expect(
-      transformSelector(':host([aria-hidden="true"])', 'swc-TabPanel')
-    ).toBe('.swc-TabPanel[aria-hidden="true"]');
+  it('distinguishes aria-hidden="true" from aria-disabled="true" (no shared modifier collision), real-world case: tab-panel.css', () => {
+    const hidden = transformSelector(
+      ':host([aria-hidden="true"])',
+      'swc-TabPanel'
+    );
+    const disabled = transformSelector(
+      ':host([aria-disabled="true"])',
+      'swc-TabPanel'
+    );
+    expect(hidden).toBe('.swc-TabPanel[aria-hidden="true"]');
+    expect(disabled).toBe('.swc-TabPanel[aria-disabled="true"]');
+    expect(hidden).not.toBe(disabled);
   });
 
   it(':host([aria-x="y"]) .block:is(*, :hover) → single compound selector, not a descendant selector', () => {

--- a/2nd-gen/packages/tools/vite-global-elements-css/index.test.js
+++ b/2nd-gen/packages/tools/vite-global-elements-css/index.test.js
@@ -172,6 +172,70 @@ describe('transformSelector — SWC API attribute prefixing', () => {
   });
 });
 
+// ── transformSelector — reflected ARIA attributes ────────────────────────────
+
+describe('transformSelector — reflected ARIA attributes', () => {
+  it(':host([aria-x="value"]) → .block[aria-x="value"] (native attribute selector, not a modifier)', () => {
+    expect(
+      transformSelector(':host([aria-disabled="true"])', 'swc-ActionButton')
+    ).toBe('.swc-ActionButton[aria-disabled="true"]');
+  });
+
+  it('distinguishes aria-hidden="true" from aria-disabled="true" (no shared modifier collision)', () => {
+    expect(
+      transformSelector(':host([aria-hidden="true"])', 'swc-TabPanel')
+    ).toBe('.swc-TabPanel[aria-hidden="true"]');
+  });
+
+  it('real-world case: tab-panel.css :host([aria-hidden="true"])', () => {
+    expect(
+      transformSelector(':host([aria-hidden="true"])', 'swc-TabPanel')
+    ).toBe('.swc-TabPanel[aria-hidden="true"]');
+  });
+
+  it(':host([aria-x="y"]) .block:is(*, :hover) → single compound selector, not a descendant selector', () => {
+    expect(
+      transformSelector(
+        ':host([aria-disabled="true"]) .swc-ActionButton:is(*, :hover)',
+        'swc-ActionButton'
+      )
+    ).toBe('.swc-ActionButton[aria-disabled="true"]:is(*, :hover)');
+  });
+
+  it(':host([aria-x]) → .block[aria-x] (boolean reflected attribute)', () => {
+    expect(transformSelector(':host([aria-expanded])', 'swc-Button')).toBe(
+      '.swc-Button[aria-expanded]'
+    );
+  });
+
+  it('combines a BEM component-API attribute with a reflected ARIA attribute on the same element', () => {
+    expect(
+      transformSelector(
+        ':host([variant="primary"][aria-disabled="true"])',
+        'swc-Button'
+      )
+    ).toBe('.swc-Button--primary[aria-disabled="true"]');
+  });
+
+  it(':host([aria-x="y"]) .block → .block[aria-x="y"] (exact-match collapse still applies)', () => {
+    expect(
+      transformSelector(
+        ':host([aria-disabled="true"]) .swc-Button',
+        'swc-Button'
+      )
+    ).toBe('.swc-Button[aria-disabled="true"]');
+  });
+
+  it(':host([attr]) .block[open] → .block--attr[open] (attribute-selector suffix folds onto the same element, not just pseudo-classes)', () => {
+    expect(
+      transformSelector(
+        ':host([actual-placement]) .swc-Popover[open]',
+        'swc-Popover'
+      )
+    ).toBe('.swc-Popover--actual-placement[open]');
+  });
+});
+
 // ── deriveCSS — fence removal ────────────────────────────────────────────────
 
 describe('deriveCSS — fence removal', () => {


### PR DESCRIPTION
## Description

`aria-*` host attrs collapsed into a shared, meaningless `--true`/`--false` modifier class; a related collapse also missed attribute-selector suffixes (`[open]`). Fixed: `aria-*` now emits as `[attr="value"]` on the block class.

## Motivation and context
`:host([aria-disabled="true"])` and `:host([aria-hidden="true"])` both produced `.swc-Foo--true`.

## Related issue(s)
- fixes SWC-2511

## Author's checklist
- [x] Read CONTRIBUTING/PULL_REQUESTS
- [x] Reviewed Accessibility Practices
- [x] Added automated tests
- [ ] Changeset
- [ ] Docs updated

## Reviewer's checklist
- [ ] Jira ticket referenced without link
- [ ] Changeset present if needed
- [ ] Tests cover all cases
- [ ] Validated on supported browsers
- [ ] VRTs approved

### Manual review test cases
- [ ] _Global CSS regenerates correctly_
  1. `vitest run` in `vite-global-elements-css` — 58/58 pass
  2. Diff `global-action-button.css` — only new `[aria-disabled="true"]` rule

### Device review
- [ ] Desktop
- [ ] Mobile
- [ ] iPad

## Accessibility testing checklist
- [ ] **Keyboard** — no focusable parts; build-tooling/CSS-output change only
- [ ] **Screen reader** — no ARIA semantics change; visual styling only