### PR TITLE
feat(text-field): migrate API and partial a11y

### DIFF
--- a/1st-gen/packages/textfield/src/Textfield.ts
+++ b/1st-gen/packages/textfield/src/Textfield.ts
@@ -93,6 +93,8 @@ export class TextfieldBase extends ManageHelpText(
 
   /**
    * A string applied via `aria-label` to the form control when a user visible label is not provided.
+   *
+   * @deprecated Renamed to `accessible-label` in Spectrum 2.
    */
   @property()
   public label = '';
@@ -136,6 +138,8 @@ export class TextfieldBase extends ManageHelpText(
   /**
    * Whether a form control delivered with the `multiline` attribute will change size
    * vertically to accomodate longer input
+   *
+   * @deprecated Multiline moves to `<swc-text-area>` in Spectrum 2.
    */
   @property({ type: Boolean, reflect: true })
   public grows = false;
@@ -154,6 +158,8 @@ export class TextfieldBase extends ManageHelpText(
 
   /**
    * Whether the form control should accept a value longer than one line
+   *
+   * @deprecated Multiline moves to `<swc-text-area>` in Spectrum 2.
    */
   @property({ type: Boolean, reflect: true })
   public multiline = false;
@@ -167,12 +173,16 @@ export class TextfieldBase extends ManageHelpText(
   /**
    * Placement of the tooltip shown when the value is truncated (e.g. 'bottom', 'top').
    * Defaults to 'bottom' per Spectrum design.
+   *
+   * @deprecated The truncated-value tooltip is removed in Spectrum 2.
    */
   @property({ attribute: 'tooltip-placement' })
   public truncatedValueTooltipPlacement: Placement = 'bottom';
 
   /**
    * The specific number of rows the form control should provide in the user interface
+   *
+   * @deprecated Multiline moves to `<swc-text-area>` in Spectrum 2.
    */
   @property({ type: Number })
   public rows = -1;
@@ -204,6 +214,8 @@ export class TextfieldBase extends ManageHelpText(
 
   /**
    * Whether to display the form control with no visible background
+   *
+   * @deprecated The `quiet` style is removed in Spectrum 2.
    */
   @property({ type: Boolean, reflect: true })
   public quiet = false;
@@ -220,6 +232,8 @@ export class TextfieldBase extends ManageHelpText(
    * Note: combobox overrides `autocomplete` intentionally with `aria-autocomplete` values, which is
    * why those values (although invalid for native `autocomplete`) are included here to support the
    * combobox accessibility pattern.
+   *
+   * @deprecated The `list`/`none` values are removed in Spectrum 2; use `<sp-combobox>`.
    */
   @property({ type: String, reflect: true })
   public autocomplete?:
@@ -427,6 +441,78 @@ export class TextfieldBase extends ManageHelpText(
     }
   }
 
+  protected override updated(changedProperties: PropertyValues): void {
+    super.updated(changedProperties);
+    const url =
+      'https://opensource.adobe.com/spectrum-web-components/components/textfield/';
+    // Scope to sp-textfield: subclasses (number-field, color-field, combobox,
+    // search) use these properties legitimately and migrate on their own schedule.
+    if (window.__swc?.DEBUG && this.localName === 'sp-textfield') {
+      if (changedProperties.has('label') && this.label.length > 0) {
+        window.__swc.warn(
+          this,
+          `The "label" attribute on <${this.localName}> has been deprecated and will be removed in a future release. Set "aria-label" or "aria-labelledby" on the element instead.`,
+          url,
+          { level: 'deprecation' }
+        );
+      }
+      if (changedProperties.has('quiet') && this.quiet) {
+        window.__swc.warn(
+          this,
+          `The "quiet" attribute on <${this.localName}> has been deprecated and will be removed in a future release.`,
+          url,
+          { level: 'deprecation' }
+        );
+      }
+      if (changedProperties.has('multiline') && this.multiline) {
+        window.__swc.warn(
+          this,
+          `The "multiline" attribute on <${this.localName}> has been deprecated and will be removed in a future release.`,
+          url,
+          { level: 'deprecation' }
+        );
+      }
+      if (changedProperties.has('grows') && this.grows) {
+        window.__swc.warn(
+          this,
+          `The "grows" attribute on <${this.localName}> has been deprecated and will be removed in a future release.`,
+          url,
+          { level: 'deprecation' }
+        );
+      }
+      if (changedProperties.has('rows') && this.rows !== -1) {
+        window.__swc.warn(
+          this,
+          `The "rows" attribute on <${this.localName}> has been deprecated and will be removed in a future release.`,
+          url,
+          { level: 'deprecation' }
+        );
+      }
+      if (
+        changedProperties.has('truncatedValueTooltipPlacement') &&
+        this.truncatedValueTooltipPlacement !== 'bottom'
+      ) {
+        window.__swc.warn(
+          this,
+          `The "tooltip-placement" attribute on <${this.localName}> has been deprecated and will be removed in a future release.`,
+          url,
+          { level: 'deprecation' }
+        );
+      }
+      if (
+        changedProperties.has('autocomplete') &&
+        (this.autocomplete === 'list' || this.autocomplete === 'none')
+      ) {
+        window.__swc.warn(
+          this,
+          `The "list" and "none" values for the "autocomplete" attribute on <${this.localName}> have been deprecated and will be removed in a future release. Use <sp-combobox> for the combobox autocomplete pattern instead.`,
+          url,
+          { level: 'deprecation' }
+        );
+      }
+    }
+  }
+
   public checkValidity(): boolean {
     let validity = this.inputElement.checkValidity();
     if (this.required || (this.value && this.pattern)) {
@@ -446,8 +532,8 @@ export class TextfieldBase extends ManageHelpText(
 
 /**
  * @element sp-textfield
- * @slot help-text - default or non-negative help text to associate to your form element
- * @slot negative-help-text - negative help text to associate to your form element when `invalid`
+ * @slot help-text - default or non-negative help text to associate to your form element (deprecated: renamed to `description` in Spectrum 2)
+ * @slot negative-help-text - negative help text to associate to your form element when `invalid` (deprecated: renamed to `error-text` in Spectrum 2)
  */
 export class Textfield extends TextfieldBase {
   @property({ type: String })

--- a/2nd-gen/packages/core/components/text-field/TextField.base.ts
+++ b/2nd-gen/packages/core/components/text-field/TextField.base.ts
@@ -9,13 +9,24 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { PropertyValues } from 'lit';
+import { property } from 'lit/decorators.js';
+
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
 import { SizedMixin } from '@adobe/spectrum-wc-core/mixins/index.js';
+import { validateEnum } from '@adobe/spectrum-wc-core/utils/index.js';
 
 import {
+  TEXT_FIELD_LABEL_POSITIONS,
+  TEXT_FIELD_TYPES,
   TEXT_FIELD_VALID_SIZES,
+  type TextFieldLabelPosition,
   type TextFieldSize,
+  type TextFieldType,
 } from './TextField.types.js';
+
+const DOCS_URL =
+  'https://spectrum-web-components.adobe.com/?path=/docs/components-text-field--docs';
 
 /**
  * A single-line text field for entering and editing text.
@@ -27,19 +38,148 @@ export abstract class TextFieldBase extends SizedMixin(SpectrumElement, {
   defaultSize: 'm',
 }) {
   /**
+   * Route host focus to the internal native `<input>` so the field is a single
+   * tab stop with focus landing on the real control.
+   */
+  static override shadowRootOptions: ShadowRootInit = {
+    ...SpectrumElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
+  /**
    * The size of the text field.
    *
    * @default m
    */
   declare public size: TextFieldSize;
 
+  /**
+   * Accessible name for the input, applied as `aria-label`. Use when there is no
+   * visible label slotted.
+   */
+  @property({ type: String, attribute: 'accessible-label' })
+  public accessibleLabel = '';
+
+  /**
+   * The value of the input.
+   */
+  @property({ type: String })
+  public value = '';
+
+  /**
+   * The form control name submitted with the field's value.
+   */
+  @property({ type: String, reflect: true })
+  public name: string | undefined;
+
+  /**
+   * The type of input to render.
+   */
+  @property({ type: String, reflect: true })
+  public type: TextFieldType = 'text';
+
+  /**
+   * Placeholder text shown when the field is empty. Never used as the accessible name.
+   */
+  @property({ type: String })
+  public placeholder = '';
+
+  /**
+   * A regular expression the value is checked against during constraint validation.
+   */
+  @property({ type: String })
+  public pattern?: string;
+
+  /**
+   * Hint for the virtual keyboard to display.
+   */
+  @property({ type: String })
+  public inputmode?: string;
+
+  /**
+   * Hint for the browser's autofill feature.
+   */
+  @property({ type: String, reflect: true })
+  public autocomplete?: HTMLInputElement['autocomplete'];
+
+  /**
+   * The maximum number of characters the value may contain.
+   */
+  @property({ type: Number })
+  public maxlength?: number;
+
+  /**
+   * The minimum number of characters the value may contain.
+   */
+  @property({ type: Number })
+  public minlength?: number;
+
+  /**
+   * Whether the field is focusable but not editable. Distinct from `disabled`.
+   */
+  @property({ type: Boolean, reflect: true })
+  public readonly = false;
+
+  /**
+   * Whether the field must have a value for the form to submit.
+   */
+  @property({ type: Boolean, reflect: true })
+  public required = false;
+
+  /**
+   * Whether the field is in an invalid state.
+   */
+  @property({ type: Boolean, reflect: true })
+  public invalid = false;
+
+  /**
+   * Whether the field is in a valid state. The value lets consumers react to a
+   * valid state; the visual checkmark is deferred.
+   */
+  @property({ type: Boolean, reflect: true })
+  public valid = false;
+
+  /**
+   * Position of the visible label relative to the input.
+   *
+   * @default top
+   */
+  @property({ type: String, reflect: true, attribute: 'label-position' })
+  public labelPosition: TextFieldLabelPosition = 'top';
+
+  /**
+   * Whether the field is disabled: not editable and removed from tab order.
+   */
+  @property({ type: Boolean, reflect: true })
+  public disabled = false;
+
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────
 
-  // @todo (Phase 3, API): implement the public API surface, dev-warnings, and
-  // value/validity normalization per the migration plan.
+  // @todo (SWC-2466): accessible-labelledby / accessible-describedby element-ref
+  // properties and the "unlabeled field" dev-warning are LabellingController inputs;
+  // add them with the controller.
 
-  // @todo (SWC-2466 / SWC-2467): wire the shared LabellingController and
-  // FieldAssociationController once they land.
+  // @todo (SWC-2467): wire the FieldAssociationController (formAssociated,
+  // attachInternals, setFormValue, formResetCallback, formDisabledCallback).
+
+  // @todo (Phase 5): checkValidity() / setSelectionRange() / select() delegate to
+  // the rendered native <input>, so they land with the render implementation.
+
+  protected override update(changedProperties: PropertyValues): void {
+    validateEnum(this, {
+      prop: 'type',
+      value: this.type,
+      valid: TEXT_FIELD_TYPES,
+      url: DOCS_URL,
+    });
+    validateEnum(this, {
+      prop: 'label-position',
+      value: this.labelPosition,
+      valid: TEXT_FIELD_LABEL_POSITIONS,
+      url: DOCS_URL,
+    });
+    super.update(changedProperties);
+  }
 }

--- a/2nd-gen/packages/core/components/text-field/TextField.base.ts
+++ b/2nd-gen/packages/core/components/text-field/TextField.base.ts
@@ -162,10 +162,11 @@ export abstract class TextFieldBase extends SizedMixin(SpectrumElement, {
   // add them with the controller.
 
   // @todo (SWC-2467): wire the FieldAssociationController (formAssociated,
-  // attachInternals, setFormValue, formResetCallback, formDisabledCallback).
+  // attachInternals, setFormValue, formResetCallback, formDisabledCallback) plus
+  // its checkValidity()/reportValidity()/validity pass-throughs.
 
-  // @todo (Phase 5): checkValidity() / setSelectionRange() / select() delegate to
-  // the rendered native <input>, so they land with the render implementation.
+  // @todo (Phase 5): setSelectionRange() / select() delegate to the rendered
+  // native <input>, so they land with the render implementation.
 
   protected override update(changedProperties: PropertyValues): void {
     validateEnum(this, {

--- a/2nd-gen/packages/core/components/text-field/TextField.base.ts
+++ b/2nd-gen/packages/core/components/text-field/TextField.base.ts
@@ -20,6 +20,7 @@ import {
   TEXT_FIELD_LABEL_POSITIONS,
   TEXT_FIELD_TYPES,
   TEXT_FIELD_VALID_SIZES,
+  type TextFieldAutocomplete,
   type TextFieldLabelPosition,
   type TextFieldSize,
   type TextFieldType,
@@ -32,6 +33,10 @@ const DOCS_URL =
  * A single-line text field for entering and editing text.
  *
  * @attribute {ElementSize} size - The size of the text field.
+ *
+ * @slot label - Visible label content, rendered in-shadow as a real `<label for>`.
+ * @slot description - Guidance / non-error help text, associated via `aria-describedby`.
+ * @slot error-text - Error message shown when `invalid`, targeted by `aria-errormessage`.
  */
 export abstract class TextFieldBase extends SizedMixin(SpectrumElement, {
   validSizes: TEXT_FIELD_VALID_SIZES,
@@ -59,6 +64,27 @@ export abstract class TextFieldBase extends SizedMixin(SpectrumElement, {
    */
   @property({ type: String, attribute: 'accessible-label' })
   public accessibleLabel = '';
+
+  /**
+   * Element IDs, from the light DOM, that provide the field's accessible name.
+   * Takes precedence over `accessibleLabel` and a slotted label.
+   *
+   * @todo (SWC-2466): the `LabellingController` resolves these IDREFs to the
+   * cross-root `ariaLabelledByElements` property; raw `aria-labelledby` is not
+   * exposed on the host.
+   */
+  @property({ attribute: 'accessible-labelledby' })
+  public accessibleLabelledby?: string;
+
+  /**
+   * Element IDs, from the light DOM, that describe the field.
+   *
+   * @todo (SWC-2466): the `LabellingController` resolves these IDREFs to the
+   * cross-root `ariaDescribedByElements` property; raw `aria-describedby` is not
+   * exposed on the host.
+   */
+  @property({ attribute: 'accessible-describedby' })
+  public accessibleDescribedby?: string;
 
   /**
    * The value of the input.
@@ -100,7 +126,7 @@ export abstract class TextFieldBase extends SizedMixin(SpectrumElement, {
    * Hint for the browser's autofill feature.
    */
   @property({ type: String, reflect: true })
-  public autocomplete?: HTMLInputElement['autocomplete'];
+  public autocomplete?: TextFieldAutocomplete;
 
   /**
    * The maximum number of characters the value may contain.
@@ -157,9 +183,9 @@ export abstract class TextFieldBase extends SizedMixin(SpectrumElement, {
   //     IMPLEMENTATION
   // ──────────────────────
 
-  // @todo (SWC-2466): accessible-labelledby / accessible-describedby element-ref
-  // properties and the "unlabeled field" dev-warning are LabellingController inputs;
-  // add them with the controller.
+  // @todo (SWC-2466): resolve the accessible-labelledby / accessible-describedby
+  // IDREF stubs to cross-root element references, and add the "unlabeled field"
+  // dev-warning, via the LabellingController.
 
   // @todo (SWC-2467): wire the FieldAssociationController (formAssociated,
   // attachInternals, setFormValue, formResetCallback, formDisabledCallback) plus

--- a/2nd-gen/packages/core/components/text-field/TextField.types.ts
+++ b/2nd-gen/packages/core/components/text-field/TextField.types.ts
@@ -41,3 +41,11 @@ export type TextFieldSize = (typeof TEXT_FIELD_VALID_SIZES)[number];
 export type TextFieldType = (typeof TEXT_FIELD_TYPES)[number];
 export type TextFieldLabelPosition =
   (typeof TEXT_FIELD_LABEL_POSITIONS)[number];
+
+/**
+ * Valid `autocomplete` tokens for the text field. Aliases the platform
+ * `AutoFill` union, which is the standard HTML autofill grammar and excludes
+ * the combobox-only `list`/`none` tokens 1st-gen widened it with (B5); those
+ * belong to the combobox component.
+ */
+export type TextFieldAutocomplete = AutoFill;

--- a/2nd-gen/packages/core/components/text-field/TextField.types.ts
+++ b/2nd-gen/packages/core/components/text-field/TextField.types.ts
@@ -43,9 +43,6 @@ export type TextFieldLabelPosition =
   (typeof TEXT_FIELD_LABEL_POSITIONS)[number];
 
 /**
- * Valid `autocomplete` tokens for the text field. Aliases the platform
- * `AutoFill` union, which is the standard HTML autofill grammar and excludes
- * the combobox-only `list`/`none` tokens 1st-gen widened it with (B5); those
- * belong to the combobox component.
+ * Valid `autocomplete` tokens for the text field. Aliases the platform `AutoFill` union
  */
 export type TextFieldAutocomplete = AutoFill;

--- a/2nd-gen/packages/swc/components/text-field/TextField.ts
+++ b/2nd-gen/packages/swc/components/text-field/TextField.ts
@@ -11,6 +11,7 @@
  */
 
 import { CSSResultArray, html, TemplateResult } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { TextFieldBase } from '@adobe/spectrum-wc-core/components/text-field';
 
@@ -35,11 +36,15 @@ export class TextField extends TextFieldBase {
   }
 
   protected override render(): TemplateResult {
-    // @todo (Phase 3–5): render the label, required indicator, input, validation
-    // icon, and description/error container per the migration plan.
+    // @todo (SWC-2466 / Phase 4–5): render the visible label, required indicator,
+    // validation icon, and description/error container via the LabellingController.
+    // Until then the input takes its accessible name from `accessible-label`.
     return html`
       <div class="swc-TextField">
-        <input class="input" />
+        <input
+          class="input"
+          aria-label=${ifDefined(this.accessibleLabel || undefined)}
+        />
       </div>
     `;
   }

--- a/2nd-gen/packages/swc/components/text-field/stories/text-field.stories.ts
+++ b/2nd-gen/packages/swc/components/text-field/stories/text-field.stories.ts
@@ -51,7 +51,9 @@ export default meta;
 
 export const Playground: Story = {
   tags: ['dev'],
-  args: {},
+  args: {
+    'accessible-label': 'Example text field',
+  },
   render: (args) => html`
     ${template({ ...args })}
   `,

--- a/2nd-gen/packages/swc/components/text-field/stories/text-field.stories.ts
+++ b/2nd-gen/packages/swc/components/text-field/stories/text-field.stories.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+
+import '@adobe/spectrum-wc/components/text-field/swc-text-field.js';
+
+// ────────────────
+//    METADATA
+// ────────────────
+
+const { events, args, argTypes, template } =
+  getStorybookHelpers('swc-text-field');
+
+/**
+ * A single-line text field for entering and editing text.
+ */
+const meta: Meta = {
+  title: 'Text field',
+  component: 'swc-text-field',
+  args,
+  argTypes,
+  render: (args) => template(args),
+  parameters: {
+    actions: {
+      handles: events,
+    },
+    docs: {
+      subtitle: `Single-line text field for entering and editing text`,
+    },
+  },
+  tags: ['migrated'],
+};
+
+export default meta;
+
+// ────────────────────
+//    PLAYGROUND STORY
+// ────────────────────
+
+export const Playground: Story = {
+  tags: ['dev'],
+  args: {},
+  render: (args) => html`
+    ${template({ ...args })}
+  `,
+};

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/text-field/migration-plan.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/text-field/migration-plan.md
@@ -422,9 +422,9 @@ Planned rendering shape:
 
 #### Naming and public surface
 
-- [ ] `TextField.types.ts`: define `TextFieldType`, the `size` union, and the `label-position` (`top`/`side`) union; export public types
-- [ ] `TextField.base.ts`: implement `accessible-label`/`accessible-labelledby`/`accessible-describedby`, `value` (string), `type`, `placeholder`, `pattern`, `inputmode`, `autocomplete`, `maxlength`/`minlength`, `readonly`, `required`, `invalid`/`valid`, `label-position` (core; default `top`), `size`, `disabled`
-- [ ] Remove `quiet`, `multiline`, `grows`, `rows`, `focused`, `tooltip-placement`
+- [x] `TextField.types.ts`: define `TextFieldType`, the `size` union, and the `label-position` (`top`/`side`) union; export public types
+- [x] `TextField.base.ts`: implement `accessible-label`, `value` (string), `type`, `placeholder`, `pattern`, `inputmode`, `autocomplete`, `maxlength`/`minlength`, `readonly`, `required`, `invalid`/`valid`, `label-position` (core; default `top`), `size`, `disabled`. `accessible-labelledby`/`accessible-describedby` element-refs deferred to `LabellingController` (SWC-2466); `checkValidity()`/selection methods deferred to Phase 5 (need the rendered input)
+- [x] Remove `quiet`, `multiline`, `grows`, `rows`, `focused`, `tooltip-placement` — not carried into 2nd-gen; deprecated on 1st-gen `Textfield` with `@deprecated` + `__swc.warn`
 - [ ] Resolve `allowedKeys` (Q11) before finalizing the surface
 
 #### Alignment checks


### PR DESCRIPTION
## Description

Phase 3 (API) of the text-field migration, plus the one Phase 4 (a11y) piece that's independent of the deferred controllers. 2nd-gen 

`TextField.base.ts` gets the full property surface (`accessible-label`, `value`, `name`, `type`, `placeholder`, `pattern`, `inputmode`, `autocomplete`, `maxlength`/`minlength`, `readonly`, `required`, `invalid`, `valid`, `label-position`, `disabled`) with `validateEnum` for `type` and `label-position`, and `delegatesFocus` so the field is a single tab stop. 

The removed/renamed 1st-gen surface (`label`, `quiet`, `multiline`/`grows`/`rows`, `tooltip-placement`, `autocomplete` list/none) is deprecated with `@deprecated` + `__swc.warn`, scoped to `sp-textfield` so the shared-base siblings are unaffected.

## Motivation and context

Establishes the public API and focus behavior before the controllers (SWC-2466 labelling, SWC-2467 form association) and Phase 5 render land — those will refactor this phase to adopt them via the `@todo` seams. Part of Epic SWC-2323.

## Related issue(s)

Epic SWC-2323 · stacked on #6658

## Author's checklist

- [x] Read CONTRIBUTING and PULL_REQUESTS
- [x] Reviewed accessibility practices
- [ ] Automated tests — existing 1st-gen suites verified green (textfield, number-field, color-field, combobox, search); new 2nd-gen tests land in Phase 6
- [ ] Changeset — N/A, package not yet published
- [x] Updated docs (migration plan: Q27, Phase 3/4 checklists)

### Manual review test cases

- [x] `yarn workspace @spectrum-web-components/2nd-gen build` succeeds
- [ ] Deprecation warnings fire only for `<sp-textfield>`, not for `sp-color-field`/`sp-number-field`/`sp-combobox`/`sp-search`
- [x] `<swc-text-field>` is a single tab stop; focus lands on the inner `<input>`

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

`delegatesFocus` is the only a11y behavior in this PR; accessible naming, description/error association, and `aria-invalid`/`aria-errormessage` are deferred to SWC-2466 and Phase 5 render.

- [x] **Keyboard** — <kbd>Tab</kbd> reaches `<swc-text-field>` as one stop and focus lands on the inner `<input>`; <kbd>Shift</kbd> + <kbd>Tab</kbd> leaves cleanly.
- [x] **Screen reader** — the inner `<input>` exposes role `textbox`. (Name/description wiring lands with the LabellingController, SWC-2466.)