### PR TITLE
chore: trigger snapshot release test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ debug-storybook.log
 # 2nd-gen/packages/swc/icon-source/README.md
 2nd-gen/packages/swc/icon-source/ui/*.svg
 2nd-gen/packages/swc/icon-source/workflow/*.svg
+


### PR DESCRIPTION
## Description

One-line no-op change to `.gitignore` to trigger a snapshot npm release build.

Not intended to be merged.