### PR TITLE
perf(response-status): make active-step shimmer GPU-friendly

### DIFF
--- a/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/ResponseStatusStep.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/ResponseStatusStep.ts
@@ -76,13 +76,7 @@ export class ResponseStatusStep extends SpectrumElement {
   @state()
   private _hasDescription = false;
 
-  /**
-   * Perf prototype: mirrors the current label text so an inert clone can be
-   * rendered on top of the real label and masked to its glyph shapes for the
-   * shimmer overlay (see response-status-step.css). Kept separate from
-   * `_lastActiveLabel` below, which only tracks text while `status="active"`
-   * for the parent-notification event.
-   */
+  /** Mirrors the label text for the shimmer overlay clone (see .css). */
   @state()
   private _labelText = '';
 

--- a/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/ResponseStatusStep.ts
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/ResponseStatusStep.ts
@@ -77,6 +77,16 @@ export class ResponseStatusStep extends SpectrumElement {
   private _hasDescription = false;
 
   /**
+   * Perf prototype: mirrors the current label text so an inert clone can be
+   * rendered on top of the real label and masked to its glyph shapes for the
+   * shimmer overlay (see response-status-step.css). Kept separate from
+   * `_lastActiveLabel` below, which only tracks text while `status="active"`
+   * for the parent-notification event.
+   */
+  @state()
+  private _labelText = '';
+
+  /**
    * Whether the open detail region overflows its capped height. Only steps
    * that overflow get a keyboard-focusable scroll region. Measured once per
    * toggle-open rather than continuously: a resize or additional streamed
@@ -207,8 +217,12 @@ export class ResponseStatusStep extends SpectrumElement {
       this._hasDescription = hasDescription;
     }
 
+    const label = this._readLabel();
+    if (label !== this._labelText) {
+      this._labelText = label;
+    }
+
     if (this._resolvedStatus === 'active') {
-      const label = this._readLabel();
       if (label !== this._lastActiveLabel) {
         this._lastActiveLabel = label;
         this._emit('swc-response-status-step-active-label-change', {
@@ -278,6 +292,9 @@ export class ResponseStatusStep extends SpectrumElement {
       return html`
         <p class="swc-ResponseStatusStep-title swc-Detail swc-Detail--sizeS">
           <slot name="label"></slot>
+          <span inert class="swc-ResponseStatusStep-titleShimmer">
+            ${this._labelText}
+          </span>
         </p>
       `;
     }
@@ -292,6 +309,9 @@ export class ResponseStatusStep extends SpectrumElement {
       >
         <span class="swc-ResponseStatusStep-title swc-Detail swc-Detail--sizeS">
           <slot name="label"></slot>
+          <span inert class="swc-ResponseStatusStep-titleShimmer">
+            ${this._labelText}
+          </span>
         </span>
       </button>
       <div

--- a/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/response-status-step.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/response-status-step.css
@@ -188,13 +188,8 @@
   background: token("gray-75");
 }
 
-/* Perf prototype: sweep a bright band across the label using a masked,
-   `transform`-animated overlay instead of animating `background-position`
-   on the text itself. `translate` runs on the compositor, so this avoids a
-   repaint every frame. The overlay is an inert clone of the label kept in
-   sync with the real text via `_labelText`; it sits on top of the real
-   label, masked to that clone's own glyph shapes so the moving gradient
-   only shows through the letters. */
+/* Masked, `translate`-animated overlay clone of the label: cheaper to
+   animate on the compositor than sweeping `background-position` on the text. */
 .swc-ResponseStatusStep-titleShimmer {
   --swc-response-status-step-shimmer-spread: 4ch;
 
@@ -207,10 +202,12 @@
   pointer-events: none;
 }
 
+/* stylelint-disable property-no-vendor-prefix, declaration-property-value-no-unknown -- Chrome/Safari-only `text` clip value, no unprefixed equivalent yet */
 :host([status="active"]) .swc-ResponseStatusStep-titleShimmer {
-  mask-image: linear-gradient(white, white);
-  mask-clip: text;
+  -webkit-mask-image: linear-gradient(white, white);
+  -webkit-mask-clip: text;
 }
+/* stylelint-enable property-no-vendor-prefix, declaration-property-value-no-unknown */
 
 :host([status="active"]) .swc-ResponseStatusStep-titleShimmer::after {
   position: absolute;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/response-status-step.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/response-status-step.css
@@ -202,12 +202,14 @@
   pointer-events: none;
 }
 
-/* stylelint-disable property-no-vendor-prefix, declaration-property-value-no-unknown -- Chrome/Safari-only `text` clip value, no unprefixed equivalent yet */
-:host([status="active"]) .swc-ResponseStatusStep-titleShimmer {
-  -webkit-mask-image: linear-gradient(white, white);
-  -webkit-mask-clip: text;
+@supports (-webkit-mask-clip: text) {
+  :host([status="active"]) .swc-ResponseStatusStep-titleShimmer {
+    mask-image: linear-gradient(white, white);
+
+    /* stylelint-disable-next-line property-no-vendor-prefix -- no unprefixed equivalent exists */
+    -webkit-mask-clip: text;
+  }
 }
-/* stylelint-enable property-no-vendor-prefix, declaration-property-value-no-unknown */
 
 :host([status="active"]) .swc-ResponseStatusStep-titleShimmer::after {
   position: absolute;

--- a/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/response-status-step.css
+++ b/2nd-gen/packages/swc/patterns/conversational-ai/response-status/response-status-step/response-status-step.css
@@ -173,6 +173,8 @@
 }
 
 .swc-ResponseStatusStep-title {
+  display: inline-block;
+  position: relative;
   padding: token("spacing-50") token("spacing-100");
   margin: 0;
   color: token("gray-600");
@@ -182,45 +184,50 @@
     color 100ms token("animation-ease-in-out");
 }
 
-/* Active step: sweep a bright band across the label to read as "in progress"
-   rather than flat text. `color` above stays the reduced-motion /
-   forced-colors fallback (see the media queries below), since the gradient
-   fill only shows once `color` is overridden to transparent here.
-
-   The gradient is 160% of the label's width with a bright band spanning
-   31.25%-68.75% of that image (37.5% of the image = 60% of the label once
-   scaled by the 160% background-size). `background-position` sweeps the
-   image from fully off the label's leading edge to fully off its trailing
-   edge, then holds there for the remainder of the 1800ms cycle (1500ms
-   sweep + 300ms pause) so the band spends the pause fully out of view
-   instead of idling on-screen. */
-:host([status="active"]) .swc-ResponseStatusStep-title {
-  color: transparent;
-  background-image: linear-gradient(90deg, token("gray-600") 0%, token("gray-600") 31.25%, token("gray-900") 50%, token("gray-600") 68.75%, token("gray-600") 100%);
-  background-clip: text;
-  background-size: 160% 100%;
-  animation: swc-response-status-step-shimmer 1800ms infinite;
-}
-
-/* Excludes the active step above: its shimmer sets `background-clip: text`
-   on this same element, which would clip this hover fill down to just the
-   text glyphs instead of a normal rounded chip. */
-:host(:not([status="active"])) .swc-ResponseStatusStep-toggle:hover .swc-ResponseStatusStep-title {
+.swc-ResponseStatusStep-toggle:hover .swc-ResponseStatusStep-title {
   background: token("gray-75");
 }
 
+/* Perf prototype: sweep a bright band across the label using a masked,
+   `transform`-animated overlay instead of animating `background-position`
+   on the text itself. `translate` runs on the compositor, so this avoids a
+   repaint every frame. The overlay is an inert clone of the label kept in
+   sync with the real text via `_labelText`; it sits on top of the real
+   label, masked to that clone's own glyph shapes so the moving gradient
+   only shows through the letters. */
+.swc-ResponseStatusStep-titleShimmer {
+  --swc-response-status-step-shimmer-spread: 4ch;
+
+  position: absolute;
+  inset: 0;
+  padding: token("spacing-50") token("spacing-100");
+  contain: strict;
+  color: transparent;
+  overflow: clip;
+  pointer-events: none;
+}
+
+:host([status="active"]) .swc-ResponseStatusStep-titleShimmer {
+  mask-image: linear-gradient(white, white);
+  mask-clip: text;
+}
+
+:host([status="active"]) .swc-ResponseStatusStep-titleShimmer::after {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent calc(50% - var(--swc-response-status-step-shimmer-spread)), token("gray-900") 50%, transparent calc(50% + var(--swc-response-status-step-shimmer-spread)));
+  content: "";
+  animation: swc-response-status-step-shimmer 1800ms infinite;
+  will-change: transform;
+}
+
 @keyframes swc-response-status-step-shimmer {
-  0% {
-    background-position: 183.333% 0;
-    animation-timing-function: cubic-bezier(0.41, 0.01, 0.43, 0.99);
+  from {
+    translate: -100% 0;
   }
 
-  83.333% {
-    background-position: -83.333% 0;
-  }
-
-  100% {
-    background-position: -83.333% 0;
+  to {
+    translate: 100% 0;
   }
 }
 
@@ -348,11 +355,13 @@
     animation: none;
   }
 
-  /* Fall back to the flat, opaque title color set above; no sweeping gradient. */
+  /* Fall back to the flat, opaque title color set above; no sweeping overlay. */
   :host([status="active"]) .swc-ResponseStatusStep-title {
     color: token("gray-800");
-    background-image: none;
-    animation: none;
+  }
+
+  .swc-ResponseStatusStep-titleShimmer {
+    display: none;
   }
 }
 
@@ -371,11 +380,13 @@
     animation: none;
   }
 
-  /* The gradient/transparent-text technique above is unreliable under forced
-     colors; fall back to plain, guaranteed-visible text. */
+  /* The masked shimmer overlay is unreliable under forced colors; fall back
+     to plain, guaranteed-visible text. */
   :host([status="active"]) .swc-ResponseStatusStep-title {
     color: CanvasText;
-    background-image: none;
-    animation: none;
+  }
+
+  .swc-ResponseStatusStep-titleShimmer {
+    display: none;
   }
 }


### PR DESCRIPTION
## What

The "in progress" text shimmer on the active response step used to sweep by animating `background-position` on `background-clip: text`. This PR swaps that for a masked overlay that animates `translate` instead.

## Why

Animating `background-position` isn't GPU-accelerated — the browser has to repaint the text every single frame, which is expensive for something running continuously while a step is active. Animating `translate` runs on the compositor instead, so the browser can slide the highlight around without repainting the text underneath.

## How

- The real label text is left alone (plain color, no animation).
- An invisible clone of the label sits on top of it, masked to its own letter shapes (`-webkit-mask-clip: text`) so only the part of it inside the letters is visible.
- A moving gradient band is animated across that clone using `translate`, which shows through the mask as a highlight sweeping across the text.

## Trade-offs

- Needs a small duplicate of the label text kept in sync with the real one (previously the effect lived entirely in CSS on the real text).
- **Firefox caveat:** the mask only works via `-webkit-mask-clip: text`, which Firefox doesn't support (no unprefixed equivalent exists yet). The whole thing is wrapped in `@supports (-webkit-mask-clip: text)`, so Firefox just skips it — the clone stays fully transparent and invisible, and the step title shows as plain, unanimated text there instead of shimmering.
- Reduced-motion and forced-colors users still just see flat text, same as before.