### PR TITLE
feat(core): labelling and help text mixins

### DIFF
--- a/2nd-gen/packages/core/components/text-field/TextField.base.ts
+++ b/2nd-gen/packages/core/components/text-field/TextField.base.ts
@@ -13,7 +13,11 @@ import { PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import { SpectrumElement } from '@adobe/spectrum-wc-core/element/index.js';
-import { SizedMixin } from '@adobe/spectrum-wc-core/mixins/index.js';
+import {
+  HelpTextMixin,
+  LabellingMixin,
+  SizedMixin,
+} from '@adobe/spectrum-wc-core/mixins/index.js';
 import { validateEnum } from '@adobe/spectrum-wc-core/utils/index.js';
 
 import {
@@ -38,10 +42,13 @@ const DOCS_URL =
  * @slot description - Guidance / non-error help text, associated via `aria-describedby`.
  * @slot error-text - Error message shown when `invalid`, targeted by `aria-errormessage`.
  */
-export abstract class TextFieldBase extends SizedMixin(SpectrumElement, {
-  validSizes: TEXT_FIELD_VALID_SIZES,
-  defaultSize: 'm',
-}) {
+export abstract class TextFieldBase extends SizedMixin(
+  LabellingMixin(HelpTextMixin(SpectrumElement)),
+  {
+    validSizes: TEXT_FIELD_VALID_SIZES,
+    defaultSize: 'm',
+  }
+) {
   /**
    * Route host focus to the internal native `<input>` so the field is a single
    * tab stop with focus landing on the real control.
@@ -57,34 +64,6 @@ export abstract class TextFieldBase extends SizedMixin(SpectrumElement, {
    * @default m
    */
   declare public size: TextFieldSize;
-
-  /**
-   * Accessible name for the input, applied as `aria-label`. Use when there is no
-   * visible label slotted.
-   */
-  @property({ type: String, attribute: 'accessible-label' })
-  public accessibleLabel = '';
-
-  /**
-   * Element IDs, from the light DOM, that provide the field's accessible name.
-   * Takes precedence over `accessibleLabel` and a slotted label.
-   *
-   * @todo (SWC-2466): the `LabellingController` resolves these IDREFs to the
-   * cross-root `ariaLabelledByElements` property; raw `aria-labelledby` is not
-   * exposed on the host.
-   */
-  @property({ attribute: 'accessible-labelledby' })
-  public accessibleLabelledby?: string;
-
-  /**
-   * Element IDs, from the light DOM, that describe the field.
-   *
-   * @todo (SWC-2466): the `LabellingController` resolves these IDREFs to the
-   * cross-root `ariaDescribedByElements` property; raw `aria-describedby` is not
-   * exposed on the host.
-   */
-  @property({ attribute: 'accessible-describedby' })
-  public accessibleDescribedby?: string;
 
   /**
    * The value of the input.
@@ -182,10 +161,6 @@ export abstract class TextFieldBase extends SizedMixin(SpectrumElement, {
   // ──────────────────────
   //     IMPLEMENTATION
   // ──────────────────────
-
-  // @todo (SWC-2466): resolve the accessible-labelledby / accessible-describedby
-  // IDREF stubs to cross-root element references, and add the "unlabeled field"
-  // dev-warning, via the LabellingController.
 
   // @todo (SWC-2467): wire the FieldAssociationController (formAssociated,
   // attachInternals, setFormValue, formResetCallback, formDisabledCallback) plus

--- a/2nd-gen/packages/core/directives/index.ts
+++ b/2nd-gen/packages/core/directives/index.ts
@@ -18,3 +18,13 @@ export {
   renderPendingSpinner,
   type PendingSpinnerResult,
 } from './pending-spinner/index.js';
+export {
+  renderFieldLabel,
+  type RenderFieldLabelOptions,
+  type RenderFieldLabelResult,
+} from './render-label/index.js';
+export {
+  renderFieldHelpText,
+  type RenderFieldHelpTextOptions,
+  type RenderFieldHelpTextResult,
+} from './render-help-text/index.js';

--- a/2nd-gen/packages/core/directives/render-help-text/index.ts
+++ b/2nd-gen/packages/core/directives/render-help-text/index.ts
@@ -10,21 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-/* @todo (Phase 5, styling): baseline from spectrum-css (spectrum-two) index.css and
-   consume the shared form-fields stylesheet fragment (including the
-   label-position="side" grid variant, Q22). Keep styling on .swc-TextField,
-   not :host. */
-.swc-TextField {
-  display: inline-flex;
-  flex-direction: column;
-  gap: var(--swc-spacing-75, 4px);
-}
-
-.swc-FieldLabel {
-  font: inherit;
-}
-
-.swc-FieldDescription,
-.swc-FieldErrorText {
-  font-size: var(--swc-body-size-s);
-}
+export {
+  renderFieldHelpText,
+  type RenderFieldHelpTextOptions,
+  type RenderFieldHelpTextResult,
+} from './src/render-help-text.js';

--- a/2nd-gen/packages/core/directives/render-help-text/src/render-help-text.ts
+++ b/2nd-gen/packages/core/directives/render-help-text/src/render-help-text.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing, type TemplateResult } from 'lit';
+import { ref } from 'lit/directives/ref.js';
+
+/** Return type of {@link renderFieldHelpText}: the help-text template, or `nothing`. */
+export type RenderFieldHelpTextResult = TemplateResult | typeof nothing;
+
+/** Options accepted by {@link renderFieldHelpText}. */
+export interface RenderFieldHelpTextOptions {
+  /** Whether slotted `description` content is present in the host's light DOM. */
+  hasDescriptionSlotContent: boolean;
+  /** Whether slotted `error-text` content is present in the host's light DOM. */
+  hasErrorTextSlotContent: boolean;
+  /** Whether the host is currently in an invalid state. Gates the error-text element. */
+  invalid: boolean;
+  /** Called with the rendered description element (or `undefined` on removal). */
+  onDescriptionElement: (element: Element | undefined) => void;
+  /** Called with the rendered error-text element (or `undefined` on removal). */
+  onErrorTextElement: (element: Element | undefined) => void;
+}
+
+/**
+ * Renders the shared description/error-text markup used by
+ * help-text-capable components. Returns `nothing` when neither the
+ * description nor an active (`invalid`) error message has content, so callers
+ * can interpolate unconditionally.
+ *
+ * Most consumers do not call this directly: `HelpTextMixin` exposes
+ * `renderHelpText()`, which calls this with the mixin's own resolved state and
+ * uses the element callbacks to build `ariaDescribedByElements` /
+ * `ariaErrorMessageElements`. Use this directive directly only for stateless
+ * rendering without the mixin.
+ *
+ * This is render-only and carries no design-token dependency. Pair it with a
+ * shared style fragment that themes the `swc-FieldDescription` /
+ * `swc-FieldErrorText` classes this emits.
+ */
+export function renderFieldHelpText({
+  hasDescriptionSlotContent,
+  hasErrorTextSlotContent,
+  invalid,
+  onDescriptionElement,
+  onErrorTextElement,
+}: RenderFieldHelpTextOptions): RenderFieldHelpTextResult {
+  const showError = invalid && hasErrorTextSlotContent;
+  if (!hasDescriptionSlotContent && !showError) {
+    return nothing;
+  }
+  return html`
+    ${hasDescriptionSlotContent
+      ? html`
+          <span class="swc-FieldDescription" ${ref(onDescriptionElement)}>
+            <slot name="description"></slot>
+          </span>
+        `
+      : nothing}
+    ${showError
+      ? html`
+          <span class="swc-FieldErrorText" ${ref(onErrorTextElement)}>
+            <slot name="error-text"></slot>
+          </span>
+        `
+      : nothing}
+  `;
+}

--- a/2nd-gen/packages/core/directives/render-label/index.ts
+++ b/2nd-gen/packages/core/directives/render-label/index.ts
@@ -10,21 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-/* @todo (Phase 5, styling): baseline from spectrum-css (spectrum-two) index.css and
-   consume the shared form-fields stylesheet fragment (including the
-   label-position="side" grid variant, Q22). Keep styling on .swc-TextField,
-   not :host. */
-.swc-TextField {
-  display: inline-flex;
-  flex-direction: column;
-  gap: var(--swc-spacing-75, 4px);
-}
-
-.swc-FieldLabel {
-  font: inherit;
-}
-
-.swc-FieldDescription,
-.swc-FieldErrorText {
-  font-size: var(--swc-body-size-s);
-}
+export {
+  renderFieldLabel,
+  type RenderFieldLabelOptions,
+  type RenderFieldLabelResult,
+} from './src/render-label.js';

--- a/2nd-gen/packages/core/directives/render-label/src/render-label.ts
+++ b/2nd-gen/packages/core/directives/render-label/src/render-label.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html, nothing, type TemplateResult } from 'lit';
+
+/** Return type of {@link renderFieldLabel}: the label template, or `nothing`. */
+export type RenderFieldLabelResult = TemplateResult | typeof nothing;
+
+/** Options accepted by {@link renderFieldLabel}. */
+export interface RenderFieldLabelOptions {
+  /** Whether slotted `label` content is present in the host's light DOM. */
+  hasLabelSlotContent: boolean;
+
+  /**
+   * The `id` of the field's role element (e.g. the `<input>`). When set, the
+   * slotted label is the field's active accessible-name source and renders as
+   * a real `<label for>`, giving native click-to-focus. When `null` (a
+   * higher-precedence source, `accessible-labelledby` or `accessible-label`,
+   * is active instead), the label renders as a plain, non-`for` `<span>`:
+   * still visible, but excluded from the accessible-name computation so it
+   * doesn't create a conflicting second name.
+   */
+  forId: string | null;
+}
+
+/**
+ * Renders the shared field-label markup used by labelling-capable components.
+ * Returns `nothing` when there is no slotted `label` content, so callers can
+ * interpolate unconditionally: `${renderFieldLabel({ hasLabelSlotContent, forId })}`.
+ *
+ * Most consumers do not call this directly: `LabellingMixin` exposes
+ * `renderLabel()`, which calls this with the mixin's own resolved state. Use
+ * this directive directly only for stateless label rendering without the mixin.
+ *
+ * This is render-only and carries no design-token dependency. Pair it with a
+ * shared field-label style fragment that themes the `swc-FieldLabel` class
+ * this emits.
+ */
+export function renderFieldLabel({
+  hasLabelSlotContent,
+  forId,
+}: RenderFieldLabelOptions): RenderFieldLabelResult {
+  if (!hasLabelSlotContent) {
+    return nothing;
+  }
+  if (forId) {
+    return html`
+      <label class="swc-FieldLabel" for=${forId}>
+        <slot name="label"></slot>
+      </label>
+    `;
+  }
+  return html`
+    <span class="swc-FieldLabel"><slot name="label"></slot></span>
+  `;
+}

--- a/2nd-gen/packages/core/global.d.ts
+++ b/2nd-gen/packages/core/global.d.ts
@@ -27,6 +27,7 @@ type BrandedSWCWarningID =
  */
 interface ARIAMixin {
   ariaDescribedByElements: readonly Element[] | null;
+  ariaErrorMessageElements: readonly Element[] | null;
   ariaLabelledByElements: readonly Element[] | null;
 }
 

--- a/2nd-gen/packages/core/mixins/help-text-mixin.mdx
+++ b/2nd-gen/packages/core/mixins/help-text-mixin.mdx
@@ -1,0 +1,100 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { DocsFooter, DocsHeader } from '../../swc/.storybook/blocks';
+
+import * as Stories from './stories/help-text-mixin.stories';
+
+<Meta of={Stories} />
+
+<DocsHeader />
+
+## Usage
+
+`HelpTextMixin` adds description/error-text rendering and accessible description wiring to a host so components do not hand-roll it. It is one of two decoupled primitives for form-field labelling:
+
+- **`HelpTextMixin`** (`@adobe/spectrum-wc-core/mixins`) — the `accessible-describedby` property, `description` / `error-text` slot presence tracking, and `renderHelpText()`.
+- **`renderFieldHelpText`** (`@adobe/spectrum-wc-core/directives/render-help-text`) — the underlying render-only directive. The mixin owns and exposes it; use it directly only for stateless rendering without the mixin.
+
+`LabellingMixin` (`@adobe/spectrum-wc-core/mixins`) is the companion mixin for accessible-name association; `swc-text-field` composes both.
+
+### What it does
+
+- **Combined description sources** — unlike accessible-name sources, a slotted `description` and an external `accessibleDescribedby` reference combine rather than override each other: the role element's `ariaDescribedByElements` lists the in-shadow description first, then the resolved external elements.
+- **Invalid-gated error message** — the role element's `ariaErrorMessageElements` points at the in-shadow error-text element only while the host reads as `invalid` (read structurally, so a host that doesn't declare `invalid` at all simply never surfaces an error message).
+- **Conditional rendering** — `renderHelpText()` renders nothing when there is no description content and no active error message.
+
+### Basic usage
+
+1. Apply the mixin to your base class: `class MyField extends HelpTextMixin(SpectrumElement) {}`.
+2. Override `roleElement` to return the element the description/error-message relationships should be wired onto.
+3. Call `renderHelpText()` in your template.
+
+```typescript
+import { html, LitElement } from 'lit';
+import { HelpTextMixin } from '@adobe/spectrum-wc-core/mixins';
+
+class MyField extends HelpTextMixin(LitElement) {
+  invalid = false;
+
+  override get roleElement() {
+    return this.renderRoot.querySelector('input');
+  }
+
+  render() {
+    return html`
+      <input />
+      ${this.renderHelpText()}
+    `;
+  }
+}
+```
+
+## Behaviors
+
+### Combined description sources
+
+<Canvas of={Stories.CombinedDescription} />
+
+### Error text gated by invalid
+
+The error-text element and its `ariaErrorMessageElements` association only appear while the host is `invalid`; the description remains associated regardless.
+
+<Canvas of={Stories.ErrorTextGating} />
+
+## Accessibility
+
+### Features
+
+- **`aria-errormessage`, in addition to `aria-describedby`** — the error message is never the sole description source; it supplements the combined `ariaDescribedByElements` set while `invalid` is `true`.
+- **No default live region** — help/error content is wired through `ariaDescribedByElements`/`ariaErrorMessageElements`, not an `aria-live` region, so a screen reader announces it when focus lands on the field.
+
+### Best practices
+
+- Pair `invalid` with slotted `error-text` so the invalid state is not conveyed by color alone.
+- Use `accessibleDescribedby` for a description composed from light-DOM content the field doesn't own; it combines with, rather than replaces, a slotted `description`.
+
+<Canvas of={Stories.Accessibility} />
+
+## API
+
+### Constructor
+
+`HelpTextMixin(BaseClass)` — returns `BaseClass` extended with the help-text API.
+
+### Members
+
+| Member                      | Description                                                                                                |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `accessibleDescribedby`     | Space-separated element `id`s that describe the role element. Combines with a slotted `description`.       |
+| `hasDescriptionSlotContent` | Read-only. Whether slotted `description` content is present.                                               |
+| `hasErrorTextSlotContent`   | Read-only. Whether slotted `error-text` content is present.                                                |
+| `roleElement`               | `@internal`. The element the resolved description/error relationships are wired onto.                      |
+| `renderHelpText()`          | Renders the description/error-text markup for the current state (via the `renderFieldHelpText` directive). |
+
+### Related primitives
+
+| Export                | Module                                                | Purpose                                                                  |
+| --------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------ |
+| `renderFieldHelpText` | `@adobe/spectrum-wc-core/directives/render-help-text` | Underlying help-text render; exposed via the mixin's `renderHelpText()`. |
+| `LabellingMixin`      | `@adobe/spectrum-wc-core/mixins`                      | Companion mixin for accessible-name association.                         |
+
+<DocsFooter />

--- a/2nd-gen/packages/core/mixins/help-text-mixin.ts
+++ b/2nd-gen/packages/core/mixins/help-text-mixin.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { PropertyValues, ReactiveElement } from 'lit';
+import { property } from 'lit/decorators.js';
+
+import { SlotPresenceController } from '../controllers/slot-presence-controller/index.js';
+import {
+  renderFieldHelpText,
+  type RenderFieldHelpTextResult,
+} from '../directives/render-help-text/index.js';
+
+type Constructor<T = Record<string, unknown>> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): T;
+  prototype: T;
+};
+
+const DESCRIPTION_SLOT_SELECTOR = '[slot="description"]';
+const ERROR_TEXT_SLOT_SELECTOR = '[slot="error-text"]';
+
+/**
+ * An element carrying the ARIA element-reflection properties `HelpTextMixin`
+ * writes the resolved description/error-message relationships onto (for
+ * example, the `<input>` inside a text field's own shadow root).
+ */
+type DescribedByTarget = Element & {
+  ariaDescribedByElements: Element[] | null;
+  ariaErrorMessageElements: Element[] | null;
+};
+
+/** The API {@link HelpTextMixin} adds to its host. */
+export interface HelpTextInterface {
+  accessibleDescribedby?: string;
+  readonly hasDescriptionSlotContent: boolean;
+  readonly hasErrorTextSlotContent: boolean;
+
+  /**
+   * @internal
+   *
+   * The element `HelpTextMixin` wires the resolved description/error-message
+   * ARIA relationships onto. Defaults to `null`; a rendering subclass
+   * overrides this to return its real role element (e.g. the `<input>`).
+   */
+  readonly roleElement: Element | null;
+  /** Renders the description/error-text markup for the current state. */
+  renderHelpText(): RenderFieldHelpTextResult;
+}
+
+/**
+ * A mixin that adds description/error-text rendering and accessible
+ * description wiring to a host: the reactive `accessible-describedby`
+ * property, light-DOM `description`/`error-text` slot presence tracking (via
+ * `SlotPresenceController`), and `renderHelpText()` — which renders the
+ * shared help-text markup via the `renderFieldHelpText` directive.
+ *
+ * Unlike accessible-name sources (see `LabellingMixin`), description sources
+ * combine rather than override one another: when both a slotted `description`
+ * and an external `accessibleDescribedby` are set, {@link roleElement}'s
+ * `ariaDescribedByElements` lists the in-shadow description first, then the
+ * resolved external elements. The error message, by contrast, is always
+ * same-root (there is no external error-text source): {@link roleElement}'s
+ * `ariaErrorMessageElements` points at the in-shadow error-text element only
+ * while the host reads as `invalid`, read structurally so hosts that don't
+ * declare `invalid` at all simply never surface an error message.
+ *
+ * Because the role element a text-like field describes is created by the
+ * host's own render (e.g. the `<input>`), this mixin never assumes the role
+ * element's shape: hosts applying `HelpTextMixin` before their own render
+ * layer exists (for example, a core base class) override {@link roleElement}
+ * once the real element is available.
+ *
+ * @example
+ * ```typescript
+ * class MyField extends HelpTextMixin(SpectrumElement) {
+ *   override get roleElement() {
+ *     return this.renderRoot.querySelector('input');
+ *   }
+ *
+ *   render() {
+ *     return html`
+ *       <input />
+ *       ${this.renderHelpText()}
+ *     `;
+ *   }
+ * }
+ * ```
+ */
+export function HelpTextMixin<T extends Constructor<ReactiveElement>>(
+  constructor: T
+): T & Constructor<HelpTextInterface> {
+  class HelpTextElement extends constructor implements HelpTextInterface {
+    /**
+     * Observes the light-DOM `description` and `error-text` slots so the
+     * shadow-DOM containers and slots can be fully conditional.
+     */
+    private readonly _helpTextSlotPresence = new SlotPresenceController(this, [
+      DESCRIPTION_SLOT_SELECTOR,
+      ERROR_TEXT_SLOT_SELECTOR,
+    ]);
+
+    /**
+     * Space-separated element `id`s, resolved against the host's root node,
+     * that describe the role element. Combines with a slotted `description`
+     * rather than overriding it: the in-shadow description, when present,
+     * comes first in the resulting `ariaDescribedByElements`.
+     */
+    @property({ attribute: 'accessible-describedby' })
+    public accessibleDescribedby?: string;
+
+    /** @internal */
+    private _descriptionElement: Element | undefined;
+
+    /** @internal */
+    private _errorTextElement: Element | undefined;
+
+    /**
+     * @internal
+     */
+    public get hasDescriptionSlotContent(): boolean {
+      return this._helpTextSlotPresence.getPresence(DESCRIPTION_SLOT_SELECTOR);
+    }
+
+    /**
+     * @internal
+     */
+    public get hasErrorTextSlotContent(): boolean {
+      return this._helpTextSlotPresence.getPresence(ERROR_TEXT_SLOT_SELECTOR);
+    }
+
+    /**
+     * @internal
+     */
+    public get roleElement(): Element | null {
+      return null;
+    }
+
+    /**
+     * @internal
+     *
+     * Reads `invalid` via a structural (not generic-constrained) check so
+     * this mixin stays composable on hosts that don't declare `invalid` at
+     * all — they simply never show an error message.
+     */
+    private get _isInvalid(): boolean {
+      return (
+        'invalid' in this &&
+        Boolean((this as unknown as { invalid?: boolean }).invalid)
+      );
+    }
+
+    /**
+     * @internal
+     *
+     * Resolves `accessibleDescribedby`'s space-separated `id`s against the
+     * host's root node. `id`s that don't resolve to an element are dropped
+     * silently.
+     */
+    private get _resolvedDescribedbyElements(): Element[] {
+      if (!this.accessibleDescribedby) {
+        return [];
+      }
+      const root = this.getRootNode() as Document | ShadowRoot;
+      return this.accessibleDescribedby
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((id) => root.getElementById(id))
+        .filter((element): element is HTMLElement => element !== null);
+    }
+
+    public renderHelpText(): RenderFieldHelpTextResult {
+      return renderFieldHelpText({
+        hasDescriptionSlotContent: this.hasDescriptionSlotContent,
+        hasErrorTextSlotContent: this.hasErrorTextSlotContent,
+        invalid: this._isInvalid,
+        onDescriptionElement: (element) => {
+          this._descriptionElement = element;
+        },
+        onErrorTextElement: (element) => {
+          this._errorTextElement = element;
+        },
+      });
+    }
+
+    protected override updated(changedProperties: PropertyValues): void {
+      super.updated(changedProperties);
+      this._syncHelpText();
+    }
+
+    private _syncHelpText(): void {
+      const target = this.roleElement as DescribedByTarget | null;
+      if (!target) {
+        return;
+      }
+      const describedBy = [
+        ...(this._descriptionElement ? [this._descriptionElement] : []),
+        ...this._resolvedDescribedbyElements,
+      ];
+      target.ariaDescribedByElements =
+        describedBy.length > 0 ? describedBy : null;
+
+      const showError = this._isInvalid && this.hasErrorTextSlotContent;
+      target.ariaErrorMessageElements =
+        showError && this._errorTextElement ? [this._errorTextElement] : null;
+    }
+  }
+  return HelpTextElement as unknown as T & Constructor<HelpTextInterface>;
+}

--- a/2nd-gen/packages/core/mixins/index.ts
+++ b/2nd-gen/packages/core/mixins/index.ts
@@ -11,6 +11,8 @@
  */
 
 export { DisabledMixin, type DisabledInterface } from './disabled-mixin.js';
+export { HelpTextMixin, type HelpTextInterface } from './help-text-mixin.js';
+export { LabellingMixin, type LabellingInterface } from './labelling-mixin.js';
 export {
   LINEAR_PROGRESS_LABEL_POSITIONS,
   LINEAR_PROGRESS_STATIC_COLORS,

--- a/2nd-gen/packages/core/mixins/labelling-mixin.mdx
+++ b/2nd-gen/packages/core/mixins/labelling-mixin.mdx
@@ -1,0 +1,95 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { DocsFooter, DocsHeader } from '../../swc/.storybook/blocks';
+
+import * as Stories from './stories/labelling-mixin.stories';
+
+<Meta of={Stories} />
+
+<DocsHeader />
+
+## Usage
+
+`LabellingMixin` adds visible-label rendering and accessible-name wiring to a host so components do not hand-roll it. It is one of two decoupled primitives for form-field labelling:
+
+- **`LabellingMixin`** (`@adobe/spectrum-wc-core/mixins`) — the `accessible-label` / `accessible-labelledby` properties, `label` slot presence tracking, the "no accessible name" dev warning, and `renderLabel()`.
+- **`renderFieldLabel`** (`@adobe/spectrum-wc-core/directives/render-label`) — the underlying render-only directive. The mixin owns and exposes it; use it directly only for stateless label rendering without the mixin.
+
+`HelpTextMixin` (`@adobe/spectrum-wc-core/mixins`) is the companion mixin for description/error-text association; `swc-text-field` composes both.
+
+### What it does
+
+- **Precedence-ordered accessible name** — three sources, highest precedence first: `accessibleLabelledby` (resolved against the host's root node, written to the role element's `ariaLabelledByElements`), `accessibleLabel` (written to the role element's `aria-label` attribute), and a slotted visible label (rendered as a real, same-root `<label for>`). Only the highest-precedence source that is actually set is wired.
+- **Conditional label rendering** — `renderLabel()` renders nothing when there is no slotted `label` content, and renders a plain, non-`for` `<span>` (not a `<label for>`) when a higher-precedence source is active, so the visible text isn't hidden but is excluded from the accessible-name computation.
+- **Dev-mode warning** — warns when no accessible-name source resolves to anything.
+
+### Basic usage
+
+1. Apply the mixin to your base class: `class MyField extends LabellingMixin(SpectrumElement) {}`.
+2. Override `roleElement` to return the element the accessible name should be wired onto (usually the rendered `<input>` or other native control).
+3. Call `renderLabel(inputId)` in your template, passing the `id` of that role element (or `null` if it doesn't have one yet).
+
+```typescript
+import { html, LitElement } from 'lit';
+import { LabellingMixin } from '@adobe/spectrum-wc-core/mixins';
+
+class MyField extends LabellingMixin(LitElement) {
+  override get roleElement() {
+    return this.renderRoot.querySelector('input');
+  }
+
+  render() {
+    return html`
+      ${this.renderLabel('my-field-input')}
+      <input id="my-field-input" />
+    `;
+  }
+}
+```
+
+## Behaviors
+
+### Name source precedence
+
+`accessible-labelledby` overrides both `accessible-label` and a slotted label; `accessible-label` overrides a slotted label. Only the winning source is wired onto the role element — a lower-precedence slotted label still renders visually, but is not part of the accessible-name computation, avoiding a [Label in Name (2.5.3)](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html) mismatch.
+
+<Canvas of={Stories.NameSourcePrecedence} />
+
+## Accessibility
+
+### Features
+
+- **One accessible-name writer** — exactly one of `ariaLabelledByElements`, `aria-label`, or a same-root `<label for>` is wired at a time, by construction.
+- **Native click-to-focus** — when the slotted label is the active source, it renders as a real `<label for>`, so clicking the label focuses the field natively.
+- **Dev-mode warning** — a field with no accessible-name source at all triggers a console warning in development builds.
+
+### Best practices
+
+- Prefer a slotted label for ordinary fields; reserve `accessible-label`/`accessible-labelledby` for fields with no visible label of their own or a name composed from elements the field doesn't own (for example, a grid cell named by its row and column headers).
+- Don't combine a slotted label with `accessible-label`/`accessible-labelledby` that carries different text.
+
+<Canvas of={Stories.Accessibility} />
+
+## API
+
+### Constructor
+
+`LabellingMixin(BaseClass)` — returns `BaseClass` extended with the labelling API.
+
+### Members
+
+| Member                 | Description                                                                                         |
+| ---------------------- | --------------------------------------------------------------------------------------------------- |
+| `accessibleLabel`      | Accessible name, applied as `aria-label`. Lowest precedence after `accessibleLabelledby`.           |
+| `accessibleLabelledby` | Space-separated element `id`s that provide the accessible name. Highest precedence.                 |
+| `hasLabelSlotContent`  | Read-only. Whether slotted `label` content is present.                                              |
+| `roleElement`          | `@internal`. The element the resolved name is wired onto. Override to return the real role element. |
+| `renderLabel(forId)`   | Renders the label markup for the current state (via the `renderFieldLabel` directive).              |
+
+### Related primitives
+
+| Export             | Module                                            | Purpose                                                           |
+| ------------------ | ------------------------------------------------- | ----------------------------------------------------------------- |
+| `renderFieldLabel` | `@adobe/spectrum-wc-core/directives/render-label` | Underlying label render; exposed via the mixin's `renderLabel()`. |
+| `HelpTextMixin`    | `@adobe/spectrum-wc-core/mixins`                  | Companion mixin for description/error-text association.           |
+
+<DocsFooter />

--- a/2nd-gen/packages/core/mixins/labelling-mixin.ts
+++ b/2nd-gen/packages/core/mixins/labelling-mixin.ts
@@ -1,0 +1,249 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { PropertyValues, ReactiveElement } from 'lit';
+import { property } from 'lit/decorators.js';
+
+import { SlotPresenceController } from '../controllers/slot-presence-controller/index.js';
+import {
+  renderFieldLabel,
+  type RenderFieldLabelResult,
+} from '../directives/render-label/index.js';
+import { isDebug, warnIf } from '../utils/index.js';
+
+type Constructor<T = Record<string, unknown>> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): T;
+  prototype: T;
+};
+
+const LABEL_SLOT_SELECTOR = '[slot="label"]';
+
+/**
+ * An element carrying the ARIA element-reflection properties `LabellingMixin`
+ * writes the resolved accessible name onto (for example, the `<input>` inside
+ * a text field's own shadow root).
+ */
+type LabelledByTarget = Element & {
+  ariaLabelledByElements: Element[] | null;
+};
+
+/** The API {@link LabellingMixin} adds to its host. */
+export interface LabellingInterface {
+  accessibleLabel: string;
+  accessibleLabelledby?: string;
+  readonly hasLabelSlotContent: boolean;
+
+  /**
+   * @internal
+   *
+   * The element `LabellingMixin` wires the resolved accessible-name ARIA
+   * relationship onto. Defaults to `null`; a rendering subclass overrides this
+   * to return its real role element (e.g. the `<input>`).
+   */
+  readonly roleElement: Element | null;
+
+  /**
+   * Renders the visible label for the given role-element `id`. Pass `null`
+   * when the role element has no stable `id` yet.
+   */
+  renderLabel(forId: string | null): RenderFieldLabelResult;
+}
+
+/**
+ * A mixin that adds visible-label rendering and accessible-name wiring to a
+ * host: the reactive `accessible-label` / `accessible-labelledby` properties,
+ * light-DOM `label` slot presence tracking (via `SlotPresenceController`), the
+ * "no accessible name" dev warning, and `renderLabel()` — which renders the
+ * shared label markup via the `renderFieldLabel` directive.
+ *
+ * Three accessible-name sources are supported, in precedence order (highest
+ * first): `accessibleLabelledby` (resolved against the host's root node and
+ * written to {@link roleElement}'s `ariaLabelledByElements`), `accessibleLabel`
+ * (written to {@link roleElement}'s `aria-label` attribute), and a slotted
+ * visible label (rendered as a real, same-root `<label for>`). Only the
+ * highest-precedence source that is actually set is wired; a lower-precedence
+ * slotted label still renders visually (as a plain, non-`for` `<span>`) so it
+ * isn't hidden, just excluded from the accessible-name computation.
+ *
+ * Because the role element a text-like field names is created by the host's
+ * own render (e.g. the `<input>`), this mixin never assumes the role element's
+ * shape: hosts applying `LabellingMixin` before their own render layer exists
+ * (for example, a core base class) override {@link roleElement} once the real
+ * element is available.
+ *
+ * @example
+ * ```typescript
+ * class MyField extends LabellingMixin(SpectrumElement) {
+ *   override get roleElement() {
+ *     return this.renderRoot.querySelector('input');
+ *   }
+ *
+ *   render() {
+ *     return html`
+ *       ${this.renderLabel('my-field-input')}
+ *       <input id="my-field-input" />
+ *     `;
+ *   }
+ * }
+ * ```
+ */
+export function LabellingMixin<T extends Constructor<ReactiveElement>>(
+  constructor: T
+): T & Constructor<LabellingInterface> {
+  class LabellingElement extends constructor implements LabellingInterface {
+    /**
+     * Observes the light-DOM `label` slot so the shadow-DOM label element can
+     * be fully conditional.
+     */
+    private readonly _labelSlotPresence = new SlotPresenceController(
+      this,
+      LABEL_SLOT_SELECTOR
+    );
+
+    /**
+     * Accessible name for the role element, applied as `aria-label`. Lowest
+     * precedence after `accessibleLabelledby`; use when there is no visible
+     * label slotted and no external labelling element to reference.
+     */
+    @property({ type: String, attribute: 'accessible-label' })
+    public accessibleLabel = '';
+
+    /**
+     * Space-separated element `id`s, resolved against the host's root node,
+     * that provide the role element's accessible name. Highest precedence:
+     * overrides both `accessibleLabel` and a slotted label.
+     */
+    @property({ attribute: 'accessible-labelledby' })
+    public accessibleLabelledby?: string;
+
+    /**
+     * @internal
+     */
+    public get hasLabelSlotContent(): boolean {
+      return this._labelSlotPresence.isPresent;
+    }
+
+    /**
+     * @internal
+     */
+    public get roleElement(): Element | null {
+      return null;
+    }
+
+    /**
+     * @internal
+     *
+     * Documentation URL used in the missing-accessible-name DEBUG warning.
+     * Derived from the custom element tag name so each concrete component
+     * gets an accurate link with no per-subclass override needed.
+     */
+    protected get docsHref(): string {
+      const name = this.localName.replace(/^swc-/, '');
+      return `https://spectrum-web-components.adobe.com/?path=/docs/components-${name}--docs`;
+    }
+
+    /**
+     * @internal
+     *
+     * Resolves `accessibleLabelledby`'s space-separated `id`s against the
+     * host's root node. `id`s that don't resolve to an element are dropped
+     * silently; the caller falls back to a lower-precedence source.
+     */
+    private get _resolvedLabelledbyElements(): Element[] {
+      if (!this.accessibleLabelledby) {
+        return [];
+      }
+      const root = this.getRootNode() as Document | ShadowRoot;
+      return this.accessibleLabelledby
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((id) => root.getElementById(id))
+        .filter((element): element is HTMLElement => element !== null);
+    }
+
+    /**
+     * @internal
+     *
+     * The currently active accessible-name source, in precedence order.
+     */
+    private get _activeNameSource(): 'labelledby' | 'label' | 'slot' | 'none' {
+      if (this._resolvedLabelledbyElements.length > 0) {
+        return 'labelledby';
+      }
+      if (this.accessibleLabel) {
+        return 'label';
+      }
+      if (this.hasLabelSlotContent) {
+        return 'slot';
+      }
+      return 'none';
+    }
+
+    public renderLabel(forId: string | null): RenderFieldLabelResult {
+      return renderFieldLabel({
+        hasLabelSlotContent: this.hasLabelSlotContent,
+        forId: this._activeNameSource === 'slot' ? forId : null,
+      });
+    }
+
+    protected override updated(changedProperties: PropertyValues): void {
+      super.updated(changedProperties);
+      this._syncLabelling();
+      // The accessible name can come from a property or the label slot
+      // (tracked by a slot controller that requests an update without
+      // surfacing a changed property), so re-check on every dev render and
+      // let the warning dedup handle repeats rather than gating on one
+      // property.
+      if (isDebug()) {
+        this._warnMissingAccessibleName();
+      }
+    }
+
+    private _syncLabelling(): void {
+      const target = this.roleElement as LabelledByTarget | null;
+      if (!target) {
+        return;
+      }
+      const source = this._activeNameSource;
+      target.ariaLabelledByElements =
+        source === 'labelledby' ? this._resolvedLabelledbyElements : null;
+      if (source === 'label') {
+        target.setAttribute('aria-label', this.accessibleLabel);
+      } else {
+        target.removeAttribute('aria-label');
+      }
+    }
+
+    private _warnMissingAccessibleName(): void {
+      // Early return when a name is present so the message is not built on
+      // every in-named render.
+      if (this._activeNameSource !== 'none') {
+        return;
+      }
+      warnIf(
+        this,
+        true,
+        `<${this.localName}> requires an accessible name.`,
+        this.docsHref,
+        {
+          type: 'accessibility',
+          issues: [
+            'add visible label content via the "label" named slot, or',
+            'set the "accessible-label" attribute (or "accessibleLabel" property), or',
+            'set "accessible-labelledby" (or "accessibleLabelledby") to reference an external label.',
+          ],
+        }
+      );
+    }
+  }
+  return LabellingElement as unknown as T & Constructor<LabellingInterface>;
+}

--- a/2nd-gen/packages/core/mixins/stories/demo-hosts.ts
+++ b/2nd-gen/packages/core/mixins/stories/demo-hosts.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { css, html, LitElement, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+import { HelpTextMixin, LabellingMixin } from '../index.js';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'demo-labelling-host': DemoLabellingHost;
+    'demo-help-text-host': DemoHelpTextHost;
+  }
+}
+
+const DEMO_STYLES = css`
+  :host {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 4px;
+    font: inherit;
+  }
+
+  input {
+    box-sizing: border-box;
+    padding: 6px 8px;
+    font: inherit;
+    border: 1px solid var(--swc-gray-500);
+    border-radius: 4px;
+  }
+
+  .swc-FieldDescription,
+  .swc-FieldErrorText {
+    font-size: smaller;
+  }
+`;
+
+/**
+ * @internal
+ *
+ * Storybook-only host that consumes {@link LabellingMixin} directly, the way
+ * a non-text-field component would: it renders a bare `<input>` as its role
+ * element and calls `renderLabel()` in its own template.
+ */
+@customElement('demo-labelling-host')
+export class DemoLabellingHost extends LabellingMixin(LitElement) {
+  static override styles = DEMO_STYLES;
+
+  private get _inputId(): string {
+    return 'demo-labelling-host-input';
+  }
+
+  public override get roleElement(): HTMLInputElement | null {
+    return this.renderRoot.querySelector('input');
+  }
+
+  protected override render(): TemplateResult {
+    return html`
+      ${this.renderLabel(this._inputId)}
+      <input id=${this._inputId} />
+    `;
+  }
+}
+
+/**
+ * @internal
+ *
+ * Storybook-only host that consumes {@link HelpTextMixin} directly. Exposes a
+ * plain `invalid` property so the demo can show `error-text` gating.
+ */
+@customElement('demo-help-text-host')
+export class DemoHelpTextHost extends HelpTextMixin(LitElement) {
+  static override styles = DEMO_STYLES;
+
+  /** Whether the demo field is in an invalid state. */
+  @property({ type: Boolean, reflect: true })
+  public invalid = false;
+
+  public override get roleElement(): HTMLInputElement | null {
+    return this.renderRoot.querySelector('input');
+  }
+
+  protected override render(): TemplateResult {
+    return html`
+      <input aria-invalid=${ifDefined(this.invalid ? 'true' : undefined)} />
+      ${this.renderHelpText()}
+    `;
+  }
+}

--- a/2nd-gen/packages/core/mixins/stories/help-text-mixin.stories.ts
+++ b/2nd-gen/packages/core/mixins/stories/help-text-mixin.stories.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import './demo-hosts.js';
+
+// ────────────────
+//    METADATA
+// ────────────────
+
+/**
+ * `HelpTextMixin` adds description/error-text rendering and accessible
+ * description wiring to a host: the `accessible-describedby` property,
+ * `description` / `error-text` slot presence tracking, and `renderHelpText()`.
+ *
+ * A slotted `description` and an external `accessible-describedby` reference
+ * combine rather than override each other; the in-shadow description comes
+ * first. The error message is always same-root and shows only while the host
+ * reads as `invalid`. `LabellingMixin` (`@adobe/spectrum-wc-core/mixins`) is
+ * the companion mixin for accessible-name association.
+ */
+const meta: Meta = {
+  title: 'Mixins/Help text mixin',
+  component: 'demo-help-text-host',
+  parameters: {
+    docs: {
+      subtitle:
+        'Description/error-text rendering and combined accessible-description wiring.',
+    },
+    layout: 'centered',
+  },
+  tags: ['migrated', 'controller'],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// ────────────────────
+//    PLAYGROUND STORY
+// ────────────────────
+
+export const Playground: Story = {
+  render: () => html`
+    <demo-help-text-host>
+      <span slot="description">Example description</span>
+    </demo-help-text-host>
+  `,
+  tags: ['dev'],
+};
+
+// ──────────────────────────
+//    OVERVIEW STORY
+// ──────────────────────────
+
+export const Overview: Story = {
+  render: () => html`
+    <demo-help-text-host>
+      <span slot="description">Example description</span>
+    </demo-help-text-host>
+  `,
+  tags: ['overview'],
+};
+
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+export const CombinedDescription: Story = {
+  render: () => html`
+    <demo-help-text-host>
+      <span slot="description">Slotted description only</span>
+    </demo-help-text-host>
+    <p id="help-text-mixin-external-description">External description text</p>
+    <demo-help-text-host
+      accessible-describedby="help-text-mixin-external-description"
+    >
+      <span slot="description">Combined with a slotted description</span>
+    </demo-help-text-host>
+  `,
+  tags: ['behaviors'],
+};
+CombinedDescription.storyName = 'Combined description sources';
+
+export const ErrorTextGating: Story = {
+  render: () => html`
+    <demo-help-text-host>
+      <span slot="description">Not shown while valid</span>
+      <span slot="error-text">Only visible while invalid</span>
+    </demo-help-text-host>
+    <demo-help-text-host invalid>
+      <span slot="description">Still associated while invalid</span>
+      <span slot="error-text">Only visible while invalid</span>
+    </demo-help-text-host>
+  `,
+  tags: ['behaviors'],
+};
+ErrorTextGating.storyName = 'Error text gated by invalid';
+
+// ────────────────────────────────
+//    ACCESSIBILITY STORIES
+// ────────────────────────────────
+
+export const Accessibility: Story = {
+  render: () => html`
+    <demo-help-text-host invalid>
+      <span slot="description">Helper text</span>
+      <span slot="error-text">Error message shown to assistive technology</span>
+    </demo-help-text-host>
+  `,
+  tags: ['a11y'],
+};

--- a/2nd-gen/packages/core/mixins/stories/labelling-mixin.stories.ts
+++ b/2nd-gen/packages/core/mixins/stories/labelling-mixin.stories.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import type { Meta, StoryObj } from '@storybook/web-components';
+
+import './demo-hosts.js';
+
+// ────────────────
+//    METADATA
+// ────────────────
+
+/**
+ * `LabellingMixin` adds visible-label rendering and accessible-name wiring to
+ * a host: the `accessible-label` / `accessible-labelledby` properties, `label`
+ * slot presence tracking, the "no accessible name" dev warning, and
+ * `renderLabel()`.
+ *
+ * Three accessible-name sources are supported, in precedence order (highest
+ * first): `accessible-labelledby`, `accessible-label`, and a slotted visible
+ * label. Only the highest-precedence source that is set is wired.
+ * `HelpTextMixin` (`@adobe/spectrum-wc-core/mixins`) is the companion mixin
+ * for description/error-text association.
+ */
+const meta: Meta = {
+  title: 'Mixins/Labelling mixin',
+  component: 'demo-labelling-host',
+  parameters: {
+    docs: {
+      subtitle:
+        'Visible-label rendering and precedence-ordered accessible-name wiring.',
+    },
+    layout: 'centered',
+  },
+  tags: ['migrated', 'controller'],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// ────────────────────
+//    PLAYGROUND STORY
+// ────────────────────
+
+export const Playground: Story = {
+  render: () => html`
+    <demo-labelling-host>
+      <span slot="label">Example label</span>
+    </demo-labelling-host>
+  `,
+  tags: ['dev'],
+};
+
+// ──────────────────────────
+//    OVERVIEW STORY
+// ──────────────────────────
+
+export const Overview: Story = {
+  render: () => html`
+    <demo-labelling-host>
+      <span slot="label">Example label</span>
+    </demo-labelling-host>
+  `,
+  tags: ['overview'],
+};
+
+// ──────────────────────────────
+//    BEHAVIORS STORIES
+// ──────────────────────────────
+
+export const NameSourcePrecedence: Story = {
+  render: () => html`
+    <demo-labelling-host>
+      <span slot="label">Slotted label only</span>
+    </demo-labelling-host>
+    <demo-labelling-host
+      accessible-label="accessible-label only"
+    ></demo-labelling-host>
+    <div id="labelling-mixin-row-header">Name</div>
+    <div id="labelling-mixin-col-header">Billing address</div>
+    <demo-labelling-host
+      accessible-labelledby="labelling-mixin-row-header labelling-mixin-col-header"
+    >
+      <span slot="label">Ignored: accessible-labelledby wins</span>
+    </demo-labelling-host>
+  `,
+  tags: ['behaviors'],
+};
+NameSourcePrecedence.storyName = 'Name source precedence';
+
+// ────────────────────────────────
+//    ACCESSIBILITY STORIES
+// ────────────────────────────────
+
+export const Accessibility: Story = {
+  render: () => html`
+    <demo-labelling-host>
+      <span slot="label">Accessibly labelled field</span>
+    </demo-labelling-host>
+  `,
+  tags: ['a11y'],
+};

--- a/2nd-gen/packages/core/mixins/test/help-text-mixin.test.ts
+++ b/2nd-gen/packages/core/mixins/test/help-text-mixin.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '../stories/demo-hosts.js';
+
+import type { DemoHelpTextHost } from '../stories/demo-hosts.js';
+import helpTextMeta, {
+  CombinedDescription,
+  ErrorTextGating,
+} from '../stories/help-text-mixin.stories.js';
+
+export default {
+  ...helpTextMeta,
+  title: 'Mixins/Help text mixin/Tests',
+  parameters: {
+    ...helpTextMeta.parameters,
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Combined description sources
+// ──────────────────────────────────────────────────────────────
+
+export const CombinedDescriptionTest: Story = {
+  ...CombinedDescription,
+  play: async ({ canvasElement, step }) => {
+    const hosts = Array.from(
+      canvasElement.querySelectorAll<DemoHelpTextHost>('demo-help-text-host')
+    );
+    const [slottedOnly, combined] = hosts;
+
+    await step('slotted description alone resolves to one element', () => {
+      expect(slottedOnly.roleElement?.ariaDescribedByElements).toHaveLength(1);
+    });
+
+    await step(
+      'shadow description is listed before the resolved external element',
+      () => {
+        const resolved = combined.roleElement?.ariaDescribedByElements ?? [];
+        expect(resolved).toHaveLength(2);
+        expect(resolved[0]?.closest('demo-help-text-host')).toBe(combined);
+        expect(resolved[1]?.id).toBe('help-text-mixin-external-description');
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Error text gated by invalid
+// ──────────────────────────────────────────────────────────────
+
+export const ErrorTextGatingTest: Story = {
+  ...ErrorTextGating,
+  play: async ({ canvasElement, step }) => {
+    const hosts = Array.from(
+      canvasElement.querySelectorAll<DemoHelpTextHost>('demo-help-text-host')
+    );
+    const [valid, invalid] = hosts;
+
+    await step('valid host has no error-message association', () => {
+      expect(valid.roleElement?.ariaErrorMessageElements).toBeNull();
+      expect(valid.shadowRoot?.querySelector('.swc-FieldErrorText')).toBeNull();
+    });
+
+    await step('invalid host associates the error-text element', () => {
+      const resolved = invalid.roleElement?.ariaErrorMessageElements;
+      expect(resolved).toHaveLength(1);
+      expect(
+        invalid.shadowRoot?.querySelector('.swc-FieldErrorText')
+      ).toBeTruthy();
+      // Description remains associated regardless of invalid.
+      expect(invalid.roleElement?.ariaDescribedByElements).toHaveLength(1);
+    });
+
+    await step(
+      'clearing invalid removes the error-message association',
+      async () => {
+        invalid.invalid = false;
+        await invalid.updateComplete;
+        expect(invalid.roleElement?.ariaErrorMessageElements).toBeNull();
+      }
+    );
+  },
+};

--- a/2nd-gen/packages/core/mixins/test/labelling-mixin.test.ts
+++ b/2nd-gen/packages/core/mixins/test/labelling-mixin.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { html } from 'lit';
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import '../stories/demo-hosts.js';
+
+import type { DemoLabellingHost } from '../stories/demo-hosts.js';
+import labellingMeta, {
+  NameSourcePrecedence,
+} from '../stories/labelling-mixin.stories.js';
+
+// Enables DEBUG mode and captures window.__swc.warn calls for the duration of `fn`.
+async function withWarningSpy(
+  fn: (warnCalls: unknown[][]) => void | Promise<void>
+): Promise<void> {
+  const originalDebug = window.__swc?.DEBUG;
+  const originalWarn = window.__swc?.warn;
+  const warnCalls: unknown[][] = [];
+  window.__swc = {
+    ...window.__swc,
+    DEBUG: true,
+    warn: (...args: unknown[]) => {
+      warnCalls.push(args);
+    },
+  } as Window['__swc'];
+  try {
+    await fn(warnCalls);
+  } finally {
+    window.__swc = {
+      ...window.__swc,
+      DEBUG: originalDebug,
+      warn: originalWarn,
+    } as Window['__swc'];
+  }
+}
+
+export default {
+  ...labellingMeta,
+  title: 'Mixins/Labelling mixin/Tests',
+  parameters: {
+    ...labellingMeta.parameters,
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Name source precedence
+// ──────────────────────────────────────────────────────────────
+
+export const NameSourcePrecedenceTest: Story = {
+  ...NameSourcePrecedence,
+  play: async ({ canvasElement, step }) => {
+    const hosts = canvasElement.querySelectorAll<DemoLabellingHost>(
+      'demo-labelling-host'
+    );
+    const [slotOnly, labelOnly, labelledbyWins] = Array.from(hosts);
+
+    await step('slotted label renders as a real <label for>', () => {
+      const label = slotOnly.shadowRoot?.querySelector('label');
+      expect(label).toBeTruthy();
+      expect(label?.getAttribute('for')).toBe(slotOnly.roleElement?.id);
+      expect(slotOnly.roleElement?.hasAttribute('aria-label')).toBe(false);
+      expect(slotOnly.roleElement?.ariaLabelledByElements).toBeNull();
+    });
+
+    await step('accessible-label sets aria-label, not a <label for>', () => {
+      expect(labelOnly.shadowRoot?.querySelector('label')).toBeNull();
+      expect(labelOnly.roleElement?.getAttribute('aria-label')).toBe(
+        'accessible-label only'
+      );
+    });
+
+    await step(
+      'accessible-labelledby wins over a slotted label: no aria-label, no <label for>, ariaLabelledByElements resolved',
+      () => {
+        expect(labelledbyWins.roleElement?.hasAttribute('aria-label')).toBe(
+          false
+        );
+        expect(labelledbyWins.shadowRoot?.querySelector('label')).toBeNull();
+        // The slotted label still renders visually as a plain span.
+        expect(labelledbyWins.shadowRoot?.querySelector('span')).toBeTruthy();
+        const resolved = labelledbyWins.roleElement?.ariaLabelledByElements;
+        expect(resolved).toHaveLength(2);
+        expect(resolved?.map((el) => el.id)).toEqual([
+          'labelling-mixin-row-header',
+          'labelling-mixin-col-header',
+        ]);
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Missing accessible-name DEBUG warning
+// ──────────────────────────────────────────────────────────────
+
+export const MissingAccessibleNameTest: Story = {
+  render: () => html`
+    <span></span>
+  `,
+  play: async ({ step }) => {
+    await step('warns when no source resolves to a name', () =>
+      withWarningSpy(async (warnCalls) => {
+        const host = document.createElement('demo-labelling-host');
+        document.body.append(host);
+        await (host as DemoLabellingHost).updateComplete;
+        const messages = warnCalls.map((c) => String(c?.[1] ?? ''));
+        expect(messages.some((m) => m.includes('accessible name'))).toBe(true);
+        host.remove();
+      })
+    );
+
+    await step('does not warn when accessible-label is set', () =>
+      withWarningSpy(async (warnCalls) => {
+        const host = document.createElement('demo-labelling-host');
+        host.setAttribute('accessible-label', 'Named');
+        document.body.append(host);
+        await (host as DemoLabellingHost).updateComplete;
+        const messages = warnCalls.map((c) => String(c?.[1] ?? ''));
+        expect(messages.some((m) => m.includes('accessible name'))).toBe(false);
+        host.remove();
+      })
+    );
+  },
+};

--- a/2nd-gen/packages/core/package.json
+++ b/2nd-gen/packages/core/package.json
@@ -231,6 +231,22 @@
       "types": "./dist/directives/pending-spinner/index.d.ts",
       "import": "./dist/directives/pending-spinner/index.js"
     },
+    "./directives/render-label": {
+      "types": "./dist/directives/render-label/index.d.ts",
+      "import": "./dist/directives/render-label/index.js"
+    },
+    "./directives/render-label/index.js": {
+      "types": "./dist/directives/render-label/index.d.ts",
+      "import": "./dist/directives/render-label/index.js"
+    },
+    "./directives/render-help-text": {
+      "types": "./dist/directives/render-help-text/index.d.ts",
+      "import": "./dist/directives/render-help-text/index.js"
+    },
+    "./directives/render-help-text/index.js": {
+      "types": "./dist/directives/render-help-text/index.d.ts",
+      "import": "./dist/directives/render-help-text/index.js"
+    },
     "./element": {
       "types": "./dist/element/index.d.ts",
       "import": "./dist/element/index.js"

--- a/2nd-gen/packages/swc/components/text-field/TextField.ts
+++ b/2nd-gen/packages/swc/components/text-field/TextField.ts
@@ -17,6 +17,8 @@ import { TextFieldBase } from '@adobe/spectrum-wc-core/components/text-field';
 
 import styles from './text-field.css';
 
+let nextTextFieldId = 0;
+
 /**
  * A single-line text field for entering and editing text.
  *
@@ -35,16 +37,41 @@ export class TextField extends TextFieldBase {
     return [styles];
   }
 
+  private readonly _instanceId = ++nextTextFieldId;
+
+  private get _inputId(): string {
+    return `swc-text-field-input-${this._instanceId}`;
+  }
+
+  /**
+   * The real role element `LabellingMixin`/`HelpTextMixin` wire the resolved
+   * ARIA relationships onto.
+   */
+  public override get roleElement(): HTMLInputElement | null {
+    return this.renderRoot.querySelector('input.input');
+  }
+
   protected override render(): TemplateResult {
-    // @todo (SWC-2466 / Phase 4–5): render the visible label, required indicator,
-    // validation icon, and description/error container via the LabellingController.
-    // Until then the input takes its accessible name from `accessible-label`.
     return html`
       <div class="swc-TextField">
+        ${this.renderLabel(this._inputId)}
         <input
+          id=${this._inputId}
           class="input"
-          aria-label=${ifDefined(this.accessibleLabel || undefined)}
+          type=${this.type}
+          .value=${this.value}
+          placeholder=${ifDefined(this.placeholder || undefined)}
+          pattern=${ifDefined(this.pattern)}
+          inputmode=${ifDefined(this.inputmode)}
+          autocomplete=${ifDefined(this.autocomplete)}
+          maxlength=${ifDefined(this.maxlength)}
+          minlength=${ifDefined(this.minlength)}
+          ?readonly=${this.readonly}
+          ?required=${this.required}
+          ?disabled=${this.disabled}
+          aria-invalid=${ifDefined(this.invalid ? 'true' : undefined)}
         />
+        ${this.renderHelpText()}
       </div>
     `;
   }

--- a/2nd-gen/packages/swc/components/text-field/stories/text-field.stories.ts
+++ b/2nd-gen/packages/swc/components/text-field/stories/text-field.stories.ts
@@ -58,3 +58,113 @@ export const Playground: Story = {
     ${template({ ...args })}
   `,
 };
+
+// ──────────────────────────
+//    OVERVIEW STORY
+// ──────────────────────────
+
+export const Overview: Story = {
+  tags: ['overview'],
+  args: {
+    'accessible-label': 'Example text field',
+  },
+};
+
+// ──────────────────────────
+//    ANATOMY STORIES
+// ──────────────────────────
+
+export const Anatomy: Story = {
+  render: () => html`
+    <swc-text-field>
+      <span slot="label">Email address</span>
+      <span slot="description">Used for order updates only.</span>
+    </swc-text-field>
+    <swc-text-field invalid>
+      <span slot="label">Email address</span>
+      <span slot="error-text">Enter a valid email address.</span>
+    </swc-text-field>
+  `,
+  tags: ['anatomy'],
+  parameters: {
+    flexLayout: 'row-wrap',
+  },
+};
+
+// ──────────────────────────
+//    OPTIONS STORIES
+// ──────────────────────────
+
+export const Labelling: Story = {
+  render: () => html`
+    <swc-text-field>
+      <span slot="label">Slotted visible label</span>
+    </swc-text-field>
+    <swc-text-field
+      accessible-label="Accessible-label only (no visible label)"
+    ></swc-text-field>
+    <div id="labelling-row-header">Name</div>
+    <div id="labelling-col-header">Billing address</div>
+    <swc-text-field
+      accessible-labelledby="labelling-row-header labelling-col-header"
+    ></swc-text-field>
+  `,
+  tags: ['options'],
+  parameters: {
+    flexLayout: 'row-wrap',
+  },
+};
+
+// ──────────────────────────
+//    STATES STORIES
+// ──────────────────────────
+
+export const States: Story = {
+  render: () => html`
+    <swc-text-field>
+      <span slot="label">Default</span>
+    </swc-text-field>
+    <swc-text-field required>
+      <span slot="label">Required</span>
+    </swc-text-field>
+    <swc-text-field readonly value="Read-only value">
+      <span slot="label">Read-only</span>
+    </swc-text-field>
+    <swc-text-field disabled>
+      <span slot="label">Disabled</span>
+    </swc-text-field>
+    <swc-text-field invalid>
+      <span slot="label">Email address</span>
+      <span slot="description">We'll never share your email.</span>
+      <span slot="error-text">Enter a valid email address.</span>
+    </swc-text-field>
+  `,
+  tags: ['states'],
+  parameters: {
+    flexLayout: 'row-wrap',
+  },
+};
+
+// ────────────────────────────────
+//    ACCESSIBILITY STORIES
+// ────────────────────────────────
+
+export const Accessibility: Story = {
+  render: () => html`
+    <swc-text-field>
+      <span slot="label">Comments</span>
+      <span slot="description">Optional; visible to your team only.</span>
+    </swc-text-field>
+    <p id="accessibility-external-description">
+      Describe the issue in as much detail as possible.
+    </p>
+    <swc-text-field
+      accessible-label="Issue details"
+      accessible-describedby="accessibility-external-description"
+    ></swc-text-field>
+  `,
+  tags: ['a11y'],
+  parameters: {
+    flexLayout: 'row-wrap',
+  },
+};

--- a/2nd-gen/packages/swc/components/text-field/test/text-field.test.ts
+++ b/2nd-gen/packages/swc/components/text-field/test/text-field.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { html } from 'lit';
+import { expect } from '@storybook/test';
+import type { Meta, StoryObj as Story } from '@storybook/web-components';
+
+import { TextField } from '@adobe/spectrum-wc/text-field';
+
+import '@adobe/spectrum-wc/components/text-field/swc-text-field.js';
+
+import {
+  fixture,
+  getComponents,
+  withWarningSpy,
+} from '../../../utils/test-utils.js';
+import meta from '../stories/text-field.stories.js';
+import {
+  Accessibility,
+  Labelling,
+  States,
+} from '../stories/text-field.stories.js';
+
+// This file defines dev-only test stories that reuse the main story metadata.
+export default {
+  ...meta,
+  title: 'Text field/Tests',
+  parameters: {
+    ...meta.parameters,
+    docs: { disable: true, page: null },
+  },
+  tags: ['!autodocs', 'dev'],
+} as Meta;
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Labelling precedence in context
+// ──────────────────────────────────────────────────────────────
+
+export const LabellingTest: Story = {
+  ...Labelling,
+  play: async ({ canvasElement, step }) => {
+    const fields = await getComponents<TextField>(
+      canvasElement,
+      'swc-text-field'
+    );
+    const [slotOnly, labelOnly, labelledbyWins] = fields;
+
+    await step('slotted label renders as a real <label for>', () => {
+      const label = slotOnly.shadowRoot?.querySelector('label');
+      const input = slotOnly.shadowRoot?.querySelector('input');
+      expect(label).toBeTruthy();
+      expect(label?.getAttribute('for')).toBe(input?.id);
+    });
+
+    await step('accessible-label sets aria-label on the input', () => {
+      const input = labelOnly.shadowRoot?.querySelector('input');
+      expect(input?.getAttribute('aria-label')).toBe(
+        'Accessible-label only (no visible label)'
+      );
+    });
+
+    await step(
+      'accessible-labelledby resolves external row/column headers',
+      () => {
+        const input = labelledbyWins.shadowRoot?.querySelector('input');
+        const resolved = input?.ariaLabelledByElements;
+        expect(resolved).toHaveLength(2);
+        expect(resolved?.map((el) => el.id)).toEqual([
+          'labelling-row-header',
+          'labelling-col-header',
+        ]);
+      }
+    );
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Invalid state wires description + error text
+// ──────────────────────────────────────────────────────────────
+
+export const StatesTest: Story = {
+  ...States,
+  play: async ({ canvasElement, step }) => {
+    const fields = await getComponents<TextField>(
+      canvasElement,
+      'swc-text-field'
+    );
+    const invalidField = fields[fields.length - 1];
+    const input = invalidField.shadowRoot?.querySelector('input');
+
+    await step('invalid input carries aria-invalid', () => {
+      expect(input?.getAttribute('aria-invalid')).toBe('true');
+    });
+
+    await step(
+      'error text is associated via ariaErrorMessageElements, in addition to ariaDescribedByElements',
+      () => {
+        expect(input?.ariaErrorMessageElements).toHaveLength(1);
+        expect(input?.ariaDescribedByElements).toHaveLength(2);
+      }
+    );
+
+    await step('required is reflected onto the native input', () => {
+      const requiredField = fields[1];
+      const requiredInput = requiredField.shadowRoot?.querySelector('input');
+      expect(requiredInput?.required).toBe(true);
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: accessible-describedby combines with a slotted description
+// ──────────────────────────────────────────────────────────────
+
+export const AccessibilityTest: Story = {
+  ...Accessibility,
+  play: async ({ canvasElement, step }) => {
+    const fields = await getComponents<TextField>(
+      canvasElement,
+      'swc-text-field'
+    );
+    const externallyDescribed = fields[1];
+    const input = externallyDescribed.shadowRoot?.querySelector('input');
+
+    await step('accessible-describedby resolves the external paragraph', () => {
+      const resolved = input?.ariaDescribedByElements ?? [];
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0]?.id).toBe('accessibility-external-description');
+    });
+  },
+};
+
+// ──────────────────────────────────────────────────────────────
+// TEST: Missing accessible-name DEBUG warning
+// ──────────────────────────────────────────────────────────────
+
+export const MissingAccessibleNameTest: Story = {
+  render: () => html`
+    <span></span>
+  `,
+  play: async ({ step }) => {
+    await step('warns when no label source is set', () =>
+      withWarningSpy(async (warnCalls) => {
+        const field = await fixture<TextField>(html`
+          <swc-text-field></swc-text-field>
+        `);
+        await field.updateComplete;
+        const messages = warnCalls.map((c) => String(c?.[1] ?? ''));
+        expect(messages.some((m) => m.includes('accessible name'))).toBe(true);
+        field.parentElement?.remove();
+      })
+    );
+  },
+};

--- a/2nd-gen/packages/swc/components/text-field/text-field.mdx
+++ b/2nd-gen/packages/swc/components/text-field/text-field.mdx
@@ -1,0 +1,63 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { DocsFooter, DocsHeader } from '../../.storybook/blocks';
+
+import * as TextFieldStories from './stories/text-field.stories';
+
+<Meta of={TextFieldStories} />
+
+<DocsHeader />
+
+## Anatomy
+
+A text field consists of:
+
+- **Input**: the real, focusable `<input>` that carries the value and native `textbox` role
+- **Label** (optional), provided through the `label` slot: visible text rendered as a real, same-root `<label for>`
+- **Description** (optional), provided through the `description` slot: guidance text associated via `aria-describedby`
+- **Error text** (optional), provided through the `error-text` slot: shown and associated via `aria-errormessage` only while `invalid`
+
+<Canvas of={TextFieldStories.Anatomy} />
+
+## Options
+
+### Labelling
+
+Three sources can provide the field's accessible name, in precedence order (highest first): `accessible-labelledby`, `accessible-label`, and a slotted `label`. Only the highest-precedence source that is set becomes the accessible name — a lower-precedence source with different text does not get silently combined into it, avoiding a [Label in Name (2.5.3)](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html) mismatch.
+
+- **Slotted `label`**: the default, recommended path for an ordinary standalone field. Renders as a real, same-root `<label for>`, giving native click-to-focus.
+- **`accessible-label`**: a string accessible name for a field with no visible label of its own.
+- **`accessible-labelledby`**: space-separated element `id`s, resolved against the field's root node, for composing a name from elements the field does not own (for example, a grid cell named by its row and column headers).
+
+<Canvas of={TextFieldStories.Labelling} />
+
+## States
+
+Text fields can exist in various states:
+
+- **Default**: normal, editable state
+- **Required**: the native `required` attribute is reflected onto the input; no separate `aria-required` is set
+- **Read-only**: focusable and selectable, but not editable; distinct from disabled
+- **Disabled**: not editable and removed from the tab order
+- **Invalid**: shows the slotted `error-text` and associates it via `aria-errormessage`, in addition to `aria-describedby`
+
+<Canvas of={TextFieldStories.States} />
+
+## Accessibility
+
+### Features
+
+- **Native role** — the host sets no ARIA role; the real `<input>` supplies the implicit `textbox` role.
+- **One accessible-name writer** — `accessible-labelledby` &gt; `accessible-label` &gt; slotted label, in that order; exactly one source is wired at a time.
+- **Combining descriptions** — a slotted `description` and an external `accessible-describedby` reference combine rather than override each other; the in-shadow description comes first.
+- **`aria-errormessage`** — set only while `invalid` is `true`, alongside `aria-describedby`, so the error text is both visible and specifically identified to assistive technology.
+- **Dev-mode warning** — a field with no visible label, no `accessible-label`, and no `accessible-labelledby` triggers a console warning in development builds.
+
+### Best practices
+
+- Prefer a slotted `label` for ordinary fields; reserve `accessible-label`/`accessible-labelledby` for fields with no visible label of their own or a name composed from elements the field doesn't own.
+- Don't combine a slotted label with `accessible-label`/`accessible-labelledby` that carries different text — only the highest-precedence source is used, so a lower-precedence mismatch is a likely authoring error.
+- Always pair `invalid` with slotted `error-text` so the invalid state is not conveyed by color or the validation icon alone.
+
+<Canvas of={TextFieldStories.Accessibility} />
+
+<DocsFooter />


### PR DESCRIPTION
## Description

Replaces the never-built `LabellingController` (planned in the forms-strategy RFC and the text-field migration plan) with two composable mixins in `2nd-gen/packages/core/mixins`:

- **`LabellingMixin`** — visible-label rendering and precedence-ordered accessible-name wiring: `accessible-label` (→ `aria-label`), `accessible-labelledby` (→ `ariaLabelledByElements`), and a slotted `label` (rendered as a real, same-root `<label for>`). Only the highest-precedence source that is set is wired; a lower-precedence slotted label still renders visually as a plain `<span>`.
- **`HelpTextMixin`** — description/error-text rendering and accessible-description wiring: `accessible-describedby` combines with a slotted `description` (shadow content first) into `ariaDescribedByElements`; a slotted `error-text` is wired to `ariaErrorMessageElements` only while the host reads as `invalid`.

Each mixin owns state + wiring and delegates rendering to a new stateless directive (`renderFieldLabel`, `renderFieldHelpText` under `2nd-gen/packages/core/directives`), mirroring the existing `PendingController` → `renderPendingSpinner` split. Both mixins expose an overridable `roleElement` getter (defaulting to `null`) so a core base class can apply them before a render layer exists, with the concrete render class supplying the real element (matches `TooltipBase.tipElement`'s existing pattern).

`swc-text-field` is refactored to consume both mixins as the proving-ground component: `TextField.base.ts` now composes `SizedMixin(LabellingMixin(HelpTextMixin(SpectrumElement)))` (dropping the old `@todo (SWC-2466)` property stubs), and `TextField.ts` has a real `render()` — a functional `<input>` with the label, description, and error text wired around it, and a `roleElement` override pointing at that input.

Also adds `ariaErrorMessageElements` to the project's local `ARIAMixin` type augmentation (`core/global.d.ts`), alongside the existing `ariaDescribedByElements`/`ariaLabelledByElements`.

**New:**
- `core/mixins/labelling-mixin.ts`, `core/mixins/help-text-mixin.ts` (+ tests, Storybook demo stories, and per-mixin `.mdx` docs — a first for mixins in this repo, following the controller-doc conventions)
- `core/directives/render-label/`, `core/directives/render-help-text/`
- `swc/components/text-field/text-field.mdx`, `swc/components/text-field/test/text-field.test.ts`

**Changed:**
- `core/components/text-field/TextField.base.ts`, `swc/components/text-field/TextField.ts`, `text-field.css`, `stories/text-field.stories.ts` (added Anatomy/Labelling/States/Accessibility stories)
- `core/global.d.ts`, `core/mixins/index.ts`, `core/directives/index.ts`, `core/package.json` (export entries for the new directives)

**Explicitly out of scope** (separate, already-tracked work): `FieldAssociationController` (SWC-2467, form participation), the shared `.swc-FormFieldTemplate` CSS grid / `label-position` layout, and the shared `form-fields` stylesheet location decision (Q22).

## Motivation and context

The migration plan called for a single `LabellingController` to own in-shadow label/description/error rendering for form fields, following the `LinearProgressMixin` precedent of "prove it on the first consumer, generalize later." Since meter/progress-bar already prove that shared form-adjacent behavior scales better as composable mixins than as a single controller, this splits the controller's two genuinely independent responsibilities (naming vs. describing) into two mixins instead, so future field components (`text-area`, `number-field`, `color-field`) can adopt only the one they need.

## Related issue(s)

- Addresses SWC-2466 (`LabellingController`), delivered as `LabellingMixin` + `HelpTextMixin` instead of a single controller — see epic SWC-2323.

## Screenshots (if appropriate)

N/A — see the new Storybook stories under **Text field** (Anatomy, Options → Labelling, States, Accessibility) and **Mixins → Labelling mixin** / **Mixins → Help text mixin** for visual coverage.

## Author's checklist

- [x] I have read the **[CONTRIBUTING](https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)** and **[PULL_REQUESTS](https://github.com/adobe/spectrum-web-components/blob/main/PULL_REQUESTS.md)** documents.
- [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
- [x] I have added automated tests to cover my changes.
- [ ] I have included a well-written changeset if my change needs to be published.
- [x] I have included updated documentation if my change required it.

## Reviewer's checklist

- [ ] Includes a Github Issue with appropriate flag or Jira ticket number without a link
- [ ] Includes thoughtfully written changeset if changes suggested include `patch`, `minor`, or `major` features
- [ ] Automated tests cover all use cases and follow best practices for writing
- [ ] Validated on all supported browsers
- [ ] All VRTs are approved before the author can update Golden Hash

### Manual review test cases

- [ ] _Label precedence resolves correctly_
  1. Go to **Text field → Options → Labelling** in Storybook.
  2. Inspect the three fields: slotted-label-only, `accessible-label`-only, and `accessible-labelledby` (pointing at the row/column header `div`s).
  3. Expect: field 1 renders a real `<label for>` in its shadow root; field 2 has `aria-label` on the input and no `<label>`; field 3 has no `aria-label`/`<label for>` and `input.ariaLabelledByElements` resolves to the two header elements (open devtools and check the input's shadow DOM / property).

- [ ] _Invalid state wires error text_
  1. Go to **Text field → States**.
  2. Inspect the "Email address" field (rendered with `invalid`).
  3. Expect: the error-text span is visible, `input.ariaErrorMessageElements` has length 1, and `input.ariaDescribedByElements` includes both the description and error-text elements.

- [ ] _Missing accessible name warns in dev mode_
  1. Open the browser console with Storybook running in dev mode.
  2. Navigate to **Text field → Tests → MissingAccessibleNameTest** (or add a bare `<swc-text-field>` with no label/description via the console).
  3. Expect: a console warning mentioning "accessible name."

- [ ] _Mixins work standalone, outside text-field_
  1. Go to **Mixins → Labelling mixin** and **Mixins → Help text mixin**.
  2. Review the "Behaviors" stories (Name source precedence; Combined description sources; Error text gated by invalid).
  3. Expect: behavior matches the description in each mixin's `.mdx` page.

### Device review

- [ ] Did it pass in Desktop?
- [ ] Did it pass in (emulated) Mobile?
- [ ] Did it pass in (emulated) iPad?

## Accessibility testing checklist
