### PR TITLE
fix(response-status): align with Figma for hover/expanded state, complete label, and Storybook leak

### DIFF
--- a/.changeset/response-status-figma-parity.md
+++ b/.changeset/response-status-figma-parity.md
@@ -1,0 +1,10 @@
+---
+'@adobe/spectrum-wc': patch
+---
+
+Fix several `swc-response-status` visual/behavior mismatches against the Figma spec:
+
+- The header label no longer stays in its lighter, unfocused color while the step timeline is expanded — it now darkens to match the hover treatment.
+- The completed-status default label reads "Response complete" instead of "Response generated".
+- The header toggle button no longer relies on the browser's native `<button>` text color, which some mobile browsers rendered as accent blue for the completed checkmark icon.
+- The `Status only` Storybook story no longer leaks into the sidebar/docs/prod build; it was incorrectly tagged `dev`, a tag reserved for the Playground story.

--- a/.changeset/response-status-figma-parity.md
+++ b/.changeset/response-status-figma-parity.md
@@ -8,3 +8,4 @@ Fix several `swc-response-status` visual/behavior mismatches against the Figma s
 - The completed-status default label reads "Response complete" instead of "Response generated".
 - The header toggle button no longer relies on the browser's native `<button>` text color, which some mobile browsers rendered as accent blue for the completed checkmark icon.
 - The `Status only` Storybook story no longer leaks into the sidebar/docs/prod build; it was incorrectly tagged `dev`, a tag reserved for the Playground story.
+- The header toggle's clickable area now spans the full row, not just the fit-content label and chevron.

--- a/.changeset/response-status-figma-parity.md
+++ b/.changeset/response-status-figma-parity.md
@@ -8,4 +8,4 @@ Fix several `swc-response-status` visual/behavior mismatches against the Figma s
 - The completed-status default label reads "Response complete" instead of "Response generated".
 - The header toggle button no longer relies on the browser's native `<button>` text color, which some mobile browsers rendered as accent blue for the completed checkmark icon.
 - The `Status only` Storybook story no longer leaks into the sidebar/docs/prod build; it was incorrectly tagged `dev`, a tag reserved for the Playground story.
-- The header toggle's clickable area now spans the full row, not just the fit-content label and chevron.
+- The header toggle's clickable area now spans the full row.

--- a/.changeset/response-status-figma-parity.md
+++ b/.changeset/response-status-figma-parity.md
@@ -8,4 +8,5 @@ Fix several `swc-response-status` visual/behavior mismatches against the Figma s
 - The completed-status default label reads "Response complete" instead of "Response generated".
 - The header toggle button no longer relies on the browser's native `<button>` text color, which some mobile browsers rendered as accent blue for the completed checkmark icon.
 - The `Status only` Storybook story no longer leaks into the sidebar/docs/prod build; it was incorrectly tagged `dev`, a tag reserved for the Playground story.
-- The header toggle's clickable area now spans the full row.
+- The header toggle's clickable area now spans the full row, while the visible label and chevron stay grouped together instead of stretching apart.
+- The chevron's open/close rotation is smooth again; a hover/expanded color rule was overwriting its rotation transition.

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/conversation-thread/stories/conversation-thread.stories.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/conversation-thread/stories/conversation-thread.stories.ts
@@ -243,7 +243,7 @@ const DEMO_LOADING_STEP_COUNT = DEMO_RESPONSE_STEPS.length - 1;
 // How long each step stays active before the next one takes over. The total
 // generation time scales with the step count so pacing stays even as more
 // steps are added.
-const DEMO_STEP_INTERVAL_MS = 1200;
+const DEMO_STEP_INTERVAL_MS = 2200;
 const DEMO_GENERATION_DURATION_MS =
   (DEMO_LOADING_STEP_COUNT + 1) * DEMO_STEP_INTERVAL_MS;
 

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/ResponseStatus.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/ResponseStatus.ts
@@ -75,7 +75,7 @@ export class ResponseStatus extends SpectrumElement {
   private static readonly DEFAULT_LABELS: Record<ResponseStatusStatus, string> =
     {
       active: 'Generating response',
-      complete: 'Response generated',
+      complete: 'Response complete',
       stopped: 'You stopped the response',
     };
 

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status.css
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status.css
@@ -39,7 +39,7 @@
 }
 
 /* When the row is a button (reasoning toggle). Full inline-size so the
-   entire row is clickable, not just the fit-content label/chevron. */
+   entire row is clickable. */
 .swc-ResponseStatus-row--button {
   inline-size: 100%;
   padding: var(--_swc-response-status-toggle-padding-block, 3px) token("spacing-100");

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status.css
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status.css
@@ -43,6 +43,7 @@
   inline-size: fit-content;
   max-inline-size: 580px;
   padding: var(--_swc-response-status-toggle-padding-block, 3px) token("spacing-100");
+  color: inherit;
   background: transparent;
   border: none;
   border-radius: token("corner-radius-medium-default");
@@ -193,18 +194,21 @@
   transform: rotate(90deg);
 }
 
-.swc-ResponseStatus-row--button:hover .swc-ResponseStatus-label {
+.swc-ResponseStatus-row--button:hover .swc-ResponseStatus-label,
+.swc-ResponseStatus-row--button[aria-expanded="true"] .swc-ResponseStatus-label {
   --swc-body-font-color: token("gray-800");
 
   transition: all token("animation-duration-100") token("animation-ease-in-out");
 }
 
-.swc-ResponseStatus-row--button:hover .swc-ResponseStatus-chevron {
+.swc-ResponseStatus-row--button:hover .swc-ResponseStatus-chevron,
+.swc-ResponseStatus-row--button[aria-expanded="true"] .swc-ResponseStatus-chevron {
   color: token("gray-800");
   transition: color token("animation-duration-100") token("animation-ease-in-out");
 }
 
-.swc-ResponseStatus-row--button:hover .swc-ResponseStatus-loader {
+.swc-ResponseStatus-row--button:hover .swc-ResponseStatus-loader,
+.swc-ResponseStatus-row--button[aria-expanded="true"] .swc-ResponseStatus-loader {
   --swc-pixel-loader-color: token("gray-800");
 }
 

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status.css
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status.css
@@ -44,6 +44,7 @@
   inline-size: 100%;
   padding: var(--_swc-response-status-toggle-padding-block, 3px) token("spacing-100");
   color: inherit;
+  text-align: start;
   background: transparent;
   border: none;
   border-radius: token("corner-radius-medium-default");
@@ -53,11 +54,6 @@
   --swc-body-font-color: token("gray-700");
 
   text-align: start;
-}
-
-.swc-ResponseStatus-row--button .swc-ResponseStatus-label {
-  flex: 1;
-  min-inline-size: 0;
 }
 
 /* Label + chevron trail (header label roll) */
@@ -80,12 +76,6 @@
 .swc-ResponseStatus-headerTrailViewport--settled {
   block-size: auto;
   overflow: visible;
-}
-
-.swc-ResponseStatus-row--button .swc-ResponseStatus-headerTrail,
-.swc-ResponseStatus-row--button .swc-ResponseStatus-headerTrailViewport {
-  flex: 1;
-  min-inline-size: 0;
 }
 
 /* The incoming line stays in normal flow, so the container's fit-content
@@ -187,11 +177,12 @@
 .swc-ResponseStatus-chevron {
   flex-shrink: 0;
   color: token("gray-700");
-  transition: transform token("animation-duration-100") cubic-bezier(0.21, 0, 0.15, 0.99);
+  rotate: 0deg;
+  transition: rotate token("animation-duration-100") token("animation-ease-in-out");
 }
 
 .swc-ResponseStatus-chevron--down {
-  transform: rotate(90deg);
+  rotate: 90deg;
 }
 
 .swc-ResponseStatus-row--button:hover .swc-ResponseStatus-label,
@@ -204,7 +195,9 @@
 .swc-ResponseStatus-row--button:hover .swc-ResponseStatus-chevron,
 .swc-ResponseStatus-row--button[aria-expanded="true"] .swc-ResponseStatus-chevron {
   color: token("gray-800");
-  transition: color token("animation-duration-100") token("animation-ease-in-out");
+  transition:
+    rotate token("animation-duration-100") token("animation-ease-in-out"),
+    color token("animation-duration-100") token("animation-ease-in-out");
 }
 
 .swc-ResponseStatus-row--button:hover .swc-ResponseStatus-loader,

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status.css
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status.css
@@ -38,10 +38,10 @@
   padding-inline: token("spacing-100");
 }
 
-/* When the row is a button (reasoning toggle) */
+/* When the row is a button (reasoning toggle). Full inline-size so the
+   entire row is clickable, not just the fit-content label/chevron. */
 .swc-ResponseStatus-row--button {
-  inline-size: fit-content;
-  max-inline-size: 580px;
+  inline-size: 100%;
   padding: var(--_swc-response-status-toggle-padding-block, 3px) token("spacing-100");
   color: inherit;
   background: transparent;

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/stories/response-status.stories.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/stories/response-status.stories.ts
@@ -317,7 +317,6 @@ export const StatusOnly: Story = {
       <span slot="label">Searching repositories for Europe trips</span>
     </swc-response-status>
   `,
-  tags: ['dev'],
 };
 
 export const GeneratingPresets: Story = {

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/test/response-status.test.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/test/response-status.test.ts
@@ -132,7 +132,7 @@ export const StatusApiTest: Story = {
             el.shadowRoot
               ?.querySelector('.swc-ResponseStatus-label')
               ?.textContent?.trim()
-          ).toBe('Response generated');
+          ).toBe('Response complete');
         },
         { timeout: 2000 }
       );


### PR DESCRIPTION
## Summary
Fixes several `swc-response-status` issues found during design QA:
- Header darkens on hover and while expanded
- Completed label reads "Response complete"
- Checkmark no longer shows blue on mobile
- Header row is fully clickable, not just the label
- Chevron rotates smoothly again
- `Status only` story no longer leaks into the sidebar/docs/prod build
- Pattern overview demo steps roll at a more readable pace

## Test plan
- [x] Unit tests passing
- [x] Lint clean
- [x] Manually verified in Storybook