### PR TITLE
docs(ai-toolkit): add @since 2.0.0-beta.3 tags

### DIFF
--- a/2nd-gen/packages/swc/patterns/ai-toolkit/conversation-thread/ConversationThread.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/conversation-thread/ConversationThread.ts
@@ -30,6 +30,7 @@ import styles from './conversation-thread.css';
  *
  * @element swc-conversation-thread
  * @slot - Conversation turns, typically `<swc-conversation-turn>` elements.
+ * @since 2.0.0-beta.3
  */
 export class ConversationThread extends SpectrumElement {
   @queryAssignedElements({ flatten: true, selector: 'swc-conversation-turn' })

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/conversation-turn/ConversationTurn.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/conversation-turn/ConversationTurn.ts
@@ -34,6 +34,7 @@ import styles from './conversation-turn.css';
  *
  * @element swc-conversation-turn
  * @slot - Turn body (message stack or bubble)
+ * @since 2.0.0-beta.3
  */
 export class ConversationTurn extends SpectrumElement {
   /**

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/message-feedback/MessageFeedback.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/message-feedback/MessageFeedback.ts
@@ -31,6 +31,7 @@ import styles from './message-feedback.css';
  * @element swc-message-feedback
  * @fires swc-message-feedback-change - Dispatched when the user toggles feedback selection.
  * Detail: `{ status: 'positive' | 'negative' | undefined }`
+ * @since 2.0.0-beta.3
  */
 export class MessageFeedback extends SpectrumElement {
   /**

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/message-sources/MessageSources.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/message-sources/MessageSources.ts
@@ -35,6 +35,7 @@ import styles from './message-sources.css';
  * @slot - Anchor (`<a>`) elements projected into a numbered list when expanded
  * @fires swc-message-sources-toggle - Dispatched when the panel is toggled.
  * Detail: `{ open: boolean }`
+ * @since 2.0.0-beta.3
  */
 export class MessageSources extends SpectrumElement {
   private readonly panelId = uniqueId('swc-sources-panel');

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/pixel-loader/PixelLoader.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/pixel-loader/PixelLoader.ts
@@ -76,6 +76,7 @@ const DOCS_URL =
  *
  * @cssprop --swc-pixel-loader-size - Rendered inline and block size of the loader. Defaults to 56px. There is no `size` attribute; set this custom property to resize the loader.
  * @cssprop --swc-pixel-loader-color - Color of the pixel cells. Defaults to `currentcolor`, so the loader inherits the surrounding text color unless overridden.
+ * @since 2.0.0-beta.3
  */
 export class PixelLoader extends SpectrumElement {
   // Relative so the rounding scales with `--swc-pixel-loader-size` and reads as

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/prompt-field/PromptField.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/prompt-field/PromptField.ts
@@ -105,6 +105,7 @@ const SUPPORTS_FIELD_SIZING =
  * elements from `files` externally, same as the upload-click flow.
  *
  * @cssprop --swc-prompt-field-brand-color - Brand hue driving the AI treatment's ring, wash, and glow colors. Defaults to a fuchsia OKLCH value; only the hue is meaningfully used, lightness/chroma come from each layer's own derived values.
+ * @since 2.0.0-beta.3
  */
 export class PromptField extends SpectrumElement {
   private readonly labelId = uniqueId('swc-prompt-field-label');

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/ResponseStatus.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/ResponseStatus.ts
@@ -67,6 +67,7 @@ export type ResponseStatusStatus = (typeof RESPONSE_STATUSES)[number];
  * Detail: `{ open: boolean }`
  * @fires swc-response-status-step-toggle - Dispatched when the user expands or collapses
  * a step's description. Detail: `{ open: boolean, index: number }`
+ * @since 2.0.0-beta.3
  */
 export class ResponseStatus extends SpectrumElement {
   private static readonly STATUS_LABEL_CLASS =

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status-step/ResponseStatusStep.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/response-status/response-status-step/ResponseStatusStep.ts
@@ -57,6 +57,7 @@ export type ResponseStatusStepStatus =
  * @fires swc-response-status-step-active-label-change - Dispatched when this
  * step's label text changes while `status="active"`, so the parent can keep
  * its header label in sync with streamed text. Detail: `{ label: string }`
+ * @since 2.0.0-beta.3
  */
 export class ResponseStatusStep extends SpectrumElement {
   private readonly _toggleId = uniqueId('swc-response-status-step-toggle');

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/suggestion-item/SuggestionItem.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/suggestion-item/SuggestionItem.ts
@@ -29,6 +29,7 @@ import styles from './suggestion-item.css';
  * @slot - Suggestion label text/content.
  * @fires swc-suggestion - Dispatched when the suggestion chip is activated.
  * Detail: `{ label: string }`
+ * @since 2.0.0-beta.3
  */
 export class SuggestionItem extends SpectrumElement {
   public static override get styles(): CSSResultArray {

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/suggestion/SuggestionGroup.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/suggestion/SuggestionGroup.ts
@@ -33,6 +33,7 @@ import styles from './suggestion-group.css';
  * @element swc-suggestion-group
  * @slot heading - Required heading content; consumer controls semantic element.
  * @slot - Suggestion items (recommended: `<swc-suggestion-item>`)
+ * @since 2.0.0-beta.3
  */
 export class SuggestionGroup extends SpectrumElement {
   /**

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/system-message/SystemMessage.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/system-message/SystemMessage.ts
@@ -37,6 +37,7 @@ import styles from './system-message.css';
  * @slot feedback - Positive / negative feedback controls
  * @slot sources - Collapsible list of sources
  * @slot suggestions - Follow-up suggestion chips (rendered outside the main body)
+ * @since 2.0.0-beta.3
  */
 export class SystemMessage extends SpectrumElement {
   public static override get styles(): CSSResultArray {

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/upload-attachment/UploadAttachment.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/upload-attachment/UploadAttachment.ts
@@ -47,6 +47,7 @@ import styles from './upload-attachment.css';
  * @slot actions - Optional trailing actions.
  * @fires swc-upload-attachment-dismiss - Dispatched when the dismiss button is pressed.
  * Detail: `{ attachment: this }`
+ * @since 2.0.0-beta.3
  */
 export class UploadAttachment extends SpectrumElement {
   /** Visual treatment type for this attachment. */

--- a/2nd-gen/packages/swc/patterns/ai-toolkit/user-message/UserMessage.ts
+++ b/2nd-gen/packages/swc/patterns/ai-toolkit/user-message/UserMessage.ts
@@ -29,6 +29,7 @@ export type UserMessageType = 'copy' | 'card' | 'media';
  * @slot thumbnail - Attachment preview when `type="card"` or `type="media"`.
  * @slot title - Attachment title when `type="card"` or `type="media"`.
  * @slot subtitle - Attachment subtitle when `type="card"` or `type="media"`.
+ * @since 2.0.0-beta.3
  */
 export class UserMessage extends SpectrumElement {
   /**


### PR DESCRIPTION
## Summary
- Add `@since 2.0.0-beta.3` JSDoc tags to all `ai-toolkit` pattern components (suggestion, suggestion-item, pixel-loader, user-message, message-feedback, prompt-field, conversation-thread, conversation-turn, system-message, upload-attachment, response-status, response-status-step, message-sources), documenting the release each component was introduced in.

## Test plan
- [x] Docs-only change; no behavior affected.