### PR TITLE
chore(sizes): add reusable size labels helper

### DIFF
--- a/2nd-gen/packages/swc/.storybook/helpers/index.ts
+++ b/2nd-gen/packages/swc/.storybook/helpers/index.ts
@@ -16,6 +16,8 @@ export { formatTitle } from './format-title.js';
 export { iconForSize } from './icon-for-size.js';
 export { forcePseudoState } from './pseudo-state.js';
 export type { ForcedPseudoState } from './pseudo-state.js';
+export { SIZE_LABELS } from './size-labels.js';
+export type { SizeLabelKey } from './size-labels.js';
 export {
   coveredCustomProperties,
   customPropertyRows,

--- a/2nd-gen/packages/swc/.storybook/helpers/size-labels.ts
+++ b/2nd-gen/packages/swc/.storybook/helpers/size-labels.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Canonical t-shirt size labels for stories and VRT files.
+ * Full xs–xxl set. Components index it with their own narrower size union —
+ * an unsupported size fails to type-check at the call site, not here.
+ */
+export const SIZE_LABELS = {
+  xs: 'Extra-small',
+  s: 'Small',
+  m: 'Medium',
+  l: 'Large',
+  xl: 'Extra-large',
+  xxl: 'Extra-extra-large',
+} as const;
+
+export type SizeLabelKey = keyof typeof SIZE_LABELS;

--- a/2nd-gen/packages/swc/.storybook/helpers/size-labels.ts
+++ b/2nd-gen/packages/swc/.storybook/helpers/size-labels.ts
@@ -16,12 +16,12 @@
  * an unsupported size fails to type-check at the call site, not here.
  */
 export const SIZE_LABELS = {
-  xs: 'Extra-small',
+  xs: 'Extra small',
   s: 'Small',
   m: 'Medium',
   l: 'Large',
-  xl: 'Extra-large',
-  xxl: 'Extra-extra-large',
+  xl: 'Extra large',
+  xxl: 'Extra extra large',
 } as const;
 
 export type SizeLabelKey = keyof typeof SIZE_LABELS;

--- a/2nd-gen/packages/swc/components/accordion/test/vrt/accordion.vrt.ts
+++ b/2nd-gen/packages/swc/components/accordion/test/vrt/accordion.vrt.ts
@@ -28,6 +28,7 @@ import {
   forcedColorsVrtParameters,
   forcePseudoStates,
   row,
+  SIZE_LABELS,
   theme,
   vrtParameters,
 } from '../../../../.storybook/helpers/index.js';
@@ -43,13 +44,6 @@ const meta: Meta = {
 export default meta;
 
 // Helpers
-
-const sizeLabels = {
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<(typeof ACCORDION_VALID_SIZES)[number], string>;
 
 const densityLabels = {
   compact: 'Compact',
@@ -157,8 +151,8 @@ const permutationContent = () => html`
       renderAccordion({
         size,
         items: html`
-          ${renderItem({ label: `${sizeLabels[size]} · open`, open: true })}
-          ${renderItem({ label: `${sizeLabels[size]} · closed` })}
+          ${renderItem({ label: `${SIZE_LABELS[size]} · open`, open: true })}
+          ${renderItem({ label: `${SIZE_LABELS[size]} · closed` })}
         `,
       })
     ),

--- a/2nd-gen/packages/swc/components/action-button/stories/action-button.stories.ts
+++ b/2nd-gen/packages/swc/components/action-button/stories/action-button.stories.ts
@@ -17,10 +17,11 @@ import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 import {
   ACTION_BUTTON_STATIC_COLORS,
   ACTION_BUTTON_VALID_SIZES,
-  type ActionButtonSize,
 } from '@adobe/spectrum-wc-core/components/action-button';
 
 import '@adobe/spectrum-wc/components/action-button/swc-action-button.js';
+
+import { SIZE_LABELS } from '../../../.storybook/helpers/index.js';
 
 // ────────────────
 //    METADATA
@@ -74,14 +75,6 @@ export default meta;
 // ────────────────────
 //    HELPERS
 // ────────────────────
-
-const sizeLabels = {
-  xs: 'Extra-small',
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<ActionButtonSize, string>;
 
 const editIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" aria-hidden="true" focusable="false"><path d="M33.567 8.2 27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945ZM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73Z"/></svg>`;
 
@@ -147,7 +140,7 @@ export const Sizes: Story = {
       template({
         ...args,
         size,
-        'default-slot': sizeLabels[size],
+        'default-slot': SIZE_LABELS[size],
         'icon-slot': editIconSvg,
       })
     )}

--- a/2nd-gen/packages/swc/components/action-button/test/action-button.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/action-button/test/action-button.a11y.spec.ts
@@ -59,11 +59,11 @@ test.describe('Action Button - ARIA Snapshots', () => {
       'swc-action-button'
     );
     await expect(root).toMatchAriaSnapshot(`
-      - button "Extra-small"
+      - button "Extra small"
       - button "Small"
       - button "Medium"
       - button "Large"
-      - button "Extra-large"
+      - button "Extra large"
     `);
   });
 

--- a/2nd-gen/packages/swc/components/badge/badge.mdx
+++ b/2nd-gen/packages/swc/components/badge/badge.mdx
@@ -26,7 +26,7 @@ Badges come in four sizes to fit various contexts:
 - **Small (`s`)**: default size; compact spaces, inline with text, or in tables
 - **Medium (`m`)**: common usage when slightly more emphasis is needed
 - **Large (`l`)**: increased emphasis in cards or content areas
-- **Extra-large (`xl`)**: maximum visibility for primary status indicators
+- **Extra large (`xl`)**: maximum visibility for primary status indicators
 
 The `s` size is the default. Use larger sizes sparingly to create a hierarchy of importance on a page.
 

--- a/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
+++ b/2nd-gen/packages/swc/components/badge/stories/badge.stories.ts
@@ -30,7 +30,7 @@ import {
 import '@adobe/spectrum-wc/components/badge/swc-badge.js';
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 
-import { iconForSize } from '../../../.storybook/helpers/index.js';
+import { iconForSize, SIZE_LABELS } from '../../../.storybook/helpers/index.js';
 import * as Icons from '../../icon/elements/index.js';
 
 // ────────────────
@@ -127,13 +127,6 @@ export default meta;
 // ────────────────────
 //    HELPERS
 // ────────────────────
-
-const sizeLabels = {
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<BadgeSize, string>;
 
 const semanticLabels = {
   accent: 'New',
@@ -274,7 +267,7 @@ export const Sizes: Story = {
             <swc-icon size=${size} slot="icon">
               ${iconForSize(Icons, 'Checkmark', size)}
             </swc-icon>
-            ${sizeLabels[size]}
+            ${SIZE_LABELS[size]}
           </swc-badge>
         `
       )}
@@ -285,7 +278,7 @@ export const Sizes: Story = {
       ${BADGE_VALID_SIZES.map(
         (size) => html`
           <swc-badge variant=${args.variant} size=${size}>
-            ${sizeLabels[size]}
+            ${SIZE_LABELS[size]}
           </swc-badge>
         `
       )}
@@ -299,7 +292,7 @@ export const Sizes: Story = {
             variant=${args.variant}
             size=${size}
             role="img"
-            aria-label=${sizeLabels[size]}
+            aria-label=${SIZE_LABELS[size]}
           >
             <swc-icon size=${size} slot="icon">
               ${iconForSize(Icons, 'Checkmark', size)}

--- a/2nd-gen/packages/swc/components/badge/test/badge.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/badge/test/badge.a11y.spec.ts
@@ -62,11 +62,11 @@ test.describe('Badge - ARIA Snapshots', () => {
   test('should handle different sizes', async ({ page }) => {
     const root = await gotoStory(page, 'components-badge--sizes', 'swc-badge');
     await expect(root).toMatchAriaSnapshot(`
-      - text: Small Medium Large Extra-large Small Medium Large Extra-large
+      - text: Small Medium Large Extra large Small Medium Large Extra large
       - img "Small"
       - img "Medium"
       - img "Large"
-      - img "Extra-large"
+      - img "Extra large"
     `);
   });
 

--- a/2nd-gen/packages/swc/components/button/stories/button.stories.ts
+++ b/2nd-gen/packages/swc/components/button/stories/button.stories.ts
@@ -20,12 +20,13 @@ import {
   BUTTON_VALID_SIZES,
   BUTTON_VARIANTS,
   type ButtonFillStyle,
-  type ButtonSize,
   type ButtonStaticColor,
   type ButtonVariant,
 } from '@adobe/spectrum-wc-core/components/button';
 
 import '@adobe/spectrum-wc/components/button/swc-button.js';
+
+import { SIZE_LABELS } from '../../../.storybook/helpers/index.js';
 
 // ────────────────
 //    METADATA
@@ -90,13 +91,6 @@ export default meta;
 // ────────────────────
 //    HELPERS
 // ────────────────────
-
-const sizeLabels = {
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<ButtonSize, string>;
 
 const variantLabels = {
   primary: 'Primary',
@@ -192,7 +186,7 @@ export const Anatomy: Story = {
 export const Sizes: Story = {
   render: (args) => html`
     ${BUTTON_VALID_SIZES.map((size) =>
-      template({ ...args, size, 'default-slot': sizeLabels[size] })
+      template({ ...args, size, 'default-slot': SIZE_LABELS[size] })
     )}
   `,
   parameters: { flexLayout: 'row-wrap' },

--- a/2nd-gen/packages/swc/components/button/test/button.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/button/test/button.a11y.spec.ts
@@ -77,7 +77,7 @@ test.describe('Button - ARIA Snapshots', () => {
       - button "Small"
       - button "Medium"
       - button "Large"
-      - button "Extra-large"
+      - button "Extra large"
     `);
   });
 

--- a/2nd-gen/packages/swc/components/icon/icon.internal.mdx
+++ b/2nd-gen/packages/swc/components/icon/icon.internal.mdx
@@ -25,11 +25,11 @@ An icon consists of:
 
 Icons come in five sizes to fit different layout contexts:
 
-- **Extra-small (`xs`)**: dense UIs and compact metadata rows
+- **Extra small (`xs`)**: dense UIs and compact metadata rows
 - **Small (`s`)**: supporting iconography in constrained spaces
 - **Medium (`m`)**: default size for general component usage
 - **Large (`l`)**: prominent icon usage in larger controls
-- **Extra-large (`xl`)**: high-emphasis icon presentation
+- **Extra large (`xl`)**: high-emphasis icon presentation
 
 <Canvas of={IconStories.Sizes} />
 

--- a/2nd-gen/packages/swc/components/icon/stories/icon.internal.stories.ts
+++ b/2nd-gen/packages/swc/components/icon/stories/icon.internal.stories.ts
@@ -14,13 +14,11 @@ import { styleMap } from 'lit/directives/style-map.js';
 import type { Meta, StoryObj as Story } from '@storybook/web-components';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 
-import {
-  ICON_VALID_SIZES,
-  type IconSize,
-} from '@adobe/spectrum-wc-core/components/icon';
+import { ICON_VALID_SIZES } from '@adobe/spectrum-wc-core/components/icon';
 
 import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 
+import { SIZE_LABELS } from '../../../.storybook/helpers/index.js';
 import { Chevron100Icon } from '../elements/index.js';
 import * as iconElements from '../elements/index.js';
 
@@ -63,14 +61,6 @@ export default meta;
 // ────────────────────
 
 const iconSvg = Chevron100Icon();
-
-const sizeLabels = {
-  xs: 'Extra-small',
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<IconSize, string>;
 
 const iconCardStyles = {
   display: 'inline-flex',
@@ -133,7 +123,7 @@ export const Sizes: Story = {
       template(
         {
           ...args,
-          'accessible-label': args['accessible-label'] || sizeLabels[size],
+          'accessible-label': args['accessible-label'] || SIZE_LABELS[size],
           size,
         },
         iconSvg

--- a/2nd-gen/packages/swc/components/icon/test/icon.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/icon/test/icon.a11y.spec.ts
@@ -45,11 +45,11 @@ test.describe('Icon - ARIA Snapshots', () => {
   test('should expose all sizes with correct aria-labels', async ({ page }) => {
     const root = await gotoStory(page, 'components-icon--sizes', 'swc-icon');
     await expect(root).toMatchAriaSnapshot(`
-      - img "Extra-small"
+      - img "Extra small"
       - img "Small"
       - img "Medium"
       - img "Large"
-      - img "Extra-large"
+      - img "Extra large"
     `);
   });
 });

--- a/2nd-gen/packages/swc/components/icon/test/vrt/icon.vrt.ts
+++ b/2nd-gen/packages/swc/components/icon/test/vrt/icon.vrt.ts
@@ -23,6 +23,7 @@ import '@adobe/spectrum-wc/components/icon/swc-icon.js';
 import {
   forcedColorsVrtParameters,
   row,
+  SIZE_LABELS,
   theme,
   vrtParameters,
 } from '../../../../.storybook/helpers/index.js';
@@ -42,14 +43,6 @@ export default meta;
 
 const iconSvg = Chevron100Icon();
 
-const sizeLabels = {
-  xs: 'Extra-small',
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<IconSize, string>;
-
 const icon = ({
   size,
   accessibleLabel,
@@ -65,7 +58,7 @@ const icon = ({
 const permutationContent = () => html`
   ${row(
     ICON_VALID_SIZES.map((size) =>
-      icon({ size, accessibleLabel: sizeLabels[size] })
+      icon({ size, accessibleLabel: SIZE_LABELS[size] })
     ),
     'Sizes'
   )}

--- a/2nd-gen/packages/swc/components/meter/stories/meter.stories.ts
+++ b/2nd-gen/packages/swc/components/meter/stories/meter.stories.ts
@@ -24,11 +24,12 @@ import {
   LINEAR_PROGRESS_STATIC_COLORS,
   LINEAR_PROGRESS_VALID_SIZES,
   type LinearProgressLabelPosition,
-  type LinearProgressSize,
   type LinearProgressStaticColor,
 } from '@adobe/spectrum-wc-core/mixins/index.js';
 
 import '@adobe/spectrum-wc/components/meter/swc-meter.js';
+
+import { SIZE_LABELS } from '../../../.storybook/helpers/index.js';
 
 // ────────────────
 //    METADATA
@@ -114,13 +115,6 @@ export default meta;
 // ────────────────────
 //    HELPERS
 // ────────────────────
-
-const sizeLabels = {
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<LinearProgressSize, string>;
 
 const variantLabels = {
   informative: 'Informative',
@@ -208,7 +202,7 @@ export const Sizes: Story = {
       template({
         ...args,
         size,
-        'label-slot': sizeLabels[size],
+        'label-slot': SIZE_LABELS[size],
       })
     )}
   `,

--- a/2nd-gen/packages/swc/components/meter/test/meter.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/meter/test/meter.a11y.spec.ts
@@ -58,7 +58,7 @@ test.describe('Meter - ARIA Snapshots', () => {
       - meter "Small"
       - meter "Medium"
       - meter "Large"
-      - meter "Extra-large"
+      - meter "Extra large"
     `);
   });
 

--- a/2nd-gen/packages/swc/components/meter/test/vrt/meter.vrt.ts
+++ b/2nd-gen/packages/swc/components/meter/test/vrt/meter.vrt.ts
@@ -31,6 +31,7 @@ import '@adobe/spectrum-wc/components/meter/swc-meter.js';
 import {
   forcedColorsVrtParameters,
   row,
+  SIZE_LABELS,
   staticColorBackground,
   theme,
   vrtParameters,
@@ -47,13 +48,6 @@ const meta: Meta = {
 export default meta;
 
 // Helpers
-
-const sizeLabels = {
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<LinearProgressSize, string>;
 
 const variantLabels = {
   informative: 'Informative',
@@ -148,7 +142,7 @@ const renderMeter = ({
 const permutationContent = () => html`
   ${row(
     LINEAR_PROGRESS_VALID_SIZES.map((size) =>
-      renderMeter({ size, label: sizeLabels[size] })
+      renderMeter({ size, label: SIZE_LABELS[size] })
     ),
     'Sizes'
   )}

--- a/2nd-gen/packages/swc/components/status-light/status-light.mdx
+++ b/2nd-gen/packages/swc/components/status-light/status-light.mdx
@@ -25,7 +25,7 @@ Status lights come in four sizes to fit various contexts:
 - **Small (`s`)**: used for inline indicators or space-constrained areas
 - **Medium (`m`)**: default size, used for typical use cases
 - **Large (`l`)**: used for prominent displays or primary content areas
-- **Extra-large (`xl`)**: maximum visibility for high-priority statuses
+- **Extra large (`xl`)**: maximum visibility for high-priority statuses
 
 <Canvas of={StatusLightStories.Sizes} />
 

--- a/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
+++ b/2nd-gen/packages/swc/components/status-light/stories/status-light.stories.ts
@@ -21,12 +21,12 @@ import {
   STATUS_LIGHT_VARIANTS_SEMANTIC,
   StatusLightColorVariant,
   StatusLightSemanticVariant,
-  type StatusLightSize,
 } from '@adobe/spectrum-wc-core/components/status-light';
 
 import '@adobe/spectrum-wc/components/status-light/swc-status-light.js';
 
 import { getTranslationKey } from '../../../.storybook/helpers/get-translation-key.js';
+import { SIZE_LABELS } from '../../../.storybook/helpers/index.js';
 import translations from '../../../.storybook/intl/translations.json';
 type TranslationKey = keyof typeof translations;
 
@@ -112,13 +112,6 @@ const nonSemanticLabels = {
   silver: 'Version 1.2.10',
 } as const satisfies Record<StatusLightColorVariant, string>;
 
-const sizeLabels = {
-  s: 'Small',
-  m: 'Medium',
-  l: 'Large',
-  xl: 'Extra-large',
-} as const satisfies Record<StatusLightSize, string>;
-
 // ────────────────────
 //    PLAYGROUND STORY
 // ────────────────────
@@ -166,7 +159,7 @@ export const Sizes: Story = {
       template({
         ...args,
         size,
-        'default-slot': sizeLabels[size],
+        'default-slot': SIZE_LABELS[size],
       })
     )}
   `,

--- a/2nd-gen/packages/swc/components/status-light/test/status-light.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/status-light/test/status-light.a11y.spec.ts
@@ -64,7 +64,7 @@ test.describe('Status Light - ARIA Snapshots', () => {
       'swc-status-light'
     );
     await expect(root).toMatchAriaSnapshot(`
-      - text: Small Medium Large Extra-large
+      - text: Small Medium Large Extra large
     `);
   });
 });

--- a/CONTRIBUTOR-DOCS/03_project-planning/03_components/icon/accessibility-migration-analysis.md
+++ b/CONTRIBUTOR-DOCS/03_project-planning/03_components/icon/accessibility-migration-analysis.md
@@ -145,11 +145,11 @@ Confirmed by `icon.a11y.spec.ts`:
 **Sizes story (`icon.a11y.spec.ts`):**
 
 ```text
-- img "Extra-small"
+- img "Extra small"
 - img "Small"
 - img "Medium"
 - img "Large"
-- img "Extra-large"
+- img "Extra large"
 ```
 
 **Meaningful workflow icon (with `label`) — exotic, discouraged use case**


### PR DESCRIPTION
## Description

- New shared helper: `.storybook/helpers/size-labels.ts` — exports `SIZE_LABELS` (xs–xxl) + `SizeLabelKey` type
- Removed 7 duplicate local `sizeLabels` maps and replaced with imports from the shared helper:
  - `badge` (stories)
  - `meter` (stories + VRT)
  - `accordion` (VRT)
  - `icon` (stories + VRT)
  - `action-button` (stories)
  - `button` (stories)
  - `status-light` (stories)
- Each file already ordered sizes via its own `*_VALID_SIZES` array — that didn't change
- No visual or behavioral change. Label text, size ordering, and VRT snapshots are identical to before

## Motivation and context

- Same `xs/s/m/l/xl → display text` map was copy-pasted across 8+ files
- One shared source of truth instead of 8 near-identical copies
- Surfaced during review of `cdransf/icons-vrt-coverage`

## Related issue(s)

- SWC-2517

## Screenshots (if appropriate)

N/A — no rendered output changed.

## Author's checklist

- [ ] I have read the **CONTRIBUTING** and **PULL_REQUESTS** documents.
- [ ] I have reviewed the Accessibility Practices for this feature.
- [x] I have added automated tests to coveests confirm no regression — no new testcases needed since behavior is unchanged)*
- [ ] I have included a well-written chang be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changenclude `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Sizes stories render unchanged_
  1. Open any of: Badge, Meter, Accordion,on, Status light in Storybook
  2. Go to its **Sizes** (or equivalent VRT) story
  3. Expect identical labels/order to `mai

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

> This PR only touches internal Storybook/mponent runtime, ARIA, or focus behaviorchanged. No new interactive elements were introduced.

- [ ] **Keyboard** (required — document steps below)
  1. Open the **Sizes** story for any affe)
  2. Tab through the story canvas
  3. Expect: tab order/focus unchanged froe elements

- [ ] **Screen reader** (required — docume
  1. Open the **Sizes** story for any affected component with VoiceOver/NVDA on
  2. Navigate through each size instance
  3. Expect: announced label text (e.g. "Small", "Medium", "Large", "Extra-large") is identical to `main`