### PR TITLE
docs(conversational-ai): add usage and accessibility guidelines to pattern overview

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/pattern-overview.mdx
@@ -323,3 +323,50 @@ Interactive chip used inside the group. Emits a bubbled `swc-suggestion` event w
     },
   ]}
 />
+
+---
+
+## Usage guidelines
+
+#### Display the legal disclaimer on all prompt-enabled surfaces
+
+Other than the home screen, the prompt field must always be displayed together with the legal disclaimer. This ensures users have continuous access to legal and attribution information.
+
+#### In a panel modality, all artifacts show up as an image preview
+
+Due to limited space in a panel modality, all uploaded artifacts display in an image preview, regardless of type.
+
+#### Default the prompt field's input height to one line
+
+As the user types, the input height expands up to a maximum of four visible lines.
+
+#### Limit the input to four visible lines
+
+Once the four-line limit is reached, additional content is accessed via an internal scroll bar.
+
+#### Keep uploaded artifacts and prompt input visible while scrolling
+
+When the prompt input scrolls, keep the uploaded artifacts and the prompt label fixed at the top.
+
+---
+
+## Accessibility guidelines
+
+#### Focus order
+
+<kbd>Tab</kbd> moves focus through the prompt bar in this order: the prompt
+input, the upload button, the send button, any uploaded image, its close button,
+the legal footer, and the information button.
+
+#### Accessible name
+
+Every interactive part of the prompt bar needs an accessible name. Values in `[square brackets]` are dynamic and populated at runtime; values in `(parentheses)` are fixed names sourced from Spectrum and should not be redefined.
+
+| Part                | Accessible name                   | Note                                          |
+| ------------------- | --------------------------------- | --------------------------------------------- |
+| Prompt input        | `Prompt {text area/edit text}`    |                                               |
+| Upload button       | `Add images and files (button)`   |                                               |
+| Send button         | `Send prompt (button)`            |                                               |
+| Prompt bar artifact | `Open [file name] to preview`     | Only when a preview is available for the file |
+| Close button        | `Delete [artifact name] (button)` |                                               |
+| Information button  | `Information [context] (button)`  |                                               |


### PR DESCRIPTION
## Description

Adds a **Usage guidelines** and **Accessibility guidelines** section to the Conversational AI pattern overview docs page, covering the prompt bar's legal disclaimer, panel-modality artifact previews, input height behavior, focus order, and accessible name requirements.

## Motivation and context

Brings the pattern overview docs in line with the guidelines defined in the SUE Conversational AI Kit Figma file (node `18812-2045`), which were not previously documented here.

## Screenshots (if appropriate)

N/A (docs-only change)

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [ ] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Docs page renders correctly_
  1. Go to `/?path=/docs/patterns-conversational-ai--pattern-overview`
  2. Scroll to the new Usage guidelines and Accessibility guidelines sections
  3. Expect prose, `<kbd>` tags, and the accessible name table to render correctly

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist

- [ ] **Keyboard** (required — document steps below)
  1. No new focusable parts are introduced; this is a docs-only content change.
  2. Confirm no regressions in surrounding Storybook docs navigation.

- [ ] **Screen reader** (required — document steps below)
  1. Navigate to the new sections in the docs page with a screen reader.
  2. Confirm headings, table, and `<kbd>` content are announced with correct structure and no duplicate announcements.