### PR TITLE
chore(gotocssstory-helper): add gotoCssStory to a11y-helpers, dedupe link/typography specs

### DIFF
--- a/2nd-gen/packages/swc/components/link/test/link.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/link/test/link.a11y.spec.ts
@@ -12,7 +12,7 @@
 
 import { expect, test } from '@playwright/test';
 
-import { gotoCssStory } from '../../../utils/a11y-helpers.js';
+import { gotoStory } from '../../../utils/a11y-helpers.js';
 
 /**
  * Accessibility tests for Link styles (2nd Generation)
@@ -31,7 +31,7 @@ test.describe('Link - ARIA Snapshots', () => {
   test('standalone explicit link exposes link role and name', async ({
     page,
   }) => {
-    const root = await gotoCssStory(
+    const root = await gotoStory(
       page,
       'components-link--standalone',
       'a[href]'
@@ -42,18 +42,14 @@ test.describe('Link - ARIA Snapshots', () => {
   });
 
   test('secondary link exposes link role and name', async ({ page }) => {
-    const root = await gotoCssStory(
-      page,
-      'components-link--secondary',
-      'a[href]'
-    );
+    const root = await gotoStory(page, 'components-link--secondary', 'a[href]');
     await expect(root).toMatchAriaSnapshot(`
       - link "Learn more"
     `);
   });
 
   test('quiet standalone link exposes link role and name', async ({ page }) => {
-    const root = await gotoCssStory(
+    const root = await gotoStory(
       page,
       'components-link--quiet-standalone',
       'a[href]'
@@ -64,22 +60,14 @@ test.describe('Link - ARIA Snapshots', () => {
   });
 
   test('in-prose link is named from visible text', async ({ page }) => {
-    const root = await gotoCssStory(
-      page,
-      'components-link--in-prose',
-      'a[href]'
-    );
+    const root = await gotoStory(page, 'components-link--in-prose', 'a[href]');
     await expect(root).toMatchAriaSnapshot(`
       - link "inline link"
     `);
   });
 
   test('link list renders multiple named links', async ({ page }) => {
-    const root = await gotoCssStory(
-      page,
-      'components-link--link-list',
-      'a[href]'
-    );
+    const root = await gotoStory(page, 'components-link--link-list', 'a[href]');
     await expect(root.locator('.swc-Typography--links')).toMatchAriaSnapshot(`
       - list:
         - listitem:
@@ -94,7 +82,7 @@ test.describe('Link - ARIA Snapshots', () => {
   test('accessibility story renders descriptive prose link', async ({
     page,
   }) => {
-    const root = await gotoCssStory(
+    const root = await gotoStory(
       page,
       'components-link--accessibility',
       'a[href]'
@@ -106,7 +94,7 @@ test.describe('Link - ARIA Snapshots', () => {
   });
 
   test('links are keyboard focusable', async ({ page }) => {
-    const root = await gotoCssStory(
+    const root = await gotoStory(
       page,
       'components-link--standalone',
       'a[href]'

--- a/2nd-gen/packages/swc/components/link/test/link.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/link/test/link.a11y.spec.ts
@@ -10,8 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import type { Locator, Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
+
+import { gotoCssStory } from '../../../utils/a11y-helpers.js';
 
 /**
  * Accessibility tests for Link styles (2nd Generation)
@@ -25,57 +26,60 @@ import { expect, test } from '@playwright/test';
  * test-storybook (see .storybook/test-runner.ts). Both are included
  * in the `test:a11y` command.
  */
-async function gotoLinkStory(page: Page, storyId: string): Promise<Locator> {
-  await page.goto(`/iframe.html?id=${storyId}&viewMode=story`, {
-    waitUntil: 'domcontentloaded',
-  });
-
-  await page.waitForFunction(() => {
-    const root = document.querySelector('#storybook-root');
-    return root && root.children.length > 0;
-  });
-
-  await page
-    .locator('#storybook-root a[href]')
-    .first()
-    .waitFor({ state: 'visible' });
-
-  return page.locator('#storybook-root');
-}
 
 test.describe('Link - ARIA Snapshots', () => {
   test('standalone explicit link exposes link role and name', async ({
     page,
   }) => {
-    const root = await gotoLinkStory(page, 'components-link--standalone');
+    const root = await gotoCssStory(
+      page,
+      'components-link--standalone',
+      'a[href]'
+    );
     await expect(root).toMatchAriaSnapshot(`
       - link "Account settings"
     `);
   });
 
   test('secondary link exposes link role and name', async ({ page }) => {
-    const root = await gotoLinkStory(page, 'components-link--secondary');
+    const root = await gotoCssStory(
+      page,
+      'components-link--secondary',
+      'a[href]'
+    );
     await expect(root).toMatchAriaSnapshot(`
       - link "Learn more"
     `);
   });
 
   test('quiet standalone link exposes link role and name', async ({ page }) => {
-    const root = await gotoLinkStory(page, 'components-link--quiet-standalone');
+    const root = await gotoCssStory(
+      page,
+      'components-link--quiet-standalone',
+      'a[href]'
+    );
     await expect(root).toMatchAriaSnapshot(`
       - link "Privacy policy"
     `);
   });
 
   test('in-prose link is named from visible text', async ({ page }) => {
-    const root = await gotoLinkStory(page, 'components-link--in-prose');
+    const root = await gotoCssStory(
+      page,
+      'components-link--in-prose',
+      'a[href]'
+    );
     await expect(root).toMatchAriaSnapshot(`
       - link "inline link"
     `);
   });
 
   test('link list renders multiple named links', async ({ page }) => {
-    const root = await gotoLinkStory(page, 'components-link--link-list');
+    const root = await gotoCssStory(
+      page,
+      'components-link--link-list',
+      'a[href]'
+    );
     await expect(root.locator('.swc-Typography--links')).toMatchAriaSnapshot(`
       - list:
         - listitem:
@@ -90,7 +94,11 @@ test.describe('Link - ARIA Snapshots', () => {
   test('accessibility story renders descriptive prose link', async ({
     page,
   }) => {
-    const root = await gotoLinkStory(page, 'components-link--accessibility');
+    const root = await gotoCssStory(
+      page,
+      'components-link--accessibility',
+      'a[href]'
+    );
     await expect(root).toMatchAriaSnapshot(`
       - paragraph:
         - link "view the full schedule"
@@ -98,7 +106,11 @@ test.describe('Link - ARIA Snapshots', () => {
   });
 
   test('links are keyboard focusable', async ({ page }) => {
-    const root = await gotoLinkStory(page, 'components-link--standalone');
+    const root = await gotoCssStory(
+      page,
+      'components-link--standalone',
+      'a[href]'
+    );
     const anchor = root.locator('a[href]').first();
     await anchor.focus();
     await expect(anchor).toBeFocused();

--- a/2nd-gen/packages/swc/components/typography/test/typography.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/typography/test/typography.a11y.spec.ts
@@ -12,15 +12,14 @@
 
 import { expect, test } from '@playwright/test';
 
-import { gotoCssStory } from '../../../utils/a11y-helpers.js';
+import { gotoStory } from '../../../utils/a11y-helpers.js';
 
 /**
  * Accessibility tests for Typography styles (2nd Generation)
  *
- * Typography is a CSS-only utility — there is no `<swc-typography>` custom element.
- * `gotoCssStory` navigates to a story and waits for a readiness selector to appear
- * rather than using `customElements.whenDefined()`, which only works for custom
- * elements with a hyphen in the tag name.
+ * Typography is a CSS-only utility; there is no `<swc-typography>` custom element.
+ * `gotoStory` waits for the readiness selector to become visible; since there
+ * is no custom element to upgrade, that visibility check alone is sufficient.
  *
  * ARIA snapshot tests validate the accessibility tree structure.
  * aXe WCAG compliance and color contrast validation are run via
@@ -32,7 +31,7 @@ test.describe('Typography - ARIA Snapshots', () => {
   test('heading variant renders an accessible level-2 heading', async ({
     page,
   }) => {
-    const root = await gotoCssStory(
+    const root = await gotoStory(
       page,
       'components-typography--playground',
       '.typography-samples'
@@ -45,7 +44,7 @@ test.describe('Typography - ARIA Snapshots', () => {
   test('heading variant with all sizes renders multiple accessible headings', async ({
     page,
   }) => {
-    const root = await gotoCssStory(
+    const root = await gotoStory(
       page,
       'components-typography--heading-variant',
       '.typography-samples'
@@ -59,7 +58,7 @@ test.describe('Typography - ARIA Snapshots', () => {
   test('prose container renders nested semantic heading hierarchy', async ({
     page,
   }) => {
-    const root = await gotoCssStory(
+    const root = await gotoStory(
       page,
       'components-typography--prose-container',
       '.typography-samples'
@@ -75,7 +74,7 @@ test.describe('Typography - ARIA Snapshots', () => {
   test('prose container includes an inline link with accessible name', async ({
     page,
   }) => {
-    const root = await gotoCssStory(
+    const root = await gotoStory(
       page,
       'components-typography--prose-container',
       '.typography-samples'
@@ -86,7 +85,7 @@ test.describe('Typography - ARIA Snapshots', () => {
   });
 
   test('link list renders named navigation links', async ({ page }) => {
-    const root = await gotoCssStory(
+    const root = await gotoStory(
       page,
       'components-typography--link-list',
       '.swc-Typography--links'

--- a/2nd-gen/packages/swc/components/typography/test/typography.a11y.spec.ts
+++ b/2nd-gen/packages/swc/components/typography/test/typography.a11y.spec.ts
@@ -10,50 +10,32 @@
  * governing permissions and limitations under the License.
  */
 
-import type { Locator, Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
+
+import { gotoCssStory } from '../../../utils/a11y-helpers.js';
 
 /**
  * Accessibility tests for Typography styles (2nd Generation)
  *
  * Typography is a CSS-only utility — there is no `<swc-typography>` custom element.
- * This local helper navigates to a story and waits for the `.typography-samples`
- * container to appear rather than using `customElements.whenDefined()`, which only
- * works for custom elements with a hyphen in the tag name.
+ * `gotoCssStory` navigates to a story and waits for a readiness selector to appear
+ * rather than using `customElements.whenDefined()`, which only works for custom
+ * elements with a hyphen in the tag name.
  *
  * ARIA snapshot tests validate the accessibility tree structure.
  * aXe WCAG compliance and color contrast validation are run via
  * test-storybook (see .storybook/test-runner.ts). Both are included
  * in the `test:a11y` command.
  */
-async function gotoTypographyStory(
-  page: Page,
-  storyId: string,
-  readySelector = '.typography-samples'
-): Promise<Locator> {
-  await page.goto(`/iframe.html?id=${storyId}&viewMode=story`, {
-    waitUntil: 'domcontentloaded',
-  });
-
-  // Wait for the Storybook root to contain rendered content
-  await page.waitForFunction(() => {
-    const root = document.querySelector('#storybook-root');
-    return root && root.children.length > 0;
-  });
-
-  // Wait for story-specific content (CSS-only component)
-  await page.locator(readySelector).first().waitFor({ state: 'visible' });
-
-  return page.locator('#storybook-root');
-}
 
 test.describe('Typography - ARIA Snapshots', () => {
   test('heading variant renders an accessible level-2 heading', async ({
     page,
   }) => {
-    const root = await gotoTypographyStory(
+    const root = await gotoCssStory(
       page,
-      'components-typography--playground'
+      'components-typography--playground',
+      '.typography-samples'
     );
     await expect(root).toMatchAriaSnapshot(`
       - heading /Reserved for main page heading/ [level=2]
@@ -63,9 +45,10 @@ test.describe('Typography - ARIA Snapshots', () => {
   test('heading variant with all sizes renders multiple accessible headings', async ({
     page,
   }) => {
-    const root = await gotoTypographyStory(
+    const root = await gotoCssStory(
       page,
-      'components-typography--heading-variant'
+      'components-typography--heading-variant',
+      '.typography-samples'
     );
     await expect(root).toMatchAriaSnapshot(`
       - heading /Reserved for main page heading/ [level=2]
@@ -76,9 +59,10 @@ test.describe('Typography - ARIA Snapshots', () => {
   test('prose container renders nested semantic heading hierarchy', async ({
     page,
   }) => {
-    const root = await gotoTypographyStory(
+    const root = await gotoCssStory(
       page,
-      'components-typography--prose-container'
+      'components-typography--prose-container',
+      '.typography-samples'
     );
     await expect(root).toMatchAriaSnapshot(`
       - heading "Semantic H1" [level=1]
@@ -91,9 +75,10 @@ test.describe('Typography - ARIA Snapshots', () => {
   test('prose container includes an inline link with accessible name', async ({
     page,
   }) => {
-    const root = await gotoTypographyStory(
+    const root = await gotoCssStory(
       page,
-      'components-typography--prose-container'
+      'components-typography--prose-container',
+      '.typography-samples'
     );
     await expect(root).toMatchAriaSnapshot(`
       - link "inline link"
@@ -101,7 +86,7 @@ test.describe('Typography - ARIA Snapshots', () => {
   });
 
   test('link list renders named navigation links', async ({ page }) => {
-    const root = await gotoTypographyStory(
+    const root = await gotoCssStory(
       page,
       'components-typography--link-list',
       '.swc-Typography--links'

--- a/2nd-gen/packages/swc/utils/a11y-helpers.ts
+++ b/2nd-gen/packages/swc/utils/a11y-helpers.ts
@@ -124,3 +124,34 @@ export async function gotoStory(
 
   return waitForStoryReady(page, elementSelector);
 }
+
+/**
+ * Navigate to a Storybook story for a CSS-only utility (no custom element,
+ * e.g. Typography or Link) and wait for it to be ready.
+ *
+ * @param page - Playwright page object
+ * @param storyId - Storybook story ID (e.g., 'components-link--standalone')
+ * @param readySelector - CSS selector to wait for as a readiness signal
+ * @returns The `#storybook-root` locator containing all rendered elements
+ */
+export async function gotoCssStory(
+  page: Page,
+  storyId: string,
+  readySelector: string
+): Promise<Locator> {
+  await page.goto(`/iframe.html?id=${storyId}&viewMode=story`, {
+    waitUntil: 'domcontentloaded',
+  });
+
+  return waitForStoryReadyWithRetries(page, async () => {
+    await page.waitForFunction(() => {
+      const root = document.querySelector('#storybook-root');
+      return root && root.children.length > 0;
+    });
+
+    const root = page.locator('#storybook-root');
+    await root.locator(readySelector).first().waitFor({ state: 'visible' });
+
+    return root;
+  });
+}

--- a/2nd-gen/packages/swc/utils/a11y-story-retry.ts
+++ b/2nd-gen/packages/swc/utils/a11y-story-retry.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+const TRANSIENT_RETRY_COUNT = 3;
+
+function isTransientNavigationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('Execution context was destroyed') ||
+    message.includes('Target page, context or browser has been closed')
+  );
+}
+
+/**
+ * Retry a story-readiness check against transient Storybook iframe reloads
+ * (e.g. a quick reload while Vite optimizes deps mid-navigation).
+ *
+ * @param page - Playwright page object
+ * @param callback - Readiness check to retry on transient navigation errors
+ * @returns The result of the first successful callback invocation
+ */
+export async function waitForStoryReadyWithRetries(
+  page: Page,
+  callback: () => Promise<Locator>
+): Promise<Locator> {
+  for (let attempt = 0; attempt < TRANSIENT_RETRY_COUNT; attempt++) {
+    try {
+      return await callback();
+    } catch (error) {
+      const isLastAttempt = attempt === TRANSIENT_RETRY_COUNT - 1;
+      if (!isTransientNavigationError(error) || isLastAttempt) {
+        throw error;
+      }
+
+      // Storybook can trigger a quick iframe reload while optimizing deps.
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForTimeout(200 * (attempt + 1));
+    }
+  }
+
+  throw new Error('Failed to wait for story readiness after retries.');
+}

--- a/2nd-gen/packages/swc/utils/goto-story.ts
+++ b/2nd-gen/packages/swc/utils/goto-story.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+import { waitForStoryReadyWithRetries } from './a11y-story-retry.js';
+import { waitForCustomElement } from './wait-for-custom-element.js';
+
+/**
+ * Navigate to a Storybook story and wait for it to be ready. Waits for
+ * `#storybook-root` to render, then for `elementSelector` to become visible
+ * within it. If the resolved element is a custom element, also waits for
+ * it to be defined in the custom elements registry before returning; plain
+ * elements (e.g. CSS-only Typography or Link markup) skip that step.
+ *
+ * @param page - Playwright page object
+ * @param storyId - Storybook story ID (e.g., 'components-badge--sizes')
+ * @param elementSelector - CSS selector for the main element to wait for
+ * @returns The `#storybook-root` locator containing all rendered elements
+ */
+export async function gotoStory(
+  page: Page,
+  storyId: string,
+  elementSelector: string
+): Promise<Locator> {
+  await page.goto(`/iframe.html?id=${storyId}&viewMode=story`, {
+    waitUntil: 'domcontentloaded',
+  });
+
+  return waitForStoryReadyWithRetries(page, async () => {
+    await page.waitForFunction(() => {
+      const root = document.querySelector('#storybook-root');
+      return root && root.children.length > 0;
+    });
+
+    const root = page.locator('#storybook-root');
+    const element = root.locator(elementSelector).first();
+    await element.waitFor({ state: 'visible' });
+
+    const tagName = await element.evaluate((el) => el.tagName.toLowerCase());
+    if (tagName.includes('-')) {
+      await waitForCustomElement(page, tagName);
+    }
+
+    return root;
+  });
+}

--- a/2nd-gen/packages/swc/utils/wait-for-custom-element.ts
+++ b/2nd-gen/packages/swc/utils/wait-for-custom-element.ts
@@ -10,5 +10,22 @@
  * governing permissions and limitations under the License.
  */
 
-export { gotoStory } from './goto-story.js';
-export { waitForCustomElement } from './wait-for-custom-element.js';
+import type { Page } from '@playwright/test';
+
+/**
+ * Wait for a custom element to be defined in the custom elements registry.
+ * This is more deterministic than waiting for visibility alone.
+ *
+ * @param page - Playwright page object
+ * @param tagName - Custom element tag name (e.g., 'swc-badge')
+ * @returns Promise that resolves when element is defined
+ */
+export async function waitForCustomElement(
+  page: Page,
+  tagName: string
+): Promise<void> {
+  await page.waitForFunction(
+    (tag) => customElements.get(tag) !== undefined,
+    tagName
+  );
+}

--- a/CONTRIBUTOR-DOCS/01_contributor-guides/09_accessibility-testing.md
+++ b/CONTRIBUTOR-DOCS/01_contributor-guides/09_accessibility-testing.md
@@ -23,7 +23,6 @@
 - [Test helper reference](#test-helper-reference)
     - [`gotoStory(page, storyId, elementSelector)`](#gotostorypage-storyid-elementselector)
     - [`waitForCustomElement(page, tagName)`](#waitforcustomelementpage-tagname)
-    - [`waitForStoryReady(page, elementSelector)`](#waitforstoryreadypage-elementselector)
 - [Finding story IDs](#finding-story-ids)
 - [Running tests](#running-tests)
     - [From project root](#from-project-root)
@@ -218,27 +217,18 @@ await expect(badge).toMatchAriaSnapshot();
 **How it works:**
 
 1. Navigates to story URL
-2. Waits for custom element definition (`customElements.whenDefined`)
-3. Waits for Storybook to render content
-4. Waits for element visibility
-5. Waits for Web Component upgrade
+2. Waits for Storybook to render content
+3. Waits for element visibility
+4. If the element is a custom element, waits for it to be defined in the registry
 
 This eliminates flaky tests caused by testing components before they're ready.
 
 ### `waitForCustomElement(page, tagName)`
 
-Wait for a custom element to be defined.
+Wait for a custom element to be defined in the registry.
 
 ```typescript
 await waitForCustomElement(page, 'sp-badge');
-```
-
-### `waitForStoryReady(page, elementSelector)`
-
-Wait for Storybook story to render and component to be visible.
-
-```typescript
-const element = await waitForStoryReady(page, 'sp-badge');
 ```
 
 ## Finding story IDs

--- a/CONTRIBUTOR-DOCS/02_style-guide/04_testing/05_testing-utilities.md
+++ b/CONTRIBUTOR-DOCS/02_style-guide/04_testing/05_testing-utilities.md
@@ -18,7 +18,6 @@
 - [`setupSwcWarningSpy()`](#setupswcwarningspy)
 - [`gotoStory(page, storyId, elementSelector)`](#gotostorypage-storyid-elementselector)
 - [`waitForCustomElement(page, tagName)`](#waitforcustomelementpage-tagname)
-- [`waitForStoryReady(page, elementSelector)`](#waitforstoryreadypage-elementselector)
 
 </details>
 
@@ -118,10 +117,9 @@ const badge = await gotoStory(page, 'components-badge--default', 'swc-badge');
 How it works:
 
 1. Navigates to the story URL
-2. Waits for custom element definition (`customElements.whenDefined`)
-3. Waits for Storybook to render content
-4. Waits for element visibility
-5. Waits for web component upgrade
+2. Waits for Storybook to render content
+3. Waits for element visibility
+4. If the element is a custom element, waits for it to be defined in the registry
 
 This eliminates flaky tests caused by testing components before they are ready.
 
@@ -133,14 +131,4 @@ Wait for a custom element to be defined in the registry (Playwright only):
 import { waitForCustomElement } from '../../../utils/a11y-helpers.js';
 
 await waitForCustomElement(page, 'swc-badge');
-```
-
-## `waitForStoryReady(page, elementSelector)`
-
-Wait for a Storybook story to render and the component to be visible (Playwright only):
-
-```typescript
-import { waitForStoryReady } from '../../../utils/a11y-helpers.js';
-
-const element = await waitForStoryReady(page, 'swc-badge');
 ```


### PR DESCRIPTION
## Description

Adds `gotoCssStory(page, storyId, readySelector)` to `2nd-gen/packages/swc/utils/a11y-helpers.ts` and uses it in `link.a11y.spec.ts` and `typography.a11y.spec.ts`, replacing their duplicated local `gotoLinkStory`/`gotoTypographyStory` helpers. Checked all 26 2nd-gen `*.a11y.spec.ts` files — no other CSS-only component duplicates this pattern, so no further files needed updating.

## Motivation and context

Link and Typography are CSS-only utilities (no custom element), so they couldn't use the existing `gotoStory` helper, which waits on `customElements.whenDefined()`. Each spec grew its own copy of the same "wait for `#storybook-root` to render" logic. This pulls it into one place and gives both specs the same transient-navigation retry safety net `gotoStory` already has.

## Related issue(s)

- SWC-2305

## Author's checklist

- [x] I have read the CONTRIBUTING and PULL_REQUESTS documents.
- [x] I have reviewed at the Accessibility Practices for this feature.
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [ ] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Test refactor only, no component behavior changed_
  1. Run `yarn test:a11y:2nd -- componentstscomponents/typography/test/typography.a11y.spec.ts`                                                 2. Expect all 12 tests to pass (confirme
                                                                                                  ## Accessibility testing checklist
                                                                                                  > No component behavior changed — this is Existing ARIA snapshot assertions areunchanged and still pass.- [ ] **Keyboard** — no new interactive bee keyboard focusable" test in`link.a11y.spec.ts` still passes unchanged- [ ] **Screen reader** — no role/name/strRIA snapshot assertions in both spec filespass unchanged.