### PR TITLE
chore(ai): update github label to accurate one

### DIFF
--- a/.ai/skills/github-description/SKILL.md
+++ b/.ai/skills/github-description/SKILL.md
@@ -153,7 +153,7 @@ Common additional labels include:
 
 ### Pull request template
 
-**Note:** All pull requests should include the `ready-for-review` label.
+**Note:** All pull requests should include the `Status:Ready for review` label.
 
 **When returning the template, check off the author requirements in the Author's checklist section. Do not check off the Manual review test cases or Device review sections as these are for reviewers to complete. Fill in the **Accessibility testing checklist** with concrete steps; leave its checkboxes unchecked unless the user confirms testing is done.**
 

--- a/CONTRIBUTOR-DOCS/01_contributor-guides/05_participating-in-pr-reviews.md
+++ b/CONTRIBUTOR-DOCS/01_contributor-guides/05_participating-in-pr-reviews.md
@@ -133,7 +133,7 @@ Remember that code reviews are a collaborative process aimed at improving code q
 ### References and alignment
 
 - **[Conventional Comments](https://conventionalcomments.org/)** can clarify what is blocking versus optional.
-- **[Working agreements](https://www.swarms.com/blog/agile-team-working-agreements/)** are one way to capture shared norms (review load, draft vs ready-for-review and tracker states, **AI** assistance in review or drafting, **external contributor** expectations and stale branches, and similar topics).
+- **[Working agreements](https://www.swarms.com/blog/agile-team-working-agreements/)** are one way to capture shared norms (review load, draft vs `Status:Ready for review` and tracker states, **AI** assistance in review or drafting, **external contributor** expectations and stale branches, and similar topics).
 
 ### Reviewer quick reference
 


### PR DESCRIPTION
<!---
    - Following conventional commit format, provide a general summary of your changes in the title above.
    - Acceptable commit types in order of severity (high to low): feat, fix, docs, style, chore, perf, and test. Commit types are defined in PULL_REQUESTS.md.
    - For example,`type(component): general summary`
-->

## Description

Minor fix to ai skill that applies the correct status label to PRs when an agent helps create one.

## Motivation and context

Status labels are important for our slack bot and this ensure the right one is used 
