### PR TITLE
fix(gen2): disable Vite's redundant publicDir copy to fix flaky prod Storybook build

### DIFF
--- a/2nd-gen/packages/swc/vite.config.ts
+++ b/2nd-gen/packages/swc/vite.config.ts
@@ -109,6 +109,13 @@ export default defineConfig({
       },
     }),
   ],
+  // Storybook's `staticDirs: ['../public', ...]` (.storybook/main.ts) already copies
+  // this package's public/ directory into the Storybook build output. Vite's own
+  // built-in publicDir copy is redundant with that and, run right after it against the
+  // same output directory, throws EEXIST on the pre-existing nested directories. It
+  // also has no reason to bundle public/ (Storybook-only static assets) into the
+  // library's published dist/.
+  publicDir: false,
   css: {
     transformer: 'postcss',
     postcss: {


### PR DESCRIPTION
## Description

Fixes an intermittent failure in the "Build Gen2 Storybook (prod mode)" CI step (`preview-docs.yml`):

```
Error: EEXIST: file already exists, mkdir
'./storybook-static-prod/.well-known/agent-skills/spectrum-web-components/references/guides'
```

**Root cause:** `2nd-gen/packages/swc/public/` was getting copied into the Storybook build output twice:
1. Storybook's own `staticDirs: ['../public', ...]` (`.storybook/main.ts`) copies it first.
2. Right after, `vite build` runs its own separate built-in `publicDir` → `outDir` copy, since `vite.config.ts` never set `publicDir: false` (it defaults to the same `public/` folder, same output dir). Vite's copy doesn't know Storybook already put those files there, so it tries to `mkdir` a directory that already exists and crashes.

It's sequential, not a timing race - copy #2 always runs into copy #1's leftovers. The "sometimes passes" flakiness comes from `fs.cp`'s inconsistent handling of pre-existing nested directories, not the two copies actually overlapping in time.

**Fix:** set `publicDir: false` in `vite.config.ts` - Storybook's `staticDirs` already does this copy correctly, so Vite's redundant one is disabled. Side benefit: this also stops `public/.well-known/agent-skills/...` (Storybook-only static assets) from leaking into the npm-published `dist/` during the library build, which shares this same config.

## Motivation and context

CI has been intermittently failing on this step, requiring manual re-runs. No known reason to keep the duplicate copy.

## Testing

Verified locally: `yarn storybook:build --output-dir storybook-static-prod-test` in `2nd-gen/packages/swc` completes successfully with this change, and `.well-known/agent-skills/...` still lands correctly in the output (via `staticDirs` alone).